### PR TITLE
Quote all SQL identifiers with quoteName() across codebase

### DIFF
--- a/admin/src/Addons/Servers/Legacy/Field/DocmanField.php
+++ b/admin/src/Addons/Servers/Legacy/Field/DocmanField.php
@@ -55,9 +55,9 @@ class DocmanField extends ListField
 
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('dm.docman_document_id, dm.title');
-        $query->from('#__docman_documents AS dm');
-        $query->order('dm.docman_document_id DESC');
+        $query->select($db->qn('dm.docman_document_id') . ', ' . $db->qn('dm.title'));
+        $query->from($db->qn('#__docman_documents', 'dm'));
+        $query->order($db->qn('dm.docman_document_id') . ' DESC');
         $db->setQuery((string)$query);
         $docs    = $db->loadObjectList();
         $options = [];

--- a/admin/src/Addons/Servers/Legacy/Field/VirtuemartField.php
+++ b/admin/src/Addons/Servers/Legacy/Field/VirtuemartField.php
@@ -64,11 +64,11 @@ class VirtuemartField extends ListField
 
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('v.virtuemart_product_id, v.product_name');
-        $query->from('#__virtuemart_products_' . VMLANG . ' AS v');
-        $query->select('p.product_sku');
-        $query->join('LEFT', '#__virtuemart_products as p ON v.virtuemart_product_id = p.virtuemart_product_id');
-        $query->order('v.virtuemart_product_id DESC');
+        $query->select($db->qn('v.virtuemart_product_id') . ', ' . $db->qn('v.product_name'));
+        $query->from($db->qn('#__virtuemart_products_' . VMLANG, 'v'));
+        $query->select($db->qn('p.product_sku'));
+        $query->join('LEFT', $db->qn('#__virtuemart_products', 'p') . ' ON ' . $db->qn('v.virtuemart_product_id') . ' = ' . $db->qn('p.virtuemart_product_id'));
+        $query->order($db->qn('v.virtuemart_product_id') . ' DESC');
         $db->setQuery((string)$query);
         $products = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -113,8 +113,8 @@ class CwmadminController extends FormController
 
         if ($from !== 'x' && $to !== 'x') {
             $query = $db->getQuery(true);
-            $query->select('id, params')
-                ->from('#__bsms_mediafiles');
+            $query->select($db->qn(['id', 'params']))
+                ->from($db->qn('#__bsms_mediafiles'));
             $db->setQuery($query);
 
             foreach ($db->loadObjectList() as $media) {
@@ -125,9 +125,9 @@ class CwmadminController extends FormController
                     $reg->set('player', $to);
 
                     $query = $db->getQuery(true);
-                    $query->update('#__bsms_mediafiles')
-                        ->set('params = ' . $db->q($reg->toString()))
-                        ->where('id = ' . (int)$media->id);
+                    $query->update($db->qn('#__bsms_mediafiles'))
+                        ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                        ->where($db->qn('id') . ' = ' . (int)$media->id);
                     $db->setQuery($query);
 
                     if (!$db->execute()) {
@@ -169,8 +169,8 @@ class CwmadminController extends FormController
         $to    = $reg->get('pTo', 'x');
         $msg   = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
         $query = $db->getQuery(true);
-        $query->select('id, params')
-            ->from('#__bsms_mediafiles');
+        $query->select($db->qn(['id', 'params']))
+            ->from($db->qn('#__bsms_mediafiles'));
         $db->setQuery($query);
 
         foreach ($db->loadObjectList() as $media) {
@@ -188,9 +188,9 @@ class CwmadminController extends FormController
                 $reg->set('popup', $to);
 
                 $query = $db->getQuery(true);
-                $query->update('#__bsms_mediafiles')
-                    ->set('params = ' . $db->q($reg->toString()))
-                    ->where('id = ' . (int)$media->id);
+                $query->update($db->qn('#__bsms_mediafiles'))
+                    ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                    ->where($db->qn('id') . ' = ' . (int)$media->id);
                 $db->setQuery($query);
 
                 if (!$db->execute()) {
@@ -224,8 +224,8 @@ class CwmadminController extends FormController
         $decoded = json_decode($post['mediaimage'], true, 512, JSON_THROW_ON_ERROR);
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
-        $query->select('id, params')
-            ->from('#__bsms_mediafiles');
+        $query->select($db->qn(['id', 'params']))
+            ->from($db->qn('#__bsms_mediafiles'));
         $db->setQuery($query);
         $images    = $db->loadObjectList();
         $error     = 0;
@@ -264,9 +264,9 @@ class CwmadminController extends FormController
                         $db->setQuery($query);
 
                         try {
-                            $query->update('#__bsms_mediafiles')
-                                ->set('params = ' . $db->q($reg->toString()))
-                                ->where('id = ' . (int)$media->id);
+                            $query->update($db->qn('#__bsms_mediafiles'))
+                                ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                                ->where($db->qn('id') . ' = ' . (int)$media->id);
                             $db->execute();
                             $rows  = $db->getAffectedRows();
                             $added = $added + $rows;
@@ -303,9 +303,9 @@ class CwmadminController extends FormController
                         $db->setQuery($query);
 
                         try {
-                            $query->update('#__bsms_mediafiles')
-                                ->set('params = ' . $db->q($reg->toString()))
-                                ->where('id = ' . (int)$media->id);
+                            $query->update($db->qn('#__bsms_mediafiles'))
+                                ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                                ->where($db->qn('id') . ' = ' . (int)$media->id);
                             $db->execute();
                             $rows  = $db->getAffectedRows();
                             $added = $added + $rows;
@@ -346,9 +346,9 @@ class CwmadminController extends FormController
                         $db->setQuery($query);
 
                         try {
-                            $query->update('#__bsms_mediafiles')
-                                ->set('params = ' . $db->q($reg->toString()))
-                                ->where('id = ' . (int)$media->id);
+                            $query->update($db->qn('#__bsms_mediafiles'))
+                                ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                                ->where($db->qn('id') . ' = ' . (int)$media->id);
                             $db->execute();
                             $rows  = $db->getAffectedRows();
                             $added = $added + $rows;
@@ -393,9 +393,9 @@ class CwmadminController extends FormController
 
                         try {
                             $db->setQuery($query);
-                            $query->update('#__bsms_mediafiles')
-                                ->set('params = ' . $db->q($reg->toString()))
-                                ->where('id = ' . (int)$media->id);
+                            $query->update($db->qn('#__bsms_mediafiles'))
+                                ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                                ->where($db->qn('id') . ' = ' . (int)$media->id);
                             $db->execute();
                             $rows  = $db->getAffectedRows();
                             $added += $rows;
@@ -439,9 +439,9 @@ class CwmadminController extends FormController
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $msg   = null;
         $query = $db->getQuery(true);
-        $query->update('#__bsms_mediafiles')
-            ->set('hits = ' . 0)
-            ->where('hits != 0');
+        $query->update($db->qn('#__bsms_mediafiles'))
+            ->set($db->qn('hits') . ' = 0')
+            ->where($db->qn('hits') . ' != 0');
         $db->setQuery($query);
 
         if (!$db->execute()) {
@@ -473,9 +473,9 @@ class CwmadminController extends FormController
         $msg   = null;
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->update('#__bsms_mediafiles')
-            ->set('downloads = ' . 0)
-            ->where('downloads != 0');
+        $query->update($db->qn('#__bsms_mediafiles'))
+            ->set($db->qn('downloads') . ' = 0')
+            ->where($db->qn('downloads') . ' != 0');
         $db->setQuery($query);
 
         if (!$db->execute()) {
@@ -508,9 +508,9 @@ class CwmadminController extends FormController
         $msg   = null;
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->update('#__bsms_mediafiles')
-            ->set('plays = ' . 0)
-            ->where('plays != 0');
+        $query->update($db->qn('#__bsms_mediafiles'))
+            ->set($db->qn('plays') . ' = 0')
+            ->where($db->qn('plays') . ' != 0');
         $db->setQuery($query);
 
         if (!$db->execute()) {

--- a/admin/src/Controller/CwmassetsController.php
+++ b/admin/src/Controller/CwmassetsController.php
@@ -243,9 +243,12 @@ class CwmassetsController extends BaseController
 
         // Load a batch of records
         $query = $db->getQuery(true);
-        $query->select('j.id, j.asset_id, a.id as aid, a.parent_id, a.rules')
-            ->from($db->qn($tableName) . ' as j')
-            ->leftJoin('#__assets as a ON (a.id = j.asset_id)')
+        $query->select(
+            $db->qn('j.id') . ', ' . $db->qn('j.asset_id') . ', '
+            . $db->qn('a.id', 'aid') . ', ' . $db->qn('a.parent_id') . ', ' . $db->qn('a.rules')
+        )
+            ->from($db->qn($tableName, 'j'))
+            ->leftJoin($db->qn('#__assets', 'a') . ' ON (' . $db->qn('a.id') . ' = ' . $db->qn('j.asset_id') . ')')
             ->setLimit($batchSize, $offset);
         $db->setQuery($query);
         $results = $db->loadObjectList();
@@ -295,9 +298,9 @@ class CwmassetsController extends BaseController
         if (empty($item->asset_id) || $item->asset_id == 0 || !$assetExists) {
             // Check if asset already exists by name
             $query = $db->getQuery(true);
-            $query->select('id')
-                ->from('#__assets')
-                ->where('name = ' . $db->quote($assetFullName));
+            $query->select($db->qn('id'))
+                ->from($db->qn('#__assets'))
+                ->where($db->qn('name') . ' = ' . $db->quote($assetFullName));
             $db->setQuery($query);
             $existingAssetId = $db->loadResult();
 
@@ -305,15 +308,15 @@ class CwmassetsController extends BaseController
                 // Asset exists, just update the record's asset_id
                 $query = $db->getQuery(true);
                 $query->update($db->qn($tableName))
-                    ->set('asset_id = ' . (int) $existingAssetId)
-                    ->where('id = ' . (int) $item->id);
+                    ->set($db->qn('asset_id') . ' = ' . (int) $existingAssetId)
+                    ->where($db->qn('id') . ' = ' . (int) $item->id);
                 $db->setQuery($query);
                 $db->execute();
             } else {
                 // Create a new asset
                 $query = $db->getQuery(true);
-                $query->insert('#__assets')
-                    ->columns(['parent_id', 'level', 'name', 'title', 'rules'])
+                $query->insert($db->qn('#__assets'))
+                    ->columns($db->qn(['parent_id', 'level', 'name', 'title', 'rules']))
                     ->values(
                         (int) $parentId . ', 4, ' . $db->quote($assetFullName) . ', ' .
                         $db->quote($assetName . ' ' . $item->id) . ', ' .
@@ -326,8 +329,8 @@ class CwmassetsController extends BaseController
                 // Update the record with new asset_id
                 $query = $db->getQuery(true);
                 $query->update($db->qn($tableName))
-                    ->set('asset_id = ' . (int) $newAssetId)
-                    ->where('id = ' . (int) $item->id);
+                    ->set($db->qn('asset_id') . ' = ' . (int) $newAssetId)
+                    ->where($db->qn('id') . ' = ' . (int) $item->id);
                 $db->setQuery($query);
                 $db->execute();
             }
@@ -338,15 +341,15 @@ class CwmassetsController extends BaseController
         // Case 2: Has valid asset_id with existing asset but parent_id mismatch or empty rules
         if ($item->parent_id != $parentId || empty($item->rules)) {
             $query = $db->getQuery(true);
-            $query->update('#__assets')
-                ->set('parent_id = ' . (int) $parentId)
-                ->set('name = ' . $db->quote($assetFullName));
+            $query->update($db->qn('#__assets'))
+                ->set($db->qn('parent_id') . ' = ' . (int) $parentId)
+                ->set($db->qn('name') . ' = ' . $db->quote($assetFullName));
 
             if (empty($item->rules)) {
-                $query->set('rules = ' . $db->quote($defaultRules));
+                $query->set($db->qn('rules') . ' = ' . $db->quote($defaultRules));
             }
 
-            $query->where('id = ' . (int) $item->asset_id);
+            $query->where($db->qn('id') . ' = ' . (int) $item->asset_id);
             $db->setQuery($query);
             $db->execute();
 

--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -626,9 +626,12 @@ class CwmbackupController extends FormController
                 while ($offset < $total) {
                     // Load a batch of records
                     $query = $db->getQuery(true);
-                    $query->select('j.id, j.asset_id, a.id as aid, a.parent_id, a.rules')
-                        ->from($db->qn($tableInfo['name']) . ' as j')
-                        ->leftJoin('#__assets as a ON (a.id = j.asset_id)')
+                    $query->select(
+                        $db->qn('j.id') . ', ' . $db->qn('j.asset_id') . ', '
+                        . $db->qn('a.id', 'aid') . ', ' . $db->qn('a.parent_id') . ', ' . $db->qn('a.rules')
+                    )
+                        ->from($db->qn($tableInfo['name'], 'j'))
+                        ->leftJoin($db->qn('#__assets', 'a') . ' ON (' . $db->qn('a.id') . ' = ' . $db->qn('j.asset_id') . ')')
                         ->setLimit($batchSize, $offset);
                     $db->setQuery($query);
                     $results = $db->loadObjectList();
@@ -678,9 +681,9 @@ class CwmbackupController extends FormController
         if (empty($item->asset_id) || $item->asset_id == 0 || empty($item->aid)) {
             // Check if asset already exists by name (in case asset_id just wasn't set)
             $query = $db->getQuery(true);
-            $query->select('id')
-                ->from('#__assets')
-                ->where('name = ' . $db->quote($assetName));
+            $query->select($db->qn('id'))
+                ->from($db->qn('#__assets'))
+                ->where($db->qn('name') . ' = ' . $db->quote($assetName));
             $db->setQuery($query);
             $existingAssetId = $db->loadResult();
 
@@ -688,15 +691,15 @@ class CwmbackupController extends FormController
                 // Asset exists, just update the record's asset_id
                 $query = $db->getQuery(true);
                 $query->update($db->qn($tableInfo['name']))
-                    ->set('asset_id = ' . (int) $existingAssetId)
-                    ->where('id = ' . (int) $item->id);
+                    ->set($db->qn('asset_id') . ' = ' . (int) $existingAssetId)
+                    ->where($db->qn('id') . ' = ' . (int) $item->id);
                 $db->setQuery($query);
                 $db->execute();
             } else {
                 // Create new asset
                 $query = $db->getQuery(true);
-                $query->insert('#__assets')
-                    ->columns(['parent_id', 'level', 'name', 'title', 'rules'])
+                $query->insert($db->qn('#__assets'))
+                    ->columns($db->qn(['parent_id', 'level', 'name', 'title', 'rules']))
                     ->values(
                         (int) $parentId . ', 4, ' . $db->quote($assetName) . ', ' .
                         $db->quote($tableInfo['assetname'] . ' ' . $item->id) . ', ' .
@@ -709,8 +712,8 @@ class CwmbackupController extends FormController
                 // Update the record with new asset_id
                 $query = $db->getQuery(true);
                 $query->update($db->qn($tableInfo['name']))
-                    ->set('asset_id = ' . (int) $newAssetId)
-                    ->where('id = ' . (int) $item->id);
+                    ->set($db->qn('asset_id') . ' = ' . (int) $newAssetId)
+                    ->where($db->qn('id') . ' = ' . (int) $item->id);
                 $db->setQuery($query);
                 $db->execute();
             }
@@ -722,15 +725,15 @@ class CwmbackupController extends FormController
         if ($item->parent_id != $parentId || empty($item->rules)) {
             // Update the existing asset record
             $query = $db->getQuery(true);
-            $query->update('#__assets')
-                ->set('parent_id = ' . (int) $parentId)
-                ->set('name = ' . $db->quote($assetName));
+            $query->update($db->qn('#__assets'))
+                ->set($db->qn('parent_id') . ' = ' . (int) $parentId)
+                ->set($db->qn('name') . ' = ' . $db->quote($assetName));
 
             if (empty($item->rules)) {
-                $query->set('rules = ' . $db->quote($defaultRules));
+                $query->set($db->qn('rules') . ' = ' . $db->quote($defaultRules));
             }
 
-            $query->where('id = ' . (int) $item->asset_id);
+            $query->where($db->qn('id') . ' = ' . (int) $item->asset_id);
             $db->setQuery($query);
             $db->execute();
         }
@@ -792,9 +795,9 @@ class CwmbackupController extends FormController
         try {
             // Get all templatecode records
             $query = $db->getQuery(true);
-            $query->select('id, type, filename, templatecode')
-                ->from('#__bsms_templatecode')
-                ->where('published = 1');
+            $query->select($db->qn(['id', 'type', 'filename', 'templatecode']))
+                ->from($db->qn('#__bsms_templatecode'))
+                ->where($db->qn('published') . ' = 1');
             $db->setQuery($query);
             $records = $db->loadObjectList();
 

--- a/admin/src/Controller/CwmmessageController.php
+++ b/admin/src/Controller/CwmmessageController.php
@@ -62,9 +62,9 @@ class CwmmessageController extends FormController
         $id    = $input->get('id', 0, 'int');
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->update('#__bsms_studies')
-            ->set('hits = ' . $db->q('0'))
-            ->where(' id = ' . (int)$id);
+        $query->update($db->qn('#__bsms_studies'))
+            ->set($db->qn('hits') . ' = ' . $db->q('0'))
+            ->where($db->qn('id') . ' = ' . (int)$id);
         $db->setQuery($query);
 
         if (!$db->execute()) {
@@ -148,8 +148,8 @@ class CwmmessageController extends FormController
         // Remove Exerting StudyTopics tags
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $qurey = $db->getQuery(true);
-        $qurey->delete('#__bsms_studytopics')
-            ->where('study_id =' . $data['id']);
+        $qurey->delete($db->qn('#__bsms_studytopics'))
+            ->where($db->qn('study_id') . ' = ' . (int) $data['id']);
         $db->setQuery($qurey);
 
         if (!$db->execute()) {

--- a/admin/src/Field/FiltersField.php
+++ b/admin/src/Field/FiltersField.php
@@ -170,11 +170,21 @@ class FiltersField extends FormField
 
         // Get the user groups from the database.
         $query = $db->getQuery(true);
-        $query->select('a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level, a.parent_id as parent');
-        $query->from('#__usergroups AS a');
-        $query->join('LEFT', '#__usergroups AS b on a.lft > b.lft AND a.rgt < b.rgt');
-        $query->group('a.id, a.title, a.lft');
-        $query->order('a.lft ASC');
+        $query->select(
+            $db->qn('a.id', 'value') . ', '
+                . $db->qn('a.title', 'text') . ', '
+                . 'COUNT(DISTINCT ' . $db->qn('b.id') . ') AS ' . $db->qn('level') . ', '
+                . $db->qn('a.parent_id', 'parent')
+        );
+        $query->from($db->qn('#__usergroups', 'a'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__usergroups', 'b') . ' ON '
+                . $db->qn('a.lft') . ' > ' . $db->qn('b.lft') . ' AND '
+                . $db->qn('a.rgt') . ' < ' . $db->qn('b.rgt')
+        );
+        $query->group($db->qn(['a.id', 'a.title', 'a.lft']));
+        $query->order($db->qn('a.lft') . ' ASC');
         $db->setQuery($query);
 
         return $db->loadObjectList();

--- a/admin/src/Field/LocationListField.php
+++ b/admin/src/Field/LocationListField.php
@@ -49,9 +49,9 @@ class LocationListField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id,location_text');
-        $query->from('#__bsms_locations');
-        $query->order('location_text');
+        $query->select($db->qn('id') . ', ' . $db->qn('location_text'));
+        $query->from($db->qn('#__bsms_locations'));
+        $query->order($db->qn('location_text'));
         $db->setQuery((string)$query);
         $messages = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Field/LocationsField.php
+++ b/admin/src/Field/LocationsField.php
@@ -49,9 +49,9 @@ class LocationsField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id,location_text');
-        $query->from('#__bsms_locations');
-        $query->order('location_text');
+        $query->select($db->qn('id') . ', ' . $db->qn('location_text'));
+        $query->from($db->qn('#__bsms_locations'));
+        $query->order($db->qn('location_text'));
         $db->setQuery((string)$query);
         $messages = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Field/MediaFileImagesField.php
+++ b/admin/src/Field/MediaFileImagesField.php
@@ -53,7 +53,7 @@ class MediaFileImagesField extends ListField
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('*');
-        $query->from('#__bsms_mediafiles');
+        $query->from($db->qn('#__bsms_mediafiles'));
         $db->setQuery((string)$query);
         $mediafiles = $db->loadObjectList();
         $options    = [];

--- a/admin/src/Field/MessageTypeListField.php
+++ b/admin/src/Field/MessageTypeListField.php
@@ -49,10 +49,10 @@ class MessageTypeListField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id,message_type');
-        $query->from('#__bsms_message_type');
-        $query->where('published = 1');
-        $query->order('message_type');
+        $query->select($db->qn('id') . ', ' . $db->qn('message_type'));
+        $query->from($db->qn('#__bsms_message_type'));
+        $query->where($db->qn('published') . ' = 1');
+        $query->order($db->qn('message_type'));
         $db->setQuery((string)$query);
         $messages = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Field/SeriesField.php
+++ b/admin/src/Field/SeriesField.php
@@ -48,10 +48,10 @@ class SeriesField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id,series_text');
-        $query->from('#__bsms_series');
-        $query->where('published = 1');
-        $query->order('series_text');
+        $query->select($db->qn('id') . ', ' . $db->qn('series_text'));
+        $query->from($db->qn('#__bsms_series'));
+        $query->where($db->qn('published') . ' = 1');
+        $query->order($db->qn('series_text'));
         $db->setQuery((string)$query);
         $messages = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Field/ServerField.php
+++ b/admin/src/Field/ServerField.php
@@ -114,9 +114,9 @@ class ServerField extends FormField
         if ($value) {
             // Get a reverse lookup of the server ID to server name
             $db    = Factory::getContainer()->get('DatabaseDriver');
-            $query = $db->getQuery('true');
+            $query = $db->getQuery(true);
             $query->select($db->quoteName('server_name'))
-                ->from('#__bsms_servers')
+                ->from($db->qn('#__bsms_servers'))
                 ->where($db->quoteName('id') . ' = :value')
                 ->bind(':value', $value, ParameterType::INTEGER);
             $db->setQuery($query);

--- a/admin/src/Field/StudyImageField.php
+++ b/admin/src/Field/StudyImageField.php
@@ -49,7 +49,7 @@ class StudyImageField extends MediaField
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__extensions')
+            ->from($db->qn('#__extensions'))
             ->where($db->qn('name') . ' = ' . $db->q('plg_filesystem_local'));
         $db->setQuery($query);
         $local   = $db->loadObject();
@@ -67,7 +67,7 @@ class StudyImageField extends MediaField
             }
 
             $query = $db->getQuery(true);
-            $query->update('#__extensions')
+            $query->update($db->qn('#__extensions'))
                 ->set($db->qn('params') . ' = ' . $db->q($newmedia))
                 ->where($db->qn('name') . ' = ' . $db->q('plg_filesystem_local'));
             $db->setQuery($query);

--- a/admin/src/Field/TeacherListField.php
+++ b/admin/src/Field/TeacherListField.php
@@ -49,9 +49,9 @@ class TeacherListField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id,teachername');
-        $query->from('#__bsms_teachers');
-        $query->order('teachername');
+        $query->select($db->qn('id') . ', ' . $db->qn('teachername'));
+        $query->from($db->qn('#__bsms_teachers'));
+        $query->order($db->qn('teachername'));
         $db->setQuery((string)$query);
         $teachers = $db->loadObjectList();
         $options  = [];

--- a/admin/src/Field/TopicsFormField.php
+++ b/admin/src/Field/TopicsFormField.php
@@ -98,10 +98,10 @@ class TopicsFormField extends FormField
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
 
-        $query->select('id, topic_text, params AS topic_params')
-            ->from('#__bsms_topics')
-            ->where('published = 1')
-            ->order('topic_text ASC');
+        $query->select($db->qn('id') . ', ' . $db->qn('topic_text') . ', ' . $db->qn('params', 'topic_params'))
+            ->from($db->qn('#__bsms_topics'))
+            ->where($db->qn('published') . ' = 1')
+            ->order($db->qn('topic_text') . ' ASC');
 
         $db->setQuery($query);
         $topics  = $db->loadObjectList();
@@ -150,9 +150,9 @@ class TopicsFormField extends FormField
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
 
-        $query->select('topic_id')
-            ->from('#__bsms_studytopics')
-            ->where('study_id = ' . (int)$messageId);
+        $query->select($db->qn('topic_id'))
+            ->from($db->qn('#__bsms_studytopics'))
+            ->where($db->qn('study_id') . ' = ' . (int)$messageId);
 
         $db->setQuery($query);
         $result = $db->loadColumn();

--- a/admin/src/Field/TopicsListField.php
+++ b/admin/src/Field/TopicsListField.php
@@ -52,12 +52,22 @@ class TopicsListField extends ListField
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('DISTINCT #__bsms_topics.id, #__bsms_topics.topic_text, #__bsms_topics.params as topic_params')
-            ->from('#__bsms_studies')
-            ->leftJoin('#__bsms_studytopics ON #__bsms_studies.id = #__bsms_studytopics.study_id')
-            ->leftJoin('#__bsms_topics ON #__bsms_topics.id = #__bsms_studytopics.topic_id')
-            ->where('#__bsms_topics.published = 1')
-            ->order('#__bsms_topics.topic_text ASC');
+        $query->select(
+            'DISTINCT ' . $db->qn('#__bsms_topics.id') . ', '
+                . $db->qn('#__bsms_topics.topic_text') . ', '
+                . $db->qn('#__bsms_topics.params', 'topic_params')
+        )
+            ->from($db->qn('#__bsms_studies'))
+            ->leftJoin(
+                $db->qn('#__bsms_studytopics') . ' ON '
+                    . $db->qn('#__bsms_studies.id') . ' = ' . $db->qn('#__bsms_studytopics.study_id')
+            )
+            ->leftJoin(
+                $db->qn('#__bsms_topics') . ' ON '
+                    . $db->qn('#__bsms_topics.id') . ' = ' . $db->qn('#__bsms_studytopics.topic_id')
+            )
+            ->where($db->qn('#__bsms_topics.published') . ' = 1')
+            ->order($db->qn('#__bsms_topics.topic_text') . ' ASC');
         $db->setQuery($query);
         $topics  = $db->loadObjectList();
         $options = [];

--- a/admin/src/Helper/CwmImageCleanup.php
+++ b/admin/src/Helper/CwmImageCleanup.php
@@ -159,7 +159,7 @@ class CwmImageCleanup
             return [];
         }
 
-        $query->select('id')->from($table);
+        $query->select($db->qn('id'))->from($db->qn($table));
         $db->setQuery($query);
 
         $results = $db->loadColumn();

--- a/admin/src/Helper/CwmImageMigration.php
+++ b/admin/src/Helper/CwmImageMigration.php
@@ -43,27 +43,36 @@ class CwmImageMigration
 
         switch ($type) {
             case 'studies':
-                $query->select('id, studytitle, alias, thumbnailm as image_path')
-                    ->from('#__bsms_studies')
-                    ->where('thumbnailm IS NOT NULL')
-                    ->where('thumbnailm != ' . $db->q(''))
-                    ->where('thumbnailm NOT LIKE ' . $db->q('images/biblestudy/studies/%-%/%'));
+                $query->select(
+                    $db->qn('id') . ', ' . $db->qn('studytitle') . ', ' . $db->qn('alias') . ', '
+                    . $db->qn('thumbnailm', 'image_path')
+                )
+                    ->from($db->qn('#__bsms_studies'))
+                    ->where($db->qn('thumbnailm') . ' IS NOT NULL')
+                    ->where($db->qn('thumbnailm') . ' != ' . $db->q(''))
+                    ->where($db->qn('thumbnailm') . ' NOT LIKE ' . $db->q('images/biblestudy/studies/%-%/%'));
                 break;
 
             case 'teachers':
-                $query->select('id, teachername, alias, teacher_thumbnail as image_path')
-                    ->from('#__bsms_teachers')
-                    ->where('teacher_thumbnail IS NOT NULL')
-                    ->where('teacher_thumbnail != ' . $db->q(''))
-                    ->where('teacher_thumbnail NOT LIKE ' . $db->q('images/biblestudy/teachers/%-%/%'));
+                $query->select(
+                    $db->qn('id') . ', ' . $db->qn('teachername') . ', ' . $db->qn('alias') . ', '
+                    . $db->qn('teacher_thumbnail', 'image_path')
+                )
+                    ->from($db->qn('#__bsms_teachers'))
+                    ->where($db->qn('teacher_thumbnail') . ' IS NOT NULL')
+                    ->where($db->qn('teacher_thumbnail') . ' != ' . $db->q(''))
+                    ->where($db->qn('teacher_thumbnail') . ' NOT LIKE ' . $db->q('images/biblestudy/teachers/%-%/%'));
                 break;
 
             case 'series':
-                $query->select('id, series_text as title, alias, series_thumbnail as image_path')
-                    ->from('#__bsms_series')
-                    ->where('series_thumbnail IS NOT NULL')
-                    ->where('series_thumbnail != ' . $db->q(''))
-                    ->where('series_thumbnail NOT LIKE ' . $db->q('images/biblestudy/series/%-%/%'));
+                $query->select(
+                    $db->qn('id') . ', ' . $db->qn('series_text', 'title') . ', ' . $db->qn('alias') . ', '
+                    . $db->qn('series_thumbnail', 'image_path')
+                )
+                    ->from($db->qn('#__bsms_series'))
+                    ->where($db->qn('series_thumbnail') . ' IS NOT NULL')
+                    ->where($db->qn('series_thumbnail') . ' != ' . $db->q(''))
+                    ->where($db->qn('series_thumbnail') . ' NOT LIKE ' . $db->q('images/biblestudy/series/%-%/%'));
                 break;
 
             default:
@@ -151,14 +160,14 @@ class CwmImageMigration
 
         switch ($type) {
             case 'studies':
-                $query->update('#__bsms_studies')
+                $query->update($db->qn('#__bsms_studies'))
                     ->set($db->qn('thumbnailm') . ' = ' . $db->q($result['thumbnail']))
                     ->set($db->qn('image') . ' = ' . $db->q($result['image']))
                     ->where($db->qn('id') . ' = ' . (int) $id);
                 break;
 
             case 'teachers':
-                $query->update('#__bsms_teachers')
+                $query->update($db->qn('#__bsms_teachers'))
                     ->set($db->qn('teacher_thumbnail') . ' = ' . $db->q($result['thumbnail']))
                     ->set($db->qn('teacher_image') . ' = ' . $db->q($result['image']))
                     ->set($db->qn('image') . ' = ' . $db->q($result['image']))
@@ -166,7 +175,7 @@ class CwmImageMigration
                 break;
 
             case 'series':
-                $query->update('#__bsms_series')
+                $query->update($db->qn('#__bsms_series'))
                     ->set($db->qn('series_thumbnail') . ' = ' . $db->q($result['thumbnail']))
                     ->set($db->qn('image') . ' = ' . $db->q($result['image']))
                     ->where($db->qn('id') . ' = ' . (int) $id);

--- a/admin/src/Helper/Cwmalias.php
+++ b/admin/src/Helper/Cwmalias.php
@@ -112,8 +112,8 @@ class Cwmalias
 
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id, alias, ' . $title)
-            ->from($table);
+        $query->select($db->qn('id') . ', ' . $db->qn('alias') . ', ' . $db->qn($title))
+            ->from($db->qn($table));
         $db->setQuery($query);
         $results = $db->loadObjectList();
 

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -344,7 +344,7 @@ class CwmdbHelper
         // Start by getting existing Style
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__bsms_styles');
+        $query->select('*')->from($db->qn('#__bsms_styles'));
 
         if ($filename) {
             $query->where($db->qn('filename') . ' = ' . $db->q($filename));
@@ -391,7 +391,7 @@ class CwmdbHelper
         // No apply the new css back to the table
 
         $query = $db->getQuery(true);
-        $query->update('#__bsms_styles')->set($db->qn('stylecode') . ' = ' . $db->q($newcss));
+        $query->update($db->qn('#__bsms_styles'))->set($db->qn('stylecode') . ' = ' . $db->q($newcss));
 
         if ($filename) {
             $query->where($db->qn('filename') . ' = ' . $db->q($filename));
@@ -515,8 +515,8 @@ class CwmdbHelper
 
         // Remove old assets.
         $query = $db->getQuery(true);
-        $query->delete('#__assets')
-            ->where('name LIKE ' . $db->q('com_proclaim.%'));
+        $query->delete($db->qn('#__assets'))
+            ->where($db->qn('name') . ' LIKE ' . $db->q('com_proclaim.%'));
         $db->setQuery($query);
         $db->execute();
 
@@ -541,14 +541,14 @@ class CwmdbHelper
         $app   = Factory::getApplication();
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id')->from('#__bsms_studies');
+        $query->select($db->qn('id'))->from($db->qn('#__bsms_studies'));
         $db->setQuery($query);
         $results = $db->loadObjectList();
 
         foreach ($results as $result) {
             $query = $db->getQuery(true);
             $query->select($db->qn(['id', 'topic_id']))
-                ->from('#__bsms_studytopics')
+                ->from($db->qn('#__bsms_studytopics'))
                 ->where($db->qn('study_id') . ' = ' . (int) $result->id);
             $db->setQuery($query);
             $resulta = $db->loadObjectList();
@@ -560,7 +560,7 @@ class CwmdbHelper
                 foreach ($resulta as $study_topics) {
                     $query = $db->getQuery(true);
                     $query->select($db->qn('id'))
-                        ->from('#__bsms_studytopics')
+                        ->from($db->qn('#__bsms_studytopics'))
                         ->where($db->qn('study_id') . ' = ' . (int) $result->id)
                         ->where($db->qn('topic_id') . ' = ' . (int) $study_topics->topic_id)
                         ->order($db->qn('id') . ' DESC');
@@ -572,7 +572,7 @@ class CwmdbHelper
                         foreach ($results as $id) {
                             if ($t < $records) {
                                 $query = $db->getQuery(true);
-                                $query->delete('#__bsms_studytopics')
+                                $query->delete($db->qn('#__bsms_studytopics'))
                                     ->where($db->qn('id') . ' = ' . (int) $id->id);
                                 $db->setQuery($query);
 

--- a/admin/src/Helper/CwmguidedtourHelper.php
+++ b/admin/src/Helper/CwmguidedtourHelper.php
@@ -242,7 +242,7 @@ class CwmguidedtourHelper
     protected function getExtensionId(): int
     {
         $query = $this->db->getQuery(true)
-            ->select('extension_id')
+            ->select($this->db->quoteName('extension_id'))
             ->from($this->db->quoteName('#__extensions'))
             ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
             ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'));
@@ -404,7 +404,7 @@ class CwmguidedtourHelper
         }
 
         $query = $this->db->getQuery(true)
-            ->select('id')
+            ->select($this->db->quoteName('id'))
             ->from($this->db->quoteName('#__guidedtours'))
             ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($uid));
         $this->db->setQuery($query);
@@ -671,7 +671,7 @@ class CwmguidedtourHelper
 
         foreach ($this->tours as $tour) {
             $query = $this->db->getQuery(true)
-                ->select('id')
+                ->select($this->db->quoteName('id'))
                 ->from($this->db->quoteName('#__guidedtours'))
                 ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($tour['uid']));
             $this->db->setQuery($query);

--- a/admin/src/Helper/Cwmhelper.php
+++ b/admin/src/Helper/Cwmhelper.php
@@ -143,9 +143,9 @@ class Cwmhelper
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('id, params')
-            ->from('#__bsms_mediafiles')
-            ->where('id = ' . (int)$id);
+        $query->select($db->qn(['id', 'params']))
+            ->from($db->qn('#__bsms_mediafiles'))
+            ->where($db->qn('id') . ' = ' . (int) $id);
 
         $db->setQuery($query);
         $media = $db->loadObject();

--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -216,9 +216,9 @@ class Cwmhtml
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('id As value, teachername As text');
-        $query->from('#__bsms_teachers AS a');
-        $query->order('a.teachername ASC');
+        $query->select($db->qn('id', 'value') . ', ' . $db->qn('teachername', 'text'));
+        $query->from($db->qn('#__bsms_teachers', 'a'));
+        $query->order($db->qn('a.teachername') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -273,9 +273,9 @@ class Cwmhtml
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('id As value, message_type As text');
-        $query->from('#__bsms_message_type AS a');
-        $query->order('a.message_type ASC');
+        $query->select($db->qn('id', 'value') . ', ' . $db->qn('message_type', 'text'));
+        $query->from($db->qn('#__bsms_message_type', 'a'));
+        $query->order($db->qn('a.message_type') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -330,9 +330,9 @@ class Cwmhtml
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('id As value, series_text As text');
-        $query->from('#__bsms_series AS a');
-        $query->order('a.series_text ASC');
+        $query->select($db->qn('id', 'value') . ', ' . $db->qn('series_text', 'text'));
+        $query->from($db->qn('#__bsms_series', 'a'));
+        $query->order($db->qn('a.series_text') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -47,8 +47,8 @@ class CwmmigrationHelper
 
         foreach ($replacements as $old => $new) {
             $query = $db->getQuery(true);
-            $query->update('#__menu')
-                ->set('link = REPLACE(' . $db->qn('link') . ', ' . $db->q($old) . ', ' . $db->q($new) . ')')
+            $query->update($db->qn('#__menu'))
+                ->set($db->qn('link') . ' = REPLACE(' . $db->qn('link') . ', ' . $db->q($old) . ', ' . $db->q($new) . ')')
                 ->where($db->qn('menutype') . ' != ' . $db->q('main'))
                 ->where($db->qn('link') . ' LIKE ' . $db->q('%com_proclaim%'))
                 ->where($db->qn('link') . ' LIKE ' . $db->q('%' . $old . '%'));
@@ -90,7 +90,7 @@ class CwmmigrationHelper
         // Correct blank or not set records
         foreach ($tables as $table) {
             $query = $db->getQuery(true);
-            $query->update($table['table'])
+            $query->update($db->qn($table['table']))
                 ->set($db->qn('access') . ' = ' . (int) $id)
                 ->where(
                     '(' . $db->qn('access') . ' = ' . $db->q('0') .
@@ -124,7 +124,7 @@ class CwmmigrationHelper
         // Correct blank records
         foreach ($tables as $table) {
             $query = $db->getQuery(true);
-            $query->update($table['table'])
+            $query->update($db->qn($table['table']))
                 ->set($db->qn('language') . ' = ' . $db->q('*'))
                 ->where($db->qn('language') . ' = ' . $db->q(''));
             $db->setQuery($query);
@@ -175,7 +175,7 @@ class CwmmigrationHelper
         foreach ($tables as $table) {
             if (!str_contains($table['name'], '_bsms_timeset')) {
                 $query = $db->getQuery(true);
-                $query->select('*')->from($table['name']);
+                $query->select('*')->from($db->qn($table['name']));
                 $db->setQuery($query);
                 $data = $db->loadObjectList();
 
@@ -251,8 +251,8 @@ class CwmmigrationHelper
         // Find Extension ID of a component
         $query = $db->getQuery(true);
         $query
-            ->select('extension_id')
-            ->from('#__extensions')
+            ->select($db->qn('extension_id'))
+            ->from($db->qn('#__extensions'))
             ->where($db->qn('name') . ' = ' . $db->q('com_proclaim'));
         $db->setQuery($query);
         $biblestudyEid         = $db->loadResult();

--- a/admin/src/Helper/CwmnotificationHelper.php
+++ b/admin/src/Helper/CwmnotificationHelper.php
@@ -119,9 +119,13 @@ class CwmnotificationHelper
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true)
-            ->select('s.studytitle, s.studydate, b.bookname')
+            ->select($db->quoteName(['s.studytitle', 's.studydate', 'b.bookname']))
             ->from($db->quoteName('#__bsms_studies', 's'))
-            ->join('LEFT', $db->quoteName('#__bsms_books', 'b') . ' ON b.booknumber = s.booknumber')
+            ->join(
+                'LEFT',
+                $db->quoteName('#__bsms_books', 'b') . ' ON '
+                . $db->quoteName('b.booknumber') . ' = ' . $db->quoteName('s.booknumber')
+            )
             ->where($db->quoteName('s.id') . ' = ' . (int) $studyId);
         $db->setQuery($query);
 

--- a/admin/src/Helper/Cwmparams.php
+++ b/admin/src/Helper/Cwmparams.php
@@ -74,7 +74,7 @@ class Cwmparams
             $db    = Factory::getContainer()->get('DatabaseDriver');
             $query = $db->getQuery(true);
             $query->select('*')
-                ->from('#__bsms_admin')
+                ->from($db->qn('#__bsms_admin'))
                 ->where($db->qn('id') . ' = ' . 1);
             $db->setQuery($query);
             $admin = $db->loadObject();
@@ -125,7 +125,7 @@ class Cwmparams
             self::$templateId = $pk;
             $query            = $db->getQuery(true);
             $query->select('*')
-                ->from('#__bsms_templates')
+                ->from($db->qn('#__bsms_templates'))
                 ->where($db->qn('published') . ' = 1')
                 ->where($db->qn('id') . ' = ' . (int) self::$templateId);
             $db->setQuery($query);
@@ -136,7 +136,7 @@ class Cwmparams
                 self::$templateId = 1;
                 $query            = $db->getQuery(true);
                 $query->select('*')
-                    ->from('#__bsms_templates')
+                    ->from($db->qn('#__bsms_templates'))
                     ->where($db->qn('published') . ' = 1')
                     ->where($db->qn('id') . ' = ' . (int) self::$templateId);
                 $db->setQuery($query);
@@ -175,7 +175,7 @@ class Cwmparams
             $db    = Factory::getContainer()->get('DatabaseDriver');
             $query = $db->getQuery(true);
             $query->select($db->qn('params'))
-                ->from('#__extensions')
+                ->from($db->qn('#__extensions'))
                 ->where($db->qn('name') . ' = ' . $db->q('com_proclaim'));
             $db->setQuery($query);
             $params = json_decode($db->loadResult(), true, 512, JSON_THROW_ON_ERROR);
@@ -188,7 +188,7 @@ class Cwmparams
             // Store the combined new and existing values back as a JSON string
             $paramsString = json_encode($params, JSON_THROW_ON_ERROR);
             $query->clear();
-            $query->update('#__extensions')
+            $query->update($db->qn('#__extensions'))
                 ->set($db->qn('params') . ' = ' . $db->q($paramsString))
                 ->where($db->qn('name') . ' = ' . $db->q('com_proclaim'));
             $db->setQuery($query);

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -256,9 +256,9 @@ class CwmproclaimHelper
         // $db      = $driver->getDriver();
         $query = $db->getQuery(true);
 
-        $query->select('DISTINCT YEAR(createdate) as value, YEAR(createdate) as text');
-        $query->from('#__bsms_mediafiles');
-        $query->order('value');
+        $query->select('DISTINCT YEAR(' . $db->qn('createdate') . ') as value, YEAR(' . $db->qn('createdate') . ') as text');
+        $query->from($db->qn('#__bsms_mediafiles'));
+        $query->order($db->qn('value'));
 
         // Get the options.
         $db->setQuery($query);
@@ -286,11 +286,14 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('messageType.id AS value, messageType.message_type AS text');
-        $query->from('#__bsms_message_type AS messageType');
-        $query->join('INNER', '#__bsms_studies AS study ON study.messagetype = messageType.id');
-        $query->group('messageType.id');
-        $query->order('messageType.message_type');
+        $query->select($db->qn('messageType.id', 'value') . ', ' . $db->qn('messageType.message_type', 'text'));
+        $query->from($db->qn('#__bsms_message_type', 'messageType'));
+        $query->join(
+            'INNER',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.messagetype') . ' = ' . $db->qn('messageType.id')
+        );
+        $query->group($db->qn('messageType.id'));
+        $query->order($db->qn('messageType.message_type'));
 
         // Get the options.
         $db->setQuery($query);
@@ -318,9 +321,9 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('DISTINCT YEAR(studydate) as value, YEAR(studydate) as text');
-        $query->from('#__bsms_studies');
-        $query->order('value DESC');
+        $query->select('DISTINCT YEAR(' . $db->qn('studydate') . ') as value, YEAR(' . $db->qn('studydate') . ') as text');
+        $query->from($db->qn('#__bsms_studies'));
+        $query->order($db->qn('value') . ' DESC');
 
         // Get the options.
         $db->setQuery($query);
@@ -349,11 +352,14 @@ class CwmproclaimHelper
         $db      = $driver->getDriver();
         $query   = $db->getQuery(true);
 
-        $query->select('teacher.id AS value, teacher.teachername AS text');
-        $query->from('#__bsms_teachers AS teacher');
-        $query->join('INNER', '#__bsms_studies AS study ON study.teacher_id = teacher.id');
-        $query->group('teacher.id');
-        $query->order('value ASC');
+        $query->select($db->qn('teacher.id', 'value') . ', ' . $db->qn('teacher.teachername', 'text'));
+        $query->from($db->qn('#__bsms_teachers', 'teacher'));
+        $query->join(
+            'INNER',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.teacher_id') . ' = ' . $db->qn('teacher.id')
+        );
+        $query->group($db->qn('teacher.id'));
+        $query->order($db->qn('value') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -381,11 +387,16 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('book.booknumber AS value, book.bookname AS text, book.id');
-        $query->from('#__bsms_books AS book');
-        $query->join('INNER', '#__bsms_studies AS study ON study.booknumber = book.booknumber');
-        $query->group('book.id');
-        $query->order('value ASC');
+        $query->select(
+            $db->qn('book.booknumber', 'value') . ', ' . $db->qn('book.bookname', 'text') . ', ' . $db->qn('book.id')
+        );
+        $query->from($db->qn('#__bsms_books', 'book'));
+        $query->join(
+            'INNER',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.booknumber') . ' = ' . $db->qn('book.booknumber')
+        );
+        $query->group($db->qn('book.id'));
+        $query->order($db->qn('value') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -417,11 +428,14 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('messageType.id AS value, messageType.message_type AS text');
-        $query->from('#__bsms_message_type AS messageType');
-        $query->join('INNER', '#__bsms_studies AS study ON study.messagetype = messageType.id');
-        $query->group('messageType.id');
-        $query->order('text ASC');
+        $query->select($db->qn('messageType.id', 'value') . ', ' . $db->qn('messageType.message_type', 'text'));
+        $query->from($db->qn('#__bsms_message_type', 'messageType'));
+        $query->join(
+            'INNER',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.messagetype') . ' = ' . $db->qn('messageType.id')
+        );
+        $query->group($db->qn('messageType.id'));
+        $query->order($db->qn('text') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -449,9 +463,9 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
 
-        $query->select('id AS value, location_text AS text');
-        $query->from('#__bsms_locations');
-        $query->order('location_text ASC');
+        $query->select($db->qn('id', 'value') . ', ' . $db->qn('location_text', 'text'));
+        $query->from($db->qn('#__bsms_locations'));
+        $query->order($db->qn('location_text') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);

--- a/admin/src/Helper/CwmtemplatemigrationHelper.php
+++ b/admin/src/Helper/CwmtemplatemigrationHelper.php
@@ -321,7 +321,7 @@ class CwmtemplatemigrationHelper
 
         // Get all templates
         $query = $this->db->getQuery(true)
-            ->select(['id', 'params', 'title'])
+            ->select($this->db->quoteName(['id', 'params', 'title']))
             ->from($this->db->quoteName('#__bsms_templates'));
         $this->db->setQuery($query);
         $templates = $this->db->loadObjectList();
@@ -380,7 +380,7 @@ class CwmtemplatemigrationHelper
 
         // Get admin record (usually just one row)
         $query = $this->db->getQuery(true)
-            ->select(['id', 'params'])
+            ->select($this->db->quoteName(['id', 'params']))
             ->from($this->db->quoteName('#__bsms_admin'));
         $this->db->setQuery($query);
         $adminRecords = $this->db->loadObjectList();
@@ -439,7 +439,7 @@ class CwmtemplatemigrationHelper
 
         // Get all templates
         $query = $this->db->getQuery(true)
-            ->select(['id', 'params', 'title'])
+            ->select($this->db->quoteName(['id', 'params', 'title']))
             ->from($this->db->quoteName('#__bsms_templates'));
         $this->db->setQuery($query);
         $templates = $this->db->loadObjectList();
@@ -495,7 +495,7 @@ class CwmtemplatemigrationHelper
 
         // Get all templates
         $query = $this->db->getQuery(true)
-            ->select(['id', 'params', 'title'])
+            ->select($this->db->quoteName(['id', 'params', 'title']))
             ->from($this->db->quoteName('#__bsms_templates'));
         $this->db->setQuery($query);
         $templates = $this->db->loadObjectList();
@@ -576,7 +576,7 @@ class CwmtemplatemigrationHelper
     public function parameterExistsInTemplates(string $paramName): bool
     {
         $query = $this->db->getQuery(true)
-            ->select('params')
+            ->select($this->db->quoteName('params'))
             ->from($this->db->quoteName('#__bsms_templates'));
         $this->db->setQuery($query);
         $templates = $this->db->loadColumn();

--- a/admin/src/Helper/Cwmtranslated.php
+++ b/admin/src/Helper/Cwmtranslated.php
@@ -134,11 +134,14 @@ class Cwmtranslated
         if ($topicItem && $topicItem->tp_id) {
             $db    = Factory::getContainer()->get('DatabaseDriver');
             $query = $db->getQuery(true);
-            $query->select('#__bsms_topics.topic_text, #__bsms_topics.params AS topic_params')
-                ->from('#__bsms_topics')
-                ->leftJoin('#__bsms_studytopics ON (#__bsms_studytopics.study_id = ' . $db->q($topicItem->id) . ') ')
-                ->where('published = ' . 1)
-                ->where('#__bsms_topics.id = #__bsms_studytopics.topic_id');
+            $query->select($db->qn('#__bsms_topics.topic_text') . ', ' . $db->qn('#__bsms_topics.params', 'topic_params'))
+                ->from($db->qn('#__bsms_topics'))
+                ->leftJoin(
+                    $db->qn('#__bsms_studytopics') . ' ON (' . $db->qn('#__bsms_studytopics.study_id')
+                    . ' = ' . $db->q($topicItem->id) . ')'
+                )
+                ->where($db->qn('published') . ' = 1')
+                ->where($db->qn('#__bsms_topics.id') . ' = ' . $db->qn('#__bsms_studytopics.topic_id'));
             $db->setQuery($query);
             $results = $db->loadObjectList();
             $output  = '';

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -111,10 +111,10 @@ class Cwmassets
 
         // Find the root asset to use as parent
         $query = $db->getQuery(true);
-        $query->select('id')
-            ->from('#__assets')
-            ->where('parent_id = 0')
-            ->where('level = 0');
+        $query->select($db->qn('id'))
+            ->from($db->qn('#__assets'))
+            ->where($db->qn('parent_id') . ' = 0')
+            ->where($db->qn('level') . ' = 0');
         $db->setQuery($query);
         $rootId = (int) $db->loadResult();
 
@@ -126,8 +126,8 @@ class Cwmassets
         $defaultRules = '{"core.admin":{"7":1},"core.manage":{"6":1},"core.create":[],"core.delete":[],"core.edit":[],"core.edit.state":[]}';
 
         $query = $db->getQuery(true);
-        $query->insert('#__assets')
-            ->columns(['parent_id', 'lft', 'rgt', 'level', 'name', 'title', 'rules'])
+        $query->insert($db->qn('#__assets'))
+            ->columns($db->qn(['parent_id', 'lft', 'rgt', 'level', 'name', 'title', 'rules']))
             ->values(
                 (int) $rootId . ', 0, 0, 1, ' .
                 $db->quote('com_proclaim') . ', ' .
@@ -168,9 +168,9 @@ class Cwmassets
 
             // First, get the new parent_id
             $query = $db->getQuery(true);
-            $query->select('id')
-                ->from('#__assets')
-                ->where('name = ' . $db->q('com_proclaim'));
+            $query->select($db->qn('id'))
+                ->from($db->qn('#__assets'))
+                ->where($db->qn('name') . ' = ' . $db->q('com_proclaim'));
             $db->setQuery($query);
             self::$parent_id = $db->loadResult();
         }
@@ -247,8 +247,8 @@ class Cwmassets
         if (isset($data->asset_id)) {
             if ((int)$data->asset_id >= 2 && (int)$data->asset_id !== self::$parent_id) {
                 $query = $db->getQuery(true);
-                $query->delete('#__assets')
-                    ->where('id = ' . $db->quote($data->asset_id));
+                $query->delete($db->qn('#__assets'))
+                    ->where($db->qn('id') . ' = ' . $db->quote($data->asset_id));
                 $db->setQuery($query);
                 $db->execute();
             }
@@ -278,9 +278,15 @@ class Cwmassets
             // Put the table into the return array
             // Get the total number of rows and collect the table into a query
             $query = $db->getQuery(true);
-            $query->select('j.id, j.asset_id, a.id as aid, a.parent_id, a.rules')
-                ->from($db->qn($object['name']) . ' as j')
-                ->leftJoin('#__assets as a ON (a.id = j.asset_id)');
+            $query->select(
+                $db->qn('j.id') . ', ' .
+                    $db->qn('j.asset_id') . ', ' .
+                    $db->qn('a.id', 'aid') . ', ' .
+                    $db->qn('a.parent_id') . ', ' .
+                    $db->qn('a.rules')
+            )
+                ->from($db->qn($object['name'], 'j'))
+                ->leftJoin($db->qn('#__assets', 'a') . ' ON (' . $db->qn('a.id') . ' = ' . $db->qn('j.asset_id') . ')');
             $db->setQuery($query);
             $results     = $db->loadObjectList();
             self::$count += \count($results);

--- a/admin/src/Lib/CwmpIconvert.php
+++ b/admin/src/Lib/CwmpIconvert.php
@@ -206,7 +206,7 @@ class CwmpIconvert
         $url   = $uri->getHost();
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__bsms_servers');
+        $query->select('*')->from($db->qn('#__bsms_servers'));
         $db->setQuery($query);
         $servers = $db->loadObjectList();
         foreach ($servers as $server) {
@@ -214,7 +214,7 @@ class CwmpIconvert
             $reg->loadString($server->params);
             $reg->set('path', $url);
             $query = $db->getQuery(true);
-            $query->update('#__bsms_servers')
+            $query->update($db->qn('#__bsms_servers'))
                 ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
                 ->where($db->qn('id') . ' = ' . (int) $server->id);
             $db->setQuery($query);
@@ -223,7 +223,7 @@ class CwmpIconvert
         //Convert comments
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__picomments');
+        $query->select('*')->from($db->qn('#__picomments'));
         $db->setQuery($query);
         $this->picomments = $db->loadObjectList();
         /** @var $piconversion string */
@@ -241,12 +241,12 @@ class CwmpIconvert
         } else {
             $this->tadd++;
             $query = $db->getQuery(true);
-            $query->select('id')->from('#__bsms_teachers')->order('id desc');
+            $query->select($db->qn('id'))->from($db->qn('#__bsms_teachers'))->order($db->qn('id') . ' DESC');
             $db->setQuery($query, 0, 1);
             $this->genericteacher = $db->loadResult();
         }
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__piteachers');
+        $query->select('*')->from($db->qn('#__piteachers'));
         $db->setQuery($query);
         $piteachers = $db->loadObjectList();
 
@@ -274,7 +274,7 @@ class CwmpIconvert
 
                     // Get the new teacherid so we can later connect it to a study
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_teachers')->order('id desc');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_teachers'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $newid               = $db->loadResult();
                     $oldid               = $pi->id;
@@ -285,7 +285,7 @@ class CwmpIconvert
 
         // Convert Ministries
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__piministry');
+        $query->select('*')->from($db->qn('#__piministry'));
         $db->setQuery($query);
         $ministries = $db->loadObjectList();
 
@@ -309,7 +309,7 @@ class CwmpIconvert
 
                     // Get the new locationid so we can later connect it to a study
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_locations')->order('id desc');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_locations'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $newid             = $db->loadResult();
                     $oldid             = $pi->id;
@@ -321,7 +321,7 @@ class CwmpIconvert
 
         // Convert Series
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__piseries');
+        $query->select('*')->from($db->qn('#__piseries'));
         $db->setQuery($query);
         $series = $db->loadObjectList();
 
@@ -344,7 +344,7 @@ class CwmpIconvert
 
                     // Get the new seriesid so we can later connect it to a study
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_series')->order('id desc');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_series'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $newid             = $db->loadResult();
                     $oldid             = $pi->id;
@@ -355,7 +355,7 @@ class CwmpIconvert
 
         // Convert podcacsts
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__pipodcast')->where('published = 1');
+        $query->select('*')->from($db->qn('#__pipodcast'))->where($db->qn('published') . ' = 1');
         $db->setQuery($query);
         $podcasts = $db->loadObjectList();
 
@@ -389,7 +389,7 @@ class CwmpIconvert
 
                     // Get the new podcast id so we can later connect it to a study
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_podcast')->order('id desc');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_podcast'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $newid              = $db->loadResult();
                     $oldid              = $pi->id;
@@ -400,7 +400,7 @@ class CwmpIconvert
         // Convert studies and media files
         $books = $this->getBooks();
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__pistudies');
+        $query->select('*')->from($db->qn('#__pistudies'));
         $db->setQuery($query);
         $studies = $db->loadObjectList();
 
@@ -527,7 +527,7 @@ class CwmpIconvert
 
                     // Get the new studiesid so we can later connect it to a study
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_studies')->order('id desc');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_studies'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $newid              = $db->loadResult();
                     $oldid              = $pi->id;
@@ -683,7 +683,7 @@ class CwmpIconvert
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('*')->from('#__pifilepath');
+        $query->select('*')->from($db->qn('#__pifilepath'));
         $db->setQuery($query);
         $folders     = $db->loadObjectList();
         $podcast_id  = '0';
@@ -701,7 +701,7 @@ class CwmpIconvert
         $player      = '';
         $pod         = [];
         $query       = $db->getQuery(true);
-        $query->select('*')->from('#__pipodcast')->where('published = 1');
+        $query->select('*')->from($db->qn('#__pipodcast'))->where($db->qn('published') . ' = 1');
         $db->setQuery($query);
         $podcasts = $db->loadObjectList();
 
@@ -722,7 +722,7 @@ class CwmpIconvert
                 case 1:
                     // JWPlayer
                     $query = $db->getQuery(true);
-                    $query->select('folder')->from('#__pifilepath')->where('id = ' . $pi->video_link);
+                    $query->select($db->qn('folder'))->from($db->qn('#__pifilepath'))->where($db->qn('id') . ' = ' . (int) $pi->video_link);
                     $db->setQuery($query);
                     $object            = $db->loadObject();
                     $path              = $object->folder;
@@ -829,7 +829,7 @@ class CwmpIconvert
         if ($type == 'notes') {
             $filesize = $pi->notesfs;
             $query    = $db->getQuery(true);
-            $query->select('folder')->from('#__pifilepath')->where('id = ' . $pi->notes_folder);
+            $query->select($db->qn('folder'))->from($db->qn('#__pifilepath'))->where($db->qn('id') . ' = ' . (int) $pi->notes_folder);
             $db->setQuery($query);
             $object           = $db->loadObject();
             $path             = $object->folder;
@@ -861,7 +861,7 @@ class CwmpIconvert
         if ($type == 'slides') {
             $filesize = $pi->slidesfs;
             $query    = $db->getQuery(true);
-            $query->select('folder')->from('#__pifilepath')->where('id = ' . $pi->slides_folder);
+            $query->select($db->qn('folder'))->from($db->qn('#__pifilepath'))->where($db->qn('id') . ' = ' . (int) $pi->slides_folder);
             $db->setQuery($query);
             $object        = $db->loadObject();
             $path          = $object->folder;
@@ -909,7 +909,7 @@ class CwmpIconvert
         $podtest = 0;
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
-        $query->select('*')->from('#__pipodcast')->where('published = 1');
+        $query->select('*')->from($db->qn('#__pipodcast'))->where($db->qn('published') . ' = 1');
         $db->setQuery($query);
         $podcasts        = $db->loadObjectList();
         $includeteacher  = [];

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -16,7 +16,6 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\InstallerHelper;
 use Joomla\CMS\Language\Text;
@@ -48,29 +47,29 @@ class Cwmrestore
 
         foreach ($backuptables as $backuptable) {
             if (substr_count($backuptable['name'], 'studies')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY studytext BLOB';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('studytext') . ' BLOB';
                 $db->setQuery($query);
                 $db->execute();
 
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY studytext2 BLOB';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('studytext2') . ' BLOB';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'podcast')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY description BLOB';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('description') . ' BLOB';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'series')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY description BLOB';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('description') . ' BLOB';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'teachers')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY information BLOB';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('information') . ' BLOB';
                 $db->setQuery($query);
                 $db->execute();
             }
@@ -120,29 +119,29 @@ class Cwmrestore
 
         foreach ($backuptables as $backuptable) {
             if (substr_count($backuptable['name'], 'studies')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY studytext TEXT';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('studytext') . ' TEXT';
                 $db->setQuery($query);
                 $db->execute();
 
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY studytext2 TEXT';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('studytext2') . ' TEXT';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'podcast')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY description TEXT';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('description') . ' TEXT';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'series')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY description TEXT';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('description') . ' TEXT';
                 $db->setQuery($query);
                 $db->execute();
             }
 
             if (substr_count($backuptable['name'], 'teachers')) {
-                $query = 'ALTER TABLE ' . $backuptable['name'] . ' MODIFY information TEXT';
+                $query = 'ALTER TABLE ' . $db->qn($backuptable['name']) . ' MODIFY ' . $db->qn('information') . ' TEXT';
                 $db->setQuery($query);
                 $db->execute();
             }
@@ -208,9 +207,9 @@ class Cwmrestore
             if ($result) {
                 // Get Proclaim extension ID
                 $query = $this->dbo->getQuery(true);
-                $query->select('extension_id');
-                $query->from('#__extensions');
-                $query->where($this->dbo->quoteName('element') . ' = ' . $this->dbo->q('com_proclaim'));
+                $query->select($this->dbo->qn('extension_id'));
+                $query->from($this->dbo->qn('#__extensions'));
+                $query->where($this->dbo->qn('element') . ' = ' . $this->dbo->q('com_proclaim'));
                 $this->dbo->setQuery($query);
                 $cid = (int) $this->dbo->loadResult();
 
@@ -479,7 +478,7 @@ class Cwmrestore
         $objects = self::getObjects();
 
         foreach ($objects as $object) {
-            $dropper = 'DROP TABLE IF EXISTS ' . $object['name'] . ';';
+            $dropper = 'DROP TABLE IF EXISTS ' . $db->qn($object['name']);
             $db->setQuery($dropper);
             $db->execute();
         }
@@ -598,7 +597,7 @@ class Cwmrestore
                 $query = $db->getQuery(true);
                 $query->update($db->quoteName($table))
                     ->set($db->quoteName('created_by') . ' = ' . (int) $currentUserId)
-                    ->where($db->quoteName('created_by') . ' NOT IN (SELECT id FROM #__users)')
+                    ->where($db->quoteName('created_by') . ' NOT IN (SELECT ' . $db->qn('id') . ' FROM ' . $db->qn('#__users') . ')')
                     ->where($db->quoteName('created_by') . ' != 0');
                 $db->setQuery($query);
                 $db->execute();
@@ -608,7 +607,7 @@ class Cwmrestore
                 $query = $db->getQuery(true);
                 $query->update($db->quoteName($table))
                     ->set($db->quoteName('modified_by') . ' = ' . (int) $currentUserId)
-                    ->where($db->quoteName('modified_by') . ' NOT IN (SELECT id FROM #__users)')
+                    ->where($db->quoteName('modified_by') . ' NOT IN (SELECT ' . $db->qn('id') . ' FROM ' . $db->qn('#__users') . ')')
                     ->where($db->quoteName('modified_by') . ' != 0');
                 $db->setQuery($query);
                 $db->execute();

--- a/admin/src/Lib/Cwmssconvert.php
+++ b/admin/src/Lib/Cwmssconvert.php
@@ -42,7 +42,7 @@ class Cwmssconvert
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__sermon_sermons');
+            ->from($db->qn('#__sermon_sermons'));
         $db->setQuery($query);
         $sermons = $db->loadObjectList();
 
@@ -50,7 +50,7 @@ class Cwmssconvert
 
         // Get a unique list of teacher ids
         $query = $db->getQuery(true);
-        $query->select('speaker_id, id, series_id')->from('#__sermon_sermons')->group('series_id');
+        $query->select($db->qn(['speaker_id', 'id', 'series_id']))->from($db->qn('#__sermon_sermons'))->group($db->qn('series_id'));
         $db->setQuery($query);
         $seriesspeakers = $db->loadObjectList();
 
@@ -71,9 +71,9 @@ class Cwmssconvert
 
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__bsms_servers')
-            ->where('published = 1')
-            ->order($db->qn('id') . ' desc');
+            ->from($db->qn('#__bsms_servers'))
+            ->where($db->qn('published') . ' = 1')
+            ->order($db->qn('id') . ' DESC');
         $db->setQuery($query, 0, 1);
         $server         = $db->loadAssoc();
         $this->serverid = $server['id'];
@@ -81,7 +81,7 @@ class Cwmssconvert
         // Make the teachers
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__sermon_speakers');
+            ->from($db->qn('#__sermon_speakers'));
         $db->setQuery($query);
 
         $teachers = $db->loadObjectList();
@@ -112,7 +112,7 @@ class Cwmssconvert
 
             // Get the last teacherid
             $query = $db->getQuery(true);
-            $query->select('id')->from('#__bsms_teachers')->order('id');
+            $query->select($db->qn('id'))->from($db->qn('#__bsms_teachers'))->order($db->qn('id'));
             $db->setQuery($query, 0, 1);
             $lastteacher = $db->loadResult();
 
@@ -127,7 +127,7 @@ class Cwmssconvert
         // Series Records
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__sermon_series');
+            ->from($db->qn('#__sermon_series'));
         $db->setQuery($query);
         $series = $db->loadObjectList();
 
@@ -170,7 +170,7 @@ class Cwmssconvert
                     $result_table .= '<tr><td>' . Text::_('JBS_IBM_ERROR_OCCURED_SS_SERIES') . '</td></tr>';
                 } else {
                     $query = $db->getQuery(true);
-                    $query->select('id')->from('#__bsms_studies')->order('id DESC');
+                    $query->select($db->qn('id'))->from($db->qn('#__bsms_studies'))->order($db->qn('id') . ' DESC');
                     $db->setQuery($query, 0, 1);
                     $lastseries = $db->loadResult();
 
@@ -191,22 +191,22 @@ class Cwmssconvert
 
         // Count the new numbers and report
         $query = $db->getQuery(true);
-        $query->select('COUNT(*)')->from('#__bsms_studies');
+        $query->select('COUNT(*)')->from($db->qn('#__bsms_studies'));
         $db->setQuery($query);
         $newstudies = $db->loadResult();
 
         $query = $db->getQuery(true);
-        $query->select('COUNT(*)')->from('#__bsms_teachers');
+        $query->select('COUNT(*)')->from($db->qn('#__bsms_teachers'));
         $db->setQuery($query);
         $newteachers = $db->loadResult();
 
         $query = $db->getQuery(true);
-        $query->select('COUNT(*)')->from('#__bsms_series');
+        $query->select('COUNT(*)')->from($db->qn('#__bsms_series'));
         $db->setQuery($query);
         $newseries = $db->loadResult();
 
         $query = $db->getQuery(true);
-        $query->select('COUNT(*)')->from('#__bsms_mediafiles');
+        $query->select('COUNT(*)')->from($db->qn('#__bsms_mediafiles'));
         $db->setQuery($query);
         $newmediafiles = $db->loadResult();
 
@@ -269,7 +269,7 @@ class Cwmssconvert
 
         $db->insertObject('#__bsms_studies', $data);
         $query = $db->getQuery(true);
-        $query->select('id')->from('#__bsms_studies')->order('id DESC');
+        $query->select($db->qn('id'))->from($db->qn('#__bsms_studies'))->order($db->qn('id') . ' DESC');
 
         $db->setQuery($query, 0, 1);
         $study              = $db->loadAssoc();

--- a/admin/src/Lib/Cwmstats.php
+++ b/admin/src/Lib/Cwmstats.php
@@ -373,7 +373,7 @@ class Cwmstats
             ->join('INNER', $db->quoteName('#__bsms_mediafiles', 'mf') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.published') . ' = 1')
             ->group($db->quoteName(['s.id', 's.studytitle', 's.studydate', 's.hits']))
-            ->order('added DESC');
+            ->order($db->qn('added') . ' DESC');
 
         $db->setQuery($query, 0, 10); // Get more to account for re-sorting if hits are included
         $results = $db->loadObjectList();

--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -186,7 +186,7 @@ class CwmadminModel extends AdminModel
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('*');
-        $query->from('#__bsms_mediafiles');
+        $query->from($db->qn('#__bsms_mediafiles'));
         $db->setQuery($query->__toString());
         $mediafiles = $db->loadObjectList();
 
@@ -310,8 +310,8 @@ class CwmadminModel extends AdminModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('extension_id')->from($db->qn('#__extensions'))
-            ->where('element = ' . $db->q('com_proclaim'));
+        $query->select($db->qn('extension_id'))->from($db->qn('#__extensions'))
+            ->where($db->qn('element') . ' = ' . $db->q('com_proclaim'));
         $db->setQuery($query);
         $result = $db->loadResult();
 
@@ -335,8 +335,8 @@ class CwmadminModel extends AdminModel
         $db              = Factory::getContainer()->get('DatabaseDriver');
         $query           = $db->getQuery(true);
         $extensionresult = $this->getExtentionId();
-        $query->select('version_id')->from($db->qn('#__schemas'))
-            ->where('extension_id = ' . $db->q($extensionresult));
+        $query->select($db->qn('version_id'))->from($db->qn('#__schemas'))
+            ->where($db->qn('extension_id') . ' = ' . $db->q($extensionresult));
         $db->setQuery($query);
 
         return $db->loadResult();
@@ -473,7 +473,7 @@ class CwmadminModel extends AdminModel
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('extension_id, name, element')->from('#__extensions');
+        $query->select($db->qn(['extension_id', 'name', 'element']))->from($db->qn('#__extensions'));
         $db->setQuery($query);
 
         return $db->loadObjectList();
@@ -514,9 +514,9 @@ class CwmadminModel extends AdminModel
         }
 
         $query = $db->getQuery(true);
-        $query->select('id, params')
-            ->from('#__bsms_mediafiles')
-            ->where('published = ' . $db->q('1'));
+        $query->select($db->qn(['id', 'params']))
+            ->from($db->qn('#__bsms_mediafiles'))
+            ->where($db->qn('published') . ' = ' . $db->q('1'));
         $db->setQuery($query);
 
         foreach ($db->loadObjectList() as $media) {
@@ -564,9 +564,9 @@ class CwmadminModel extends AdminModel
                 $reg->set('player', $to);
 
                 $query = $db->getQuery(true);
-                $query->update('#__bsms_mediafiles')
-                    ->set('params = ' . $db->q($reg->toString()))
-                    ->where('id = ' . (int)$media->id);
+                $query->update($db->qn('#__bsms_mediafiles'))
+                    ->set($db->qn('params') . ' = ' . $db->q($reg->toString()))
+                    ->where($db->qn('id') . ' = ' . (int)$media->id);
                 $db->setQuery($query);
 
                 if (!$db->execute()) {

--- a/admin/src/Model/CwmassetsModel.php
+++ b/admin/src/Model/CwmassetsModel.php
@@ -367,9 +367,15 @@ class CwmassetsModel extends ListModel
             // Put the table into the return array
             // Get the total number of rows and collect the table into a query
             $query = $db->getQuery(true);
-            $query->select('j.id as jid, j.asset_id as jasset_id, a.id as aid, a.rules as arules, a.parent_id')
-                ->from($db->qn($object['name']) . ' as j')
-                ->leftJoin('#__assets as a ON (a.id = j.asset_id)');
+            $query->select(
+                $db->qn('j.id', 'jid') . ', '
+                . $db->qn('j.asset_id', 'jasset_id') . ', '
+                . $db->qn('a.id', 'aid') . ', '
+                . $db->qn('a.rules', 'arules') . ', '
+                . $db->qn('a.parent_id')
+            )
+                ->from($db->qn($object['name'], 'j'))
+                ->leftJoin($db->qn('#__assets', 'a') . ' ON (' . $db->qn('a.id') . ' = ' . $db->qn('j.asset_id') . ')');
             $db->setQuery($query);
             $results     = $db->loadObjectList();
             $nullrows    = 0;

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -156,23 +156,39 @@ class CwmcommentsModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'comment.id, comment.published, comment.user_id, comment.full_name, comment.user_email, '
-                . 'comment.comment_date, comment.comment_text, comment.access, comment.language, comment.asset_id'
+                implode(', ', $db->qn(
+                    [
+                        'comment.id',
+                        'comment.published',
+                        'comment.user_id',
+                        'comment.full_name',
+                        'comment.user_email',
+                        'comment.comment_date',
+                        'comment.comment_text',
+                        'comment.access',
+                        'comment.language',
+                        'comment.asset_id',
+                    ]
+                ))
             )
         );
-        $query->from('#__bsms_comments AS comment');
+        $query->from($db->qn('#__bsms_comments', 'comment'));
 
         // Join over the language
-        $query->select('l.title AS language_title, l.image AS language_image');
-        $query->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = comment.language');
+        $query->select($db->qn('l.title', 'language_title'));
+        $query->select($db->qn('l.image', 'language_image'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__languages', 'l') . ' ON ' . $db->qn('l.lang_code') . ' = ' . $db->qn('comment.language')
+        );
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('comment.published = ' . (int)$published);
+            $query->where($db->qn('comment.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(comment.published = 0 OR comment.published = 1)');
+            $query->where('(' . $db->qn('comment.published') . ' = 0 OR ' . $db->qn('comment.published') . ' = 1)');
         }
 
         // Filter by search in title.
@@ -180,24 +196,36 @@ class CwmcommentsModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('comment.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('comment.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('(study.studytitle LIKE ' . $search . ' OR book.bookname LIKE ' . $search . ')');
+                $query->where('(' . $db->qn('study.studytitle') . ' LIKE ' . $search . ' OR ' . $db->qn('book.bookname') . ' LIKE ' . $search . ')');
             }
         }
 
         // Join over Studies
-        $query->select('study.studytitle AS studytitle, study.chapter_begin, study.studydate, study.booknumber');
-        $query->join('LEFT', '#__bsms_studies AS study ON study.id = comment.study_id');
+        $query->select($db->qn('study.studytitle', 'studytitle'));
+        $query->select($db->qn('study.chapter_begin'));
+        $query->select($db->qn('study.studydate'));
+        $query->select($db->qn('study.booknumber'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.id') . ' = ' . $db->qn('comment.study_id')
+        );
 
         // Join over books
-        $query->select('book.bookname as bookname');
-        $query->join('LEFT', '#__bsms_books as book ON book.booknumber = study.booknumber');
+        $query->select($db->qn('book.bookname', 'bookname'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_books', 'book') . ' ON ' . $db->qn('book.booknumber') . ' = ' . $db->qn('study.booknumber')
+        );
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level');
-        $query->join('LEFT', '#__viewlevels AS ag ON ag.id = comment.access');
+        $query->select($db->qn('ag.title', 'access_level'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('comment.access')
+        );
 
         // Add the list ordering clause
         $orderCol  = $this->state->get('list.ordering', 'study.studytitle');

--- a/admin/src/Model/CwmcpanelModel.php
+++ b/admin/src/Model/CwmcpanelModel.php
@@ -40,7 +40,7 @@ class CwmcpanelModel extends BaseModel
         $return = new \stdClass();
         $query  = $db->getQuery(true);
         $query->select('*');
-        $query->from('#__extensions');
+        $query->from($db->qn('#__extensions'));
         $query->where($db->qn('element') . ' = ' . $db->q('com_proclaim'))
             ->where($db->qn('type') . ' = ' . $db->q('component'));
         $db->setQuery($query);
@@ -85,8 +85,8 @@ class CwmcpanelModel extends BaseModel
         // Get the extension ID for our component
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('extension_id')
-            ->from('#__extensions')
+        $query->select($db->qn('extension_id'))
+            ->from($db->qn('#__extensions'))
             ->where($db->qn('element') . ' = ' . $db->q('com_proclaim'));
         $db->setQuery($query);
 

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -299,8 +299,8 @@ class CwminstallModel extends ListModel
             // Find Extension ID of Proclaim
             $query = $this->getDatabase()->getQuery(true);
             $query
-                ->select('extension_id')
-                ->from('#__extensions')
+                ->select($this->getDatabase()->qn('extension_id'))
+                ->from($this->getDatabase()->qn('#__extensions'))
                 ->where($this->getDatabase()->qn('name') . ' = ' . $this->getDatabase()->q('com_proclaim'));
             $this->getDatabase()->setQuery($query);
             $eid                 = $this->getDatabase()->loadResult();
@@ -371,8 +371,8 @@ class CwminstallModel extends ListModel
             $query = $this->getDatabase()->getQuery(true);
             $query
                 ->delete()
-                ->from('#__schemas')
-                ->where('extension_id = ' . $eid);
+                ->from($this->getDatabase()->qn('#__schemas'))
+                ->where($this->getDatabase()->qn('extension_id') . ' = ' . (int) $eid);
             $this->getDatabase()->setQuery($query);
 
             if ($this->getDatabase()->execute()) {
@@ -412,7 +412,7 @@ class CwminstallModel extends ListModel
         // (from 10.0.0 era). Preserve messages managed by CwmguidedtourHelper which use
         // proper language keys (COM_PROCLAIM_*) and should retain their enabled/hidden state.
         $query = $this->getDatabase()->getQuery(true);
-        $query->delete('#__postinstall_messages')
+        $query->delete($this->getDatabase()->qn('#__postinstall_messages'))
             ->where($this->getDatabase()->qn('language_extension') . ' = ' . $this->getDatabase()->q('com_proclaim'))
             ->where($this->getDatabase()->qn('title_key') . ' NOT LIKE ' . $this->getDatabase()->q('COM_PROCLAIM_%'));
         $this->getDatabase()->setQuery($query);
@@ -967,8 +967,8 @@ class CwminstallModel extends ListModel
                 // Find Extension ID of component
                 $query = $this->getDatabase()->getQuery(true);
                 $query
-                    ->select('extension_id')
-                    ->from('#__extensions')
+                    ->select($this->getDatabase()->qn('extension_id'))
+                    ->from($this->getDatabase()->qn('#__extensions'))
                     ->where($this->getDatabase()->qn('name') . ' = ' . $this->getDatabase()->q('com_proclaim'));
                 $this->getDatabase()->setQuery($query);
                 $eid = $this->getDatabase()->loadResult();
@@ -1056,8 +1056,8 @@ class CwminstallModel extends ListModel
         // Find the Last updated Version in the Update table
         $query = $this->getDatabase()->getQuery(true);
         $query
-            ->select('version')
-            ->from('#__bsms_update');
+            ->select($this->getDatabase()->qn('version'))
+            ->from($this->getDatabase()->qn('#__bsms_update'));
         $this->getDatabase()->setQuery($query);
         $updates = $this->getDatabase()->loadObjectList();
 
@@ -1088,8 +1088,8 @@ class CwminstallModel extends ListModel
         if ($this->getDatabase()->loadResult()) {
             $query = $this->getDatabase()->getQuery(true);
             $query->select('*')
-                ->from('#__bsms_admin')
-                ->where('id = 1');
+                ->from($this->getDatabase()->qn('#__bsms_admin'))
+                ->where($this->getDatabase()->qn('id') . ' = 1');
             $this->getDatabase()->setQuery($query);
             $adminsettings = $this->getDatabase()->loadObject();
             $drop_tables   = $adminsettings->drop_tables;
@@ -1097,27 +1097,27 @@ class CwminstallModel extends ListModel
             if ($drop_tables > 0) {
                 // We must remove the assets manually each time
                 $query = $this->getDatabase()->getQuery(true);
-                $query->select('id')
-                    ->from('#__assets')
-                    ->where('name = ' . $this->getDatabase()->q(BIBLESTUDY_COMPONENT_NAME));
+                $query->select($this->getDatabase()->qn('id'))
+                    ->from($this->getDatabase()->qn('#__assets'))
+                    ->where($this->getDatabase()->qn('name') . ' = ' . $this->getDatabase()->q(BIBLESTUDY_COMPONENT_NAME));
                 $this->getDatabase()->setQuery($query);
                 $parent_id = $this->getDatabase()->loadResult();
                 $query     = $this->getDatabase()->getQuery(true);
 
                 if ($parent_id !== '0') {
                     $query->delete()
-                        ->from('#__assets')
-                        ->where('parent_id = ' . $this->getDatabase()->q($parent_id))
-                        ->where('name != ' . $this->getDatabase()->q('root.1'));
+                        ->from($this->getDatabase()->qn('#__assets'))
+                        ->where($this->getDatabase()->qn('parent_id') . ' = ' . $this->getDatabase()->q($parent_id))
+                        ->where($this->getDatabase()->qn('name') . ' != ' . $this->getDatabase()->q('root.1'));
                     $this->getDatabase()->setQuery($query);
                     $this->getDatabase()->execute();
                 }
 
                 $query = $this->getDatabase()->getQuery(true);
                 $query->delete()
-                    ->from('#__assets')
-                    ->where('name LIKE ' . $this->getDatabase()->q(BIBLESTUDY_COMPONENT_NAME))
-                    ->where('name != ' . $this->getDatabase()->q('root.1'));
+                    ->from($this->getDatabase()->qn('#__assets'))
+                    ->where($this->getDatabase()->qn('name') . ' LIKE ' . $this->getDatabase()->q(BIBLESTUDY_COMPONENT_NAME))
+                    ->where($this->getDatabase()->qn('name') . ' != ' . $this->getDatabase()->q('root.1'));
                 $this->getDatabase()->setQuery($query);
                 $this->getDatabase()->execute();
                 $buffer = file_get_contents(
@@ -1147,7 +1147,7 @@ class CwminstallModel extends ListModel
 
         // Post Install Messages Cleanup for Component
         $query = $this->getDatabase()->getQuery(true);
-        $query->delete('#__postinstall_messages')
+        $query->delete($this->getDatabase()->qn('#__postinstall_messages'))
             ->where($this->getDatabase()->qn('language_extension') . ' = ' . $this->getDatabase()->q('com_proclaim'));
         $this->getDatabase()->setQuery($query);
         $this->getDatabase()->execute();

--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -76,9 +76,11 @@ class CwmlocationsModel extends ListModel
     public function getDeletes(): array
     {
         if (empty($this->deletes)) {
-            $query         = 'SELECT allow_deletes'
-                . ' FROM #__bsms_admin'
-                . ' WHERE id = 1';
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query->select($db->qn('allow_deletes'))
+                ->from($db->qn('#__bsms_admin'))
+                ->where($db->qn('id') . ' = 1');
             $this->deletes = $this->_getList($query);
         }
 
@@ -194,24 +196,27 @@ class CwmlocationsModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'location.id, location.published, location.access, location.location_text'
+                implode(', ', $db->qn(['location.id', 'location.published', 'location.access', 'location.location_text']))
             )
         );
-        $query->from('`#__bsms_locations` AS location');
+        $query->from($db->qn('#__bsms_locations', 'location'));
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level');
-        $query->join('LEFT', '#__viewlevels AS ag ON ag.id = location.access');
+        $query->select($db->qn('ag.title', 'access_level'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('location.access')
+        );
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
-            $query->where('location.access = ' . (int)$access);
+            $query->where($db->qn('location.access') . ' = ' . (int) $access);
         }
 
         // Implement View Level Access
         if (!$user->authorise('core.cwmadmin')) {
             $groups = implode(',', $user->getAuthorisedViewLevels());
-            $query->where('location.access IN (' . $groups . ')');
+            $query->where($db->qn('location.access') . ' IN (' . $groups . ')');
         }
 
         // Filter by search in title.
@@ -219,10 +224,10 @@ class CwmlocationsModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('location.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('location.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('location.location_text LIKE ' . $search);
+                $query->where($db->qn('location.location_text') . ' LIKE ' . $search);
             }
         }
 
@@ -230,9 +235,9 @@ class CwmlocationsModel extends ListModel
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('location.published = ' . (int)$published);
+            $query->where($db->qn('location.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(location.published = 0 OR location.published = 1)');
+            $query->where('(' . $db->qn('location.published') . ' = 0 OR ' . $db->qn('location.published') . ' = 1)');
         }
 
         // Add the list ordering clause

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -95,7 +95,9 @@ class CwmmediafileModel extends AdminModel
             return false;
         }
 
-        if (!$row->move($direction, ' study_id = ' . (int)$row->study_id . ' AND published >= 0 ')) {
+        $db = Factory::getContainer()->get('DatabaseDriver');
+
+        if (!$row->move($direction, $db->qn('study_id') . ' = ' . (int)$row->study_id . ' AND ' . $db->qn('published') . ' >= 0')) {
             return false;
         }
 
@@ -969,7 +971,7 @@ class CwmmediafileModel extends AdminModel
             if (empty($table->ordering)) {
                 $db    = Factory::getContainer()->get('DatabaseDriver');
                 $query = $db->getQuery(true);
-                $query->select('MAX(ordering)')->from('#__bsms_mediafiles');
+                $query->select('MAX(' . $db->qn('ordering') . ')')->from($db->qn('#__bsms_mediafiles'));
                 $db->setQuery($query);
                 $max = $db->loadResult();
 
@@ -1025,8 +1027,9 @@ class CwmmediafileModel extends AdminModel
      */
     protected function getReorderConditions($table): array
     {
+        $db          = Factory::getContainer()->get('DatabaseDriver');
         $condition   = [];
-        $condition[] = 'study_id = ' . (int)$table->study_id;
+        $condition[] = $db->qn('study_id') . ' = ' . (int)$table->study_id;
 
         return $condition;
     }

--- a/admin/src/Model/CwmmediafilesModel.php
+++ b/admin/src/Model/CwmmediafilesModel.php
@@ -148,9 +148,11 @@ class CwmmediafilesModel extends ListModel
     public function getDeletes(): array
     {
         if (empty($this->deletes)) {
-            $query         = 'SELECT allow_deletes'
-                . ' FROM #__bsms_admin'
-                . ' WHERE id = 1';
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true);
+            $query->select($db->qn('allow_deletes'))
+                ->from($db->qn('#__bsms_admin'))
+                ->where($db->qn('id') . ' = 1');
             $this->deletes = $this->_getList($query);
         }
 
@@ -249,31 +251,46 @@ class CwmmediafilesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'mediafile.* '
+                $db->qn('mediafile') . '.*'
             )
         );
 
-        $query->from('#__bsms_mediafiles AS mediafile');
+        $query->from($db->qn('#__bsms_mediafiles', 'mediafile'));
 
         // Join over the language
-        $query->select('l.title AS language_title');
-        $query->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = mediafile.language');
+        $query->select($db->qn('l.title', 'language_title'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__languages', 'l') . ' ON ' . $db->qn('l.lang_code') . ' = ' . $db->qn('mediafile.language')
+        );
 
         // Join over the studies
-        $query->select('study.studytitle AS studytitle');
-        $query->join('LEFT', '#__bsms_studies AS study ON study.id = mediafile.study_id');
+        $query->select($db->qn('study.studytitle', 'studytitle'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_studies', 'study') . ' ON ' . $db->qn('study.id') . ' = ' . $db->qn('mediafile.study_id')
+        );
 
         // Join over servers
-        $query->select('server.type as serverType');
-        $query->join('LEFT', '#__bsms_servers as server ON server.id = mediafile.server_id');
+        $query->select($db->qn('server.type', 'serverType'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_servers', 'server') . ' ON ' . $db->qn('server.id') . ' = ' . $db->qn('mediafile.server_id')
+        );
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level');
-        $query->join('LEFT', '#__viewlevels AS ag ON ag.id = mediafile.access');
+        $query->select($db->qn('ag.title', 'access_level'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('mediafile.access')
+        );
 
         // Join over the users for the checked out user.
-        $query->select('uc.name AS editor')
-            ->join('LEFT', '#__users AS uc ON uc.id=mediafile.checked_out');
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join(
+                'LEFT',
+                $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('mediafile.checked_out')
+            );
 
         // Filter by published state
         $published = (string) $this->getState('filter.published');
@@ -315,7 +332,7 @@ class CwmmediafilesModel extends ListModel
         $mediaYears = $this->getState('filter.mediaYears');
 
         if (!empty($mediaYears)) {
-            $query->where('YEAR(mediafile.createdate) = ' . (int)$mediaYears);
+            $query->where('YEAR(' . $db->qn('mediafile.createdate') . ') = ' . (int) $mediaYears);
         }
 
         // Filter by search in title.

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -81,7 +81,7 @@ class CwmmessageModel extends AdminModel
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('*')
-            ->from('#__bsms_studytopics')
+            ->from($db->qn('#__bsms_studytopics'))
             ->where($db->qn('study_id') . ' = ' . (int) $study_id)
             ->where($db->qn('topic_id') . ' = ' . (int) $topic_id);
         $db->setQuery($query);
@@ -117,11 +117,11 @@ class CwmmessageModel extends AdminModel
             $db    = Factory::getContainer()->get('DatabaseDriver');
             $query = $db->getQuery(true);
 
-            $query->select('topic.id, topic.topic_text, topic.params AS topic_params');
-            $query->from('#__bsms_studytopics AS studytopics');
+            $query->select($db->qn('topic.id') . ', ' . $db->qn('topic.topic_text') . ', ' . $db->qn('topic.params', 'topic_params'));
+            $query->from($db->qn('#__bsms_studytopics', 'studytopics'));
 
-            $query->join('LEFT', '#__bsms_topics AS topic ON topic.id = studytopics.topic_id');
-            $query->where('studytopics.study_id = ' . (int)$id);
+            $query->join('LEFT', $db->qn('#__bsms_topics', 'topic') . ' ON ' . $db->qn('topic.id') . ' = ' . $db->qn('studytopics.topic_id'));
+            $query->where($db->qn('studytopics.study_id') . ' = ' . (int)$id);
 
             $db->setQuery($query->__toString());
             $topics = $db->loadObjectList();
@@ -153,8 +153,8 @@ class CwmmessageModel extends AdminModel
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
 
-        $query->select('topic.id, topic.topic_text, topic.params AS topic_params');
-        $query->from('#__bsms_topics AS topic');
+        $query->select($db->qn('topic.id') . ', ' . $db->qn('topic.topic_text') . ', ' . $db->qn('topic.params', 'topic_params'));
+        $query->from($db->qn('#__bsms_topics', 'topic'));
 
         $db->setQuery($query->__toString());
         $topics         = $db->loadObjectList();
@@ -185,15 +185,19 @@ class CwmmessageModel extends AdminModel
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
 
-        $query->select('m.id, m.language, m.published, m.createdate, m.params, m.access');
-        $query->from('#__bsms_mediafiles AS m');
+        $query->select(
+            $db->qn(
+                ['m.id', 'm.language', 'm.published', 'm.createdate', 'm.params', 'm.access']
+            )
+        );
+        $query->from($db->qn('#__bsms_mediafiles', 'm'));
         $query->where($db->qn('m.study_id') . ' = ' . (int) $this->getItem()->id);
         $query->where('(' . $db->qn('m.published') . ' = 0 OR ' . $db->qn('m.published') . ' = 1)');
-        $query->order('m.createdate DESC');
+        $query->order($db->qn('m.createdate') . ' DESC');
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level');
-        $query->join('LEFT', '#__viewlevels AS ag ON ag.id = m.access');
+        $query->select($db->qn('ag.title', 'access_level'));
+        $query->join('LEFT', $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('m.access'));
 
         $db->setQuery($query->__toString());
         $mediafiles = $db->loadObjectList();
@@ -683,8 +687,8 @@ class CwmmessageModel extends AdminModel
             if (empty($table->ordering)) {
                 $db    = Factory::getContainer()->get('DatabaseDriver');
                 $query = $db->getQuery(true)
-                    ->select('MAX(ordering)')
-                    ->from($db->quoteName('#__bsms_studies'));
+                    ->select('MAX(' . $db->qn('ordering') . ')')
+                    ->from($db->qn('#__bsms_studies'));
                 $db->setQuery($query);
                 $max = $db->loadResult();
 

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -208,85 +208,120 @@ class CwmmessagesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'study.id, study.published, study.studydate, study.studytitle, study.ordering, study.hits, study.alias' .
-                ', study.language, study.access, study.publish_up, study.publish_down, study.params'
+                implode(', ', $db->qn(
+                    [
+                        'study.id',
+                        'study.published',
+                        'study.studydate',
+                        'study.studytitle',
+                        'study.ordering',
+                        'study.hits',
+                        'study.alias',
+                        'study.language',
+                        'study.access',
+                        'study.publish_up',
+                        'study.publish_down',
+                        'study.params',
+                    ]
+                ))
             )
         );
-        $query->from('#__bsms_studies AS study');
+        $query->from($db->qn('#__bsms_studies', 'study'));
 
         // Join over the language
-        $query->select('l.title AS language_title');
-        $query->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = study.language');
+        $query->select($db->qn('l.title', 'language_title'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__languages', 'l') . ' ON ' . $db->qn('l.lang_code') . ' = ' . $db->qn('study.language')
+        );
 
         // Join over Message Types
-        $query->select('messageType.message_type AS messageType');
-        $query->join('LEFT', '#__bsms_message_type AS messageType ON messageType.id = study.messagetype');
+        $query->select($db->qn('messageType.message_type', 'messageType'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_message_type', 'messageType') . ' ON ' . $db->qn('messageType.id') . ' = ' . $db->qn('study.messagetype')
+        );
 
         // Join over Teachers
-        $query->select('teacher.teachername AS teachername');
-        $query->join('LEFT', '#__bsms_teachers AS teacher ON teacher.id = study.teacher_id');
+        $query->select($db->qn('teacher.teachername', 'teachername'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_teachers', 'teacher') . ' ON ' . $db->qn('teacher.id') . ' = ' . $db->qn('study.teacher_id')
+        );
 
         // Join over Series
-        $query->select('series.series_text, series.id AS series_id');
-        $query->join('LEFT', '#__bsms_series AS series ON series.id = study.series_id');
+        $query->select($db->qn('series.series_text'));
+        $query->select($db->qn('series.id', 'series_id'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_series', 'series') . ' ON ' . $db->qn('series.id') . ' = ' . $db->qn('study.series_id')
+        );
 
         // Join over Location
-        $query->select('locations.location_text');
-        $query->join('LEFT', '#__bsms_locations AS locations ON locations.id = study.location_id');
+        $query->select($db->qn('locations.location_text'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_locations', 'locations') . ' ON ' . $db->qn('locations.id') . ' = ' . $db->qn('study.location_id')
+        );
 
         // Join over Plays/Downloads
         $query->select(
-            'SUM(mediafile.plays) AS totalplays, SUM(mediafile.downloads) as totaldownloads, mediafile.study_id'
+            'SUM(' . $db->qn('mediafile.plays') . ') AS ' . $db->qn('totalplays')
+            . ', SUM(' . $db->qn('mediafile.downloads') . ') AS ' . $db->qn('totaldownloads')
+            . ', ' . $db->qn('mediafile.study_id')
         );
-        $query->join('LEFT', '#__bsms_mediafiles AS mediafile ON mediafile.study_id = study.id');
-        $query->group('study.id');
+        $query->join(
+            'LEFT',
+            $db->qn('#__bsms_mediafiles', 'mediafile') . ' ON ' . $db->qn('mediafile.study_id') . ' = ' . $db->qn('study.id')
+        );
+        $query->group($db->qn('study.id'));
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
-            $query->where('study.access = ' . (int)$access);
+            $query->where($db->qn('study.access') . ' = ' . (int) $access);
         }
 
         // Implement View Level Access
         if (!$user->authorise('core.cwmadmin')) {
             $groups = implode(',', $user->getAuthorisedViewLevels());
-            $query->where('study.access IN (' . $groups . ')');
+            $query->where($db->qn('study.access') . ' IN (' . $groups . ')');
         }
 
         // Filter by teacher
         $teacher = $this->getState('filter.teacher');
 
         if (is_numeric($teacher)) {
-            $query->where('study.teacher_id = ' . (int)$teacher);
+            $query->where($db->qn('study.teacher_id') . ' = ' . (int) $teacher);
         }
 
         // Filter by series
         $series = $this->getState('filter.series');
 
         if (is_numeric($series)) {
-            $query->where('study.series_id = ' . (int)$series);
+            $query->where($db->qn('study.series_id') . ' = ' . (int) $series);
         }
 
         // Filter by message type
         $messageType = $this->getState('filter.messageType');
 
         if (is_numeric($messageType)) {
-            $query->where('study.messageType = ' . (int)$messageType);
+            $query->where($db->qn('study.messageType') . ' = ' . (int) $messageType);
         }
 
         // Filter by Year
         $year = $this->getState('filter.year');
 
         if (!empty($year)) {
-            $query->where('YEAR(study.studydate) = ' . (int)$year);
+            $query->where('YEAR(' . $db->qn('study.studydate') . ') = ' . (int) $year);
         }
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('study.published = ' . (int)$published);
+            $query->where($db->qn('study.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(study.published = 0 OR study.published = 1 OR study.published = 2)');
+            $query->where('(' . $db->qn('study.published') . ' = 0 OR ' . $db->qn('study.published') . ' = 1 OR ' . $db->qn('study.published') . ' = 2)');
         }
 
         // Filter by search in title.
@@ -294,11 +329,11 @@ class CwmmessagesModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('study.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('study.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = '%' . str_replace(' ', '%', trim($search)) . '%';
                 $query->where(
-                    '(' . $db->quoteName('study.studytitle') . ' LIKE :search1 OR ' . $db->quoteName('study.alias') . ' LIKE :search2)'
+                    '(' . $db->qn('study.studytitle') . ' LIKE :search1 OR ' . $db->qn('study.alias') . ' LIKE :search2)'
                 )
                     ->bind([':search1', ':search2'], $search);
             }
@@ -308,7 +343,7 @@ class CwmmessagesModel extends ListModel
         $location = $this->getState('filter.location');
 
         if (is_numeric($location)) {
-            $query->where('study.location_id = ' . (int)$location);
+            $query->where($db->qn('study.location_id') . ' = ' . (int) $location);
         }
 
         // Add the list ordering clause

--- a/admin/src/Model/CwmmessagetypeModel.php
+++ b/admin/src/Model/CwmmessagetypeModel.php
@@ -138,7 +138,7 @@ class CwmmessagetypeModel extends AdminModel
             if (empty($table->ordering)) {
                 $db    = Factory::getContainer()->get('DatabaseDriver');
                 $query = $db->getQuery(true);
-                $query->select('MAX(ordering)')->from('#__bsms_message_type');
+                $query->select('MAX(' . $db->qn('ordering') . ')')->from($db->qn('#__bsms_message_type'));
                 $db->setQuery($query);
                 $max = $db->loadResult();
 

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -74,9 +74,11 @@ class CwmmessagetypesModel extends ListModel
     public function getDeletes(): array
     {
         if (empty($this->deletes)) {
-            $query         = 'SELECT allowdeletes'
-                . ' FROM #__bsms_admin'
-                . ' WHERE id = 1';
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query->select($db->qn('allowdeletes'))
+                ->from($db->qn('#__bsms_admin'))
+                ->where($db->qn('id') . ' = 1');
             $this->deletes = $this->_getList($query);
         }
 
@@ -192,25 +194,33 @@ class CwmmessagetypesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'messagetype.id, messagetype.published, messagetype.message_type, ' .
-                'messagetype.ordering, messagetype.access, messagetype.alias'
+                implode(', ', $db->qn(
+                    [
+                        'messagetype.id',
+                        'messagetype.published',
+                        'messagetype.message_type',
+                        'messagetype.ordering',
+                        'messagetype.access',
+                        'messagetype.alias',
+                    ]
+                ))
             )
         );
 
-        $query->from('#__bsms_message_type AS messagetype');
+        $query->from($db->qn('#__bsms_message_type', 'messagetype'));
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
-            $query->where('messagetype.access = ' . (int)$access);
+            $query->where($db->qn('messagetype.access') . ' = ' . (int) $access);
         }
 
         // Implement View Level Access
         if (!$user->authorise('core.cwmadmin')) {
             $groups = implode(',', $user->getAuthorisedViewLevels());
-            $query->where('messagetype.access IN (' . $groups . ')');
+            $query->where($db->qn('messagetype.access') . ' IN (' . $groups . ')');
         }
 
         // Filter by search in title.
@@ -218,17 +228,17 @@ class CwmmessagetypesModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('messagetype.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('messagetype.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('messagetype.message_type LIKE ' . $search);
+                $query->where($db->qn('messagetype.message_type') . ' LIKE ' . $search);
             }
         }
 
         if (is_numeric($published)) {
-            $query->where('messagetype.published = ' . (int)$published);
+            $query->where($db->qn('messagetype.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(messagetype.published = 0 OR messagetype.published = 1)');
+            $query->where('(' . $db->qn('messagetype.published') . ' = 0 OR ' . $db->qn('messagetype.published') . ' = 1)');
         }
 
         // Add the list ordering clause.

--- a/admin/src/Model/CwmpodcastsModel.php
+++ b/admin/src/Model/CwmpodcastsModel.php
@@ -149,42 +149,58 @@ class CwmpodcastsModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'podcast.id, podcast.published, podcast.title, podcast.description, podcast.filename, podcast.language, podcast.access'
+                implode(', ', $db->qn(
+                    [
+                        'podcast.id',
+                        'podcast.published',
+                        'podcast.title',
+                        'podcast.description',
+                        'podcast.filename',
+                        'podcast.language',
+                        'podcast.access',
+                    ]
+                ))
             )
         );
-        $query->from('#__bsms_podcast AS podcast');
+        $query->from($db->qn('#__bsms_podcast', 'podcast'));
 
         // Join over the language
-        $query->select('l.title AS language_title');
-        $query->join('LEFT', $db->qn('#__languages') . ' AS l ON l.lang_code = podcast.language');
+        $query->select($db->qn('l.title', 'language_title'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__languages', 'l') . ' ON ' . $db->qn('l.lang_code') . ' = ' . $db->qn('podcast.language')
+        );
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level')
-            ->join('LEFT', '#__viewlevels AS ag ON ag.id = podcast.access');
+        $query->select($db->qn('ag.title', 'access_level'))
+            ->join(
+                'LEFT',
+                $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('podcast.access')
+            );
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
-            $query->where('podcast.access = ' . (int)$access);
+            $query->where($db->qn('podcast.access') . ' = ' . (int) $access);
         }
 
         // Implement View Level Access
         if (!$user->authorise('core.cwmadmin')) {
             $groups = implode(',', $user->getAuthorisedViewLevels());
-            $query->where('podcast.access IN (' . $groups . ')');
+            $query->where($db->qn('podcast.access') . ' IN (' . $groups . ')');
         }
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('podcast.published = ' . (int)$published);
+            $query->where($db->qn('podcast.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(podcast.published = 0 OR podcast.published = 1)');
+            $query->where('(' . $db->qn('podcast.published') . ' = 0 OR ' . $db->qn('podcast.published') . ' = 1)');
         }
 
         // Filter on the language.
         if ($language = $this->getState('filter.language')) {
-            $query->where('podcast.language = ' . $db->quote($language));
+            $query->where($db->qn('podcast.language') . ' = ' . $db->quote($language));
         }
 
         // Filter by search in filename or study title
@@ -192,10 +208,10 @@ class CwmpodcastsModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('podcast.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('podcast.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('(podcast.title LIKE ' . $search . ' OR podcast.description LIKE ' . $search . ')');
+                $query->where('(' . $db->qn('podcast.title') . ' LIKE ' . $search . ' OR ' . $db->qn('podcast.description') . ' LIKE ' . $search . ')');
             }
         }
 

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -151,9 +151,11 @@ class CwmserieModel extends AdminModel
     public function getTeacher(): mixed
     {
         if (empty($this->teacher)) {
-            $query         = 'SELECT id AS value, teachername AS text'
-                . ' FROM #__bsms_teachers'
-                . ' WHERE published = 1';
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true)
+                ->select($db->qn('id', 'value') . ', ' . $db->qn('teachername', 'text'))
+                ->from($db->qn('#__bsms_teachers'))
+                ->where($db->qn('published') . ' = 1');
             $this->teacher = $this->_getList($query);
         }
 
@@ -466,7 +468,7 @@ class CwmserieModel extends AdminModel
             if (empty($table->ordering)) {
                 $db    = Factory::getContainer()->get('DatabaseDriver');
                 $query = $db->getQuery(true);
-                $query->select('MAX(ordering)')->from('#__bsms_series');
+                $query->select('MAX(' . $db->qn('ordering') . ')')->from($db->qn('#__bsms_series'));
                 $db->setQuery($query);
                 $max = $db->loadResult();
 
@@ -480,7 +482,8 @@ class CwmserieModel extends AdminModel
 
         if ($table->ordering == 0) {
             $table->ordering = 1;
-            $table->reorder('id = ' . (int)$table->id);
+            $db = Factory::getContainer()->get('DatabaseDriver');
+            $table->reorder($db->qn('id') . ' = ' . (int)$table->id);
         }
     }
 

--- a/admin/src/Model/CwmseriesModel.php
+++ b/admin/src/Model/CwmseriesModel.php
@@ -160,7 +160,7 @@ class CwmseriesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                [
+                implode(', ', [
                     $db->quoteName('series.id'),
                     $db->quoteName('series.series_text'),
                     $db->quoteName('series.published'),
@@ -168,7 +168,7 @@ class CwmseriesModel extends ListModel
                     $db->quoteName('series.language'),
                     $db->quoteName('series.access'),
                     $db->quoteName('series.ordering'),
-                ]
+                ])
             )
         )
             ->select(

--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -220,9 +220,9 @@ class CwmserverModel extends AdminModel
 
         if (!empty($data) && !empty($data['id'])) {
             $query = $db->getQuery(true);
-            $query->select('id, params')
-                ->from('#__bsms_mediafiles')
-                ->where($db->quoteName('server_id') . ' = :serverId')
+            $query->select($db->qn(['id', 'params']))
+                ->from($db->qn('#__bsms_mediafiles'))
+                ->where($db->qn('server_id') . ' = :serverId')
                 ->bind(':serverId', $data['id'], \Joomla\Database\ParameterType::INTEGER);
             $db->setQuery($query);
             $studies = $db->loadObjectList();

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -234,10 +234,10 @@ class CwmteacherModel extends AdminModel
 
         if (!empty($record) && $this->getState('task') === 'trash') {
             $query = $db->getQuery(true);
-            $query->select('id, studytitle')
-                ->from('#__bsms_studies')
-                ->where('teacher_id = ' . $record->id)
-                ->where('published != ' . $db->q('-2'));
+            $query->select($db->qn(['id', 'studytitle']))
+                ->from($db->qn('#__bsms_studies'))
+                ->where($db->qn('teacher_id') . ' = ' . (int) $record->id)
+                ->where($db->qn('published') . ' != ' . $db->q('-2'));
             $db->setQuery($query, 10);
             $studies = $db->loadObjectList();
 
@@ -366,9 +366,9 @@ class CwmteacherModel extends AdminModel
 
         // Iterate the items to delete each one.
         $query = $db->getQuery(true);
-        $query->select('id, studytitle')
-            ->from('#__bsms_studies')
-            ->where('teacher_id = ' . $record->id);
+        $query->select($db->qn(['id', 'studytitle']))
+            ->from($db->qn('#__bsms_studies'))
+            ->where($db->qn('teacher_id') . ' = ' . (int) $record->id);
         $db->setQuery($query);
         $studies = $db->loadObjectList();
 
@@ -440,7 +440,7 @@ class CwmteacherModel extends AdminModel
             if (empty($table->ordering)) {
                 $db    = Factory::getContainer()->get('DatabaseDriver');
                 $query = $db->getQuery(true);
-                $query->select('MAX(ordering)')->from('#__bsms_teachers');
+                $query->select('MAX(' . $db->qn('ordering') . ')')->from($db->qn('#__bsms_teachers'));
                 $db->setQuery($query);
                 $max = $db->loadResult();
 

--- a/admin/src/Model/CwmteachersModel.php
+++ b/admin/src/Model/CwmteachersModel.php
@@ -149,35 +149,41 @@ class CwmteachersModel extends ListModel
         $query = $db->getQuery(true);
         $user  = Factory::getApplication()->getIdentity();
 
-        $query->select($this->getState('list.select', 'teacher.*'));
-        $query->from('#__bsms_teachers AS teacher');
+        $query->select($this->getState('list.select', $db->qn('teacher') . '.*'));
+        $query->from($db->qn('#__bsms_teachers', 'teacher'));
 
         // Join over the language
-        $query->select('l.title AS language_title');
-        $query->join('LEFT', '`#__languages` AS l ON l.lang_code = teacher.language');
+        $query->select($db->qn('l.title', 'language_title'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__languages', 'l') . ' ON ' . $db->qn('l.lang_code') . ' = ' . $db->qn('teacher.language')
+        );
 
         // Join over the asset groups.
-        $query->select('ag.title AS access_level');
-        $query->join('LEFT', '#__viewlevels AS ag ON ag.id = teacher.access');
+        $query->select($db->qn('ag.title', 'access_level'));
+        $query->join(
+            'LEFT',
+            $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('teacher.access')
+        );
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
-            $query->where('teacher.access = ' . (int)$access);
+            $query->where($db->qn('teacher.access') . ' = ' . (int) $access);
         }
 
         // Implement View Level Access
         if (!$user->authorise('core.cwmadmin')) {
             $groups = implode(',', $user->getAuthorisedViewLevels());
-            $query->where('teacher.access IN (' . $groups . ')');
+            $query->where($db->qn('teacher.access') . ' IN (' . $groups . ')');
         }
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('teacher.published = ' . (int)$published);
+            $query->where($db->qn('teacher.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(teacher.published = 0 OR teacher.published = 1)');
+            $query->where('(' . $db->qn('teacher.published') . ' = 0 OR ' . $db->qn('teacher.published') . ' = 1)');
         }
 
         // Filter by search in title.
@@ -185,10 +191,10 @@ class CwmteachersModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('teacher.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('teacher.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('(teacher.teachername LIKE ' . $search . ' OR teacher.alias LIKE ' . $search . ')');
+                $query->where('(' . $db->qn('teacher.teachername') . ' LIKE ' . $search . ' OR ' . $db->qn('teacher.alias') . ' LIKE ' . $search . ')');
             }
         }
 

--- a/admin/src/Model/CwmtemplatesModel.php
+++ b/admin/src/Model/CwmtemplatesModel.php
@@ -70,7 +70,13 @@ class CwmtemplatesModel extends ListModel
     public function getTemplates(): array
     {
         if (empty($this->templates)) {
-            $query           = 'SELECT id as value, title as text FROM `#__bsms_templates` WHERE published = 1 ORDER BY id ASC';
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query->select($db->qn('id', 'value'))
+                ->select($db->qn('title', 'text'))
+                ->from($db->qn('#__bsms_templates'))
+                ->where($db->qn('published') . ' = 1')
+                ->order($db->qn('id') . ' ASC');
             $this->templates = $this->_getList($query);
         }
 
@@ -89,10 +95,10 @@ class CwmtemplatesModel extends ListModel
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
 
-        $query->select('template.type AS text');
-        $query->from('#__bsms_templates AS template');
-        $query->group('template.type');
-        $query->order('template.type');
+        $query->select($db->qn('template.type', 'text'));
+        $query->from($db->qn('#__bsms_templates', 'template'));
+        $query->group($db->qn('template.type'));
+        $query->order($db->qn('template.type'));
 
         $db->setQuery($query->__toString());
 
@@ -147,18 +153,18 @@ class CwmtemplatesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'template.id, template.published, template.title'
+                implode(', ', $db->qn(['template.id', 'template.published', 'template.title']))
             )
         );
-        $query->from('#__bsms_templates AS template');
+        $query->from($db->qn('#__bsms_templates', 'template'));
 
         // Filter by published state
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('template.published = ' . (int)$published);
+            $query->where($db->qn('template.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(template.published = 0 OR template.published = 1)');
+            $query->where('(' . $db->qn('template.published') . ' = 0 OR ' . $db->qn('template.published') . ' = 1)');
         }
 
         // Filter by search in filename or study title
@@ -166,10 +172,10 @@ class CwmtemplatesModel extends ListModel
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('template.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('template.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('template.title LIKE ' . $search);
+                $query->where($db->qn('template.title') . ' LIKE ' . $search);
             }
         }
 

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -134,19 +134,22 @@ class CwmtopicsModel extends ListModel
         $query = $db->getQuery(true);
 
         $query->select(
-            $this->getState('list.select', 'topic.id, topic.topic_text, topic.published, topic.params AS topic_params')
+            $this->getState(
+                'list.select',
+                implode(', ', $db->qn(['topic.id', 'topic.topic_text', 'topic.published'])) . ', ' . $db->qn('topic.params', 'topic_params')
+            )
         );
-        $query->from('#__bsms_topics AS topic');
+        $query->from($db->qn('#__bsms_topics', 'topic'));
 
         // Filter by search in title.
         $search = $this->getState('filter.search');
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('topic.id = ' . (int)substr($search, 3));
+                $query->where($db->qn('topic.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('(topic.topic_text LIKE ' . $search . ')');
+                $query->where('(' . $db->qn('topic.topic_text') . ' LIKE ' . $search . ')');
             }
         }
 
@@ -154,9 +157,9 @@ class CwmtopicsModel extends ListModel
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('topic.published = ' . (int)$published);
+            $query->where($db->qn('topic.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(topic.published = 0 OR topic.published = 1)');
+            $query->where('(' . $db->qn('topic.published') . ' = 0 OR ' . $db->qn('topic.published') . ' = 1)');
         }
 
         // Add the list ordering clause

--- a/admin/src/View/Cwminstall/HtmlView.php
+++ b/admin/src/View/Cwminstall/HtmlView.php
@@ -249,7 +249,7 @@ class HtmlView extends BaseHtmlView
                     foreach ($modules as $module => $modulePreferences) {
                         // Was the module already installed?
                         $sql = $db->getQuery(true);
-                        $sql->select('COUNT(*)')->from('#__extensions')->where('name=' . $db->q('mod_' . $module));
+                        $sql->select('COUNT(*)')->from($db->qn('#__extensions'))->where($db->qn('name') . ' = ' . $db->q('mod_' . $module));
                         $db->setQuery($sql);
                         $result                     = $db->loadResult();
                         $this->status->cwmmodules[] = array_merge(
@@ -287,9 +287,9 @@ class HtmlView extends BaseHtmlView
                     foreach ($plugins as $plugin => $published) {
                         $query = $db->getQuery(true);
                         $query->select('COUNT(*)')
-                            ->from('#__extensions')
-                            ->where('folder=' . $db->q($folder))
-                            ->where('name=' . $db->q('plg_' . $folder . '_' . $plugin));
+                            ->from($db->qn('#__extensions'))
+                            ->where($db->qn('folder') . ' = ' . $db->q($folder))
+                            ->where($db->qn('name') . ' = ' . $db->q('plg_' . $folder . '_' . $plugin));
                         $db->setQuery($query);
                         $result                     = $db->loadResult();
                         $this->status->cwmplugins[] = array_merge(

--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -374,16 +374,18 @@ final class Proclaim extends Adapter implements SubscriberInterface
     {
         $query = $this->db->getQuery(true);
 
+        $db = $this->db;
+
         // Item ID
-        $query->select('a.id');
+        $query->select($db->qn('a.id'));
 
         // Item and category published state
-        $query->select('a.' . $this->state_field . ' AS state, s.published AS series_state');
+        $query->select($db->qn('a.' . $this->state_field, 'state') . ', ' . $db->qn('s.published', 'series_state'));
 
         // Item and series access levels
-        $query->select('a.access, s.access AS series_access')
-            ->from($this->table . ' AS a')
-            ->join('LEFT', '#__bsms_series AS s ON s.id = a.series_id');
+        $query->select($db->qn('a.access') . ', ' . $db->qn('s.access', 'series_access'))
+            ->from($db->qn($this->table, 'a'))
+            ->join('LEFT', $db->qn('#__bsms_series', 's') . ' ON ' . $db->qn('s.id') . ' = ' . $db->qn('a.series_id'));
 
         return $query;
     }
@@ -491,11 +493,11 @@ final class Proclaim extends Adapter implements SubscriberInterface
         // Add Topics
         $db    = $this->getDatabase();
         $query = $db->getQuery(true)
-            ->select('t.topic_text')
-            ->from('#__bsms_topics AS t')
-            ->join('INNER', '#__bsms_studytopics AS st ON st.topic_id = t.id')
-            ->where('st.study_id = ' . (int) $item->id)
-            ->where('t.published = 1');
+            ->select($db->qn('t.topic_text'))
+            ->from($db->qn('#__bsms_topics', 't'))
+            ->join('INNER', $db->qn('#__bsms_studytopics', 'st') . ' ON ' . $db->qn('st.topic_id') . ' = ' . $db->qn('t.id'))
+            ->where($db->qn('st.study_id') . ' = ' . (int) $item->id)
+            ->where($db->qn('t.published') . ' = 1');
         $db->setQuery($query);
         $topics = $db->loadColumn();
 
@@ -515,9 +517,9 @@ final class Proclaim extends Adapter implements SubscriberInterface
         // Add Scripture/Book
         if (!empty($item->booknumber)) {
             $query = $db->getQuery(true)
-                ->select('bookname')
-                ->from('#__bsms_books')
-                ->where('booknumber = ' . (int) $item->booknumber);
+                ->select($db->qn('bookname'))
+                ->from($db->qn('#__bsms_books'))
+                ->where($db->qn('booknumber') . ' = ' . (int) $item->booknumber);
             $db->setQuery($query);
             $bookname = $db->loadResult();
 
@@ -567,14 +569,14 @@ final class Proclaim extends Adapter implements SubscriberInterface
 
         // Check if we can use the supplied SQL query.
         $query = $query instanceof QueryInterface ? $query : $db->getQuery(true)
-            ->select('a.id, a.studytitle AS title, a.alias, a.studyintro AS summary, a.studytext as body')
-            ->select('a.thumbnailm, a.series_id')
-            ->select('a.published AS state, a.studydate AS start_date, a.user_id')
-            ->select('a.language')
-            ->select('a.access, a.ordering, a.params')
-            ->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date')
-            ->select('a.booknumber, a.chapter_begin, a.verse_begin, a.chapter_end, a.verse_end')
-            ->select('s.series_text AS series, s.published AS series_state, s.access AS series_access');
+            ->select($db->qn('a.id') . ', ' . $db->qn('a.studytitle', 'title') . ', ' . $db->qn('a.alias') . ', ' . $db->qn('a.studyintro', 'summary') . ', ' . $db->qn('a.studytext', 'body'))
+            ->select($db->qn('a.thumbnailm') . ', ' . $db->qn('a.series_id'))
+            ->select($db->qn('a.published', 'state') . ', ' . $db->qn('a.studydate', 'start_date') . ', ' . $db->qn('a.user_id'))
+            ->select($db->qn('a.language'))
+            ->select($db->qn('a.access') . ', ' . $db->qn('a.ordering') . ', ' . $db->qn('a.params'))
+            ->select($db->qn('a.publish_up', 'publish_start_date') . ', ' . $db->qn('a.publish_down', 'publish_end_date'))
+            ->select($db->qn(['a.booknumber', 'a.chapter_begin', 'a.verse_begin', 'a.chapter_end', 'a.verse_end']))
+            ->select($db->qn('s.series_text', 'series') . ', ' . $db->qn('s.published', 'series_state') . ', ' . $db->qn('s.access', 'series_access'));
 
         // Handle the alias CASE WHEN portion of the query
         $case_when_item_alias = ' CASE WHEN ';
@@ -595,10 +597,10 @@ final class Proclaim extends Adapter implements SubscriberInterface
         $case_when_series_alias .= $s_id . ' END as seriesslug';
         $query->select($case_when_series_alias);
 
-        $query->select('t.teachername AS author')
-            ->from('#__bsms_studies AS a')
-            ->join('LEFT', '#__bsms_teachers AS t ON t.id = a.teacher_id')
-            ->join('LEFT', '#__bsms_series AS s ON s.id = a.series_id');
+        $query->select($db->qn('t.teachername', 'author'))
+            ->from($db->qn('#__bsms_studies', 'a'))
+            ->join('LEFT', $db->qn('#__bsms_teachers', 't') . ' ON ' . $db->qn('t.id') . ' = ' . $db->qn('a.teacher_id'))
+            ->join('LEFT', $db->qn('#__bsms_series', 's') . ' ON ' . $db->qn('s.id') . ' = ' . $db->qn('a.series_id'));
 
         return $query;
     }

--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -286,7 +286,9 @@ class CwmsermonController extends FormController
         $comment_livesite = Uri::root();
         $db               = Factory::getContainer()->get('DatabaseDriver');
         $query            = $db->getQuery(true);
-        $query->select('id, studytitle, studydate')->from('#__bsms_studies')->where('id = ' . (int) $comment_study_id);
+        $query->select($db->quoteName(['id', 'studytitle', 'studydate']))
+            ->from($db->quoteName('#__bsms_studies'))
+            ->where($db->quoteName('id') . ' = ' . (int) $comment_study_id);
         $db->setQuery($query);
         $comment_details    = $db->loadObject();
         $comment_title      = $comment_details->studytitle;

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -52,9 +52,9 @@ class Cwmdownload
 
         // Get the template so we can find a protocol
         $query = $db->getQuery(true);
-        $query->select('id, params')
-            ->from('#__bsms_templates')
-            ->where('id = ' . $templateId);
+        $query->select($db->quoteName(['id', 'params']))
+            ->from($db->quoteName('#__bsms_templates'))
+            ->where($db->quoteName('id') . ' = ' . $templateId);
         $db->setQuery($query);
         $template = $db->loadObject();
 
@@ -69,12 +69,15 @@ class Cwmdownload
 
         $query = $db->getQuery(true);
         $query->select(
-            '#__bsms_mediafiles.*,'
-            . ' #__bsms_servers.id AS ssid, #__bsms_servers.params AS sparams'
+            $db->quoteName('#__bsms_mediafiles') . '.*,'
+            . $db->quoteName('#__bsms_servers.id', 'ssid') . ', ' . $db->quoteName('#__bsms_servers.params', 'sparams')
         )
-            ->from('#__bsms_mediafiles')
-            ->leftJoin('#__bsms_servers ON (#__bsms_servers.id = #__bsms_mediafiles.server_id)')
-            ->where('#__bsms_mediafiles.id = ' . $mid);
+            ->from($db->quoteName('#__bsms_mediafiles'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_servers') . ' ON ('
+                . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
+            )
+            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid);
         $db->setQuery($query, 0, 1);
 
         $media = $db->loadObject();
@@ -225,9 +228,9 @@ class Cwmdownload
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->update('#__bsms_mediafiles')
-            ->set('downloads = downloads + 1 ')
-            ->where('id = ' . $mid);
+        $query->update($db->quoteName('#__bsms_mediafiles'))
+            ->set($db->quoteName('downloads') . ' = ' . $db->quoteName('downloads') . ' + 1')
+            ->where($db->quoteName('id') . ' = ' . $mid);
         $db->setQuery($query);
 
         if (!$db->execute()) {

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -448,71 +448,136 @@ class Cwmlanding
 
         switch ($type) {
             case 'teachers':
-                $query->select('DISTINCT a.id, a.teachername as text, a.landing_show, ' . $null . ' as params, ' . $this->db->quote('teachers') . ' as type')
-                    ->from('#__bsms_teachers a')
-                    ->innerJoin('#__bsms_studies b ON a.id = b.teacher_id')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('a.published = 1')
-                    ->where('a.landing_show > 0');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.id') . ', '
+                    . $this->db->quoteName('a.teachername', 'text') . ', '
+                    . $this->db->quoteName('a.landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('teachers') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_teachers', 'a'))
+                    ->innerJoin(
+                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                        . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.teacher_id')
+                    )
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('a.published') . ' = 1')
+                    ->where($this->db->quoteName('a.landing_show') . ' > 0');
                 $this->addAccessFilter($query);
                 break;
 
             case 'series':
-                $query->select('DISTINCT a.id, a.series_text as text, a.landing_show, ' . $null . ' as params, ' . $this->db->quote('series') . ' as type')
-                    ->from('#__bsms_series a')
-                    ->innerJoin('#__bsms_studies b ON a.id = b.series_id')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('b.published = 1');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.id') . ', '
+                    . $this->db->quoteName('a.series_text', 'text') . ', '
+                    . $this->db->quoteName('a.landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('series') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_series', 'a'))
+                    ->innerJoin(
+                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                        . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.series_id')
+                    )
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('b.published') . ' = 1');
                 $this->addAccessFilter($query);
                 break;
 
             case 'locations':
-                $query->select('DISTINCT a.id, a.location_text as text, a.landing_show, ' . $null . ' as params, ' . $this->db->quote('locations') . ' as type')
-                    ->from('#__bsms_locations a')
-                    ->innerJoin('#__bsms_studies b ON a.id = b.location_id')
-                    ->where('b.location_id > 0')
-                    ->where('a.published = 1')
-                    ->where('b.published = 1')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('a.landing_show > 0');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.id') . ', '
+                    . $this->db->quoteName('a.location_text', 'text') . ', '
+                    . $this->db->quoteName('a.landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('locations') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_locations', 'a'))
+                    ->innerJoin(
+                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                        . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.location_id')
+                    )
+                    ->where($this->db->quoteName('b.location_id') . ' > 0')
+                    ->where($this->db->quoteName('a.published') . ' = 1')
+                    ->where($this->db->quoteName('b.published') . ' = 1')
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('a.landing_show') . ' > 0');
                 $this->addAccessFilter($query);
                 break;
 
             case 'messagetypes':
-                $query->select('DISTINCT a.id, a.message_type as text, a.landing_show, ' . $null . ' as params, ' . $this->db->quote('messagetypes') . ' as type')
-                    ->from('#__bsms_message_type a')
-                    ->innerJoin('#__bsms_studies b ON a.id = b.messagetype')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('b.published = 1')
-                    ->where('a.landing_show > 0');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.id') . ', '
+                    . $this->db->quoteName('a.message_type', 'text') . ', '
+                    . $this->db->quoteName('a.landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('messagetypes') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_message_type', 'a'))
+                    ->innerJoin(
+                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                        . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.messagetype')
+                    )
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('b.published') . ' = 1')
+                    ->where($this->db->quoteName('a.landing_show') . ' > 0');
                 $this->addAccessFilter($query);
                 break;
 
             case 'topics':
-                $query->select('DISTINCT a.id, a.topic_text as text, 0 as landing_show, a.params as params, ' . $this->db->quote('topics') . ' as type')
-                    ->from('#__bsms_studies b')
-                    ->join('LEFT', '#__bsms_studytopics st ON b.id = st.study_id')
-                    ->join('LEFT', '#__bsms_topics a ON a.id = st.topic_id')
-                    ->where('a.published = 1')
-                    ->where('b.published = 1')
-                    ->where('b.language IN (' . $language . ')');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.id') . ', '
+                    . $this->db->quoteName('a.topic_text', 'text') . ', '
+                    . '0 AS ' . $this->db->quoteName('landing_show') . ', '
+                    . $this->db->quoteName('a.params', 'params') . ', '
+                    . $this->db->quote('topics') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_studies', 'b'))
+                    ->join(
+                        'LEFT',
+                        $this->db->quoteName('#__bsms_studytopics', 'st') . ' ON '
+                        . $this->db->quoteName('b.id') . ' = ' . $this->db->quoteName('st.study_id')
+                    )
+                    ->join(
+                        'LEFT',
+                        $this->db->quoteName('#__bsms_topics', 'a') . ' ON '
+                        . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('st.topic_id')
+                    )
+                    ->where($this->db->quoteName('a.published') . ' = 1')
+                    ->where($this->db->quoteName('b.published') . ' = 1')
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')');
                 $this->addAccessFilter($query, 'b.access');
                 break;
 
             case 'books':
-                $query->select('DISTINCT a.booknumber as id, a.bookname as text, 0 as landing_show, ' . $null . ' as params, ' . $this->db->quote('books') . ' as type')
-                    ->from('#__bsms_books a')
-                    ->innerJoin('#__bsms_studies b ON a.booknumber = b.booknumber')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('b.published = 1');
+                $query->select(
+                    'DISTINCT ' . $this->db->quoteName('a.booknumber', 'id') . ', '
+                    . $this->db->quoteName('a.bookname', 'text') . ', '
+                    . '0 AS ' . $this->db->quoteName('landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('books') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_books', 'a'))
+                    ->innerJoin(
+                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                        . $this->db->quoteName('a.booknumber') . ' = ' . $this->db->quoteName('b.booknumber')
+                    )
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('b.published') . ' = 1');
                 $this->addAccessFilter($query);
                 break;
 
             case 'years':
-                $query->select('DISTINCT YEAR(b.studydate) as id, YEAR(b.studydate) as text, 0 as landing_show, ' . $null . ' as params, ' . $this->db->quote('years') . ' as type')
-                    ->from('#__bsms_studies b')
-                    ->where('b.language IN (' . $language . ')')
-                    ->where('b.published = 1');
+                $query->select(
+                    'DISTINCT YEAR(' . $this->db->quoteName('b.studydate') . ') AS ' . $this->db->quoteName('id') . ', '
+                    . 'YEAR(' . $this->db->quoteName('b.studydate') . ') AS ' . $this->db->quoteName('text') . ', '
+                    . '0 AS ' . $this->db->quoteName('landing_show') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('params') . ', '
+                    . $this->db->quote('years') . ' AS ' . $this->db->quoteName('type')
+                )
+                    ->from($this->db->quoteName('#__bsms_studies', 'b'))
+                    ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                    ->where($this->db->quoteName('b.published') . ' = 1');
                 $this->addAccessFilter($query, 'b.access');
                 break;
 
@@ -548,16 +613,19 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT a.*')
-                ->from('#__bsms_locations a')
-                ->innerJoin('#__bsms_studies b ON a.id = b.location_id')
-                ->where('b.location_id > 0')
-                ->where('a.published = 1')
-                ->where('b.published = 1')
-                ->where('b.language IN (' . $language . ')')
-                ->where('a.landing_show > 0')
-                ->group('a.id')
-                ->order('a.location_text ' . $order);
+            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
+                ->from($this->db->quoteName('#__bsms_locations', 'a'))
+                ->innerJoin(
+                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                    . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.location_id')
+                )
+                ->where($this->db->quoteName('b.location_id') . ' > 0')
+                ->where($this->db->quoteName('a.published') . ' = 1')
+                ->where($this->db->quoteName('b.published') . ' = 1')
+                ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('a.landing_show') . ' > 0')
+                ->group($this->db->quoteName('a.id'))
+                ->order($this->db->quoteName('a.location_text') . ' ' . $order);
 
             $this->addAccessFilter($query);
             $this->db->setQuery($query);
@@ -618,14 +686,17 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT a.*')
-                ->from('#__bsms_teachers a')
-                ->innerJoin('#__bsms_studies b ON a.id = b.teacher_id')
-                ->where('b.language IN (' . $language . ')')
-                ->where('a.published = 1')
-                ->where('a.landing_show > 0')
-                ->group('a.id')
-                ->order('a.teachername ' . $order);
+            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
+                ->from($this->db->quoteName('#__bsms_teachers', 'a'))
+                ->innerJoin(
+                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                    . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.teacher_id')
+                )
+                ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('a.published') . ' = 1')
+                ->where($this->db->quoteName('a.landing_show') . ' > 0')
+                ->group($this->db->quoteName('a.id'))
+                ->order($this->db->quoteName('a.teachername') . ' ' . $order);
 
             $this->addAccessFilter($query);
             $this->db->setQuery($query);
@@ -707,13 +778,16 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT a.*')
-                ->from('#__bsms_series a')
-                ->innerJoin('#__bsms_studies b ON a.id = b.series_id')
-                ->where('b.language IN (' . $language . ')')
-                ->where('b.published = 1')
-                ->group('a.id')
-                ->order('a.series_text ' . $order);
+            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
+                ->from($this->db->quoteName('#__bsms_series', 'a'))
+                ->innerJoin(
+                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                    . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.series_id')
+                )
+                ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('b.published') . ' = 1')
+                ->group($this->db->quoteName('a.id'))
+                ->order($this->db->quoteName('a.series_text') . ' ' . $order);
 
             $this->addAccessFilter($query);
             $this->db->setQuery($query);
@@ -773,12 +847,12 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT YEAR(studydate) as theYear')
-                ->from('#__bsms_studies')
-                ->where('language IN (' . $language . ')')
-                ->where('published = 1')
-                ->group('YEAR(studydate)')
-                ->order('YEAR(studydate) ' . $order);
+            $query->select('DISTINCT YEAR(' . $this->db->quoteName('studydate') . ') AS ' . $this->db->quoteName('theYear'))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('published') . ' = 1')
+                ->group('YEAR(' . $this->db->quoteName('studydate') . ')')
+                ->order('YEAR(' . $this->db->quoteName('studydate') . ') ' . $order);
 
             $this->addAccessFilter($query, 'access');
             $this->db->setQuery($query);
@@ -826,15 +900,27 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT #__bsms_topics.id, #__bsms_topics.topic_text, #__bsms_topics.params AS topic_params')
-                ->from('#__bsms_studies')
-                ->join('LEFT', '#__bsms_studytopics ON #__bsms_studies.id = #__bsms_studytopics.study_id')
-                ->join('LEFT', '#__bsms_topics ON #__bsms_topics.id = #__bsms_studytopics.topic_id')
-                ->where('#__bsms_topics.published = 1')
-                ->where('#__bsms_studies.published = 1')
-                ->where('#__bsms_studies.language IN (' . $language . ')')
-                ->group('#__bsms_topics.id')
-                ->order('#__bsms_topics.topic_text ' . $order);
+            $query->select(
+                'DISTINCT ' . $this->db->quoteName('#__bsms_topics.id') . ', '
+                . $this->db->quoteName('#__bsms_topics.topic_text') . ', '
+                . $this->db->quoteName('#__bsms_topics.params', 'topic_params')
+            )
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->join(
+                    'LEFT',
+                    $this->db->quoteName('#__bsms_studytopics') . ' ON '
+                    . $this->db->quoteName('#__bsms_studies.id') . ' = ' . $this->db->quoteName('#__bsms_studytopics.study_id')
+                )
+                ->join(
+                    'LEFT',
+                    $this->db->quoteName('#__bsms_topics') . ' ON '
+                    . $this->db->quoteName('#__bsms_topics.id') . ' = ' . $this->db->quoteName('#__bsms_studytopics.topic_id')
+                )
+                ->where($this->db->quoteName('#__bsms_topics.published') . ' = 1')
+                ->where($this->db->quoteName('#__bsms_studies.published') . ' = 1')
+                ->where($this->db->quoteName('#__bsms_studies.language') . ' IN (' . $language . ')')
+                ->group($this->db->quoteName('#__bsms_topics.id'))
+                ->order($this->db->quoteName('#__bsms_topics.topic_text') . ' ' . $order);
 
             $this->addAccessFilter($query, '#__bsms_studies.access');
             $this->db->setQuery($query);
@@ -888,14 +974,17 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT a.*')
-                ->from('#__bsms_message_type a')
-                ->innerJoin('#__bsms_studies b ON a.id = b.messagetype')
-                ->where('b.language IN (' . $language . ')')
-                ->where('b.published = 1')
-                ->where('a.landing_show > 0')
-                ->group('a.id')
-                ->order('a.message_type ' . $order);
+            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
+                ->from($this->db->quoteName('#__bsms_message_type', 'a'))
+                ->innerJoin(
+                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                    . $this->db->quoteName('a.id') . ' = ' . $this->db->quoteName('b.messagetype')
+                )
+                ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('b.published') . ' = 1')
+                ->where($this->db->quoteName('a.landing_show') . ' > 0')
+                ->group($this->db->quoteName('a.id'))
+                ->order($this->db->quoteName('a.message_type') . ' ' . $order);
 
             $this->addAccessFilter($query);
             $this->db->setQuery($query);
@@ -953,13 +1042,16 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             $query = $this->db->getQuery(true);
-            $query->select('DISTINCT a.*')
-                ->from('#__bsms_books a')
-                ->innerJoin('#__bsms_studies b ON a.booknumber = b.booknumber')
-                ->where('b.language IN (' . $language . ')')
-                ->where('b.published = 1')
-                ->group('a.bookname')
-                ->order('a.booknumber ' . $order);
+            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
+                ->from($this->db->quoteName('#__bsms_books', 'a'))
+                ->innerJoin(
+                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
+                    . $this->db->quoteName('a.booknumber') . ' = ' . $this->db->quoteName('b.booknumber')
+                )
+                ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
+                ->where($this->db->quoteName('b.published') . ' = 1')
+                ->group($this->db->quoteName('a.bookname'))
+                ->order($this->db->quoteName('a.booknumber') . ' ' . $order);
 
             $this->addAccessFilter($query);
             $this->db->setQuery($query);

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -450,14 +450,30 @@ class Cwmlisting
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select(
-            '#__bsms_mediafiles.*, #__bsms_servers.id AS ssid, #__bsms_servers.params AS sparams, #__bsms_servers.media AS smedia,'
-            . ' s.studytitle, s.studydate, s.studyintro, s.teacher_id,'
-            . ' s.booknumber, s.chapter_begin, s.chapter_end, s.verse_begin, s.verse_end, t.teachername, t.id as tid, s.id as sid, s.studyintro'
+            $db->quoteName('#__bsms_mediafiles') . '.*, '
+            . $db->quoteName('#__bsms_servers.id', 'ssid') . ', '
+            . $db->quoteName('#__bsms_servers.params', 'sparams') . ', '
+            . $db->quoteName('#__bsms_servers.media', 'smedia') . ','
+            . $db->quoteName('s.studytitle') . ', ' . $db->quoteName('s.studydate') . ', '
+            . $db->quoteName('s.studyintro') . ', ' . $db->quoteName('s.teacher_id') . ','
+            . $db->quoteName('s.booknumber') . ', ' . $db->quoteName('s.chapter_begin') . ', '
+            . $db->quoteName('s.chapter_end') . ', ' . $db->quoteName('s.verse_begin') . ', '
+            . $db->quoteName('s.verse_end') . ', ' . $db->quoteName('t.teachername') . ', '
+            . $db->quoteName('t.id', 'tid') . ', ' . $db->quoteName('s.id', 'sid')
         );
-        $query->from('#__bsms_mediafiles');
-        $query->leftJoin('#__bsms_servers ON (#__bsms_servers.id = #__bsms_mediafiles.server_id)');
-        $query->leftJoin('#__bsms_studies AS s ON (s.id = #__bsms_mediafiles.study_id)');
-        $query->leftJoin('#__bsms_teachers AS t ON (t.id = s.teacher_id)');
+        $query->from($db->quoteName('#__bsms_mediafiles'));
+        $query->leftJoin(
+            $db->quoteName('#__bsms_servers') . ' ON ('
+            . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
+        );
+        $query->leftJoin(
+            $db->quoteName('#__bsms_studies', 's') . ' ON ('
+            . $db->quoteName('s.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
+        );
+        $query->leftJoin(
+            $db->quoteName('#__bsms_teachers', 't') . ' ON ('
+            . $db->quoteName('t.id') . ' = ' . $db->quoteName('s.teacher_id') . ')'
+        );
 
         $ids = [];
 
@@ -475,7 +491,7 @@ class Cwmlisting
             return [];
         }
 
-        $query->where('#__bsms_mediafiles.id IN (' . implode(',', array_unique($ids)) . ')');
+        $query->where($db->quoteName('#__bsms_mediafiles.id') . ' IN (' . implode(',', array_unique($ids)) . ')');
 
         // Include archived media when showing archived messages
         $showArchived = '0';
@@ -486,16 +502,16 @@ class Cwmlisting
             }
         }
         if ($showArchived === '1' || $showArchived === '2') {
-            $query->where('#__bsms_mediafiles.published IN (1, 2)');
+            $query->where($db->quoteName('#__bsms_mediafiles.published') . ' IN (1, 2)');
         } else {
-            $query->where('#__bsms_mediafiles.published = 1');
+            $query->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
         }
 
         $query->where(
-            '#__bsms_mediafiles.language in ('
+            $db->quoteName('#__bsms_mediafiles.language') . ' IN ('
             . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
         );
-        $query->order('ordering ASC');
+        $query->order($db->quoteName('ordering') . ' ASC');
         $db->setQuery($query);
 
         return $db->loadObjectList();
@@ -2208,9 +2224,9 @@ class Cwmlisting
         $link  = '';
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->select('#__bsms_mediafiles.*')
-            ->from('#__bsms_mediafiles')
-            ->where('study_id = ' . $db->q($id3));
+        $query->select($db->quoteName('#__bsms_mediafiles') . '.*')
+            ->from($db->quoteName('#__bsms_mediafiles'))
+            ->where($db->quoteName('study_id') . ' = ' . $db->quote($id3));
 
         // Include archived media when showing archived messages
         $showArchived = $params->get('show_archived', '');
@@ -2218,9 +2234,9 @@ class Cwmlisting
             $showArchived = $params->get('default_show_archived', '0');
         }
         if ($showArchived === '1' || $showArchived === '2') {
-            $query->where('#__bsms_mediafiles.published IN (1, 2)');
+            $query->where($db->quoteName('#__bsms_mediafiles.published') . ' IN (1, 2)');
         } else {
-            $query->where('#__bsms_mediafiles.published = 1');
+            $query->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
         }
 
         $db->setQuery($query);

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -1017,9 +1017,9 @@ class Cwmmedia
     {
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
-        $query->update('#__bsms_mediafiles')
-            ->set('plays = plays + 1')
-            ->where('id = ' . $db->q($id));
+        $query->update($db->quoteName('#__bsms_mediafiles'))
+            ->set($db->quoteName('plays') . ' = ' . $db->quoteName('plays') . ' + 1')
+            ->where($db->quoteName('id') . ' = ' . (int) $id);
         $db->setQuery($query);
 
         if ($db->execute()) {
@@ -1045,22 +1045,43 @@ class Cwmmedia
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select(
-            '#__bsms_mediafiles.*, #__bsms_servers.params AS sparams,'
-            . ' s.studyintro, s.series_id, s.studytitle, s.studydate, s.teacher_id, s.booknumber, s.chapter_begin, s.chapter_end, s.verse_begin,'
-            . ' s.verse_end, t.teachername, t.teacher_thumbnail, t.teacher_image, t.thumb, t.image, t.id as tid, s.id as sid, s.studyintro,'
-            . ' se.id as seriesid, se.series_text, se.series_thumbnail'
+            $db->quoteName('#__bsms_mediafiles') . '.*, ' . $db->quoteName('#__bsms_servers.params', 'sparams') . ','
+            . $db->quoteName('s.studyintro') . ', ' . $db->quoteName('s.series_id') . ', '
+            . $db->quoteName('s.studytitle') . ', ' . $db->quoteName('s.studydate') . ', '
+            . $db->quoteName('s.teacher_id') . ', ' . $db->quoteName('s.booknumber') . ', '
+            . $db->quoteName('s.chapter_begin') . ', ' . $db->quoteName('s.chapter_end') . ', '
+            . $db->quoteName('s.verse_begin') . ', ' . $db->quoteName('s.verse_end') . ', '
+            . $db->quoteName('t.teachername') . ', ' . $db->quoteName('t.teacher_thumbnail') . ', '
+            . $db->quoteName('t.teacher_image') . ', ' . $db->quoteName('t.thumb') . ', '
+            . $db->quoteName('t.image') . ', ' . $db->quoteName('t.id', 'tid') . ', '
+            . $db->quoteName('s.id', 'sid') . ', '
+            . $db->quoteName('se.id', 'seriesid') . ', ' . $db->quoteName('se.series_text') . ', '
+            . $db->quoteName('se.series_thumbnail')
         )
-            ->from('#__bsms_mediafiles')
-            ->leftJoin('#__bsms_servers ON (#__bsms_servers.id = #__bsms_mediafiles.server_id)')
-            ->leftJoin('#__bsms_studies AS s ON (s.id = #__bsms_mediafiles.study_id)')
-            ->leftJoin('#__bsms_teachers AS t ON (t.id = s.teacher_id)')
-            ->leftJoin('#__bsms_series AS se ON (s.series_id = se.id)')
-            ->where('#__bsms_mediafiles.id = ' . (int)$id)
-            ->where('#__bsms_mediafiles.published IN (1, 2)')
-            ->where(
-                '#__bsms_mediafiles.language in (' . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
+            ->from($db->quoteName('#__bsms_mediafiles'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_servers') . ' ON ('
+                . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
             )
-            ->order('ordering asc');
+            ->leftJoin(
+                $db->quoteName('#__bsms_studies', 's') . ' ON ('
+                . $db->quoteName('s.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_teachers', 't') . ' ON ('
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('s.teacher_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_series', 'se') . ' ON ('
+                . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id') . ')'
+            )
+            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . (int) $id)
+            ->where($db->quoteName('#__bsms_mediafiles.published') . ' IN (1, 2)')
+            ->where(
+                $db->quoteName('#__bsms_mediafiles.language') . ' IN ('
+                . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
+            )
+            ->order($db->quoteName('ordering') . ' ASC');
         $db->setQuery($query);
         $media = $db->loadObject();
 

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -266,62 +266,117 @@ class Cwmpagebuilder
 		                study.verse_end2, study.verse_begin2, ' . $query->length('study.studytext') . ' AS readmore ,'
             . ' CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END as slug '
         );
-        $query->from('#__bsms_studies AS study');
+        $query->from($db->quoteName('#__bsms_studies', 'study'));
 
         // Join over Message Types
-        $query->select('messageType.message_type AS message_type');
-        $query->join('LEFT', '#__bsms_message_type AS messageType ON messageType.id = study.messagetype');
+        $query->select($db->quoteName('messageType.message_type', 'message_type'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_message_type', 'messageType') . ' ON '
+            . $db->quoteName('messageType.id') . ' = ' . $db->quoteName('study.messagetype')
+        );
 
         // Join over Teachers
         $query->select(
-            'teacher.teachername AS teachername, teacher.title as teachertitle, teacher.thumb, teacher.thumbh, teacher.thumbw'
+            $db->quoteName('teacher.teachername', 'teachername') . ', '
+            . $db->quoteName('teacher.title', 'teachertitle') . ', '
+            . $db->quoteName('teacher.thumb') . ', ' . $db->quoteName('teacher.thumbh') . ', '
+            . $db->quoteName('teacher.thumbw')
         );
-        $query->join('LEFT', '#__bsms_teachers AS teacher ON teacher.id = study.teacher_id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_teachers', 'teacher') . ' ON '
+            . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('study.teacher_id')
+        );
 
         // Join over Series
         $query->select(
-            'series.series_text, series.series_thumbnail, series.description as sdescription, series.access'
+            $db->quoteName('series.series_text') . ', ' . $db->quoteName('series.series_thumbnail') . ', '
+            . $db->quoteName('series.description', 'sdescription') . ', ' . $db->quoteName('series.access')
         );
-        $query->join('LEFT', '#__bsms_series AS series ON series.id = study.series_id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_series', 'series') . ' ON '
+            . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id')
+        );
 
         // Join over Books
-        $query->select('book.bookname');
-        $query->join('LEFT', '#__bsms_books AS book ON book.booknumber = study.booknumber');
+        $query->select($db->quoteName('book.bookname'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_books', 'book') . ' ON '
+            . $db->quoteName('book.booknumber') . ' = ' . $db->quoteName('study.booknumber')
+        );
 
-        $query->select('book2.bookname as bookname2');
-        $query->join('LEFT', '#__bsms_books AS book2 ON book2.booknumber = study.booknumber2');
+        $query->select($db->quoteName('book2.bookname', 'bookname2'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_books', 'book2') . ' ON '
+            . $db->quoteName('book2.booknumber') . ' = ' . $db->quoteName('study.booknumber2')
+        );
 
         // Join over Plays/Downloads
         $query->select(
-            'GROUP_CONCAT(DISTINCT mediafile.id) as mids, SUM(mediafile.plays) AS totalplays,
-		SUM(mediafile.downloads) as totaldownloads, mediafile.study_id'
+            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('mediafile.id') . ') AS ' . $db->quoteName('mids') . ', '
+            . 'SUM(' . $db->quoteName('mediafile.plays') . ') AS ' . $db->quoteName('totalplays') . ', '
+            . 'SUM(' . $db->quoteName('mediafile.downloads') . ') AS ' . $db->quoteName('totaldownloads') . ', '
+            . $db->quoteName('mediafile.study_id')
         );
-        $query->join('LEFT', '#__bsms_mediafiles AS mediafile ON mediafile.study_id = study.id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON '
+            . $db->quoteName('mediafile.study_id') . ' = ' . $db->quoteName('study.id')
+        );
 
         // Join over Locations
-        $query->select('locations.location_text');
-        $query->join('LEFT', '#__bsms_locations AS locations ON study.location_id = locations.id');
+        $query->select($db->quoteName('locations.location_text'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_locations', 'locations') . ' ON '
+            . $db->quoteName('study.location_id') . ' = ' . $db->quoteName('locations.id')
+        );
 
         // Join over studytopics
-        $query->select('GROUP_CONCAT(DISTINCT st.topic_id)');
-        $query->join('LEFT', '#__bsms_studytopics AS st ON study.id = st.study_id');
-        $query->select(
-            'GROUP_CONCAT(DISTINCT t.id), GROUP_CONCAT(DISTINCT t.topic_text) as topic_text,' .
-            'GROUP_CONCAT(DISTINCT t.params) as topic_params'
+        $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('st.topic_id') . ')');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_studytopics', 'st') . ' ON '
+            . $db->quoteName('study.id') . ' = ' . $db->quoteName('st.study_id')
         );
-        $query->join('LEFT', '#__bsms_topics AS t ON t.id = st.topic_id');
+        $query->select(
+            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.id') . '), '
+            . 'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.topic_text') . ') AS ' . $db->quoteName('topic_text') . ', '
+            . 'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.params') . ') AS ' . $db->quoteName('topic_params')
+        );
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_topics', 't') . ' ON '
+            . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.topic_id')
+        );
 
         // Join over the users for the author and modified_by names.
-        $query->select("CASE WHEN study.user_name > ' ' THEN study.user_name ELSE users.name END AS submitted")
-            ->select("users.email AS author_email")
-            ->join('LEFT', '#__users AS users ON study.user_id = users.id')
-            ->join('LEFT', '#__users AS uam ON uam.id = study.modified_by');
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.user_name') . ' > ' . $db->quote(' ')
+            . ' THEN ' . $db->quoteName('study.user_name') . ' ELSE ' . $db->quoteName('users.name')
+            . ' END AS ' . $db->quoteName('submitted')
+        )
+            ->select($db->quoteName('users.email', 'author_email'))
+            ->join(
+                'LEFT',
+                $db->quoteName('#__users', 'users') . ' ON '
+                . $db->quoteName('study.user_id') . ' = ' . $db->quoteName('users.id')
+            )
+            ->join(
+                'LEFT',
+                $db->quoteName('#__users', 'uam') . ' ON '
+                . $db->quoteName('uam.id') . ' = ' . $db->quoteName('study.modified_by')
+            );
 
-        $query->group('study.id');
+        $query->group($db->quoteName('study.id'));
 
         // Select only published studies
-        $query->where('study.published = 1');
-        $query->where('(series.published = 1 OR study.series_id <= 0)');
+        $query->where($db->quoteName('study.published') . ' = 1');
+        $query->where('(' . $db->quoteName('series.published') . ' = 1 OR ' . $db->quoteName('study.series_id') . ' <= 0)');
 
         if ($wherefield && $whereitem) {
             $query->where($wherefield . ' = ' . $whereitem);
@@ -346,18 +401,18 @@ class Cwmpagebuilder
         $language = $params->get('language', '*');
 
         if ($language === '*') {
-            $query->where('study.language in (' . $db->quote($language) . ',' . $db->quote('*') . ')');
+            $query->where($db->quoteName('study.language') . ' IN (' . $db->quote($language) . ',' . $db->quote('*') . ')');
         } elseif ($language !== '*') {
             $query->where(
-                'study.language in (' . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
+                $db->quoteName('study.language') . ' IN (' . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
             );
         }
 
-        $query->order('studydate ' . $order);
+        $query->order($db->quoteName('studydate') . ' ' . $order);
 
         // Filter only for authorized view
-        $query->where('(series.access IN (' . $groups . ') or study.series_id <= 0)');
-        $query->where('study.access IN (' . $groups . ')');
+        $query->where('(' . $db->quoteName('series.access') . ' IN (' . $groups . ') OR ' . $db->quoteName('study.series_id') . ' <= 0)');
+        $query->where($db->quoteName('study.access') . ' IN (' . $groups . ')');
 
         $db->setQuery($query, 0, $limit);
 

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -104,7 +104,7 @@ class Cwmpodcast
 
             // Check if there's any media file associated
             $query = $db->getQuery(true);
-            $query->select('id')
+            $query->select($db->quoteName('id'))
                 ->from($db->quoteName('#__bsms_mediafiles'))
                 ->where('FIND_IN_SET(' . (int) $podinfo->id . ', ' . $db->quoteName('podcast_id') . ')')
                 ->where($db->quoteName('published') . ' = 1');
@@ -852,7 +852,7 @@ class Cwmpodcast
         $db = Factory::getContainer()->get('DatabaseDriver');
 
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 's.studytitle', 's.studyintro'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 's.studytitle', 's.studyintro']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
             ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where('FIND_IN_SET(' . $podcastId . ', ' . $db->quoteName('mf.podcast_id') . ')')
@@ -1073,7 +1073,7 @@ class Cwmpodcast
 
         // Get media files with missing duration
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
             ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.published') . ' = 1');
@@ -1103,7 +1103,7 @@ class Cwmpodcast
 
             // Get server path
             $serverQuery = $db->getQuery(true);
-            $serverQuery->select('params')
+            $serverQuery->select($db->quoteName('params'))
                 ->from($db->quoteName('#__bsms_servers'))
                 ->where($db->quoteName('id') . ' = ' . (int) $media->server_id);
             $db->setQuery($serverQuery);
@@ -1344,9 +1344,9 @@ class Cwmpodcast
         $db = Factory::getContainer()->get('DatabaseDriver');
 
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 's.studytitle'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 's.studytitle']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON s.id = mf.study_id')
+            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.published') . ' = 1');
 
         if ($podcastId !== null) {
@@ -1395,9 +1395,9 @@ class Cwmpodcast
 
         // Get the media file
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON s.id = mf.study_id')
+            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.id') . ' = ' . $mediaId);
 
         $db->setQuery($query);
@@ -1416,7 +1416,7 @@ class Cwmpodcast
 
         // Get server path
         $serverQuery = $db->getQuery(true);
-        $serverQuery->select('params')
+        $serverQuery->select($db->quoteName('params'))
             ->from($db->quoteName('#__bsms_servers'))
             ->where($db->quoteName('id') . ' = ' . (int) $media->server_id);
         $db->setQuery($serverQuery);
@@ -1627,9 +1627,9 @@ class Cwmpodcast
         $db = Factory::getContainer()->get('DatabaseDriver');
 
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 's.studytitle'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 's.studytitle']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON s.id = mf.study_id')
+            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.published') . ' = 1');
 
         if ($podcastId !== null) {
@@ -1699,9 +1699,9 @@ class Cwmpodcast
 
         // Get the media file
         $query = $db->getQuery(true);
-        $query->select(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle'])
+        $query->select($db->quoteName(['mf.id', 'mf.params', 'mf.server_id', 's.studytitle']))
             ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON s.id = mf.study_id')
+            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->where($db->quoteName('mf.id') . ' = ' . $mediaId);
 
         $db->setQuery($query);
@@ -1736,7 +1736,7 @@ class Cwmpodcast
 
         // Get server path
         $serverQuery = $db->getQuery(true);
-        $serverQuery->select('params')
+        $serverQuery->select($db->quoteName('params'))
             ->from($db->quoteName('#__bsms_servers'))
             ->where($db->quoteName('id') . ' = ' . (int) $media->server_id);
         $db->setQuery($serverQuery);

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -112,7 +112,7 @@ class Cwmrelatedstudies
         $query = $db->getQuery(true);
         $query->select($db->quoteName(['s.id', 's.params', 's.access']))
             ->from($db->quoteName('#__bsms_studies', 's'))
-            ->select('GROUP_CONCAT(stp.id SEPARATOR ", ") AS tp_id')
+            ->select('GROUP_CONCAT(' . $db->quoteName('stp.id') . ' SEPARATOR ", ") AS ' . $db->quoteName('tp_id'))
             ->leftJoin($db->quoteName('#__bsms_studytopics', 'tp') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('tp.study_id'))
             ->leftJoin($db->quoteName('#__bsms_topics', 'stp') . ' ON ' . $db->quoteName('stp.id') . ' = ' . $db->quoteName('tp.topic_id'))
             ->where($db->quoteName('s.published') . ' = 1')

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -190,29 +190,59 @@ class Cwmserieslist extends Cwmlisting
         $groups = implode(',', $user->getAuthorisedViewLevels());
         $query  = $db->getQuery(true);
         $query->select(
-            's.*, se.id AS seid, t.id AS tid, t.teachername, t.title AS teachertitle, t.thumb, t.thumbh, t.thumbw, '
-            . ' t.teacher_thumbnail, se.series_text, se.description AS sdescription, '
-            . ' se.series_thumbnail, #__bsms_message_type.id AS mid,'
-            . ' #__bsms_message_type.message_type AS message_type, #__bsms_books.bookname,'
-            . ' group_concat(#__bsms_topics.id separator ", ") AS tp_id, group_concat(#__bsms_topics.topic_text separator ", ")'
-            . ' as topic_text, group_concat(#__bsms_topics.params separator ", ") as topic_params, '
-            . ' #__bsms_locations.id AS lid, #__bsms_locations.location_text '
+            $db->quoteName('s') . '.*, '
+            . $db->quoteName('se.id', 'seid') . ', '
+            . $db->quoteName('t.id', 'tid') . ', ' . $db->quoteName('t.teachername') . ', '
+            . $db->quoteName('t.title', 'teachertitle') . ', ' . $db->quoteName('t.thumb') . ', '
+            . $db->quoteName('t.thumbh') . ', ' . $db->quoteName('t.thumbw') . ', '
+            . $db->quoteName('t.teacher_thumbnail') . ', ' . $db->quoteName('se.series_text') . ', '
+            . $db->quoteName('se.description', 'sdescription') . ', '
+            . $db->quoteName('se.series_thumbnail') . ', '
+            . $db->quoteName('#__bsms_message_type.id', 'mid') . ', '
+            . $db->quoteName('#__bsms_message_type.message_type', 'message_type') . ', '
+            . $db->quoteName('#__bsms_books.bookname') . ', '
+            . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.id') . ' SEPARATOR ", ") AS ' . $db->quoteName('tp_id') . ', '
+            . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.topic_text') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_text') . ', '
+            . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.params') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_params') . ', '
+            . $db->quoteName('#__bsms_locations.id', 'lid') . ', '
+            . $db->quoteName('#__bsms_locations.location_text')
         )
-            ->from('#__bsms_studies AS s')
-            ->leftJoin('#__bsms_series AS se ON (s.series_id = se.id)')
-            ->leftJoin('#__bsms_teachers AS t ON (s.teacher_id = t.id)')
-            ->leftJoin('#__bsms_books ON (s.booknumber = #__bsms_books.booknumber)')
-            ->leftJoin('#__bsms_message_type ON (s.messagetype = #__bsms_message_type.id)')
-            ->leftJoin('#__bsms_studytopics ON (#__bsms_studytopics.study_id = s.id)')
-            ->leftJoin('#__bsms_topics ON (#__bsms_topics.id = #__bsms_studytopics.topic_id)')
-            ->leftJoin('#__bsms_locations ON (s.location_id = #__bsms_locations.id)')
-            ->where('s.series_id = ' . (int) $id)
-            ->where('s.published = ' . 1)
-            ->where('s.language in (' . $language . ')')
-            ->where('s.access IN (' . $groups . ')')
-            ->group('s.id')
+            ->from($db->quoteName('#__bsms_studies', 's'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_series', 'se') . ' ON ('
+                . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_teachers', 't') . ' ON ('
+                . $db->quoteName('s.teacher_id') . ' = ' . $db->quoteName('t.id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_books') . ' ON ('
+                . $db->quoteName('s.booknumber') . ' = ' . $db->quoteName('#__bsms_books.booknumber') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_message_type') . ' ON ('
+                . $db->quoteName('s.messagetype') . ' = ' . $db->quoteName('#__bsms_message_type.id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_studytopics') . ' ON ('
+                . $db->quoteName('#__bsms_studytopics.study_id') . ' = ' . $db->quoteName('s.id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_topics') . ' ON ('
+                . $db->quoteName('#__bsms_topics.id') . ' = ' . $db->quoteName('#__bsms_studytopics.topic_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_locations') . ' ON ('
+                . $db->quoteName('s.location_id') . ' = ' . $db->quoteName('#__bsms_locations.id') . ')'
+            )
+            ->where($db->quoteName('s.series_id') . ' = ' . (int) $id)
+            ->where($db->quoteName('s.published') . ' = 1')
+            ->where($db->quoteName('s.language') . ' IN (' . $language . ')')
+            ->where($db->quoteName('s.access') . ' IN (' . $groups . ')')
+            ->group($db->quoteName('s.id'))
             ->order(
-                $params->get('series_detail_sort', 'studydate') . ' ' . $params->get('series_detail_order', 'desc')
+                $db->quoteName($params->get('series_detail_sort', 'studydate')) . ' ' . $params->get('series_detail_order', 'DESC')
             );
 
         $db->setQuery($query, 0, $limit);

--- a/site/src/Helper/Cwmteacher.php
+++ b/site/src/Helper/Cwmteacher.php
@@ -58,8 +58,8 @@ class Cwmteacher extends Cwmlisting
             $database = Factory::getContainer()->get('DatabaseDriver');
             $query    = $database->getQuery(true);
             $query->select('*')
-                ->from('#__bsms_teachers')
-                ->where('id IN (' . implode(',', array_map('intval', $teacherIDs)) . ')');
+                ->from($database->quoteName('#__bsms_teachers'))
+                ->where($database->quoteName('id') . ' IN (' . implode(',', array_map('intval', $teacherIDs)) . ')');
             $database->setQuery($query);
             $results = $database->loadObjectList();
 

--- a/site/src/Model/CwmlandingpageModel.php
+++ b/site/src/Model/CwmlandingpageModel.php
@@ -140,26 +140,26 @@ class CwmlandingpageModel extends ListModel
         $query->select(
             $db->quoteName(['t.id', 't.teachername', 't.title', 't.language'], ['tid', 'teachertitle', null, null])
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON s.teacher_id = t.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON ' . $db->quoteName('s.teacher_id') . ' = ' . $db->quoteName('t.id'));
         $query->select(
             $db->quoteName(
                 ['se.id', 'se.series_text', 'se.description', 'se.series_thumbnail'],
                 ['sid', null, 'sdescription', null]
             )
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_series', 'se') . ' ON s.series_id = se.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_series', 'se') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id'));
         $query->select($db->quoteName(['m.id', 'm.message_type'], ['mid', null]));
-        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'm') . ' ON s.messagetype = m.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'm') . ' ON ' . $db->quoteName('s.messagetype') . ' = ' . $db->quoteName('m.id'));
         $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('st.topic_id') . ')');
-        $query->join('LEFT', $db->quoteName('#__bsms_studytopics', 'st') . ' ON s.id = st.study_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_studytopics', 'st') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('st.study_id'));
         $query->select(
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.id') . '), ' .
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.topic_text') . ') as topics_text, ' .
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.params') . ')'
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_topics', 'tp') . ' ON tp.id = st.topic_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_topics', 'tp') . ' ON ' . $db->quoteName('tp.id') . ' = ' . $db->quoteName('st.topic_id'));
         $query->select($db->quoteName(['l.id', 'l.location_text'], ['lid', null]));
-        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'l') . ' ON s.location_id = l.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'l') . ' ON ' . $db->quoteName('s.location_id') . ' = ' . $db->quoteName('l.id'));
 
         $rightnow = date('Y-m-d H:i:s');
 

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -75,7 +75,7 @@ class CwmseriesdisplayModel extends ItemModel
                     ['tid', null, 'teachertitle', null, null, null, null]
                 )
             );
-            $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON se.teacher = t.id');
+            $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON ' . $db->quoteName('se.teacher') . ' = ' . $db->quoteName('t.id'));
             $query->where($db->quoteName('se.id') . ' = :id')
                 ->bind(':id', $pk, ParameterType::INTEGER);
             $db->setQuery($query);
@@ -140,7 +140,7 @@ class CwmseriesdisplayModel extends ItemModel
 
         // Join over Message Types
         $query->select($db->quoteName('messageType.message_type', 'message_type'));
-        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'messageType') . ' ON messageType.id = study.messagetype');
+        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'messageType') . ' ON ' . $db->quoteName('messageType.id') . ' = ' . $db->quoteName('study.messagetype'));
 
         // Join over Teachers
         $query->select(
@@ -150,7 +150,7 @@ class CwmseriesdisplayModel extends ItemModel
             $db->quoteName('teacher.thumbh') . ', ' .
             $db->quoteName('teacher.thumbw')
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON teacher.id = study.teacher_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('study.teacher_id'));
 
         // Join over Series
         $query->select(
@@ -159,14 +159,14 @@ class CwmseriesdisplayModel extends ItemModel
                 [null, null, 'sdescription', 'series_access']
             )
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_series', 'series') . ' ON series.id = study.series_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id'));
 
         // Join over Books
         $query->select($db->quoteName('book.bookname'));
-        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book') . ' ON book.booknumber = study.booknumber');
+        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book') . ' ON ' . $db->quoteName('book.booknumber') . ' = ' . $db->quoteName('study.booknumber'));
 
         $query->select($db->quoteName('book2.bookname', 'bookname2'));
-        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book2') . ' ON book2.booknumber = study.booknumber2');
+        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book2') . ' ON ' . $db->quoteName('book2.booknumber') . ' = ' . $db->quoteName('study.booknumber2'));
 
         // Join over Plays/Downloads
         $query->select(
@@ -174,30 +174,30 @@ class CwmseriesdisplayModel extends ItemModel
             'SUM(' . $db->quoteName('mediafile.downloads') . ') AS totaldownloads, ' .
             $db->quoteName('mediafile.study_id')
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON mediafile.study_id = study.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON ' . $db->quoteName('mediafile.study_id') . ' = ' . $db->quoteName('study.id'));
 
         // Join over Locations
         $query->select($db->quoteName('locations.location_text'));
-        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'locations') . ' ON study.location_id = locations.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'locations') . ' ON ' . $db->quoteName('study.location_id') . ' = ' . $db->quoteName('locations.id'));
 
         // Join over topics
         $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('st.topic_id') . ')');
-        $query->join('LEFT', $db->quoteName('#__bsms_studytopics', 'st') . ' ON study.id = st.study_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_studytopics', 'st') . ' ON ' . $db->quoteName('study.id') . ' = ' . $db->quoteName('st.study_id'));
         $query->select(
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.id') . '), ' .
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.topic_text') . ') AS topics_text, ' .
             'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.params') . ')'
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_topics', 't') . ' ON t.id = st.topic_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_topics', 't') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.topic_id'));
 
         // Join over users
         $query->select($db->quoteName('users.name', 'submitted'));
-        $query->join('LEFT', $db->quoteName('#__users', 'users') . ' ON study.user_id = users.id');
+        $query->join('LEFT', $db->quoteName('#__users', 'users') . ' ON ' . $db->quoteName('study.user_id') . ' = ' . $db->quoteName('users.id'));
 
         $query->group($db->quoteName('study.id'));
 
         $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('m.id') . ') AS mids');
-        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'm') . ' ON study.id = m.study_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'm') . ' ON ' . $db->quoteName('study.id') . ' = ' . $db->quoteName('m.study_id'));
 
         // Filter only for authorized view
         $query->whereIn($db->quoteName('study.access'), $groups);

--- a/site/src/Model/CwmseriesdisplaysModel.php
+++ b/site/src/Model/CwmseriesdisplaysModel.php
@@ -92,7 +92,7 @@ class CwmseriesdisplaysModel extends ListModel
         $query->select($db->quoteName(['t.id', 't.teachername'], ['value', 'text']));
         $query->from($db->quoteName('#__bsms_teachers', 't'));
         $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON t.id = series.teacher');
+        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('series.teacher'));
         $query->group($db->quoteName('t.id'));
         $query->order($db->quoteName('t.teachername') . ' ASC');
 
@@ -115,8 +115,8 @@ class CwmseriesdisplaysModel extends ListModel
         $query->select('YEAR(' . $db->quoteName('s.studydate') . ') as text');
         $query->from($db->quoteName('#__bsms_studies', 's'));
         $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON s.series_id = series.id');
-        $query->order('value');
+        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('series.id'));
+        $query->order($db->quoteName('value'));
 
         $db->setQuery($query);
 
@@ -137,7 +137,7 @@ class CwmseriesdisplaysModel extends ListModel
 
         $query->select($db->quoteName(['series.id', 'series.series_text', 'series.access'], ['value', 'text', 'access']));
         $query->from($db->quoteName('#__bsms_series', 'series'));
-        $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON study.series_id = series.id');
+        $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.series_id') . ' = ' . $db->quoteName('series.id'));
         $query->group($db->quoteName('series.id'));
         $query->order($db->quoteName('series.series_text'));
 
@@ -332,14 +332,28 @@ class CwmseriesdisplaysModel extends ListModel
                 'se.*,CASE WHEN CHAR_LENGTH(se.alias) THEN CONCAT_WS(\':\', se.id, se.alias) ELSE se.id END as slug'
             )
         );
-        $query->from('#__bsms_series as se');
+        $query->from($db->quoteName('#__bsms_series', 'se'));
         $query->select(
-            't.id as tid, t.teachername, t.title as teachertitle, t.thumb, t.thumbh, t.thumbw, t.teacher_thumbnail'
+            $db->quoteName('t.id', 'tid') . ', ' . $db->quoteName('t.teachername') . ', '
+            . $db->quoteName('t.title', 'teachertitle') . ', ' . $db->quoteName('t.thumb') . ', '
+            . $db->quoteName('t.thumbh') . ', ' . $db->quoteName('t.thumbw') . ', '
+            . $db->quoteName('t.teacher_thumbnail')
         );
-        $query->join('LEFT', '#__bsms_teachers as t on se.teacher = t.id');
-        $query->select('s.id as sid, s.series_id, s.studydate');
-        $query->join('INNER', '#__bsms_studies as s on s.series_id = se.id');
-        $query->group('se.id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_teachers', 't') . ' ON '
+            . $db->quoteName('se.teacher') . ' = ' . $db->quoteName('t.id')
+        );
+        $query->select(
+            $db->quoteName('s.id', 'sid') . ', ' . $db->quoteName('s.series_id') . ', '
+            . $db->quoteName('s.studydate')
+        );
+        $query->join(
+            'INNER',
+            $db->quoteName('#__bsms_studies', 's') . ' ON '
+            . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id')
+        );
+        $query->group($db->quoteName('se.id'));
 
         // Filter by access level.
         if ($this->getState('filter.access', true)) {
@@ -350,7 +364,7 @@ class CwmseriesdisplaysModel extends ListModel
         $search = $this->getState('filter.search');
         if (!empty($search)) {
             $like = $db->quote('%' . $search . '%');
-            $query->where('se.description LIKE ' . $like);
+            $query->where($db->quoteName('se.description') . ' LIKE ' . $like);
         }
 
         // Filter by language
@@ -374,13 +388,13 @@ class CwmseriesdisplaysModel extends ListModel
         $showArchived = $this->getState('filter.show_archived', '0');
         switch ($showArchived) {
             case '1': // Archived only
-                $query->where('se.published = 2');
+                $query->where($db->quoteName('se.published') . ' = 2');
                 break;
             case '2': // Both published and archived
-                $query->where('se.published IN (1, 2)');
+                $query->where($db->quoteName('se.published') . ' IN (1, 2)');
                 break;
             default: // Published only (backward compatible)
-                $query->where('se.published = 1');
+                $query->where($db->quoteName('se.published') . ' = 1');
                 break;
         }
 

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -76,7 +76,7 @@ class CwmseriespodcastdisplayModel extends ItemModel
                         ['tid', null, 'teachertitle', null, null, null, null]
                     )
                 );
-                $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON se.teacher = t.id');
+                $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON ' . $db->quoteName('se.teacher') . ' = ' . $db->quoteName('t.id'));
                 $query->where($db->quoteName('se.id') . ' = :id')
                     ->bind(':id', $pk, ParameterType::INTEGER);
                 $db->setQuery($query);
@@ -143,7 +143,7 @@ class CwmseriespodcastdisplayModel extends ItemModel
 
         // Join over Message Types
         $query->select($db->quoteName('messageType.message_type', 'message_type'));
-        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'messageType') . ' ON messageType.id = study.messagetype');
+        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'messageType') . ' ON ' . $db->quoteName('messageType.id') . ' = ' . $db->quoteName('study.messagetype'));
 
         // Join over Teachers
         $query->select(
@@ -153,7 +153,7 @@ class CwmseriespodcastdisplayModel extends ItemModel
             $db->quoteName('teacher.thumbh') . ', ' .
             $db->quoteName('teacher.thumbw')
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON teacher.id = study.teacher_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('study.teacher_id'));
 
         // Join over Series
         $query->select(
@@ -162,14 +162,14 @@ class CwmseriespodcastdisplayModel extends ItemModel
                 [null, null, 'sdescription', 'series_access']
             )
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_series', 'series') . ' ON series.id = study.series_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id'));
 
         // Join over Books
         $query->select($db->quoteName('book.bookname'));
-        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book') . ' ON book.booknumber = study.booknumber');
+        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book') . ' ON ' . $db->quoteName('book.booknumber') . ' = ' . $db->quoteName('study.booknumber'));
 
         $query->select($db->quoteName('book2.bookname', 'bookname2'));
-        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book2') . ' ON book2.booknumber = study.booknumber2');
+        $query->join('LEFT', $db->quoteName('#__bsms_books', 'book2') . ' ON ' . $db->quoteName('book2.booknumber') . ' = ' . $db->quoteName('study.booknumber2'));
 
         // Join over Plays/Downloads
         $query->select(
@@ -177,20 +177,20 @@ class CwmseriespodcastdisplayModel extends ItemModel
             'SUM(' . $db->quoteName('mediafile.downloads') . ') AS totaldownloads, ' .
             $db->quoteName('mediafile.study_id')
         );
-        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON mediafile.study_id = study.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON ' . $db->quoteName('mediafile.study_id') . ' = ' . $db->quoteName('study.id'));
 
         // Join over Locations
         $query->select($db->quoteName('locations.location_text'));
-        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'locations') . ' ON study.location_id = locations.id');
+        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'locations') . ' ON ' . $db->quoteName('study.location_id') . ' = ' . $db->quoteName('locations.id'));
 
         // Join over users
         $query->select($db->quoteName('users.name', 'submitted'));
-        $query->join('LEFT', $db->quoteName('#__users', 'users') . ' ON study.user_id = users.id');
+        $query->join('LEFT', $db->quoteName('#__users', 'users') . ' ON ' . $db->quoteName('study.user_id') . ' = ' . $db->quoteName('users.id'));
 
         $query->group($db->quoteName('study.id'));
 
         $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('m.id') . ') AS mids');
-        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'm') . ' ON study.id = m.study_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_mediafiles', 'm') . ' ON ' . $db->quoteName('study.id') . ' = ' . $db->quoteName('m.study_id'));
 
         // Filter only for authorized view
         $query->whereIn($db->quoteName('study.access'), $groups);

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -98,47 +98,95 @@ class CwmsermonModel extends FormModel
                         's.*,CASE WHEN CHAR_LENGTH(s.alias) THEN CONCAT_WS(\':\', s.id, s.alias) ELSE s.id END as slug'
                     )
                 );
-                $query->from('#__bsms_studies AS s');
+                $query->from($db->quoteName('#__bsms_studies', 's'));
 
                 // Join over teachers
                 $query->select(
-                    't.id AS tid, t.teachername AS teachername, t.title AS teachertitle, t.image, t.imagew, t.imageh,' .
-                    't.teacher_thumbnail as thumb, t.thumbw, t.thumbh'
+                    $db->quoteName('t.id', 'tid') . ', '
+                    . $db->quoteName('t.teachername', 'teachername') . ', '
+                    . $db->quoteName('t.title', 'teachertitle') . ', '
+                    . $db->quoteName('t.image') . ', ' . $db->quoteName('t.imagew') . ', ' . $db->quoteName('t.imageh') . ', '
+                    . $db->quoteName('t.teacher_thumbnail', 'thumb') . ', '
+                    . $db->quoteName('t.thumbw') . ', ' . $db->quoteName('t.thumbh')
                 );
 
-                $query->join('LEFT', '#__bsms_teachers as t on s.teacher_id = t.id');
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_teachers', 't') . ' ON '
+                    . $db->quoteName('s.teacher_id') . ' = ' . $db->quoteName('t.id')
+                );
 
                 // Join over series
-                $query->select('se.id AS sid, se.series_text, se.series_thumbnail, se.description as sdescription');
-                $query->join('LEFT', '#__bsms_series as se on s.series_id = se.id');
+                $query->select(
+                    $db->quoteName('se.id', 'sid') . ', ' . $db->quoteName('se.series_text') . ', '
+                    . $db->quoteName('se.series_thumbnail') . ', ' . $db->quoteName('se.description', 'sdescription')
+                );
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_series', 'se') . ' ON '
+                    . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id')
+                );
 
                 // Join over message type
-                $query->select('mt.id as mid, mt.message_type');
-                $query->join('LEFT', '#__bsms_message_type as mt on s.messagetype = mt.id');
+                $query->select($db->quoteName('mt.id', 'mid') . ', ' . $db->quoteName('mt.message_type'));
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_message_type', 'mt') . ' ON '
+                    . $db->quoteName('s.messagetype') . ' = ' . $db->quoteName('mt.id')
+                );
 
                 // Join over books
-                $query->select('b.bookname as bookname');
-                $query->join('LEFT', '#__bsms_books as b on s.booknumber = b.booknumber');
+                $query->select($db->quoteName('b.bookname', 'bookname'));
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_books', 'b') . ' ON '
+                    . $db->quoteName('s.booknumber') . ' = ' . $db->quoteName('b.booknumber')
+                );
 
-                $query->select('book2.bookname as bookname2');
-                $query->join('LEFT', '#__bsms_books AS book2 ON book2.booknumber = s.booknumber2');
+                $query->select($db->quoteName('book2.bookname', 'bookname2'));
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_books', 'book2') . ' ON '
+                    . $db->quoteName('book2.booknumber') . ' = ' . $db->quoteName('s.booknumber2')
+                );
 
                 // Join over locations
-                $query->select('l.id as lid, l.location_text');
-                $query->join('LEFT', '#__bsms_locations as l on s.location_id = l.id');
+                $query->select($db->quoteName('l.id', 'lid') . ', ' . $db->quoteName('l.location_text'));
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_locations', 'l') . ' ON '
+                    . $db->quoteName('s.location_id') . ' = ' . $db->quoteName('l.id')
+                );
 
                 // Join over topics
                 $query->select(
-                    'group_concat(stp.id separator ", ") AS tp_id, group_concat(stp.topic_text separator ", ")
-					 as topic_text, group_concat(stp.params separator ", ") as topic_params'
+                    'GROUP_CONCAT(' . $db->quoteName('stp.id') . ' SEPARATOR ", ") AS ' . $db->quoteName('tp_id') . ', '
+                    . 'GROUP_CONCAT(' . $db->quoteName('stp.topic_text') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_text') . ', '
+                    . 'GROUP_CONCAT(' . $db->quoteName('stp.params') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_params')
                 );
-                $query->join('LEFT', '#__bsms_studytopics as tp on s.id = tp.study_id');
-                $query->join('LEFT', '#__bsms_topics as stp on stp.id = tp.topic_id');
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_studytopics', 'tp') . ' ON '
+                    . $db->quoteName('s.id') . ' = ' . $db->quoteName('tp.study_id')
+                );
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_topics', 'stp') . ' ON '
+                    . $db->quoteName('stp.id') . ' = ' . $db->quoteName('tp.topic_id')
+                );
 
                 // Join over media files
-                $query->select('sum(m.plays) AS totalplays, sum(m.downloads) AS totaldownloads, m.id');
-                $query->select('GROUP_CONCAT(DISTINCT m.id) as mids');
-                $query->join('LEFT', '#__bsms_mediafiles AS m on s.id = m.study_id');
+                $query->select(
+                    'SUM(' . $db->quoteName('m.plays') . ') AS ' . $db->quoteName('totalplays') . ', '
+                    . 'SUM(' . $db->quoteName('m.downloads') . ') AS ' . $db->quoteName('totaldownloads') . ', '
+                    . $db->quoteName('m.id')
+                );
+                $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('m.id') . ') AS ' . $db->quoteName('mids'));
+                $query->join(
+                    'LEFT',
+                    $db->quoteName('#__bsms_mediafiles', 'm') . ' ON '
+                    . $db->quoteName('s.id') . ' = ' . $db->quoteName('m.study_id')
+                );
 
                 if (
                     (!$user->authorise('core.edit.state', 'com_proclaim')) && (!$user->authorise(
@@ -159,7 +207,7 @@ class CwmsermonModel extends FormModel
                 // Implement View Level Access
                 if (!$user->authorise('core.cwmadmin')) {
                     $groups = implode(',', $user->getAuthorisedViewLevels());
-                    $query->where('s.access IN (' . $groups . ')');
+                    $query->where($db->quoteName('s.access') . ' IN (' . $groups . ')');
                 }
 
                 // Filter by published state.
@@ -167,11 +215,11 @@ class CwmsermonModel extends FormModel
                 $archived  = $this->getState('filter.archived');
 
                 if (is_numeric($published)) {
-                    $query->where('(s.published = ' . (int)$published . ' OR s.published =' . (int)$archived . ')');
+                    $query->where('(' . $db->quoteName('s.published') . ' = ' . (int) $published . ' OR ' . $db->quoteName('s.published') . ' = ' . (int) $archived . ')');
                 }
 
-                $query->group('s.id');
-                $query->where('s.id = ' . (int)$pk);
+                $query->group($db->quoteName('s.id'));
+                $query->where($db->quoteName('s.id') . ' = ' . (int) $pk);
                 $db->setQuery($query);
                 $data = $db->loadObject();
 

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -214,7 +214,7 @@ class CwmsermonsModel extends ListModel
         $query->select($db->quoteName(['t.id', 't.teachername'], ['value', 'text']));
         $query->from($db->quoteName('#__bsms_teachers', 't'));
         $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON t.id = series.teacher');
+        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('series.teacher'));
         $query->group($db->quoteName('t.id'));
         $query->order($db->quoteName('t.teachername') . ' ASC');
 
@@ -237,8 +237,8 @@ class CwmsermonsModel extends ListModel
         $query->select('YEAR(' . $db->quoteName('s.studydate') . ') as text');
         $query->from($db->quoteName('#__bsms_studies', 's'));
         $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON s.series_id = series.id');
-        $query->order('value');
+        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('series.id'));
+        $query->order($db->quoteName('value'));
 
         $db->setQuery($query);
 
@@ -259,7 +259,7 @@ class CwmsermonsModel extends ListModel
 
         $query->select($db->quoteName(['series.id', 'series.series_text', 'series.access'], ['value', 'text', 'access']));
         $query->from($db->quoteName('#__bsms_series', 'series'));
-        $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON study.series_id = series.id');
+        $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.series_id') . ' = ' . $db->quoteName('series.id'));
         $query->group($db->quoteName('series.id'));
         $query->order($db->quoteName('series.series_text'));
 
@@ -555,56 +555,112 @@ class CwmsermonsModel extends ListModel
 		                study.verse_end2, study.verse_begin2, ' . ' ' . $query->length('study.studytext') . ' AS readmore'
             ) . ', CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END as slug '
         );
-        $query->from('#__bsms_studies AS study');
+        $query->from($db->quoteName('#__bsms_studies', 'study'));
 
         // Join over Message Types
-        $query->select('messageType.message_type AS message_type');
-        $query->join('LEFT', '#__bsms_message_type AS messageType ON messageType.id = study.messagetype');
+        $query->select($db->quoteName('messageType.message_type', 'message_type'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_message_type', 'messageType') . ' ON '
+            . $db->quoteName('messageType.id') . ' = ' . $db->quoteName('study.messagetype')
+        );
 
         // Join over Teachers
         $query->select(
-            'teacher.teachername AS teachername, teacher.title as title, teacher.teacher_thumbnail as thumb,
-			teacher.thumbh, teacher.thumbw'
+            $db->quoteName('teacher.teachername', 'teachername') . ', '
+            . $db->quoteName('teacher.title', 'title') . ', '
+            . $db->quoteName('teacher.teacher_thumbnail', 'thumb') . ', '
+            . $db->quoteName('teacher.thumbh') . ', ' . $db->quoteName('teacher.thumbw')
         );
-        $query->join('LEFT', '#__bsms_teachers AS teacher ON teacher.id = study.teacher_id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_teachers', 'teacher') . ' ON '
+            . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('study.teacher_id')
+        );
 
         // Join over Series
         $query->select(
-            'series.series_text, series.series_thumbnail, series.description as sdescription, series.access as series_access'
+            $db->quoteName('series.series_text') . ', ' . $db->quoteName('series.series_thumbnail') . ', '
+            . $db->quoteName('series.description', 'sdescription') . ', '
+            . $db->quoteName('series.access', 'series_access')
         );
-        $query->join('LEFT', '#__bsms_series AS series ON series.id = study.series_id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_series', 'series') . ' ON '
+            . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id')
+        );
 
         // Join over Books
-        $query->select('book.bookname');
-        $query->join('LEFT', '#__bsms_books AS book ON book.booknumber = study.booknumber');
+        $query->select($db->quoteName('book.bookname'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_books', 'book') . ' ON '
+            . $db->quoteName('book.booknumber') . ' = ' . $db->quoteName('study.booknumber')
+        );
 
-        $query->select('book2.bookname as bookname2');
-        $query->join('LEFT', '#__bsms_books AS book2 ON book2.booknumber = study.booknumber2');
+        $query->select($db->quoteName('book2.bookname', 'bookname2'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_books', 'book2') . ' ON '
+            . $db->quoteName('book2.booknumber') . ' = ' . $db->quoteName('study.booknumber2')
+        );
 
         // Join over Plays/Downloads
         $query->select(
-            'GROUP_CONCAT(DISTINCT mediafile.id) as mids, SUM(mediafile.plays) AS totalplays,' .
-            'SUM(mediafile.downloads) as totaldownloads, mediafile.study_id'
+            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('mediafile.id') . ') AS ' . $db->quoteName('mids') . ', '
+            . 'SUM(' . $db->quoteName('mediafile.plays') . ') AS ' . $db->quoteName('totalplays') . ', '
+            . 'SUM(' . $db->quoteName('mediafile.downloads') . ') AS ' . $db->quoteName('totaldownloads') . ', '
+            . $db->quoteName('mediafile.study_id')
         );
-        $query->join('LEFT', '#__bsms_mediafiles AS mediafile ON mediafile.study_id = study.id');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_mediafiles', 'mediafile') . ' ON '
+            . $db->quoteName('mediafile.study_id') . ' = ' . $db->quoteName('study.id')
+        );
 
         // Join over Locations
-        $query->select('locations.location_text');
-        $query->join('LEFT', '#__bsms_locations AS locations ON study.location_id = locations.id');
+        $query->select($db->quoteName('locations.location_text'));
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_locations', 'locations') . ' ON '
+            . $db->quoteName('study.location_id') . ' = ' . $db->quoteName('locations.id')
+        );
 
         // Join over topics
-        $query->select('GROUP_CONCAT(DISTINCT st.topic_id)');
-        $query->join('LEFT', '#__bsms_studytopics AS st ON study.id = st.study_id');
-        $query->select(
-            'GROUP_CONCAT(DISTINCT t.id), GROUP_CONCAT(DISTINCT t.topic_text) as topics_text, GROUP_CONCAT(DISTINCT t.params)'
+        $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('st.topic_id') . ')');
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_studytopics', 'st') . ' ON '
+            . $db->quoteName('study.id') . ' = ' . $db->quoteName('st.study_id')
         );
-        $query->join('LEFT', '#__bsms_topics AS t ON t.id = st.topic_id');
+        $query->select(
+            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.id') . '), '
+            . 'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.topic_text') . ') AS ' . $db->quoteName('topics_text') . ', '
+            . 'GROUP_CONCAT(DISTINCT ' . $db->quoteName('t.params') . ')'
+        );
+        $query->join(
+            'LEFT',
+            $db->quoteName('#__bsms_topics', 't') . ' ON '
+            . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.topic_id')
+        );
 
         // Join over the users for the author and modified_by names.
-        $query->select("CASE WHEN study.user_name > ' ' THEN study.user_name ELSE users.name END AS submitted")
-            ->select("users.email AS author_email")
-            ->join('LEFT', '#__users AS users ON study.user_id = users.id')
-            ->join('LEFT', '#__users AS uam ON uam.id = study.modified_by');
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.user_name') . ' > ' . $db->quote(' ')
+            . ' THEN ' . $db->quoteName('study.user_name') . ' ELSE ' . $db->quoteName('users.name') . ' END AS '
+            . $db->quoteName('submitted')
+        )
+            ->select($db->quoteName('users.email', 'author_email'))
+            ->join(
+                'LEFT',
+                $db->quoteName('#__users', 'users') . ' ON '
+                . $db->quoteName('study.user_id') . ' = ' . $db->quoteName('users.id')
+            )
+            ->join(
+                'LEFT',
+                $db->quoteName('#__users', 'uam') . ' ON '
+                . $db->quoteName('uam.id') . ' = ' . $db->quoteName('study.modified_by')
+            );
 
         $query->group($db->quoteName('study.id'));
 
@@ -623,16 +679,16 @@ class CwmsermonsModel extends ListModel
         $showArchived = $this->getState('filter.show_archived', '0');
         switch ($showArchived) {
             case '1': // Archived only
-                $query->where('study.published = 2');
+                $query->where($db->quoteName('study.published') . ' = 2');
                 break;
             case '2': // Both published and archived
-                $query->where('study.published IN (1, 2)');
+                $query->where($db->quoteName('study.published') . ' IN (1, 2)');
                 break;
             default: // Published only (backward compatible)
-                $query->where('study.published = 1');
+                $query->where($db->quoteName('study.published') . ' = 1');
                 break;
         }
-        $query->where('(series.published = 1 or study.series_id <= 0)');
+        $query->where('(' . $db->quoteName('series.published') . ' = 1 OR ' . $db->quoteName('study.series_id') . ' <= 0)');
 
         // Define null and now dates
         $nullDate = $db->quote($db->getNullDate());
@@ -1013,8 +1069,12 @@ class CwmsermonsModel extends ListModel
         if (!empty($search)) {
             $like = $db->quote('%' . trim($search) . '%');
             $query->where(
-                'study.studytitle LIKE ' . $like . ' OR study.studytext LIKE ' . $like . ' OR study.studyintro LIKE ' .
-                $like . ' OR series.series_text LIKE ' . $like . ' OR series.description LIKE ' . $like . ' OR t.topic_text LIKE ' . $like
+                $db->quoteName('study.studytitle') . ' LIKE ' . $like
+                . ' OR ' . $db->quoteName('study.studytext') . ' LIKE ' . $like
+                . ' OR ' . $db->quoteName('study.studyintro') . ' LIKE ' . $like
+                . ' OR ' . $db->quoteName('series.series_text') . ' LIKE ' . $like
+                . ' OR ' . $db->quoteName('series.description') . ' LIKE ' . $like
+                . ' OR ' . $db->quoteName('t.topic_text') . ' LIKE ' . $like
             );
         }
 

--- a/site/src/Model/CwmteachersModel.php
+++ b/site/src/Model/CwmteachersModel.php
@@ -81,7 +81,7 @@ class CwmteachersModel extends ListModel
         );
         $query->from($db->quoteName('#__bsms_teachers', 'teachers'));
         $query->select($db->quoteName('s.id', 'sid'));
-        $query->join('LEFT', $db->quoteName('#__bsms_studies', 's') . ' ON teachers.id = s.teacher_id');
+        $query->join('LEFT', $db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('teachers.id') . ' = ' . $db->quoteName('s.teacher_id'));
 
         // Filter by language
         if (isset($item->language) && $item->language !== '*') {

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -408,10 +408,13 @@ class HtmlView extends BaseHtmlView
         // Added database queries from the default template - moved here instead
         $database = Factory::getContainer()->get('DatabaseDriver');
         $query    = $database->getQuery(true);
-        $query->select('id')->from('#__menu')->where(
-            'link =' .
-            $database->q('index.php?option=com_proclaim&view=cwmsermons')
-        )->where('published = 1');
+        $query->select($database->quoteName('id'))
+            ->from($database->quoteName('#__menu'))
+            ->where(
+                $database->quoteName('link') . ' = '
+                . $database->quote('index.php?option=com_proclaim&view=cwmsermons')
+            )
+            ->where($database->quoteName('published') . ' = 1');
         $database->setQuery($query);
         $menuid       = $database->loadResult();
         $this->menuid = $menuid;

--- a/site/src/View/Cwmterms/HtmlView.php
+++ b/site/src/View/Cwmterms/HtmlView.php
@@ -98,10 +98,10 @@ class HtmlView extends BaseHtmlView
         $this->params       = $template->params;
         $this->termstext    = $this->params->get('terms');
         $db                 = Factory::getContainer()->get('DatabaseDriver');
-        $query              = $db->getQuery('true');
+        $query              = $db->getQuery(true);
         $query->select('*');
-        $query->from('#__bsms_mediafiles');
-        $query->where('id= ' . (int)$mid);
+        $query->from($db->quoteName('#__bsms_mediafiles'));
+        $query->where($db->quoteName('id') . ' = ' . (int) $mid);
         $db->setQuery($query);
         $this->media = $db->loadObject();
 


### PR DESCRIPTION
## Summary
- Wrap all raw SQL field/table names with `$db->quoteName()` / `$db->qn()` across 76 files (admin fields, helpers, models, controllers, libs, views, site helpers, models, views, finder plugin, legacy addon fields)
- Fix critical `$db->qn([...])` array bug in 8 list models where array was passed to `getState('list.select')` causing "Unknown column 'Array'" SQL errors — wrapped with `implode(', ', ...)`
- Use parameterized queries (`->bind()`) where possible, `(int)` casts for integer values

## Test plan
- [x] `composer lint` — clean (PSR-12)
- [x] `composer test` — 358 tests, 1162 assertions pass
- [x] `composer lint:syntax` — no errors in 1270 files
- [ ] Manual test: admin list views load without SQL errors
- [ ] Manual test: site sermon/series/teacher views load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)