### PR TITLE
fixed custom fields with more than one placeholder

### DIFF
--- a/com_biblestudy/site/helpers/custom.php
+++ b/com_biblestudy/site/helpers/custom.php
@@ -34,6 +34,7 @@ class JBSMCustom extends JBSMElements
 	 */
 	public function getCustom($rowid, $custom, $row, $params, $admin_params, $template)
 	{
+		$isCustom = ($rowid == 24) ? true : false;
 		$elementid   = new stdClass;
 		$countbraces = substr_count($custom, '{');
 
@@ -43,7 +44,7 @@ class JBSMCustom extends JBSMElements
 			$braceend   = strpos($custom, '}');
 			$subcustom  = substr($custom, ($bracebegin + 1), (($braceend - $bracebegin) - 1));
 
-			if (!$rowid || $rowid == 24)
+			if (!$rowid || $isCustom)
 			{
 				$rowid = $this->getElementnumber($subcustom);
 			}


### PR DESCRIPTION
When using custom fields with more than one placeholder ex. "{studytitle} - {teachername}" it will only fill both fields with the content of {studytitle}, because for the second field getElementnumber() will not be called as $rowid has been overwritten (see line 47).

By reading that field at the beginning of the method, we are sure nothing is overwritten.
