### PR TITLE
Using playerheight and width instead of image size

### DIFF
--- a/com_biblestudy/site/lib/biblestudy.media.class.php
+++ b/com_biblestudy/site/lib/biblestudy.media.class.php
@@ -568,8 +568,8 @@ class jbsMedia
 									<script language=\"javascript\" type=\"text/javascript\">
 									    jwplayer('placeholder').setup({
 										    'file' : '" . $path . "',
-										    'height' : '" . $height . "',
-										    'width' : '" . $width . "',
+										    'height' : '" . $player->playerheight . "',
+										    'width' : '" . $player->playerwidth . "',
 									        'image':'" . $params->get('popupimage', 'media/com_biblestudy/images/speaker24.png') . "',
 									        'flashplayer':'" . $base . "media/com_biblestudy/player/jwplayer.flash.swf',
 									        'backcolor':'" . $backcolor . "',


### PR DESCRIPTION
When i tried to use the inline internal player for playing mp3's, it was squeezed together to 24x24px.

I don't know about the development branch, does this need to be fixed too? https://github.com/Joomla-Bible-Study/Joomla-Bible-Study/blob/development/com_biblestudy/site/helpers/media.php#L527-L528

I'm also puzzled why I'm the only one who had that problem, because that code has existed for quite a while. Am I doing the right thing?
