### PR TITLE
Replace getSession()->get('user') with getIdentity()

### DIFF
--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -589,7 +589,7 @@ class CwmadminController extends FormController
      */
     public function dbReset(): void
     {
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         if ($user->authorise('core.admin')) {
             CwmdbHelper::resetdb();

--- a/admin/src/Model/CwmcommentModel.php
+++ b/admin/src/Model/CwmcommentModel.php
@@ -106,7 +106,7 @@ class CwmcommentModel extends AdminModel
             $id = $jinput->get('id', 0);
         }
 
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         // Modify the form based on Edit State access controls.
@@ -150,7 +150,7 @@ class CwmcommentModel extends AdminModel
 
         // Check that the user has create permission for the component
         $extension = Factory::getApplication()->getInput()->get('option', '');
-        $user      = $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         if (!$user->authorise('core.create', $extension)) {
             $this->setError(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'));
@@ -263,7 +263,7 @@ class CwmcommentModel extends AdminModel
                 return false;
             }
 
-            return Factory::getApplication()->getSession()->get('user')->authorise(
+            return Factory::getApplication()->getIdentity()->authorise(
                 'core.delete',
                 'com_proclaim.comment.' . (int)$record->id
             );
@@ -284,7 +284,7 @@ class CwmcommentModel extends AdminModel
      */
     protected function canEditState($record): bool
     {
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         if (!empty($record->id)) {

--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -189,7 +189,7 @@ class CwmlocationsModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select(
             $this->getState(

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -616,7 +616,7 @@ class CwmmediafileModel extends AdminModel
             $id = $input->get('id', 0);
         }
 
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         // Modify the form based on Edit State access controls.
@@ -652,7 +652,7 @@ class CwmmediafileModel extends AdminModel
     protected function batchPlayer($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
         /** @type CwmmediafileTable $table */
         $table = $this->getTable();
 
@@ -713,7 +713,7 @@ class CwmmediafileModel extends AdminModel
     protected function batchLinkType($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
         /** @type CwmmediafileTable $table */
         $table = $this->getTable();
 
@@ -759,7 +759,7 @@ class CwmmediafileModel extends AdminModel
     protected function batchMimetype($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
         /** @type CwmmediafileTable $table */
         $table = $this->getTable();
 
@@ -805,7 +805,7 @@ class CwmmediafileModel extends AdminModel
     protected function batchMediatype($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
         $table = $this->getTable();
 
         foreach ($pks as $pk) {
@@ -850,7 +850,7 @@ class CwmmediafileModel extends AdminModel
     protected function batchPopup($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
         $table = $this->getTable();
 
         foreach ($pks as $pk) {
@@ -937,7 +937,7 @@ class CwmmediafileModel extends AdminModel
                 return false;
             }
 
-            return Factory::getApplication()->getSession()->get('user')->authorise(
+            return Factory::getApplication()->getIdentity()->authorise(
                 'core.delete',
                 'com_proclaim.mediafile.' . (int)$record->id
             );

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -203,7 +203,7 @@ class CwmmessagesModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select(
             $this->getState(

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -187,7 +187,7 @@ class CwmmessagetypesModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select(
             $this->getState(

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -166,7 +166,7 @@ class CwmpodcastModel extends AdminModel
     protected function batchLinkType($value, $pks, $contexts): bool
     {
         // Set the variables
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
         /** @var CwmpodcastTable $table */
         $table = $this->getTable();
 

--- a/admin/src/Model/CwmpodcastsModel.php
+++ b/admin/src/Model/CwmpodcastsModel.php
@@ -144,7 +144,7 @@ class CwmpodcastsModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select(
             $this->getState(

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -100,7 +100,7 @@ class CwmserieModel extends AdminModel
             $id = $jinput->get('id', 0);
         }
 
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         // Modify the form based on Edit State access controls.
@@ -287,7 +287,7 @@ class CwmserieModel extends AdminModel
 
         // Check that the user has create permission for the component
         $extension = $app->input->get('option', '');
-        $user      = $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         if (!$user->authorise('core.create', $extension)) {
             $app->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'), 'error');
@@ -403,7 +403,7 @@ class CwmserieModel extends AdminModel
                 return false;
             }
 
-            return Factory::getApplication()->getSession()->get('user')->authorise(
+            return Factory::getApplication()->getIdentity()->authorise(
                 'core.delete',
                 'com_proclaim.serie.' . (int)$record->id
             );
@@ -424,7 +424,7 @@ class CwmserieModel extends AdminModel
      */
     protected function canEditState($record): bool
     {
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         if (!empty($record->id)) {

--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -342,7 +342,7 @@ class CwmserverModel extends AdminModel
      */
     protected function canDelete($record): bool
     {
-        return Factory::getApplication()->getSession()->get('user')->authorise(
+        return Factory::getApplication()->getIdentity()->authorise(
             'core.delete',
             'com_proclaim.cwmserver.' . (int)$record->id
         );
@@ -361,7 +361,7 @@ class CwmserverModel extends AdminModel
      */
     protected function canEditState($record): bool
     {
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing server record
         if (!empty($record->id)) {

--- a/admin/src/Model/CwmserversModel.php
+++ b/admin/src/Model/CwmserversModel.php
@@ -179,7 +179,7 @@ class CwmserversModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select($this->getState('list.select', 'server.id, server.published, server.server_name, server.type'));
         $query->from($db->quoteName('#__bsms_servers', 'server'));

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -104,7 +104,7 @@ class CwmteacherModel extends AdminModel
             $id = $jinput->get('id', 0);
         }
 
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Check for existing article.
         // Modify the form based on Edit State access controls.

--- a/admin/src/Model/CwmteachersModel.php
+++ b/admin/src/Model/CwmteachersModel.php
@@ -147,7 +147,7 @@ class CwmteachersModel extends ListModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         $query->select($this->getState('list.select', 'teacher.*'));
         $query->from('#__bsms_teachers AS teacher');

--- a/admin/src/View/Cwmcomments/HtmlView.php
+++ b/admin/src/View/Cwmcomments/HtmlView.php
@@ -114,7 +114,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar(): void
     {
         $canDo = ContentHelper::getActions('com_proclaim');
-        $user  = Factory::getApplication()->getSession()->get('user');
+        $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
         $toolbar = Toolbar::getInstance('toolbar');

--- a/admin/src/View/Cwmlocations/HtmlView.php
+++ b/admin/src/View/Cwmlocations/HtmlView.php
@@ -123,7 +123,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
         $toolbar = Toolbar::getInstance('toolbar');

--- a/admin/src/View/Cwmmediafile/HtmlView.php
+++ b/admin/src/View/Cwmmediafile/HtmlView.php
@@ -176,7 +176,7 @@ class HtmlView extends BaseHtmlView
     {
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
-        $user       = $user = Factory::getApplication()->getSession()->get('user');
+        $user = Factory::getApplication()->getIdentity();
         $userId     = $user->id;
         $isNew      = ($this->item->id === 0);
         $checkedOut = !($this->item->checked_out === null || $this->item->checked_out == $userId);

--- a/site/tmpl/cwmsermon/default_main.php
+++ b/site/tmpl/cwmsermon/default_main.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Language\Text;
 // Create shortcuts to some parameters.
 /** @type Joomla\Registry\Registry $params */
 $params  = $this->item->params;
-$user    = Factory::getApplication()->getSession()->get('user');
+$user    = Factory::getApplication()->getIdentity();
 $canEdit = $params->get('access-edit');
 
 $this->loadHelper('title');


### PR DESCRIPTION
## Summary
- Replace 29 deprecated `getSession()->get('user')` calls with `getIdentity()` across 17 files
- Fix 3 duplicate `$user = $user = ...` assignment bugs (CwmcommentModel, CwmserieModel, Cwmmediafile/HtmlView)
- Prepares codebase for Joomla 6 without backward compatibility layer

## Test plan
- [x] `composer lint` — PSR-12 clean
- [x] `composer test` — 358/358 PHPUnit tests pass (1162 assertions)
- [x] Grep confirms 0 remaining `getSession()->get('user')` calls
- [x] Remaining `getSession()` calls are legitimate (session data storage, form tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)