### PR TITLE
Replace direct Input instantiation with app getInput()

### DIFF
--- a/admin/src/Controller/CwmmessageController.php
+++ b/admin/src/Controller/CwmmessageController.php
@@ -22,7 +22,7 @@ use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\Input\Input;
+
 
 /**
  * Controller for Message
@@ -58,7 +58,7 @@ class CwmmessageController extends FormController
         }
 
         $msg   = null;
-        $input = new Input();
+        $input = $this->input;
         $id    = $input->get('id', 0, 'int');
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);

--- a/admin/src/Controller/CwmtemplatesController.php
+++ b/admin/src/Controller/CwmtemplatesController.php
@@ -25,7 +25,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Filesystem\File;
 use Joomla\Input\Files;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -276,7 +276,7 @@ class CwmtemplatesController extends AdminController
             throw new \Exception(Text::_('JINVALID_TOKEN'));
         }
 
-        $input          = new Input();
+        $input          = $this->input;
         $data           = $input->get('template_export');
         $exporttemplate = $data;
 

--- a/admin/src/Controller/CwmuploadController.php
+++ b/admin/src/Controller/CwmuploadController.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
-use Joomla\Input\Input;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -62,7 +61,7 @@ class CwmuploadController extends AdminController
             error_reporting(0);
         }
 
-        $input   = new Input();
+        $input   = $this->input;
         $params  = ComponentHelper::getParams('com_proclaim');
         $app     = Factory::getApplication();
         $session = $app->getSession();

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -28,7 +28,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Workflow\Workflow;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -105,7 +105,7 @@ class CwmmessageModel extends AdminModel
     public function getTopics(): string
     {
         // Do search in case of present study only, suppress otherwise
-        $input          = new Input();
+        $input          = Factory::getApplication()->getInput();
         $translatedList = [];
         $id             = $input->get('a_id', 0, 'int');
 

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -27,7 +27,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -137,7 +137,7 @@ class CwmteacherModel extends AdminModel
      */
     public function getItem($pk = null): mixed
     {
-        $jinput = new Input();
+        $jinput = Factory::getApplication()->getInput();
 
         // The front end calls this model and uses a_id to avoid id clashes so we need to check for that first.
         if ($jinput->get('a_id')) {

--- a/admin/src/Model/CwmtemplatecodeModel.php
+++ b/admin/src/Model/CwmtemplatecodeModel.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
-use Joomla\Input\Input;
+
 
 /**
  * HelloWorld Model
@@ -177,7 +177,7 @@ class CwmtemplatecodeModel extends AdminModel
         $key   = $table->getKeyName();
 
         // Get the pk of the record from the request.
-        $input = new Input();
+        $input = Factory::getApplication()->getInput();
         $pk    = $input->get($key, '', 'int');
         $this->setState($this->getName() . '.id', $pk);
 

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -20,7 +20,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\QueryInterface;
-use Joomla\Input\Input;
+
 
 /**
  * Topics model class
@@ -87,7 +87,7 @@ class CwmtopicsModel extends ListModel
     protected function populateState($ordering = 'topic.topic_text', $direction = 'ASC'): void
     {
         // Adjust the context to support modal layouts.
-        $input  = new Input();
+        $input  = Factory::getApplication()->getInput();
         $layout = $input->get('layout');
 
         if ($layout) {

--- a/admin/src/View/Cwmmessage/HtmlView.php
+++ b/admin/src/View/Cwmmessage/HtmlView.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $this->form       = $this->get("Form");
         $this->item       = $this->get("Item");
         $this->canDo      = ContentHelper::getActions('com_proclaim', 'message', (int)$this->item->id);
-        $input            = new Input();
+        $input            = Factory::getApplication()->getInput();
         $option           = $input->get('option', '', 'cmd');
         $this->mediafiles = $this->get('MediaFiles');
         $this->state      = $this->get('State');

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -20,7 +20,7 @@ use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 
 /** @var CWM\Component\Proclaim\Administrator\View\Cwmcpanel\HtmlView $this */
 
@@ -31,7 +31,7 @@ $wa->useScript('core')
     ->useStyle('com_proclaim.general');
 
 $msg   = '';
-$input = new Input();
+$input = Factory::getApplication()->getInput();
 $msg   = $input->get('msg');
 
 if ($msg) {

--- a/admin/tmpl/cwmmessagetypes/modal.php
+++ b/admin/tmpl/cwmmessagetypes/modal.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
@@ -21,7 +21,7 @@ use Joomla\Input\Input;
 /** @var CWM\Component\Proclaim\Administrator\View\Cwmmediafiles\HtmlView $this */
 
 HTMLHelper::_('behavior.multiselect');
-$input     = new Input();
+$input     = Factory::getApplication()->getInput();
 $function  = $input->get('function', 'jSelectMessagetype', 'cmd');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/admin/tmpl/cwmtopic/edit.php
+++ b/admin/tmpl/cwmtopic/edit.php
@@ -20,7 +20,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')
@@ -55,7 +55,7 @@ $wa->useScript('keepalive')
 /** @type Joomla\Registry\Registry $params */
 $params = $this->state->get('params');
 $params = $params->toArray();
-$input  = new Input();
+$input  = Factory::getApplication()->getInput();
 ?>
 <form action="<?php
 echo Route::_('index.php?option=com_proclaim&layout=edit&id=' . (int)$this->item->id); ?>"

--- a/admin/tmpl/cwmupload/default_uploader.php
+++ b/admin/tmpl/cwmupload/default_uploader.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -48,7 +48,7 @@ use Joomla\Input\Input;
 </script>
 <form action="
 <?php
-$input = new Input();
+$input = Factory::getApplication()->getInput();
 if ($input->get('layout', '', 'string') === 'modal') {
     $url = 'index.php?option=com_proclaim&view=cwmupload&tmpl=component&layout=modal';
 } else {

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -20,7 +20,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -46,7 +46,7 @@ class Cwmdownload
         clearstatcache();
 
         $app        = Factory::getApplication();
-        $input      = new Input();
+        $input      = Factory::getApplication()->getInput();
         $templateId = $input->get('t', '1', 'int');
         $db         = Factory::getContainer()->get('DatabaseDriver');
 

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -27,7 +27,7 @@ use Joomla\CMS\Image\Image;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -456,7 +456,7 @@ class Cwmmedia
         $params = clone $params;
         $params->merge($media->params);
 
-        $input      = new Input();
+        $input      = Factory::getApplication()->getInput();
         $template   = $input->getInt('t', '1');
         $youtube    = new CWMAddonYoutube();
         $colorStyle = ($media->params->get("media_button_color")) ? ' style="color:' . $media->params->get("media_button_color") . '"' : '';

--- a/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
+++ b/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Input\Input;
+
 use Joomla\Registry\Registry;
 
 /**
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
     #[\Override]
     public function display($tpl = null): void
     {
-        $input = new Input();
+        $input = Factory::getApplication()->getInput();
 
         // Get the menu item object
         // Load the Admin settings and params from the template

--- a/site/tmpl/cwmseriesdisplay/default_custom.php
+++ b/site/tmpl/cwmseriesdisplay/default_custom.php
@@ -20,10 +20,8 @@ use CWM\Component\Proclaim\Site\Helper\Cwmserieslist;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Input\Input;
-
 $mainframe = Factory::getApplication();
-$input     = new Input();
+$input     = $mainframe->getInput();
 $option    = $input->get('option', '', 'cmd');
 $document  = $mainframe->getDocument();
 $params    = $this->params;

--- a/site/tmpl/cwmseriesdisplays/default_custom.php
+++ b/site/tmpl/cwmseriesdisplays/default_custom.php
@@ -19,10 +19,8 @@
 use CWM\Component\Proclaim\Site\Helper\Cwmserieslist;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
-use Joomla\Input\Input;
-
 $app         = Factory::getApplication();
-$input       = new Input();
+$input       = $app->getInput();
 $option      = $input->get('option', '', 'cmd');
 $series_menu = (int) $this->params->get('series_id', 1);
 $document    = $app->getDocument();

--- a/site/tmpl/cwmserverslist/modal.php
+++ b/site/tmpl/cwmserverslist/modal.php
@@ -20,12 +20,12 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 
 HTMLHelper::_('behavior.framework', true);
 HTMLHelper::_('formbehavior.chosen', 'select');
 
-$input     = new Input();
+$input     = Factory::getApplication()->getInput();
 $function  = $input->getCmd('function', 'jSelectServer');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
## Summary
- Replace 18 `new Input()` calls with proper Joomla 4+ patterns across admin/src, site/src, and tmpl files
- Controllers now use `$this->input` (inherited from `BaseController`)
- Models, views, helpers, and templates use `Factory::getApplication()->getInput()`
- Remove unused `Joomla\Input\Input` imports from all affected files
- YouTube addon `new Input([...])` calls preserved (valid data bag pattern for internal method signatures)

## Test plan
- [x] `composer lint` — PSR-12 clean
- [x] `composer test` — 358/358 PHPUnit tests pass (1162 assertions)
- [x] `npm test` — 120/120 Jest tests pass
- [x] Grep confirms 0 remaining `new Input()` calls (only `new Input([...])` data bags remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)