### PR TITLE
Create symbolic links

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -185,15 +185,15 @@
     	<echo message="Linking component to Joomla!"/>
 
     	<!-- Create symbolic links for component in the Joomla director -->
-		<symlink target="${basedir}/com_biblestudy/admin" link="${joomla_path}/administrator/components/com_biblestudy"/>
-		<symlink target="${basedir}/com_biblestudy/media" link="${joomla_path}/media/com_biblestudy"/>
-		<symlink target="${basedir}/com_biblestudy/site" link="${joomla_path}/components/com_biblestudy"/>
-    	<symlink target="${basedir}/mod_biblestudy" link="${joomla_path}/modules/mod_biblestudy"/>
-    	<symlink target="${basedir}/mod_biblestudy_podcast" link="${joomla_path}/modules/mod_biblestudy_podcast"/>
-    	<symlink target="${basedir}/plg_biblestudy_backup" link="${joomla_path}/plugins/system/jbsbackup"/>
-    	<symlink target="${basedir}/plg_biblestudy_finder" link="${joomla_path}/plugins/finder/biblestudy"/>
-    	<symlink target="${basedir}/plg_biblestudy_podcast" link="${joomla_path}/plugins/system/jbspodcast"/>
-    	<symlink target="${basedir}/plg_biblestudy_podcast" link="${joomla_path}/plugins/search/biblestudysearch"/>
+		<symlink target="${basedir}/com_biblestudy/admin" link="${joomla_path}/administrator/components/com_biblestudy" overwrite="true"/>
+		<symlink target="${basedir}/com_biblestudy/media" link="${joomla_path}/media/com_biblestudy" overwrite="true"/>
+		<symlink target="${basedir}/com_biblestudy/site" link="${joomla_path}/components/com_biblestudy" overwrite="true"/>
+    	<symlink target="${basedir}/mod_biblestudy" link="${joomla_path}/modules/mod_biblestudy" overwrite="true"/>
+    	<symlink target="${basedir}/mod_biblestudy_podcast" link="${joomla_path}/modules/mod_biblestudy_podcast" overwrite="true"/>
+    	<symlink target="${basedir}/plg_biblestudy_backup" link="${joomla_path}/plugins/system/jbsbackup" overwrite="true"/>
+    	<symlink target="${basedir}/plg_biblestudy_finder" link="${joomla_path}/plugins/finder/biblestudy" overwrite="true"/>
+    	<symlink target="${basedir}/plg_biblestudy_podcast" link="${joomla_path}/plugins/system/jbspodcast" overwrite="true"/>
+    	<symlink target="${basedir}/plg_biblestudy_podcast" link="${joomla_path}/plugins/search/biblestudysearch" overwrite="true"/>
     </target>
 
 	<!-- Create symbolic links for the development state -->


### PR DESCRIPTION
Also introduce "dev.setup", "dev.init", and "dev.clean"

**dev.setup** creates symbolic links in the joomla installation

**dev.init** creates symbolic links in from the `admin` folder

**dev.clean** cleans up any symbolic links created by the script that affects the component as its tracked by git. This is called automatically during a build, or a package.
