### PR TITLE
Test-dependencies with composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ tests/unit/.joomla-cms/
 /bin/phploc
 /bin/phpmd
 /bin/phpunit
+/bin/phpcs
 /composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tests/unit/.joomla-cms/
 /bin/phploc
 /bin/phpmd
 /bin/phpunit
+/composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ com_biblestudy/admin/views/test/tmpl/index.html
 tests/unit/.joomla-cms/
 
 /vendor/
+/bin/phing
+/bin/pdepend
+/bin/phpcpd
+/bin/phploc
+/bin/phpmd
+/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 
 script:
   - bin/phing pmd
-  - bin/phpcs --report=full --ignore=*/tests/*,S3.class.php,*/tmpl/*,*/plupload/* --extensions=php -p --standard=build/phpcs/Joomla .
+  - bin/phpcs --report=full --ignore=*/tests/*,S3.class.php,*/tmpl/*,*/plupload/*,/build/,/vendor/,/bin/,/.joomla-dev/ --extensions=php -p --standard=build/phpcs/Joomla .
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ services:
   - redis-server
 
 before_script:
-  # - composer self-update
-  # - composer update
-  - pyrus install -f pear/PHP_CodeSniffer-1.5.5
-  - pyrus install -f pear/Cache_Lite
-  - pear channel-discover pear.phing.info
-  - pear channel-discover pear.phpmd.org
-  - pear install phpmd/PHP_PMD
-  - pear install phing/phing
+  - composer self-update
+  - composer install --dev
+  # - pyrus install -f pear/PHP_CodeSniffer-1.5.5
+  # - pyrus install -f pear/Cache_Lite
+  # - pear channel-discover pear.phing.info
+  # - pear channel-discover pear.phpmd.org
+  # - pear install phpmd/PHP_PMD
+  # - pear install phing/phing
   - phpenv rehash
   # Set up Apache
   # - ./build/travis/php-apache.sh
@@ -29,8 +29,8 @@ before_script:
   - phpenv config-add build/travis/phpenv/redis.ini
 
 script:
-  - phing pmd
-  - phpcs --report=full --ignore=*/tests/*,S3.class.php,*/tmpl/*,*/plupload/* --extensions=php -p --standard=build/phpcs/Joomla .
+  - bin/phing pmd
+  - bin/phpcs --report=full --ignore=*/tests/*,S3.class.php,*/tmpl/*,*/plupload/* --extensions=php -p --standard=build/phpcs/Joomla .
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
 # Until we start using phpunit we only need to test are menumum version.
@@ -12,7 +14,6 @@ services:
   - redis-server
 
 before_script:
-  - composer self-update
   - composer install --dev
   # - pyrus install -f pear/PHP_CodeSniffer-1.5.5
   # - pyrus install -f pear/Cache_Lite

--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ Contributing
 ------------
 We appreciate contributions in varioius capacities, below are some ways that you can contribute to this project
 
-###Development
+###Setup
 1. [Fork this repository.][fork]
-2. [Create a topic branch.][branch]
-3. Implement your feature or bug fix.
-4. If you implemented a new feature or added an extra functionality, create/update unit tests for that feature
-4. Run `composer install --dev && vendor/bin/phing build` (requires [Composer][https://getcomposer.org] to be installed)
-5. If not building sucessfully, go back to step **3**
+2. Load dev dependencies with [Composer][composer]: `php composer.phar install --dev`
+3. [Set up your dev environment][setup]
+
+###Development
+1. [Create a topic branch.][branch]
+2. Implement your feature or bug fix.
+3. If you implemented a new feature or added an extra functionality, create/update unit tests for that feature
+4. Run `bin/phing build`
+5. If not building sucessfully, go back to step **1**
 6. Add your files to repositiory: `git add .`
 7. Commit your files: `git commit -m "Implemented feature [x]"`
 8. Push your changes: `git push`
@@ -67,7 +71,8 @@ For every major release, we prefer to have an approximate 2 week testing window.
 [branch]: http://learn.github.com/p/branching.html
 [pr]: http://help.github.com/send-pull-requests/
 [phing]: http://www.phing.info/
-
+[setup]: https://github.com/Joomla-Bible-Study/Joomla-Bible-Study/wiki/Setting-up-your-development-environment
+[composer]: https://getcomposer.org/download/
 
 Reporting Issues and requesting features
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We appreciate contributions in varioius capacities, below are some ways that you
 2. [Create a topic branch.][branch]
 3. Implement your feature or bug fix.
 4. If you implemented a new feature or added an extra functionality, create/update unit tests for that feature
-4. Run `phing build` (requires [Phing][phing] to be installed)
+4. Run `composer install --dev && vendor/bin/phing build` (requires [Composer][https://getcomposer.org] to be installed)
 5. If not building sucessfully, go back to step **3**
 6. Add your files to repositiory: `git add .`
 7. Commit your files: `git commit -m "Implemented feature [x]"`

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="biblestudy" default="build" basedir=".">
-    <property name="basedir" value="${project.basedir}" />
+	<php expression="include('vendor/autoload.php')"/>
+
+	<property name="basedir" value="${project.basedir}" />
 	<property name="project.name" value="Joomla Bible Study"/>
 
 	<!-- Joomla version to run the unit tests against -->

--- a/build.xml
+++ b/build.xml
@@ -226,13 +226,12 @@
                     <!-- Force a stage if its already staged -->
                     <property name="force" value="${stage_joomla"/>
                 </phingcall>
+				<!--Link Joomla to the webserver's root directory  -->
+				<symlink target="${basedir}/.joomla-dev" link="${joomla_path}${joomla_dir}" overwrite="true"/>
             </then>
         </if>
 
         <echo message="Joomla path set to: ${joomla_path}${joomla_dir}"/>
-
-        <!-- Link Joomla to the webserver's root directory  -->
-        <!--<symlink target="${basedir}/.joomla-dev" link="${joomla_path}${joomla_dir}" overwrite="true"/>-->
 
 		<echo message="Linking component to Joomla!"/>
 

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="project.name" value="Joomla Bible Study"/>
 
 	<!-- Joomla version to run the unit tests against -->
-	<property name="joomla.version" value="2.5.11" />
+	<property name="joomla.version" value="3.3.6" />
 
 	<property name="config_path" value="${basedir}/tests/system/servers"/>
 
@@ -254,7 +254,8 @@
 		<echo message="Initializing a development state"/>
         <symlink target="${basedir}/com_biblestudy/biblestudy.xml" link="${basedir}/com_biblestudy/admin/biblestudy.xml" overwrite="true"/>
         <symlink target="${basedir}/com_biblestudy/biblestudy.script.php" link="${basedir}/com_biblestudy/admin/biblestudy.script.php" overwrite="true"/>
-        <symlink target="${basedir}/com_biblestudy/media/css/biblestudy.css" link="${basedir}/com_biblestudy/media/css/site/biblestudy.css" overwrite="true"/>
+		<mkdir dir="${basedir}/com_biblestudy/media/css/site" />
+		<symlink target="${basedir}/com_biblestudy/media/css/biblestudy.css" link="${basedir}/com_biblestudy/media/css/site/biblestudy.css" overwrite="true"/>
 
 		<!-- Not sure what this does -->
             <!--<copy todir="${dest.test}">-->

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -13,9 +13,11 @@
  <!-- Exclude 3rd party libraries and Framework code. -->
  <exclude-pattern type="relative">libraries/compat/password/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/fof/*</exclude-pattern>
+ <exclude-pattern type="relative">libraries/framework/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/idna_convert/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/phputf8/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/simplepie/*</exclude-pattern>
+ <exclude-pattern type="relative">libraries/phpmailer/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/phpass/*</exclude-pattern>
  <exclude-pattern type="relative">libraries/vendor/*</exclude-pattern>
 
@@ -38,6 +40,10 @@
  <rule ref="Generic.Files.LineLength">
  <!-- These exceptions are temporary -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
+  <exclude-pattern type="relative">plugins/*</exclude-pattern>
+  <exclude-pattern type="relative">modules/*</exclude-pattern>
+  <exclude-pattern type="relative">libraries/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
@@ -87,6 +93,8 @@
 
  <rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
  <!-- These exceptions are temporary -->
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
@@ -117,23 +125,28 @@
  <rule ref="Joomla.Classes.MethodScope">
   <!-- We only want this for libraries, language and cli for now -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.Commenting.FunctionComment">
   <!-- We only want this for libraries, language and cli for now -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
+  <exclude-pattern type="relative">includes/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.Commenting.SingleComment">
   <!-- We only want this for libraries, language and cli for now -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
+  <exclude-pattern type="relative">includes/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.Commenting.ClassComment">
@@ -144,11 +157,20 @@
 
  <rule ref="Joomla.WhiteSpace.ConcatenationSpacing">
   <!-- We only want this for libraries, language and cli for now -->
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
+  <exclude-pattern type="relative">includes/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.ControlStructures.ControlSignature">
+  <!-- We only want this for libraries, languages and cli for now -->
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
+  <exclude-pattern type="relative">includes/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
@@ -157,6 +179,9 @@
  </rule>
 
  <rule ref="Joomla.ControlStructures.InlineControlStructure">
+  <!-- These exceptions are temporary -->
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
@@ -165,6 +190,10 @@
  </rule>
 
  <rule ref="Joomla.ControlStructures.MultiLineCondition">
+  <!-- We only want this for libraries, language and cli for now -->
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
+  <exclude-pattern type="relative">components/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "joomla-bible-study/joomla-bible-study",
+    "description": "Joomla-Bible-Study",
+    "require": {
+        
+    },
+    "require-dev": {
+        "phing/phing": "2.8.2",
+        "phpunit/phpunit": "4.0.17",
+        "sebastian/phpcpd": "2.0.0",
+        "phploc/phploc": "2.0.4",
+        "phpmd/phpmd": "1.5.0",
+        "phpunit/php-invoker": "~1.1"
+    },
+    "authors": [
+        {
+            "name": "Michael Heiniger",
+            "email": "michael.heiniger@gmail.com"
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,15 @@
         
     },
     "require-dev": {
-        "phing/phing": "2.8.2",
+        "phing/phing": "2.9.1",
+        "pdepend/pdepend": "1.1.1",
+        "sebastian/phpcpd": "*",
         "pear/versioncontrol_git": "dev-master",
         "pear/pear_exception": "dev-master",
-        "phpunit/phpunit": "4.0.17",
+        "phpunit/phpunit": "4.1.*",
         "sebastian/phpcpd": "2.0.0",
         "phploc/phploc": "2.0.4",
-        "phpmd/phpmd": "1.5.0",
+        "phpmd/phpmd": "1.4.1",
         "phpunit/php-invoker": "~1.1",
         "squizlabs/php_codesniffer": "1.5.5"
     },
@@ -23,5 +25,10 @@
     ],
     "config": {
         "bin-dir": "bin"
-    }
+    },
+    "autoload": {
+        "psr-0": { "PHP_Depend": "vendor/pdepend/pdepend/src/main/php" }
+    },
+    "include-path": ["vendor/pdepend/pdepend/src/main/php"]
+
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "sebastian/phpcpd": "2.0.0",
         "phploc/phploc": "2.0.4",
         "phpmd/phpmd": "1.5.0",
-        "phpunit/php-invoker": "~1.1"
+        "phpunit/php-invoker": "~1.1",
+        "squizlabs/php_codesniffer": "1.5.5"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,8 @@
     },
     "require-dev": {
         "phing/phing": "2.8.2",
+        "pear/versioncontrol_git": "dev-master",
+        "pear/pear_exception": "dev-master",
         "phpunit/phpunit": "4.0.17",
         "sebastian/phpcpd": "2.0.0",
         "phploc/phploc": "2.0.4",

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
             "name": "Michael Heiniger",
             "email": "michael.heiniger@gmail.com"
         }
-    ]
+    ],
+    "config": {
+        "bin-dir": "bin"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1311 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "305f79c903d646cf94f2efd4b4041f40",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "pdepend/pdepend",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "dc582a3c0180664a8fbfc5a34efaf4cc13fccc60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/dc582a3c0180664a8fbfc5a34efaf4cc13fccc60",
+                "reference": "dc582a3c0180664a8fbfc5a34efaf4cc13fccc60",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/config": "@stable",
+                "symfony/dependency-injection": "@stable",
+                "symfony/filesystem": "@stable"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.*@stable",
+                "squizlabs/php_codesniffer": "@stable"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PDepend\\": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "time": "2014-10-08 06:54:50"
+        },
+        {
+            "name": "phing/phing",
+            "version": "2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phingofficial/phing.git",
+                "reference": "345e8716122cf6c6b59c4894701d8b736f27fca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/345e8716122cf6c6b59c4894701d8b736f27fca9",
+                "reference": "345e8716122cf6c6b59c4894701d8b736f27fca9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "2.x",
+                "phpunit/phpunit": ">=3.7"
+            },
+            "suggest": {
+                "pdepend/pdepend": "PHP version of JDepend",
+                "pear/archive_tar": "Tar file management class",
+                "pear/versioncontrol_git": "A library that provides OO interface to handle Git repository",
+                "pear/versioncontrol_svn": "A simple OO-style interface for Subversion, the free/open-source version control system",
+                "phpdocumentor/phpdocumentor": "Documentation Generator for PHP",
+                "phploc/phploc": "A tool for quickly measuring the size of a PHP project",
+                "phpmd/phpmd": "PHP version of PMD tool",
+                "phpunit/php-code-coverage": "Library that provides collection, processing, and rendering functionality for PHP code coverage information",
+                "phpunit/phpunit": "The PHP Unit Testing Framework",
+                "sebastian/phpcpd": "Copy/Paste Detector (CPD) for PHP code",
+                "tedivm/jshrink": "Javascript Minifier built in PHP"
+            },
+            "bin": [
+                "bin/phing"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "classes/phing/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "classes"
+            ],
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Phing Community",
+                    "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+                }
+            ],
+            "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+            "homepage": "http://www.phing.info/",
+            "keywords": [
+                "build",
+                "phing",
+                "task",
+                "tool"
+            ],
+            "time": "2014-07-18 10:23:54"
+        },
+        {
+            "name": "phploc/phploc",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phploc.git",
+                "reference": "2b3d3f4105cb16f78f5bdd77216b992dade053d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phploc/zipball/2b3d3f4105cb16f78f5bdd77216b992dade053d0",
+                "reference": "2b3d3f4105cb16f78f5bdd77216b992dade053d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/finder-facade": ">=1.1.0",
+                "sebastian/git": ">=1.0.0",
+                "sebastian/version": ">=1.0.0",
+                "symfony/console": ">=2.2.0"
+            },
+            "bin": [
+                "composer/bin/phploc"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "A tool for quickly measuring the size of a PHP project.",
+            "homepage": "https://github.com/sebastianbergmann/phploc",
+            "time": "2013-12-18 08:31:50"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "692b7b1b64518091b2b1bea91b489dbb13598c07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/692b7b1b64518091b2b1bea91b489dbb13598c07",
+                "reference": "692b7b1b64518091b2b1bea91b489dbb13598c07",
+                "shasum": ""
+            },
+            "require": {
+                "pdepend/pdepend": ">=1.1.1",
+                "php": ">=5.3.0"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "../../pdepend/pdepend/src/main/php",
+                "src/main/php"
+            ],
+            "description": "Official version of PHPMD handled with Composer.",
+            "time": "2013-07-26 14:47:02"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
+                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "~1.0",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4.1"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-08-31 06:33:04"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10 15:34:57"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "8696484458cb43eed025ab46260846de5b74655c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/8696484458cb43eed025ab46260846de5b74655c",
+                "reference": "8696484458cb43eed025ab46260846de5b74655c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcntl": "*",
+                "php": ">=5.2.7",
+                "phpunit/php-timer": ">=1.0.4,<1.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for invoking callables with a timeout.",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2013-07-16 05:20:21"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Text/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2014-01-30 17:20:04"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2013-08-02 07:42:54"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/f8d5d08c56de5cfd592b3340424a81733259a876",
+                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2014-08-31 06:12:13"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "8185f4bd21860cc72466009070a50bed6cd2eaca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8185f4bd21860cc72466009070a50bed6cd2eaca",
+                "reference": "8185f4bd21860cc72466009070a50bed6cd2eaca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": ">=2.0.0,<2.1.0",
+                "phpunit/php-file-iterator": "~1.3.1",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": ">=2.0.0,<2.1.0",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.0",
+                "sebastian/exporter": "~1.0.1",
+                "sebastian/version": "~1.0.3",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-04-21 06:33:32"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
+                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.0.0,<4.1.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2014-06-12 07:19:48"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/5843509fed39dee4b356a306401e9dd1a931fec7",
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2014-08-15 10:29:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
+                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2014-10-07 09:23:16"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2014-09-10 00:51:36"
+        },
+        {
+            "name": "sebastian/finder-facade",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/finder-facade.git",
+                "reference": "1e396fda3449fce9df032749fa4fa2619e0347e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/finder-facade/zipball/1e396fda3449fce9df032749fa4fa2619e0347e0",
+                "reference": "1e396fda3449fce9df032749fa4fa2619e0347e0",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/finder": ">=2.2.0",
+                "theseer/fdomdocument": ">=1.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
+            "homepage": "https://github.com/sebastianbergmann/finder-facade",
+            "time": "2013-05-28 06:10:03"
+        },
+        {
+            "name": "sebastian/git",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/git.git",
+                "reference": "572c35353fefcc8607d6fef0e362a9f3a5e84d96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/git/zipball/572c35353fefcc8607d6fef0e362a9f3a5e84d96",
+                "reference": "572c35353fefcc8607d6fef0e362a9f3a5e84d96",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple wrapper for Git",
+            "homepage": "http://www.github.com/sebastianbergmann/git",
+            "keywords": [
+                "git"
+            ],
+            "time": "2014-06-14 07:12:53"
+        },
+        {
+            "name": "sebastian/phpcpd",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcpd.git",
+                "reference": "346c909de7adc3979988a6505a80814c8562d6b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcpd/zipball/346c909de7adc3979988a6505a80814c8562d6b3",
+                "reference": "346c909de7adc3979988a6505a80814c8562d6b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-timer": ">=1.0.4",
+                "sebastian/finder-facade": ">=1.1.0",
+                "sebastian/version": ">=1.0.0",
+                "symfony/console": ">=2.2.0",
+                "theseer/fdomdocument": "~1.4"
+            },
+            "bin": [
+                "composer/bin/phpcpd"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Copy/Paste Detector (CPD) for PHP code.",
+            "homepage": "https://github.com/sebastianbergmann/phpcpd",
+            "time": "2013-11-08 09:05:42"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2014-03-07 15:35:33"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/Config",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Config.git",
+                "reference": "0316364bfebc8b080077c731a99f189341476bd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/0316364bfebc8b080077c731a99f189341476bd7",
+                "reference": "0316364bfebc8b080077c731a99f189341476bd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/filesystem": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-23 05:25:11"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
+                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-25 09:53:56"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/DependencyInjection",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DependencyInjection.git",
+                "reference": "1f01a64c9047909e40700a14ee34e8c446300618"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/1f01a64c9047909e40700a14ee34e8c446300618",
+                "reference": "1f01a64c9047909e40700a14ee34e8c446300618",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/config": "~2.2",
+                "symfony/expression-language": "~2.4",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-27 08:35:39"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/Filesystem",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "4e62fab0060a826561c78b665925b37c870c45f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/4e62fab0060a826561c78b665925b37c870c45f5",
+                "reference": "4e62fab0060a826561c78b665925b37c870c45f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-22 09:14:18"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "d5033742b9a6206ef6d06e813870bca18e9205df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/d5033742b9a6206ef6d06e813870bca18e9205df",
+                "reference": "d5033742b9a6206ef6d06e813870bca18e9205df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-27 08:35:39"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.5.5",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/b1dbc53593b98c2d694ebf383660ac9134d30b96",
+                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-22 09:14:18"
+        },
+        {
+            "name": "theseer/fdomdocument",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/fDOMDocument.git",
+                "reference": "d08cf070350f884c63fc9078d27893c2ab6c7cef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/d08cf070350f884c63fc9078d27893c2ab6c7cef",
+                "reference": "d08cf070350f884c63fc9078d27893c2ab6c7cef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "lib-libxml": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
+            "homepage": "https://github.com/theseer/fDOMDocument",
+            "time": "2014-09-13 10:57:19"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "305f79c903d646cf94f2efd4b4041f40",
+    "hash": "f096b22a136018e2be9a4aa6bdc09fb7",
     "packages": [],
     "packages-dev": [
         {
             "name": "pdepend/pdepend",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "dc582a3c0180664a8fbfc5a34efaf4cc13fccc60"
+                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/dc582a3c0180664a8fbfc5a34efaf4cc13fccc60",
-                "reference": "dc582a3c0180664a8fbfc5a34efaf4cc13fccc60",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1b0acf162da4f30237987e61e177a57f78e3d87e",
+                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e",
                 "shasum": ""
             },
             "require": {
-                "symfony/config": "@stable",
-                "symfony/dependency-injection": "@stable",
-                "symfony/filesystem": "@stable"
+                "symfony/config": ">=2.4",
+                "symfony/dependency-injection": ">=2.4",
+                "symfony/filesystem": ">=2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.*@stable",
+                "phpunit/phpunit": "4.*@stable",
                 "squizlabs/php_codesniffer": "@stable"
             },
             "bin": [
@@ -44,7 +44,107 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2014-10-08 06:54:50"
+            "time": "2014-12-04 12:38:39"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "d5a3e9597040dcc56a4a2053a605e07214951202"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/d5a3e9597040dcc56a4a2053a605e07214951202",
+                "reference": "d5a3e9597040dcc56a4a2053a605e07214951202",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net",
+                    "role": "Helper"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2014-02-21 17:39:41"
+        },
+        {
+            "name": "pear/versioncontrol_git",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/VersionControl_Git.git",
+                "reference": "7e8387c0cfee8640d86a40591ec9741c5cc25c68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/VersionControl_Git/zipball/7e8387c0cfee8640d86a40591ec9741c5cc25c68",
+                "reference": "7e8387c0cfee8640d86a40591ec9741c5cc25c68",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "VersionControl": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "Apache License"
+            ],
+            "authors": [
+                {
+                    "name": "Kousuke Ebihara",
+                    "email": "ebihara@php.net",
+                    "role": "Lead"
+                }
+            ],
+            "description": "VersionControl_Git is a library that provides OO interface to handle Git repository.",
+            "time": "2014-02-21 08:06:18"
         },
         {
             "name": "phing/phing",
@@ -199,16 +299,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.11",
+            "version": "2.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7"
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
-                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca158276c1200cc27f5409a5e338486bc0b4fc94",
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94",
                 "shasum": ""
             },
             "require": {
@@ -260,7 +360,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-08-31 06:33:04"
+            "time": "2014-12-26 13:28:33"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -676,16 +776,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.1.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7"
+                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
-                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e6c71d918088c251b181ba8b3088af4ac336dd7",
+                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7",
                 "shasum": ""
             },
             "require": {
@@ -697,7 +797,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -722,7 +822,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2014-10-07 09:23:16"
+            "time": "2014-10-25 08:00:45"
         },
         {
             "name": "sebastian/exporter",
@@ -927,16 +1027,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43"
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b",
                 "shasum": ""
             },
             "type": "library",
@@ -958,21 +1058,21 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2014-03-07 15:35:33"
+            "time": "2014-12-15 14:25:24"
         },
         {
             "name": "symfony/config",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "0316364bfebc8b080077c731a99f189341476bd7"
+                "reference": "d94f222eff99a22ce313555b78642b4873418d56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/0316364bfebc8b080077c731a99f189341476bd7",
-                "reference": "0316364bfebc8b080077c731a99f189341476bd7",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/d94f222eff99a22ce313555b78642b4873418d56",
+                "reference": "d94f222eff99a22ce313555b78642b4873418d56",
                 "shasum": ""
             },
             "require": {
@@ -982,7 +1082,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1006,21 +1106,21 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-23 05:25:11"
+            "time": "2015-01-03 08:01:59"
         },
         {
             "name": "symfony/console",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661"
+                "reference": "6ac6491ff60c0e5a941db3ccdc75a07adbb61476"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
-                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/6ac6491ff60c0e5a941db3ccdc75a07adbb61476",
+                "reference": "6ac6491ff60c0e5a941db3ccdc75a07adbb61476",
                 "shasum": ""
             },
             "require": {
@@ -1028,16 +1128,18 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1"
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/process": "~2.1"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": ""
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1061,30 +1163,33 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-25 09:53:56"
+            "time": "2015-01-06 17:50:02"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/DependencyInjection",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "1f01a64c9047909e40700a14ee34e8c446300618"
+                "reference": "72db9adf2f6c42e773108038bcdaff263f325b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/1f01a64c9047909e40700a14ee34e8c446300618",
-                "reference": "1f01a64c9047909e40700a14ee34e8c446300618",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/72db9adf2f6c42e773108038bcdaff263f325b4e",
+                "reference": "72db9adf2f6c42e773108038bcdaff263f325b4e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "conflict": {
+                "symfony/expression-language": "<2.6"
+            },
             "require-dev": {
                 "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.4",
-                "symfony/yaml": "~2.0"
+                "symfony/expression-language": "~2.6",
+                "symfony/yaml": "~2.1"
             },
             "suggest": {
                 "symfony/config": "",
@@ -1094,7 +1199,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1118,21 +1223,21 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-27 08:35:39"
+            "time": "2015-01-05 17:41:06"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "4e62fab0060a826561c78b665925b37c870c45f5"
+                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/4e62fab0060a826561c78b665925b37c870c45f5",
-                "reference": "4e62fab0060a826561c78b665925b37c870c45f5",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
+                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
                 "shasum": ""
             },
             "require": {
@@ -1141,7 +1246,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1165,21 +1270,21 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-22 09:14:18"
+            "time": "2015-01-03 21:13:09"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "d5033742b9a6206ef6d06e813870bca18e9205df"
+                "reference": "16513333bca64186c01609961a2bb1b95b5e1355"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/d5033742b9a6206ef6d06e813870bca18e9205df",
-                "reference": "d5033742b9a6206ef6d06e813870bca18e9205df",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/16513333bca64186c01609961a2bb1b95b5e1355",
+                "reference": "16513333bca64186c01609961a2bb1b95b5e1355",
                 "shasum": ""
             },
             "require": {
@@ -1188,7 +1293,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1212,21 +1317,21 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-27 08:35:39"
+            "time": "2015-01-03 08:01:59"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.5.5",
+            "version": "v2.6.3",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96"
+                "reference": "82462a90848a52c2533aa6b598b107d68076b018"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/b1dbc53593b98c2d694ebf383660ac9134d30b96",
-                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/82462a90848a52c2533aa6b598b107d68076b018",
+                "reference": "82462a90848a52c2533aa6b598b107d68076b018",
                 "shasum": ""
             },
             "require": {
@@ -1235,7 +1340,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -1259,7 +1364,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-22 09:14:18"
+            "time": "2015-01-03 15:33:07"
         },
         {
             "name": "theseer/fdomdocument",
@@ -1304,7 +1409,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "pear/versioncontrol_git": 20,
+        "pear/pear_exception": 20
+    },
     "prefer-stable": false,
     "platform": [],
     "platform-dev": []

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f096b22a136018e2be9a4aa6bdc09fb7",
+    "hash": "845f7e9fba0c182ac090f8594fad3af3",
     "packages": [],
     "packages-dev": [
         {
@@ -543,16 +543,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876"
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/f8d5d08c56de5cfd592b3340424a81733259a876",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/db32c18eba00b121c145575fcbcd4d4d24e6db74",
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +565,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -588,7 +588,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-08-31 06:12:13"
+            "time": "2015-01-17 09:51:32"
         },
         {
             "name": "phpunit/phpunit",
@@ -1059,6 +1059,81 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2014-12-15 14:25:24"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5d973e59cf58a0c847f298de84374c96b42b17b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5d973e59cf58a0c847f298de84374c96b42b17b3",
+                "reference": "5d973e59cf58a0c847f298de84374c96b42b17b3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.1.2"
+            },
+            "suggest": {
+                "phpunit/php-timer": "dev-master"
+            },
+            "bin": [
+                "scripts/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-phpcs-fixer": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/CommentParser/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2014-09-25 03:33:46"
         },
         {
             "name": "symfony/config",

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,33 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "845f7e9fba0c182ac090f8594fad3af3",
+    "hash": "7f845158c02b0d375bb565a84ed8fc61",
     "packages": [],
     "packages-dev": [
         {
             "name": "pdepend/pdepend",
-            "version": "2.0.4",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e"
+                "reference": "6fcfb7666c95f341b42f02c94a47b3a51ed484e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1b0acf162da4f30237987e61e177a57f78e3d87e",
-                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/6fcfb7666c95f341b42f02c94a47b3a51ed484e0",
+                "reference": "6fcfb7666c95f341b42f02c94a47b3a51ed484e0",
                 "shasum": ""
             },
             "require": {
-                "symfony/config": ">=2.4",
-                "symfony/dependency-injection": ">=2.4",
-                "symfony/filesystem": ">=2.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*@stable",
-                "squizlabs/php_codesniffer": "@stable"
+                "php": ">=5.2.3"
             },
             "bin": [
                 "src/bin/pdepend"
             ],
             "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PDepend\\": "src/main/php/"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2014-12-04 12:38:39"
+            "time": "2013-07-25 19:23:48"
         },
         {
             "name": "pear/pear_exception",
@@ -148,24 +134,38 @@
         },
         {
             "name": "phing/phing",
-            "version": "2.8.2",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phingofficial/phing.git",
-                "reference": "345e8716122cf6c6b59c4894701d8b736f27fca9"
+                "reference": "393edeffa8a85d43636ce0c9b4deb1ff9ac60a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/phing/zipball/345e8716122cf6c6b59c4894701d8b736f27fca9",
-                "reference": "345e8716122cf6c6b59c4894701d8b736f27fca9",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/393edeffa8a85d43636ce0c9b4deb1ff9ac60a5c",
+                "reference": "393edeffa8a85d43636ce0c9b4deb1ff9ac60a5c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.0"
             },
             "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "lastcraft/simpletest": "@dev",
+                "pdepend/pdepend": "1.x",
+                "pear-pear.php.net/http_request2": "2.2.x",
+                "pear-pear.php.net/net_growl": "2.7.x",
+                "pear-pear.php.net/pear_packagefilemanager": "1.7.x",
+                "pear-pear.php.net/pear_packagefilemanager2": "1.0.x",
+                "pear-pear.php.net/xml_serializer": "0.20.x",
+                "pear/pear_exception": "@dev",
+                "pear/versioncontrol_git": "@dev",
+                "pear/versioncontrol_svn": "@dev",
                 "phpdocumentor/phpdocumentor": "2.x",
-                "phpunit/phpunit": ">=3.7"
+                "phploc/phploc": "2.x",
+                "phpunit/phpunit": ">=3.7",
+                "sebastian/phpcpd": "2.x",
+                "squizlabs/php_codesniffer": "1.5.x"
             },
             "suggest": {
                 "pdepend/pdepend": "PHP version of JDepend",
@@ -184,6 +184,11 @@
                 "bin/phing"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "classes/phing/"
@@ -198,13 +203,12 @@
             ],
             "authors": [
                 {
-                    "name": "Michiel Rook",
-                    "email": "mrook@php.net",
-                    "role": "Lead"
-                },
-                {
                     "name": "Phing Community",
                     "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+                },
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net"
                 }
             ],
             "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
@@ -215,7 +219,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2014-07-18 10:23:54"
+            "time": "2014-12-03 09:18:46"
         },
         {
             "name": "phploc/phploc",
@@ -269,20 +273,20 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "1.5.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "692b7b1b64518091b2b1bea91b489dbb13598c07"
+                "reference": "7d03a50e937811970751697ad1aea33a1089d66f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/692b7b1b64518091b2b1bea91b489dbb13598c07",
-                "reference": "692b7b1b64518091b2b1bea91b489dbb13598c07",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/7d03a50e937811970751697ad1aea33a1089d66f",
+                "reference": "7d03a50e937811970751697ad1aea33a1089d66f",
                 "shasum": ""
             },
             "require": {
-                "pdepend/pdepend": ">=1.1.1",
+                "pdepend/pdepend": "*",
                 "php": ">=5.3.0"
             },
             "bin": [
@@ -295,7 +299,7 @@
                 "src/main/php"
             ],
             "description": "Official version of PHPMD handled with Composer.",
-            "time": "2013-07-26 14:47:02"
+            "time": "2012-12-14 12:25:09"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -592,39 +596,38 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.0.17",
+            "version": "4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8185f4bd21860cc72466009070a50bed6cd2eaca"
+                "reference": "241116219bb7e3b8111a36ffd8f37546888738d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8185f4bd21860cc72466009070a50bed6cd2eaca",
-                "reference": "8185f4bd21860cc72466009070a50bed6cd2eaca",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/241116219bb7e3b8111a36ffd8f37546888738d6",
+                "reference": "241116219bb7e3b8111a36ffd8f37546888738d6",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": ">=2.0.0,<2.1.0",
+                "phpunit/php-code-coverage": "~2.0",
                 "phpunit/php-file-iterator": "~1.3.1",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "~1.0.2",
-                "phpunit/phpunit-mock-objects": ">=2.0.0,<2.1.0",
+                "phpunit/phpunit-mock-objects": "2.1.5",
+                "sebastian/comparator": "~1.0",
                 "sebastian/diff": "~1.1",
                 "sebastian/environment": "~1.0",
-                "sebastian/exporter": "~1.0.1",
-                "sebastian/version": "~1.0.3",
+                "sebastian/exporter": "~1.0",
+                "sebastian/version": "~1.0",
                 "symfony/yaml": "~2.0"
             },
             "suggest": {
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -633,7 +636,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "4.1.x-dev"
                 }
             },
             "autoload": {
@@ -663,20 +666,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-04-21 06:33:32"
+            "time": "2014-08-17 08:07:02"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.0.10",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2"
+                "reference": "7878b9c41edb3afab92b85edf5f0981014a2713a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
-                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/7878b9c41edb3afab92b85edf5f0981014a2713a",
+                "reference": "7878b9c41edb3afab92b85edf5f0981014a2713a",
                 "shasum": ""
             },
             "require": {
@@ -684,7 +687,7 @@
                 "phpunit/php-text-template": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=4.0.0,<4.1.0"
+                "phpunit/phpunit": "~4.1"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -692,7 +695,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -720,7 +723,71 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2014-06-12 07:19:48"
+            "time": "2014-06-12 07:22:15"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "c484a80f97573ab934e37826dba0135a3301b26a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c484a80f97573ab934e37826dba0135a3301b26a",
+                "reference": "c484a80f97573ab934e37826dba0135a3301b26a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.1",
+                "sebastian/exporter": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2014-11-16 21:32:38"
         },
         {
             "name": "sebastian/diff",
@@ -1136,54 +1203,6 @@
             "time": "2014-09-25 03:33:46"
         },
         {
-            "name": "symfony/config",
-            "version": "v2.6.3",
-            "target-dir": "Symfony/Component/Config",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Config.git",
-                "reference": "d94f222eff99a22ce313555b78642b4873418d56"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/d94f222eff99a22ce313555b78642b4873418d56",
-                "reference": "d94f222eff99a22ce313555b78642b4873418d56",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "symfony/filesystem": "~2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Config\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Symfony Config Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-03 08:01:59"
-        },
-        {
             "name": "symfony/console",
             "version": "v2.6.3",
             "target-dir": "Symfony/Component/Console",
@@ -1239,113 +1258,6 @@
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
             "time": "2015-01-06 17:50:02"
-        },
-        {
-            "name": "symfony/dependency-injection",
-            "version": "v2.6.3",
-            "target-dir": "Symfony/Component/DependencyInjection",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "72db9adf2f6c42e773108038bcdaff263f325b4e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/72db9adf2f6c42e773108038bcdaff263f325b4e",
-                "reference": "72db9adf2f6c42e773108038bcdaff263f325b4e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "conflict": {
-                "symfony/expression-language": "<2.6"
-            },
-            "require-dev": {
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.6",
-                "symfony/yaml": "~2.1"
-            },
-            "suggest": {
-                "symfony/config": "",
-                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
-                "symfony/yaml": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\DependencyInjection\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Symfony DependencyInjection Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-05 17:41:06"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v2.6.3",
-            "target-dir": "Symfony/Component/Filesystem",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
-                "reference": "a1f566d1f92e142fa1593f4555d6d89e3044a9b7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Symfony Filesystem Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-03 21:13:09"
         },
         {
             "name": "symfony/finder",

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -79,17 +79,21 @@ if (!defined('JPATH_THEMES'))
 {
 	define('JPATH_THEMES', JPATH_BASE . '/templates');
 }
+if (!defined('JDEBUG'))
+{
+	define('JDEBUG', false);
+}
 
 // Import the platform in legacy mode.
-//require_once JPATH_PLATFORM . '/import.php';
+require_once JPATH_PLATFORM . '/import.legacy.php';
 
 
 // Force library to be in JError legacy mode
-//JError::setErrorHandling(E_NOTICE, 'message');
-//JError::setErrorHandling(E_WARNING, 'message');
+JError::setErrorHandling(E_NOTICE, 'message');
+JError::setErrorHandling(E_WARNING, 'message');
 
 // Bootstrap the CMS libraries.
-//require_once JPATH_LIBRARIES . '/cms.php';
+require_once JPATH_LIBRARIES . '/cms.php';
 
 // Register the core Joomla test classes.
-//JLoader::registerPrefix('Test', __DIR__ . '/core');
+JLoader::registerPrefix('Test', __DIR__ . '/core');

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -23,7 +23,7 @@ ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL & ~E_STRICT);
 ini_set('display_errors', 1);
 
-/*.joomla-cms/libraries
+/*.joomla-dev/libraries
  * Ensure that required path constants are defined.  These can be overridden within the phpunit.xml file
  * if you chose to create a custom version of that file.
  */
@@ -33,15 +33,15 @@ if (!defined('JPATH_TESTS'))
 }
 if (!defined('JPATH_PLATFORM'))
 {
-	define('JPATH_PLATFORM', realpath(dirname(dirname(__FILE__)) . '/.joomla-cms/libraries'));
+	define('JPATH_PLATFORM', realpath(dirname(dirname(dirname(__FILE__))) . '/.joomla-dev/libraries'));
 }
 if (!defined('JPATH_LIBRARIES'))
 {
-	define('JPATH_LIBRARIES', realpath(dirname(dirname(__FILE__)) . '/.joomla-cms/libraries'));
+	define('JPATH_LIBRARIES', realpath(dirname(dirname(dirname(__FILE__))) . '/.joomla-dev/libraries'));
 }
 if (!defined('JPATH_BASE'))
 {
-	define('JPATH_BASE', realpath(dirname(dirname(__FILE__)) . '/.joomla-cms'));
+	define('JPATH_BASE', realpath(dirname(dirname(dirname(__FILE__))) . '/.joomla-dev'));
 }
 if (!defined('JPATH_ROOT'))
 {

--- a/tests/unit/core/case/case.php
+++ b/tests/unit/core/case/case.php
@@ -1,0 +1,505 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for unit testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCase extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var         array  The list of errors expected to be encountered during the test.
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	protected $expectedErrors;
+
+	/**
+	 * @var         array  JError handler state stashed away to be restored later.
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	private $_stashedErrorState = array();
+
+	/**
+	 * @var    array  Various JFactory static instances stashed away to be restored later.
+	 * @since  12.1
+	 */
+	private $_stashedFactoryState = array(
+		'application' => null,
+		'config' => null,
+		'dates' => null,
+		'database' => null,
+		'session' => null,
+		'language' => null,
+		'document' => null,
+		'acl' => null,
+		'mailer' => null
+	);
+
+	/**
+	 * Receives the callback from JError and logs the required error information for the test.
+	 *
+	 * @param   JException  $error  The JException object from JError
+	 *
+	 * @return  boolean  To not continue with JError processing
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	public static function errorCallback($error)
+	{
+		return false;
+	}
+
+	/**
+	 * Assigns mock callbacks to methods.
+	 *
+	 * @param   object  $mockObject  The mock object that the callbacks are being assigned to.
+	 * @param   array   $array       An array of methods names to mock with callbacks.
+	 * This method assumes that the mock callback is named {mock}{method name}.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function assignMockCallbacks($mockObject, $array)
+	{
+		foreach ($array as $index => $method)
+		{
+			if (is_array($method))
+			{
+				$methodName = $index;
+				$callback = $method;
+			}
+			else
+			{
+				$methodName = $method;
+				$callback = array(get_called_class(), 'mock' . $method);
+			}
+
+			$mockObject->expects($this->any())
+			->method($methodName)
+			->will($this->returnCallback($callback));
+		}
+	}
+
+	/**
+	 * Assigns mock values to methods.
+	 *
+	 * @param   object  $mockObject  The mock object.
+	 * @param   array   $array       An associative array of methods to mock with return values:<br />
+	 * string (method name) => mixed (return value)
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function assignMockReturns($mockObject, $array)
+	{
+		foreach ($array as $method => $return)
+		{
+			$mockObject->expects($this->any())
+			->method($method)
+			->will($this->returnValue($return));
+		}
+	}
+
+	/**
+	 * Callback receives the error from JError and deals with it appropriately
+	 * If a test expects a JError to be raised, it should call this setExpectedError first
+	 * If you don't call this method first, the test will fail.
+	 *
+	 * @param   JException  $error  The JException object from JError
+	 *
+	 * @return  JException
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	public function expectedErrorCallback($error)
+	{
+		foreach ($this->expectedErrors as $key => $err)
+		{
+			$thisError = true;
+
+			foreach ($err as $prop => $value)
+			{
+				if ($error->get($prop) !== $value)
+				{
+					$thisError = false;
+				}
+			}
+
+			if ($thisError)
+			{
+				unset($this->expectedErrors[$key]);
+
+				return $error;
+			}
+
+		}
+
+		$this->fail('An unexpected error occurred - ' . $error->get('message'));
+
+		return $error;
+	}
+
+	/**
+	 * Gets a mock application object.
+	 *
+	 * @return  JApplication
+	 *
+	 * @since   12.1
+	 */
+	public function getMockApplication()
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplication');
+
+		return TestMockApplication::create($this);
+	}
+
+	/**
+	 * Gets a mock CMS application object.
+	 *
+	 * @param   array  $options  A set of options to configure the mock.
+	 *
+	 * @return  JApplicationCms
+	 *
+	 * @since   3.2
+	 */
+	public function getMockCmsApp($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplicationCms');
+
+		return TestMockApplicationCms::create($this, $options);
+	}
+
+	/**
+	 * Gets a mock configuration object.
+	 *
+	 * @return  JConfig
+	 *
+	 * @since   12.1
+	 */
+	public function getMockConfig()
+	{
+		return TestMockConfig::create($this);
+	}
+
+	/**
+	 * Gets a mock database object.
+	 *
+	 * @return  JDatabase
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDatabase()
+	{
+		// Attempt to load the real class first.
+		class_exists('JDatabaseDriver');
+
+		return TestMockDatabaseDriver::create($this);
+	}
+
+	/**
+	 * Gets a mock dispatcher object.
+	 *
+	 * @param   boolean  $defaults  Add default register and trigger methods for testing.
+	 *
+	 * @return  JEventDispatcher
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDispatcher($defaults = true)
+	{
+		// Attempt to load the real class first.
+		class_exists('JEventDispatcher');
+
+		return TestMockDispatcher::create($this, $defaults);
+	}
+
+	/**
+	 * Gets a mock document object.
+	 *
+	 * @return  JDocument
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDocument()
+	{
+		// Attempt to load the real class first.
+		class_exists('JDocument');
+
+		return TestMockDocument::create($this);
+	}
+
+	/**
+	 * Gets a mock language object.
+	 *
+	 * @return  JLanguage
+	 *
+	 * @since   12.1
+	 */
+	public function getMockLanguage()
+	{
+		// Attempt to load the real class first.
+		class_exists('JLanguage');
+
+		return TestMockLanguage::create($this);
+	}
+
+	/**
+	 * Gets a mock session object.
+	 *
+	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 * getId : the value to be returned by the mock getId method
+	 * get.user.id : the value to assign to the user object id returned by get('user')
+	 * get.user.name : the value to assign to the user object name returned by get('user')
+	 * get.user.username : the value to assign to the user object username returned by get('user')
+	 *
+	 * @return  JSession
+	 *
+	 * @since   12.1
+	 */
+	public function getMockSession($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JSession');
+
+		return TestMockSession::create($this, $options);
+	}
+
+	/**
+	 * Gets a mock web object.
+	 *
+	 * @param   array  $options  A set of options to configure the mock.
+	 *
+	 * @return  JApplicationWeb
+	 *
+	 * @since   12.1
+	 */
+	public function getMockWeb($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplicationWeb');
+
+		return TestMockApplicationWeb::create($this, $options);
+	}
+
+	/**
+	 * Tells the unit tests that a method or action you are about to attempt
+	 * is expected to result in JError::raiseSomething being called.
+	 *
+	 * If you don't call this method first, the test will fail.
+	 * If you call this method during your test and the error does not occur, then your test
+	 * will also fail because we assume you were testing to see that an error did occur when it was
+	 * supposed to.
+	 *
+	 * If passed without argument, the array is initialized if it hsn't been already
+	 *
+	 * @param   mixed  $error  The JException object to expect.
+	 *
+	 * @return  void
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	public function setExpectedError($error = null)
+	{
+		if (!is_array($this->expectedErrors))
+		{
+			$this->expectedErrors = array();
+
+			// Handle optional usage of JError until removed.
+			if (class_exists('JError'))
+			{
+				JError::setErrorHandling(E_NOTICE, 'callback', array($this, 'expectedErrorCallback'));
+				JError::setErrorHandling(E_WARNING, 'callback', array($this, 'expectedErrorCallback'));
+				JError::setErrorHandling(E_ERROR, 'callback', array($this, 'expectedErrorCallback'));
+			}
+		}
+
+		if (!is_null($error))
+		{
+			$this->expectedErrors[] = $error;
+		}
+	}
+
+	/**
+	 * Sets the JError error handlers.
+	 *
+	 * @return  void
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	protected function restoreErrorHandlers()
+	{
+		$this->setErrorhandlers($this->_stashedErrorState);
+	}
+
+	/**
+	 * Sets the Factory pointers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function restoreFactoryState()
+	{
+		JFactory::$application = $this->_stashedFactoryState['application'];
+		JFactory::$config = $this->_stashedFactoryState['config'];
+		JFactory::$dates = $this->_stashedFactoryState['dates'];
+		JFactory::$session = $this->_stashedFactoryState['session'];
+		JFactory::$language = $this->_stashedFactoryState['language'];
+		JFactory::$document = $this->_stashedFactoryState['document'];
+		JFactory::$acl = $this->_stashedFactoryState['acl'];
+		JFactory::$mailer = $this->_stashedFactoryState['mailer'];
+		JFactory::$database = $this->_stashedFactoryState['database'];
+	}
+
+	/**
+	 * Saves the current state of the JError error handlers.
+	 *
+	 * @return  void
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	protected function saveErrorHandlers()
+	{
+		$this->_stashedErrorState = array();
+
+		// Handle optional usage of JError until removed.
+		if (class_exists('JError'))
+		{
+			$this->_stashedErrorState[E_NOTICE] = JError::getErrorHandling(E_NOTICE);
+			$this->_stashedErrorState[E_WARNING] = JError::getErrorHandling(E_WARNING);
+			$this->_stashedErrorState[E_ERROR] = JError::getErrorHandling(E_ERROR);
+		}
+	}
+
+	/**
+	 * Saves the Factory pointers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function saveFactoryState()
+	{
+		$this->_stashedFactoryState['application'] = JFactory::$application;
+		$this->_stashedFactoryState['config'] = JFactory::$config;
+		$this->_stashedFactoryState['dates'] = JFactory::$dates;
+		$this->_stashedFactoryState['session'] = JFactory::$session;
+		$this->_stashedFactoryState['language'] = JFactory::$language;
+		$this->_stashedFactoryState['document'] = JFactory::$document;
+		$this->_stashedFactoryState['acl'] = JFactory::$acl;
+		$this->_stashedFactoryState['mailer'] = JFactory::$mailer;
+		$this->_stashedFactoryState['database'] = JFactory::$database;
+	}
+
+	/**
+	 * Sets the JError error handlers.
+	 *
+	 * @param   array  $errorHandlers  araay of values and options to set the handlers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function setErrorHandlers($errorHandlers)
+	{
+		$mode = null;
+		$options = null;
+
+		foreach ($errorHandlers as $type => $params)
+		{
+			$mode = $params['mode'];
+
+			// Handle optional usage of JError until removed.
+			if (class_exists('JError'))
+			{
+				if (isset($params['options']))
+				{
+					JError::setErrorHandling($type, $mode, $params['options']);
+				}
+				else
+				{
+					JError::setErrorHandling($type, $mode);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Sets the JError error handlers to callback mode and points them at the test logging method.
+	 *
+	 * @param   string  $testName  The name of the test class for which to set the error callback method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function setErrorCallback($testName)
+	{
+		$callbackHandlers = array(
+			E_NOTICE => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
+			E_WARNING => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
+			E_ERROR => array('mode' => 'callback', 'options' => array($testName, 'errorCallback'))
+		);
+
+		$this->setErrorHandlers($callbackHandlers);
+	}
+
+	/**
+	 * Overrides the parent setup method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::setUp()
+	 * @since   11.1
+	 */
+	protected function setUp()
+	{
+		$this->setExpectedError();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   11.1
+	 */
+	protected function tearDown()
+	{
+		if (is_array($this->expectedErrors) && !empty($this->expectedErrors))
+		{
+			$this->fail('An expected error was not raised.');
+		}
+
+		// Handle optional usage of JError until removed.
+		if (class_exists('JError'))
+		{
+			JError::setErrorHandling(E_NOTICE, 'ignore');
+			JError::setErrorHandling(E_WARNING, 'ignore');
+			JError::setErrorHandling(E_ERROR, 'ignore');
+		}
+
+		parent::tearDown();
+	}
+}

--- a/tests/unit/core/case/database.php
+++ b/tests/unit/core/case/database.php
@@ -1,0 +1,519 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+if (!class_exists('PHPUnit_Extensions_Database_TestCase'))
+{
+	require_once 'PHPUnit/Extensions/Database/TestCase.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/XmlDataSet.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/QueryDataSet.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/MysqlXmlDataSet.php';
+}
+
+/**
+ * Abstract test case class for database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
+{
+	/**
+	 * @var    JDatabaseDriver  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    JDatabaseDriver  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $_stash;
+
+	/**
+	 * @var         array  JError handler state stashed away to be restored later.
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	private $_stashedErrorState = array();
+
+	/**
+	 * @var    array  Various JFactory static instances stashed away to be restored later.
+	 * @since  12.1
+	 */
+	private $_stashedFactoryState = array(
+		'application' => null,
+		'config' => null,
+		'dates' => null,
+		'session' => null,
+		'language' => null,
+		'document' => null,
+		'acl' => null,
+		'mailer' => null
+	);
+
+	/**
+	 * Receives the callback from JError and logs the required error information for the test.
+	 *
+	 * @param   JException  $error  The JException object from JError
+	 *
+	 * @return	bool	To not continue with JError processing
+	 *
+	 * @since   12.1
+	 */
+	public static function errorCallback($error)
+	{
+		return false;
+	}
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// We always want the default database test case to use an SQLite memory database.
+		$options = array(
+			'driver' => 'sqlite',
+			'database' => ':memory:',
+			'prefix' => 'jos_'
+		);
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance($options);
+
+			// Create a new PDO instance for an SQLite memory database and load the test schema into it.
+			$pdo = new PDO('sqlite::memory:');
+			$pdo->exec(file_get_contents(JPATH_TESTS . '/schema/ddl.sql'));
+
+			// Set the PDO instance to the driver using reflection whizbangery.
+			TestReflection::setValue(self::$driver, 'connection', $pdo);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$_stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$_stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Assigns mock callbacks to methods.
+	 *
+	 * @param   object  $mockObject  The mock object that the callbacks are being assigned to.
+	 * @param   array   $array       An array of methods names to mock with callbacks.
+	 * This method assumes that the mock callback is named {mock}{method name}.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function assignMockCallbacks($mockObject, $array)
+	{
+		foreach ($array as $index => $method)
+		{
+			if (is_array($method))
+			{
+				$methodName = $index;
+				$callback = $method;
+			}
+			else
+			{
+				$methodName = $method;
+				$callback = array(get_called_class(), 'mock' . $method);
+			}
+
+			$mockObject->expects($this->any())
+			->method($methodName)
+			->will($this->returnCallback($callback));
+		}
+	}
+
+	/**
+	 * Assigns mock values to methods.
+	 *
+	 * @param   object  $mockObject  The mock object.
+	 * @param   array   $array       An associative array of methods to mock with return values:<br />
+	 * string (method name) => mixed (return value)
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function assignMockReturns($mockObject, $array)
+	{
+		foreach ($array as $method => $return)
+		{
+			$mockObject->expects($this->any())
+			->method($method)
+			->will($this->returnValue($return));
+		}
+	}
+
+	/**
+	 * Gets a mock application object.
+	 *
+	 * @return  JApplication
+	 *
+	 * @since   12.1
+	 */
+	public function getMockApplication()
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplication');
+
+		return TestMockApplication::create($this);
+	}
+
+	/**
+	 * Gets a mock CMS application object.
+	 *
+	 * @param   array  $options  A set of options to configure the mock.
+	 *
+	 * @return  JApplicationCms
+	 *
+	 * @since   3.2
+	 */
+	public function getMockCmsApp($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplicationCms');
+
+		return TestMockApplicationCms::create($this, $options);
+	}
+
+	/**
+	 * Gets a mock configuration object.
+	 *
+	 * @return  JConfig
+	 *
+	 * @since   12.1
+	 */
+	public function getMockConfig()
+	{
+		return TestMockConfig::create($this);
+	}
+
+	/**
+	 * Gets a mock database object.
+	 *
+	 * @return  JDatabase
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDatabase()
+	{
+		// Attempt to load the real class first.
+		class_exists('JDatabaseDriver');
+
+		return TestMockDatabaseDriver::create($this);
+	}
+
+	/**
+	 * Gets a mock dispatcher object.
+	 *
+	 * @param   boolean  $defaults  Add default register and trigger methods for testing.
+	 *
+	 * @return  JEventDispatcher
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDispatcher($defaults = true)
+	{
+		// Attempt to load the real class first.
+		class_exists('JEventDispatcher');
+
+		return TestMockDispatcher::create($this, $defaults);
+	}
+
+	/**
+	 * Gets a mock document object.
+	 *
+	 * @return  JDocument
+	 *
+	 * @since   12.1
+	 */
+	public function getMockDocument()
+	{
+		// Attempt to load the real class first.
+		class_exists('JDocument');
+
+		return TestMockDocument::create($this);
+	}
+
+	/**
+	 * Gets a mock language object.
+	 *
+	 * @return  JLanguage
+	 *
+	 * @since   12.1
+	 */
+	public function getMockLanguage()
+	{
+		// Attempt to load the real class first.
+		class_exists('JLanguage');
+
+		return TestMockLanguage::create($this);
+	}
+
+	/**
+	 * Gets a mock session object.
+	 *
+	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 * getId : the value to be returned by the mock getId method
+	 * get.user.id : the value to assign to the user object id returned by get('user')
+	 * get.user.name : the value to assign to the user object name returned by get('user')
+	 * get.user.username : the value to assign to the user object username returned by get('user')
+	 *
+	 * @return  JSession
+	 *
+	 * @since   12.1
+	 */
+	public function getMockSession($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JSession');
+
+		return TestMockSession::create($this, $options);
+	}
+
+	/**
+	 * Gets a mock web object.
+	 *
+	 * @param   array  $options  A set of options to configure the mock.
+	 *
+	 * @return  JApplicationWeb
+	 *
+	 * @since   12.1
+	 */
+	public function getMockWeb($options = array())
+	{
+		// Attempt to load the real class first.
+		class_exists('JApplicationWeb');
+
+		return TestMockApplicationWeb::create($this, $options);
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		if (!is_null(self::$driver))
+		{
+			return $this->createDefaultDBConnection(self::$driver->getConnection(), ':memory:');
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  PHPUnit_Extensions_Database_DataSet_XmlDataSet
+	 *
+	 * @since   11.1
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(JPATH_TESTS . '/stubs/database.xml');
+	}
+
+	/**
+	 * Returns the database operation executed in test setup.
+	 *
+	 * @return  PHPUnit_Extensions_Database_Operation_DatabaseOperation
+	 *
+	 * @since   12.1
+	 */
+	protected function getSetUpOperation()
+	{
+		// Required given the use of InnoDB contraints.
+		return new PHPUnit_Extensions_Database_Operation_Composite(
+			array(
+				PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL(),
+				PHPUnit_Extensions_Database_Operation_Factory::INSERT()
+			)
+		);
+	}
+
+	/**
+	 * Returns the database operation executed in test cleanup.
+	 *
+	 * @return  PHPUnit_Extensions_Database_Operation_DatabaseOperation
+	 *
+	 * @since   12.1
+	 */
+	protected function getTearDownOperation()
+	{
+		// Required given the use of InnoDB contraints.
+		return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+	}
+
+	/**
+	 * Sets the Factory pointers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function restoreFactoryState()
+	{
+		JFactory::$application = $this->_stashedFactoryState['application'];
+		JFactory::$config = $this->_stashedFactoryState['config'];
+		JFactory::$dates = $this->_stashedFactoryState['dates'];
+		JFactory::$session = $this->_stashedFactoryState['session'];
+		JFactory::$language = $this->_stashedFactoryState['language'];
+		JFactory::$document = $this->_stashedFactoryState['document'];
+		JFactory::$acl = $this->_stashedFactoryState['acl'];
+		JFactory::$mailer = $this->_stashedFactoryState['mailer'];
+	}
+
+	/**
+	 * Saves the current state of the JError error handlers.
+	 *
+	 * @return  void
+	 *
+	 * @deprecated  13.1
+	 * @since       12.1
+	 */
+	protected function saveErrorHandlers()
+	{
+		$this->_stashedErrorState = array();
+
+		// Handle optional usage of JError until removed.
+		if (class_exists('JError'))
+		{
+			$this->_stashedErrorState[E_NOTICE] = JError::getErrorHandling(E_NOTICE);
+			$this->_stashedErrorState[E_WARNING] = JError::getErrorHandling(E_WARNING);
+			$this->_stashedErrorState[E_ERROR] = JError::getErrorHandling(E_ERROR);
+		}
+	}
+
+	/**
+	 * Saves the Factory pointers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function saveFactoryState()
+	{
+		$this->_stashedFactoryState['application'] = JFactory::$application;
+		$this->_stashedFactoryState['config'] = JFactory::$config;
+		$this->_stashedFactoryState['dates'] = JFactory::$dates;
+		$this->_stashedFactoryState['session'] = JFactory::$session;
+		$this->_stashedFactoryState['language'] = JFactory::$language;
+		$this->_stashedFactoryState['document'] = JFactory::$document;
+		$this->_stashedFactoryState['acl'] = JFactory::$acl;
+		$this->_stashedFactoryState['mailer'] = JFactory::$mailer;
+	}
+
+	/**
+	 * Sets the JError error handlers.
+	 *
+	 * @param   array  $errorHandlers  araay of values and options to set the handlers
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function setErrorHandlers($errorHandlers)
+	{
+		$mode = null;
+		$options = null;
+
+		foreach ($errorHandlers as $type => $params)
+		{
+			$mode = $params['mode'];
+
+			// Handle optional usage of JError until removed.
+			if (class_exists('JError'))
+			{
+				if (isset($params['options']))
+				{
+					JError::setErrorHandling($type, $mode, $params['options']);
+				}
+				else
+				{
+					JError::setErrorHandling($type, $mode);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Sets the JError error handlers to callback mode and points them at the test logging method.
+	 *
+	 * @param   string  $testName  The name of the test class for which to set the error callback method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function setErrorCallback($testName)
+	{
+		$callbackHandlers = array(
+			E_NOTICE => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
+			E_WARNING => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
+			E_ERROR => array('mode' => 'callback', 'options' => array($testName, 'errorCallback'))
+		);
+
+		$this->setErrorHandlers($callbackHandlers);
+	}
+
+	/**
+	 * Sets up the fixture.
+	 *
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function setUp()
+	{
+		if (empty(static::$driver))
+		{
+			$this->markTestSkipped('There is no database driver.');
+		}
+
+		parent::setUp();
+	}
+}

--- a/tests/unit/core/case/database/mysql.php
+++ b/tests/unit/core/case/database/mysql.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for MySQL database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabaseMysql extends TestCaseDatabase
+{
+	/**
+	 * @var    JDatabaseDriverMysql  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    array  The JDatabaseDriver options for the connection.
+	 * @since  12.1
+	 */
+	private static $_options = array('driver' => 'mysql');
+
+	/**
+	 * @var    JDatabaseDriverMysql  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $_stash;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_MYSQL_DSN') || getenv('JTEST_DATABASE_MYSQL_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_MYSQL_DSN') ? JTEST_DATABASE_MYSQL_DSN : getenv('JTEST_DATABASE_MYSQL_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the mysql: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'mysql:') === 0)
+		{
+			$dsn = substr($dsn, 6);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'host':
+					self::$_options['host'] = $v;
+					break;
+				case 'dbname':
+					self::$_options['database'] = $v;
+					break;
+				case 'user':
+					self::$_options['user'] = $v;
+					break;
+				case 'pass':
+					self::$_options['password'] = $v;
+					break;
+			}
+		}
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance(self::$_options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$_stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$_stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'mysql:host=' . self::$_options['host'] . ';dbname=' . self::$_options['database'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$_options['database']);
+	}
+}

--- a/tests/unit/core/case/database/mysqli.php
+++ b/tests/unit/core/case/database/mysqli.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for MySQLi database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabaseMysqli extends TestCaseDatabase
+{
+	/**
+	 * @var    JDatabaseDriverMysqli  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    array  The JDatabaseDriver options for the connection.
+	 * @since  12.1
+	 */
+	private static $_options = array('driver' => 'mysqli');
+
+	/**
+	 * @var    JDatabaseDriverMysqli  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $_stash;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_MYSQLI_DSN') || getenv('JTEST_DATABASE_MYSQLI_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_MYSQLI_DSN') ? JTEST_DATABASE_MYSQLI_DSN : getenv('JTEST_DATABASE_MYSQLI_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the mysql: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'mysql:') === 0)
+		{
+			$dsn = substr($dsn, 6);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'host':
+					self::$_options['host'] = $v;
+					break;
+				case 'dbname':
+					self::$_options['database'] = $v;
+					break;
+				case 'user':
+					self::$_options['user'] = $v;
+					break;
+				case 'pass':
+					self::$_options['password'] = $v;
+					break;
+			}
+		}
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance(self::$_options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$_stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$_stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'mysql:host=' . self::$_options['host'] . ';dbname=' . self::$_options['database'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$_options['database']);
+	}
+}

--- a/tests/unit/core/case/database/oracle.php
+++ b/tests/unit/core/case/database/oracle.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for Oracle database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabaseOracle extends TestCaseDatabase
+{
+	/**
+	 * @var    JDatabaseDriverOracle  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    array  The JDatabaseDriver options for the connection.
+	 * @since  12.1
+	 */
+	private static $_options = array('driver' => 'oracle');
+
+	/**
+	 * @var    JDatabaseDriverOracle  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $_stash;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: dbname=//localhost:1521/joomla_ut;charset=AL32UTF8;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_ORACLE_DSN') || getenv('JTEST_DATABASE_ORACLE_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_ORACLE_DSN') ? JTEST_DATABASE_ORACLE_DSN : getenv('JTEST_DATABASE_ORACLE_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the oci: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'oci:') === 0)
+		{
+			$dsn = substr($dsn, 4);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'charset':
+					self::$_options['charset'] = $v;
+					break;
+				case 'dbname':
+					$components = parse_url($v);
+					self::$_options['host'] = $components['host'];
+					self::$_options['port'] = $components['port'];
+					self::$_options['database'] = ltrim($components['path'], '/');
+					break;
+				case 'user':
+					self::$_options['user'] = $v;
+					break;
+				case 'pass':
+					self::$_options['password'] = $v;
+					break;
+				case 'dbschema':
+					self::$_options['schema'] = $v;
+					break;
+				case 'prefix':
+					self::$_options['prefix'] = $v;
+					break;
+			}
+		}
+
+		// Ensure some defaults.
+		self::$_options['charset'] = isset(self::$_options['charset']) ? self::$_options['charset'] : 'AL32UTF8';
+		self::$_options['port'] = isset(self::$_options['port']) ? self::$_options['port'] : 1521;
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance(self::$_options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$_stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$_stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'oci:dbname=//' . self::$_options['host'] . ':' . self::$_options['port'] . '/' . self::$_options['database'];
+		$dsn .= ';charset=' . self::$_options['charset'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$_options['database']);
+	}
+}

--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for PostgreSQL database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
+{
+	/**
+	 * @var    JDatabaseDriverPostgresql  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    array  The JDatabaseDriver options for the connection.
+	 * @since  12.1
+	 */
+	private static $_options = array('driver' => 'postgresql');
+
+	/**
+	 * @var    JDatabaseDriverPostgresql  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $_stash;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_POSTGRESQL_DSN') || getenv('JTEST_DATABASE_POSTGRESQL_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_POSTGRESQL_DSN') ? JTEST_DATABASE_POSTGRESQL_DSN : getenv('JTEST_DATABASE_POSTGRESQL_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the pgsql: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'pgsql:') === 0)
+		{
+			$dsn = substr($dsn, 6);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'host':
+					self::$_options['host'] = $v;
+					break;
+				case 'port':
+					self::$_options['port'] = $v;
+					break;
+				case 'dbname':
+					self::$_options['database'] = $v;
+					break;
+				case 'user':
+					self::$_options['user'] = $v;
+					break;
+				case 'pass':
+					self::$_options['password'] = $v;
+					break;
+			}
+		}
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance(self::$_options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$_stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$_stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'pgsql:host=' . self::$_options['host'] . ';port=' . self::$_options['port'] . ';dbname=' . self::$_options['database'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$_options['database']);
+	}
+}

--- a/tests/unit/core/case/database/sqlsrv.php
+++ b/tests/unit/core/case/database/sqlsrv.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Abstract test case class for Microsoft SQL Server database testing.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+abstract class TestCaseDatabaseSqlsrv extends TestCaseDatabase
+{
+	/**
+	 * @var    JDatabaseDriverSqlsrv  The active database driver being used for the tests.
+	 * @since  12.1
+	 */
+	protected static $driver;
+
+	/**
+	 * @var    array  The database driver options for the connection.
+	 * @since  12.1
+	 */
+	private static $options = array('driver' => 'sqlsrv');
+
+	/**
+	 * @var    JDatabaseDriverSqlsrv  The saved database driver to be restored after these tests.
+	 * @since  12.1
+	 */
+	private static $stash;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_SQLSRV_DSN') || getenv('JTEST_DATABASE_SQLSRV_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_SQLSRV_DSN') ? JTEST_DATABASE_SQLSRV_DSN : getenv('JTEST_DATABASE_SQLSRV_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the sqlsrv: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'sqlsrv:') === 0)
+		{
+			$dsn = substr($dsn, 7);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'host':
+					self::$options['host'] = $v;
+					break;
+				case 'dbname':
+					self::$options['database'] = $v;
+					break;
+				case 'user':
+					self::$options['user'] = $v;
+					break;
+				case 'pass':
+					self::$options['password'] = $v;
+					break;
+			}
+		}
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = JDatabaseDriver::getInstance(self::$options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof Exception)
+		{
+			self::$driver = null;
+		}
+
+		// Setup the factory pointer for the driver and stash the old one.
+		self::$stash = JFactory::$database;
+		JFactory::$database = self::$driver;
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public static function tearDownAfterClass()
+	{
+		JFactory::$database = self::$stash;
+		self::$driver = null;
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   12.1
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'sqlsrv:Server=' . self::$options['host'] . ';Database=' . self::$options['database'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new PDO($dsn, self::$options['user'], self::$options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+	}
+}

--- a/tests/unit/core/mock/application.php
+++ b/tests/unit/core/mock/application.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JApplication.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockApplication
+{
+	/**
+	 * Creates and instance of the mock JApplication object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JApplication (work in progress).
+		$methods = array(
+			'get',
+			'getCfg',
+			'getIdentity',
+			'getRouter',
+			'getTemplate',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JApplication',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		$mockObject->input = new JInput;
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/application/base.php
+++ b/tests/unit/core/mock/application/base.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JApplicationBase.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockApplicationBase
+{
+	/**
+	 * Gets the methods of the JApplicationBase object.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	public static function getMethods()
+	{
+		return array(
+			'close',
+			'getIdentity',
+			'registerEvent',
+			'triggerEvent',
+			'loadDispatcher',
+			'loadIdentity',
+		);
+	}
+
+	/**
+	 * Adds mock objects for some methods.
+	 *
+	 * @param  TestCase                                 $test        A test object.
+	 * @param  PHPUnit_Framework_MockObject_MockObject  $mockObject  The mock object.
+	 * @param  array                                    $options     A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject  The object with the behaviours added
+	 *
+	 * @since   3.4
+	 */
+	public static function addBehaviours($test, $mockObject, $options)
+	{
+		return $mockObject;
+	}
+
+	/**
+	 * Creates and instance of the mock JApplicationBase object.
+	 *
+	 * @param   TestCase  $test     A test object.
+	 * @param   array     $options  A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test, $options = array())
+	{
+		// Set expected server variables.
+		if (!isset($_SERVER['HTTP_HOST']))
+		{
+			$_SERVER['HTTP_HOST'] = 'localhost';
+		}
+
+		// Collect all the relevant methods in JApplicationBase.
+		$methods = self::getMethods();
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JApplicationBase',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			true
+		);
+
+		$mockObject = self::addBehaviours($test, $mockObject, $options);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/application/cli.php
+++ b/tests/unit/core/mock/application/cli.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JApplicationCli.
+ *
+ * @package  Joomla.Test
+ * @since    12.2
+ */
+class TestMockApplicationCli extends TestMockApplicationBase
+{
+	/**
+	 * Gets the methods of the JApplicationCli object.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	public static function getMethods()
+	{
+		// Collect all the relevant methods in JApplicationCli.
+		$methods = array(
+			'get',
+			'execute',
+			'loadConfiguration',
+			'out',
+			'in',
+			'set',
+		);
+
+		return array_merge($methods, parent::getMethods());
+	}
+
+	/**
+	 * Creates and instance of the mock JApplicationCli object.
+	 *
+	 * @param   TestCase  $test     A test object.
+	 * @param   array     $options  A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject
+	 *
+	 * @since   12.2
+	 */
+	public static function create($test, $options = array())
+	{
+		// Collect all the relevant methods in JApplicationCli.
+		$methods = self::getMethods();
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JApplicationCli',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			true
+		);
+
+		$mockObject = self::addBehaviours($test, $mockObject, $options);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/application/cms.php
+++ b/tests/unit/core/mock/application/cms.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JApplicationCms.
+ *
+ * @package  Joomla.Test
+ * @since    3.2
+ */
+class TestMockApplicationCms extends TestMockApplicationWeb
+{
+	/**
+	 * Gets the methods of the JApplicationCms object.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	public static function getMethods()
+	{
+		// Collect all the relevant methods in JApplicationCms (work in progress).
+		$methods = array(
+			'getMenu',
+			'getPathway',
+			'getTemplate',
+			'initialiseApp',
+			'isAdmin',
+			'isSite',
+		);
+
+		return array_merge($methods, parent::getMethods());
+	}
+
+	/**
+	 * Adds mock objects for some methods.
+	 *
+	 * @param  TestCase                                 $test        A test object.
+	 * @param  PHPUnit_Framework_MockObject_MockObject  $mockObject  The mock object.
+	 * @param  array                                    $options     A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject  The object with the behaviours added
+	 *
+	 * @since   3.4
+	 */
+	public static function addBehaviours($test, $mockObject, $options)
+	{
+		return parent::addBehaviours($test, $mockObject, $options);
+	}
+
+	/**
+	 * Creates and instance of the mock JApplicationCms object.
+	 *
+	 * The test can implement the following overrides:
+	 * - mockAppendBody
+	 * - mockGetBody
+	 * - mockPrepentBody
+	 * - mockSetBody
+	 *
+	 * If any *Body methods are implemented in the test class, all should be implemented otherwise behaviour will be unreliable.
+	 *
+	 * @param   TestCase  $test     A test object.
+	 * @param   array     $options  A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject
+	 *
+	 * @since   3.2
+	 */
+	public static function create($test, $options = array())
+	{
+		// Set expected server variables.
+		if (!isset($_SERVER['HTTP_HOST']))
+		{
+			$_SERVER['HTTP_HOST'] = 'localhost';
+		}
+
+		$methods = self::getMethods();
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JApplicationCms',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			true
+		);
+
+		$mockObject = self::addBehaviours($test, $mockObject, $options);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/application/web.php
+++ b/tests/unit/core/mock/application/web.php
@@ -1,0 +1,315 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JApplicationWeb.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockApplicationWeb extends TestMockApplicationBase
+{
+	/**
+	 * Mock storage for the response body.
+	 *
+	 * @var    array
+	 * @since  12.2
+	 */
+	public static $body = array();
+
+	/**
+	 * Mock storage for the response headers.
+	 *
+	 * @var    array
+	 * @since  3.2
+	 */
+	public static $headers = array();
+
+	/**
+	 * Mock storage for the response cache status.
+	 *
+	 * @var    boolean
+	 * @since  3.2
+	 */
+	public static $cachable = false;
+
+	/**
+	 * Gets the methods of the JApplicationWeb object.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	public static function getMethods()
+	{
+		// Collect all the relevant methods in JApplicationWeb (work in progress).
+		$methods = array(
+			'allowCache',
+			'appendBody',
+			'clearHeaders',
+			'execute',
+			'get',
+			'getBody',
+			'getDocument',
+			'getHeaders',
+			'getLanguage',
+			'getSession',
+			'loadConfiguration',
+			'loadDocument',
+			'loadLanguage',
+			'loadSession',
+			'prependBody',
+			'redirect',
+			'sendHeaders',
+			'set',
+			'setBody',
+			'setHeader',
+		);
+
+		return array_merge($methods, parent::getMethods());
+	}
+
+	/**
+	 * Adds mock objects for some methods.
+	 *
+	 * @param  TestCase                                 $test        A test object.
+	 * @param  PHPUnit_Framework_MockObject_MockObject  $mockObject  The mock object.
+	 * @param  array                                    $options     A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject  The object with the behaviours added
+	 *
+	 * @since   3.4
+	 */
+	public static function addBehaviours($test, $mockObject, $options)
+	{
+		// Mock calls to JApplicationWeb::getDocument().
+		$mockObject->expects($test->any())->method('getDocument')->will($test->returnValue(TestMockDocument::create($test)));
+
+		// Mock calls to JApplicationWeb::getLanguage().
+		$mockObject->expects($test->any())->method('getLanguage')->will($test->returnValue(TestMockLanguage::create($test)));
+
+		// Mock a call to JApplicationWeb::getSession().
+		if (isset($options['session']))
+		{
+			$mockObject->expects($test->any())->method('getSession')->will($test->returnValue($options['session']));
+		}
+		else
+		{
+			$mockObject->expects($test->any())->method('getSession')->will($test->returnValue(TestMockSession::create($test)));
+		}
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'appendBody' => array((is_callable(array($test, 'mockAppendBody')) ? $test : get_called_class()), 'mockAppendBody'),
+				'getBody' => array((is_callable(array($test, 'mockGetBody')) ? $test : get_called_class()), 'mockGetBody'),
+				'prependBody' => array((is_callable(array($test, 'mockPrependBody')) ? $test : get_called_class()), 'mockPrependBody'),
+				'setBody' => array((is_callable(array($test, 'mockSetBody')) ? $test : get_called_class()), 'mockSetBody'),
+				'getHeaders' => array((is_callable(array($test, 'mockGetHeaders')) ? $test : get_called_class()), 'mockGetHeaders'),
+				'setHeader' => array((is_callable(array($test, 'mockSetHeader')) ? $test : get_called_class()), 'mockSetHeader'),
+				'clearHeaders' => array((is_callable(array($test, 'mockClearHeaders')) ? $test : get_called_class()), 'mockClearHeaders'),
+				'allowCache' => array((is_callable(array($test, 'mockAllowCache')) ? $test : get_called_class()), 'mockAllowCache'),
+			)
+		);
+
+		// Reset the body storage.
+		static::$body = array();
+
+		// Reset the headers storage.
+		static::$headers = array();
+
+		// Reset the cache storage.
+		static::$cachable = false;
+
+		return parent::addBehaviours($test, $mockObject, $options);
+	}
+
+	/**
+	 * Creates and instance of the mock JApplicationWeb object.
+	 *
+	 * The test can implement the following overrides:
+	 * - mockAppendBody
+	 * - mockGetBody
+	 * - mockPrepentBody
+	 * - mockSetBody
+	 * - mockGetHeaders
+	 * - mockSetHeaders
+	 * - mockAllowCache
+	 *
+	 * If any *Body methods are implemented in the test class, all should be implemented otherwise behaviour will be unreliable.
+	 *
+	 * @param   TestCase  $test     A test object.
+	 * @param   array     $options  A set of options to configure the mock.
+	 *
+	 * @return  PHPUnit_Framework_MockObject_MockObject
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test, $options = array())
+	{
+		// Set expected server variables.
+		if (!isset($_SERVER['HTTP_HOST']))
+		{
+			$_SERVER['HTTP_HOST'] = 'localhost';
+		}
+
+		// Collect all the relevant methods in JApplicationWeb (work in progress).
+		$methods = self::getMethods();
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JApplicationWeb',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			true
+		);
+
+		$mockObject = self::addBehaviours($test, $mockObject, $options);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Mock JApplicationWeb->appendBody method.
+	 *
+	 * @param   string  $content  The content to append to the response body.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   12.2
+	 */
+	public static function mockAppendBody($content)
+	{
+		array_push(static::$body, (string) $content);
+	}
+
+	/**
+	 * Mock JApplicationWeb->getBody method.
+	 *
+	 * @param   boolean  $asArray  True to return the body as an array of strings.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   12.2
+	 */
+	public static function mockGetBody($asArray = false)
+	{
+		return $asArray ? static::$body : implode((array) static::$body);
+	}
+
+	/**
+	 * Mock JApplicationWeb->appendBody method.
+	 *
+	 * @param   string  $content  The content to append to the response body.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   12.2
+	 */
+	public static function mockPrependBody($content)
+	{
+		array_unshift(static::$body, (string) $content);
+	}
+
+	/**
+	 * Mock JApplicationWeb->setBody method.
+	 *
+	 * @param   string  $content  The body of the response.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public static function mockSetBody($content)
+	{
+		static::$body = array($content);
+	}
+
+	/**
+	 * Mock JApplicationWeb->getHeaders method.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.2
+	 */
+	public static function mockGetHeaders()
+	{
+		return static::$headers;
+	}
+
+	/**
+	 * Mock JApplicationWeb->setHeader method.
+	 *
+	 * @param   string   $name     The name of the header to set.
+	 * @param   string   $value    The value of the header to set.
+	 * @param   boolean  $replace  True to replace any headers with the same name.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function mockSetHeader($name, $value, $replace = false)
+	{
+		// Sanitize the input values.
+		$name = (string) $name;
+		$value = (string) $value;
+
+		// If the replace flag is set, unset all known headers with the given name.
+		if ($replace)
+		{
+			foreach (static::$headers as $key => $header)
+			{
+				if ($name == $header['name'])
+				{
+					unset(static::$headers[$key]);
+				}
+			}
+
+			// Clean up the array as unsetting nested arrays leaves some junk.
+			static::$headers = array_values(static::$headers);
+		}
+
+		// Add the header to the internal array.
+		static::$headers[] = array('name' => $name, 'value' => $value);
+	}
+
+	/**
+	 * Mock JApplicationWeb->clearHeaders method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public static function mockClearHeaders()
+	{
+		static::$headers = array();
+	}
+
+	/**
+	 * Mock JApplicationWeb->allowCache method.
+	 *
+	 * @param   boolean  $allow  True to allow browser caching.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.2
+	 */
+	public static function mockAllowCache($allow = null)
+	{
+		if ($allow !== null)
+		{
+			static::$cachable = (bool) $allow;
+		}
+
+		return static::$cachable;
+	}
+}

--- a/tests/unit/core/mock/cache.php
+++ b/tests/unit/core/mock/cache.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JCache.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockCache
+{
+	/**
+	 * Public cache to inject faux data.
+	 *
+	 * @var    array
+	 * @since  12.1
+	 */
+	public static $cache = array();
+
+	/**
+	 * Creates and instance of the mock JApplication object.
+	 *
+	 * @param   TestCase  $test  A test object.
+	 * @param   array     $data  Data to prime the cache with.
+	 *
+	 * @return  object
+	 *
+	 * @since   12.1
+	 */
+	public static function create(TestCase $test, $data = array())
+	{
+		self::$cache = $data;
+
+		// Collect all the relevant methods in JConfig.
+		$methods = array(
+			'get',
+			'store',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JCache',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'get' => array(get_called_class(), 'mockGet'),
+				'store' => array(get_called_class(), 'mockStore'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Callback for the cache get method.
+	 *
+	 * @param   string  $id  The name of the cache key to retrieve.
+	 *
+	 * @return  mixed  The value of the key or null if it does not exist.
+	 *
+	 * @since   12.1
+	 */
+	public function mockGet($id)
+	{
+		return isset(self::$cache[$id]) ? self::$cache[$id] : null;
+	}
+
+	/**
+	 * Callback for the cache get method.
+	 *
+	 * @param   string  $value  The value to store.
+	 * @param   string  $id     The name of the cache key.
+	 *
+	 * @return  mixed  The value of the key or null if it does not exist.
+	 *
+	 * @since   12.1
+	 */
+	public function mockStore($value, $id)
+	{
+		self::$cache[$id] = $value;
+	}
+}

--- a/tests/unit/core/mock/config.php
+++ b/tests/unit/core/mock/config.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JConfig.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockConfig
+{
+	/**
+	 * Creates and instance of the mock JApplication object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JConfig.
+		$methods = array(
+			'get',
+			'set'
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JConfig',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/controller.php
+++ b/tests/unit/core/mock/controller.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JController.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockController
+{
+	/**
+	 * Creates and instance of the mock JController object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   12.1
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JController.
+		$methods = array(
+			'execute',
+			'getApplication',
+			'getInput',
+			'serialize',
+			'unserialize',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JControllerBase',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// TODO  Mock the input.
+		TestReflection::setValue($mockObject, 'input', new JInput);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/database/driver.php
+++ b/tests/unit/core/mock/database/driver.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JDatabaseDriver.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockDatabaseDriver
+{
+	/**
+	 * A query string or object.
+	 *
+	 * @var    mixed
+	 * @since  11.3
+	 */
+	public static $lastQuery = null;
+
+	/**
+	 * Creates and instance of the mock JDatabase object.
+	 *
+	 * @param   object  $test        A test object.
+	 * @param   string  $nullDate    A null date string for the driver.
+	 * @param   string  $dateFormat  A date format for the driver.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test, $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'connect',
+			'connected',
+			'disconnect',
+			'dropTable',
+			'escape',
+			'execute',
+			'fetchArray',
+			'fetchAssoc',
+			'fetchObject',
+			'freeResult',
+			'getAffectedRows',
+			'getCollation',
+			'getConnectors',
+			'getDateFormat',
+			'getErrorMsg',
+			'getErrorNum',
+			'getInstance',
+			'getLog',
+			'getNullDate',
+			'getNumRows',
+			'getPrefix',
+			'getQuery',
+			'getTableColumns',
+			'getTableCreate',
+			'getTableKeys',
+			'getTableList',
+			'getUtfSupport',
+			'getVersion',
+			'insertId',
+			'insertObject',
+			'loadAssoc',
+			'loadAssocList',
+			'loadColumn',
+			'loadObject',
+			'loadObjectList',
+			'loadResult',
+			'loadRow',
+			'loadRowList',
+			'lockTable',
+			'query',
+			'quote',
+			'quoteName',
+			'renameTable',
+			'replacePrefix',
+			'select',
+			'setQuery',
+			'setUTF',
+			'splitSql',
+			'test',
+			'isSupported',
+			'transactionCommit',
+			'transactionRollback',
+			'transactionStart',
+			'unlockTables',
+			'updateObject',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JDatabaseDriver',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'getNullDate' => $nullDate,
+				'getDateFormat' => $dateFormat
+			)
+		);
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'escape' => array((is_callable(array($test, 'mockEscape')) ? $test : __CLASS__), 'mockEscape'),
+				'getQuery' => array((is_callable(array($test, 'mockGetQuery')) ? $test : __CLASS__), 'mockGetQuery'),
+				'quote' => array((is_callable(array($test, 'mockQuote')) ? $test : __CLASS__), 'mockQuote'),
+				'quoteName' => array((is_callable(array($test, 'mockQuoteName')) ? $test : __CLASS__), 'mockQuoteName'),
+				'setQuery' => array((is_callable(array($test, 'mockSetQuery')) ? $test : __CLASS__), 'mockSetQuery'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Callback for the dbo escape method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   11.3
+	 */
+	public function mockEscape($text)
+	{
+		return "_{$text}_";
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   boolean  $new  True to get a new query, false to get the last query.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public static function mockGetQuery($new = false)
+	{
+		if ($new)
+		{
+			return new TestMockDatabaseQuery;
+		}
+		else
+		{
+			return self::$lastQuery;
+		}
+	}
+
+	/**
+	 * Mocking the quote method.
+	 *
+	 * @param   string   $value   The value to be quoted.
+	 * @param   boolean  $escape  Optional parameter to provide extra escaping.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since   11.3
+	 */
+	public static function mockQuote($value, $escape = true)
+	{
+		if (is_array($value))
+		{
+			foreach ($value as $k => $v)
+			{
+				$value[$k] = self::mockQuote($v, $escape);
+			}
+
+			return $value;
+		}
+
+		return '\'' . ($escape ? self::mockEscape($value) : $value) . '\'';
+	}
+
+	/**
+	 * Mock quoteName method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since   11.3
+	 */
+	public static function mockQuoteName($value)
+	{
+		return "`$value`";
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   string  $query  The query.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public static function mockSetQuery($query)
+	{
+		self::$lastQuery = $query;
+	}
+}

--- a/tests/unit/core/mock/database/query.php
+++ b/tests/unit/core/mock/database/query.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JDatabaseQuery.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockDatabaseQuery extends JDatabaseQuery
+{
+}

--- a/tests/unit/core/mock/dispatcher.php
+++ b/tests/unit/core/mock/dispatcher.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JEventDispatcher.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockDispatcher
+{
+	/**
+	 * Keeps track of mock handlers.
+	 *
+	 * @var    array
+	 * @since  11.3
+	 */
+	public static $handlers = array();
+
+	/**
+	 * Keeps track of triggers.
+	 *
+	 * @var    array
+	 * @since  11.3
+	 */
+	public static $triggered = array();
+
+	/**
+	 * Creates and instance of the mock JLanguage object.
+	 *
+	 * @param   object   $test      A test object.
+	 * @param   boolean  $defaults  True to create the default mock handlers and triggers.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test, $defaults = true)
+	{
+		// Clear the static tracker properties.
+		self::$handlers = array();
+		self::$triggered = array();
+
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'register',
+			'trigger',
+			'test',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JEventDispatcher',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				// An additional 'test' method for confirming this object is successfully mocked.
+				'test' => 'ok',
+			)
+		);
+
+		if ($defaults)
+		{
+			$test->assignMockCallbacks(
+				$mockObject,
+				array(
+					'register' => array(get_called_class(), 'mockRegister'),
+					'trigger' => array(get_called_class(), 'mockTrigger'),
+				)
+			);
+
+		}
+
+		return $mockObject;
+	}
+
+	/**
+	 * Callback for the JEventDispatcher register method.
+	 *
+	 * @param   string  $event    Name of the event to register handler for.
+	 * @param   string  $handler  Name of the event handler.
+	 * @param   mixed   $return   The mock value to return for the given event handler.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function mockRegister($event, $handler, $return = null)
+	{
+		if (empty(self::$handlers[$event]))
+		{
+			self::$handlers[$event] = array();
+		}
+
+		self::$handlers[$event][(string) $handler] = $return;
+	}
+
+	/**
+	 * Callback for the JEventDispatcher trigger method.
+	 *
+	 * @param   string  $event  The event to trigger.
+	 * @param   array   $args   An array of arguments.
+	 *
+	 * @return  array  An array of results from each function call.
+	 *
+	 * @since  11.3
+	 */
+	public function mockTrigger($event, $args = array())
+	{
+		if (isset(self::$handlers[$event]))
+		{
+			// Track the events that were triggered, in order.
+			self::$triggered[] = $event;
+
+			return self::$handlers[$event];
+		}
+
+		return array();
+	}
+
+}

--- a/tests/unit/core/mock/document.php
+++ b/tests/unit/core/mock/document.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JDocument.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockDocument
+{
+	/**
+	 * Creates and instance of the mock JLanguage object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'parse',
+			'render',
+			'test',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JDocument',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'parse' => $mockObject,
+				// An additional 'test' method for confirming this object is successfully mocked.
+				'test' => 'ok'
+			)
+		);
+
+		return $mockObject;
+	}
+}

--- a/tests/unit/core/mock/language.php
+++ b/tests/unit/core/mock/language.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JLanguage.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockLanguage
+{
+	/**
+	 * Creates and instance of the mock JLanguage object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'_',
+			'getInstance',
+			'getTag',
+			'test',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JLanguage',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'getInstance' => $mockObject,
+				'getTag' => 'en-GB',
+				// An additional 'test' method for confirming this object is successfully mocked.
+				'test' => 'ok',
+			)
+		);
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'_' => array(get_called_class(), 'mock_'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Callback for the mock JLanguage::_ method.
+	 *
+	 * @param   string   $string                The string to translate
+	 * @param   boolean  $jsSafe                Make the result javascript safe
+	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n
+	 *
+	 * @return void
+	 *
+	 * @since  11.3
+	 */
+	public function mock_($string, $jsSafe = false, $interpretBackSlashes = true)
+	{
+		return $string;
+	}
+}

--- a/tests/unit/core/mock/rules.php
+++ b/tests/unit/core/mock/rules.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JRules.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockRules
+{
+	/**
+	 * Creates an instance of the mock JDatabase object.
+	 *
+	 * @param   object  $test  A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Mock all the public methods.
+		$methods = array(
+			'allow',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JRules',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'allow' => array(get_called_class(), 'mockAllow'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Mocking the allow method.
+	 *
+	 * @param   string   $action    The action.
+	 * @param   integer  $identity  The identity ID.
+	 *
+	 * @return  mixed  Boolean or null.
+	 *
+	 * @since   11.3
+	 */
+	public function mockAllow($action, $identity)
+	{
+		switch ($action)
+		{
+			case 'run':
+				if ($identity == 0)
+				{
+					return null;
+				}
+				else
+				{
+					// Odds return true, evens false.
+					return (boolean) ($identity % 2);
+				}
+				return false;
+
+			case 'walk':
+				if ($identity == 0)
+				{
+					return null;
+				}
+				else
+				{
+					// Odds return false, evens true.
+					return (boolean) (1 - ($identity % 2));
+				}
+
+			default:
+				return null;
+		}
+	}
+}

--- a/tests/unit/core/mock/session.php
+++ b/tests/unit/core/mock/session.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Class to mock JSession.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestMockSession
+{
+	/**
+	 * An array of options.
+	 *
+	 * @var    array
+	 * @since  11.3
+	 */
+	protected static $options = array();
+
+	/**
+	 * Gets an option.
+	 *
+	 * @param   string  $name     The name of the option.
+	 * @param   string  $default  The default value to use if the option is not found.
+	 *
+	 * @return  mixed  The value of the option, or the default if not found.
+	 *
+	 * @since   11.3
+	 */
+	public function getOption($name, $default = null)
+	{
+		return isset(self::$options[$name]) ? self::$options[$name] : $default;
+	}
+
+	/**
+	 * Creates an instance of the mock JSession object.
+	 *
+	 * @param   object  $test     A test object.
+	 * @param   array   $options  An array of optional configuration values.
+	 *                            getId : the value to be returned by the mock getId method
+	 *                            get.user.id : the value to assign to the user object id returned by get('user')
+	 *                            get.user.name : the value to assign to the user object name returned by get('user')
+	 *                            get.user.username : the value to assign to the user object username returned by get('user')
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test, $options = array())
+	{
+		if (is_array($options))
+		{
+			self::$options = $options;
+		}
+
+		// Mock all the public methods.
+		$methods = array(
+			'clear',
+			'close',
+			'destroy',
+			'fork',
+			'get',
+			'getExpire',
+			'getFormToken',
+			'getId',
+			'getInstance',
+			'getName',
+			'getState',
+			'getStores',
+			'getToken',
+			'has',
+			'hasToken',
+			'getPrefix',
+			'isNew',
+			'restart',
+			'set',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JSession',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'getId' => self::getOption('getId')
+			)
+		);
+
+		$test->assignMockCallbacks(
+			$mockObject,
+			array(
+				'get' => array(get_called_class(), 'mockGet'),
+			)
+		);
+
+		return $mockObject;
+	}
+
+	/**
+	 * Mocking the get method.
+	 *
+	 * @param   string  $key  The key to get.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   11.3
+	 */
+	public function mockGet($key)
+	{
+		switch ($key)
+		{
+			case 'user':
+				// Attempt to load JUser.
+				class_exists('JUser');
+
+				$user = new JUser;
+
+				$user->id = (int) self::getOption('get.user.id', 0);
+				$user->name = self::getOption('get.user.name');
+				$user->username = self::getOption('get.user.username');
+				$user->guest = (int) self::getOption('get.user.guest', 1);
+
+				return $user;
+		}
+
+		return null;
+	}
+}

--- a/tests/unit/core/reflection/reflection.php
+++ b/tests/unit/core/reflection/reflection.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Reflection helper class.
+ *
+ * @package  Joomla.Test
+ * @since    12.1
+ */
+class TestReflection
+{
+	/**
+	 * Helper method that gets a protected or private property in a class by relfection.
+	 *
+	 * @param   object  $object        The object from which to return the property value.
+	 * @param   string  $propertyName  The name of the property to return.
+	 *
+	 * @return  mixed  The value of the property.
+	 *
+	 * @since   11.3
+	 * @throws  InvalidArgumentException if property not available.
+	 */
+	public static function getValue($object, $propertyName)
+	{
+		$refl = new ReflectionClass($object);
+
+		// First check if the property is easily accessible.
+		if ($refl->hasProperty($propertyName))
+		{
+			$property = $refl->getProperty($propertyName);
+			$property->setAccessible(true);
+
+			return $property->getValue($object);
+		}
+
+		// Hrm, maybe dealing with a private property in the parent class.
+		if (get_parent_class($object))
+		{
+			$property = new \ReflectionProperty(get_parent_class($object), $propertyName);
+			$property->setAccessible(true);
+
+			return $property->getValue($object);
+		}
+
+		throw new InvalidArgumentException(sprintf('Invalid property [%s] for class [%s]', $propertyName, get_class($object)));
+	}
+
+	/**
+	 * Helper method that invokes a protected or private method in a class by reflection.
+	 *
+	 * Example usage:
+	 *
+	 * $this->assertTrue(TestReflection::invoke('methodName', $this->object, 123));
+	 *
+	 * @param   object  $object      The object on which to invoke the method.
+	 * @param   string  $methodName  The name of the method to invoke.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   11.3
+	 */
+	public static function invoke($object, $methodName)
+	{
+		// Get the full argument list for the method.
+		$args = func_get_args();
+
+		// Remove the method name from the argument list.
+		array_shift($args);
+		array_shift($args);
+
+		$method = new ReflectionMethod($object, $methodName);
+		$method->setAccessible(true);
+
+		$result = $method->invokeArgs(is_object($object) ? $object : null, $args);
+
+		return $result;
+	}
+
+	/**
+	 * Helper method that sets a protected or private property in a class by relfection.
+	 *
+	 * @param   object  $object        The object for which to set the property.
+	 * @param   string  $propertyName  The name of the property to set.
+	 * @param   mixed   $value         The value to set for the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public static function setValue($object, $propertyName, $value)
+	{
+		$refl = new ReflectionClass($object);
+
+		// First check if the property is easily accessible.
+		if ($refl->hasProperty($propertyName))
+		{
+			$property = $refl->getProperty($propertyName);
+			$property->setAccessible(true);
+
+			$property->setValue($object, $value);
+		}
+		// Hrm, maybe dealing with a private property in the parent class.
+		elseif (get_parent_class($object))
+		{
+			$property = new \ReflectionProperty(get_parent_class($object), $propertyName);
+			$property->setAccessible(true);
+
+			$property->setValue($object, $value);
+		}
+	}
+}


### PR DESCRIPTION
Update Phing to local installed packages with "Composer" instead of globally installed pear packages.
Makes the building process more operating-system independent.