### PR TITLE
Replace direct model instantiation with MVCFactory

### DIFF
--- a/admin/src/Field/Modal/ServerTypeField.php
+++ b/admin/src/Field/Modal/ServerTypeField.php
@@ -16,7 +16,6 @@ namespace CWM\Component\Proclaim\Administrator\Field\Modal;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Proclaim\Administrator\Model\CwmserversModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -126,7 +125,9 @@ class ServerTypeField extends FormField
         }
 
         // Get a reverse lookup of the endpoint type to endpoint name
-        $model    = new CwmserversModel();
+        /** @var \CWM\Component\Proclaim\Administrator\Model\CwmserversModel $model */
+        $model    = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwmservers', 'Administrator');
         $rlu_type = $model->getTypeReverseLookup();
 
         $text = (string)ArrayHelper::getValue($rlu_type, $this->value);

--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -216,7 +216,9 @@ class CwmadminModel extends AdminModel
         $changeSet->fix();
         $this->fixSchemaVersion($changeSet);
         $this->fixUpdateVersion();
-        $installer = new CwminstallModel();
+        /** @var CwminstallModel $installer */
+        $installer = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwminstall', 'Administrator');
         $installer->fixMenus();
         $installer->fixemptyaccess();
         $installer->fixemptylanguage();

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -779,7 +779,9 @@ class CwminstallModel extends ListModel
             && empty($this->allupdates)
             && empty($this->subFiles)
         ) {
-            $admin = new CwmadminModel();
+            /** @var CwmadminModel $admin */
+            $admin = Factory::getApplication()->bootComponent('com_proclaim')
+                ->getMVCFactory()->createModel('Cwmadmin', 'Administrator');
             $admin->fix();
 
             // Just finished

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -458,7 +458,9 @@ class CwmmediafileModel extends AdminModel
         }
 
         // Reverse lookup server_id to server type
-        $model       = new CwmserverModel();
+        /** @var CwmserverModel $model */
+        $model       = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwmserver', 'Administrator');
         $s_item      = $model->getItem($server_id);
         $server_type = $s_item->type;
 

--- a/admin/src/Model/CwmmediafilesModel.php
+++ b/admin/src/Model/CwmmediafilesModel.php
@@ -79,7 +79,9 @@ class CwmmediafilesModel extends ListModel
 
         try {
             // This is to load the server model into the Media Files Variable.
-            $serverModel = new CwmserverModel();
+            /** @var CwmserverModel $serverModel */
+            $serverModel = Factory::getApplication()->bootComponent('com_proclaim')
+                ->getMVCFactory()->createModel('Cwmserver', 'Administrator');
 
             $items = $this->_getList($this->_getListQuery(), $this->getStart(), $this->getState('list.limit'));
 

--- a/admin/src/View/Cwmbackup/HtmlView.php
+++ b/admin/src/View/Cwmbackup/HtmlView.php
@@ -12,7 +12,6 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmbackup;
 
 // Check to ensure this file is included in Joomla!
-use CWM\Component\Proclaim\Administrator\Model\CwmadminModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -85,7 +84,9 @@ class HtmlView extends BaseHtmlView
     #[\Override]
     public function display($tpl = null): void
     {
-        $model = new CwmadminModel();
+        /** @var \CWM\Component\Proclaim\Administrator\Model\CwmadminModel $model */
+        $model = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwmadmin', 'Administrator');
         $this->setModel($model, true);
 
         // Get data from the model

--- a/admin/src/View/Cwmcpanel/HtmlView.php
+++ b/admin/src/View/Cwmcpanel/HtmlView.php
@@ -12,8 +12,8 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmcpanel;
 
 use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
-use CWM\Component\Proclaim\Administrator\Model\CwmcpanelModel;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -81,7 +81,9 @@ class HtmlView extends BaseHtmlView
     #[\Override]
     public function display($tpl = null): void
     {
-        $model       = new CwmcpanelModel();
+        /** @var \CWM\Component\Proclaim\Administrator\Model\CwmcpanelModel $model */
+        $model       = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwmcpanel', 'Administrator');
         $component   = JPATH_ADMINISTRATOR . '/components/com_proclaim/proclaim.xml';
         $this->state = $this->get('State');
 


### PR DESCRIPTION
## Summary
- Replaced 7 instances of direct `new Cwm*Model()` instantiation with Joomla 4's `MVCFactory->createModel()` pattern
- Affected files: `ServerTypeField.php`, `CwmadminModel.php`, `CwminstallModel.php`, `CwmmediafileModel.php`, `CwmmediafilesModel.php`, `Cwmbackup/HtmlView.php`, `Cwmcpanel/HtmlView.php`
- Removed unused direct model imports where applicable

## Test plan
- [x] PHP linter passes (PSR-12 clean)
- [x] All 358 PHPUnit tests pass
- [x] Verified zero remaining `new Cwm*Model()` patterns in admin/src

🤖 Generated with [Claude Code](https://claude.com/claude-code)