### PR TITLE
Set minimum joomla version to 3.1.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="project.name" value="Joomla Bible Study"/>
 
 	<!-- Joomla version to run the unit tests against -->
-	<property name="joomla.version" value="2.5.6" />
+	<property name="joomla.version" value="3.1.1" />
 
 	<property name="config_path" value="${basedir}/tests/system/servers"/>
 


### PR DESCRIPTION
Although JBS 8.2.0 minimum requirement is set to Joomla 3.5+, the current Joomla-cms repo has tags only up to 3.1.1 currently. As newer versions of Joomla are taged, we can update the build.xml file with the minimum version.
