### PR TITLE
Remove deprecated getError/setError, _db, and getDbo patterns

### DIFF
--- a/admin/src/Model/CwmcommentModel.php
+++ b/admin/src/Model/CwmcommentModel.php
@@ -165,12 +165,6 @@ class CwmcommentModel extends AdminModel
 
             // Check that the row actually exists
             if (!$table->load($pk)) {
-                if ($error = $table->getError()) {
-                    // Fatal error
-                    throw new \RuntimeException($error);
-                }
-
-                // Not fatal error
                 Factory::getApplication()->enqueueMessage(
                     Text::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk),
                     'warning'
@@ -186,12 +180,12 @@ class CwmcommentModel extends AdminModel
 
             // Check the row.
             if (!$table->check()) {
-                throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
 
             // Store the row.
             if (!$table->store()) {
-                throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
 
             // Get the new item ID

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -667,7 +667,7 @@ class CwmmediafileModel extends AdminModel
                 $table->player = (int)$value;
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -725,7 +725,7 @@ class CwmmediafileModel extends AdminModel
                 $table->params = $reg->toString();
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -767,7 +767,7 @@ class CwmmediafileModel extends AdminModel
                 $table->params = $reg->toString();
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -808,7 +808,7 @@ class CwmmediafileModel extends AdminModel
                 $table->params = $reg->toString();
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -849,7 +849,7 @@ class CwmmediafileModel extends AdminModel
                 $table->params = $reg->toString();
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -893,7 +893,7 @@ class CwmmediafileModel extends AdminModel
                     $count++;
                 }
             } else {
-                throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_RECORD_NOT_FOUND'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_RECORD_NOT_FOUND'));
             }
         }
 

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -455,7 +455,7 @@ class CwmmessageModel extends AdminModel
                 $row->ordering = $order[$i];
 
                 if (!$row->store()) {
-                    throw new \RuntimeException($row->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
 
                 // Remember to reorder within position and client_id
@@ -514,7 +514,7 @@ class CwmmessageModel extends AdminModel
                 $table->teacher_id = (int)$value;
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -570,7 +570,7 @@ class CwmmessageModel extends AdminModel
                 $table->series_id = (int)$value;
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
@@ -609,7 +609,7 @@ class CwmmessageModel extends AdminModel
                 $table->messagetype = (int)$value;
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -177,7 +177,7 @@ class CwmpodcastModel extends AdminModel
                 $table->linktype = (int)$value;
 
                 if (!$table->store()) {
-                    throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -306,12 +306,6 @@ class CwmserieModel extends AdminModel
 
             // Check that the row actually exists
             if (!$table->load($pk)) {
-                if ($error = $table->getError()) {
-                    // Fatal error
-                    throw new \RuntimeException($error);
-                }
-
-                // Not fatal error
                 $app->enqueueMessage(Text::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk), 'warning');
                 continue;
             }
@@ -326,12 +320,12 @@ class CwmserieModel extends AdminModel
 
             // Check the row.
             if (!$table->check()) {
-                throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
 
             // Store the row.
             if (!$table->store()) {
-                throw new \RuntimeException($table->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
 
             // Get the new item ID

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -91,7 +91,7 @@ class CwmtemplateModel extends AdminModel
             $tmplCurr->title .= ' - copy';
 
             if (!$tmplCurr->store()) {
-                throw new \RuntimeException($tmplCurr->getError() ?: Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
         }
 

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -326,19 +326,20 @@ class CwmmediafileTable extends Table
         }
 
         // Check the row in by primary key.
-        $query = $this->_db->getQuery(true)
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
             ->update($this->_tbl)
-            ->set($this->_db->quoteName($this->getColumnAlias('checked_out')) . ' = 0')
+            ->set($db->quoteName($this->getColumnAlias('checked_out')) . ' = 0')
             ->set(
-                $this->_db->quoteName($this->getColumnAlias('checked_out_time')) . ' = ' . $this->_db->quote(
-                    $this->_db->getNullDate()
+                $db->quoteName($this->getColumnAlias('checked_out_time')) . ' = ' . $db->quote(
+                    $db->getNullDate()
                 )
             );
         $this->appendPrimaryKeys($query, $pk);
-        $this->_db->setQuery($query);
+        $db->setQuery($query);
 
         // Check for a database error.
-        $this->_db->execute();
+        $db->execute();
 
         // Set table values in the object.
         $this->checked_out      = 0;

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -193,7 +193,7 @@ class CwmtemplateTable extends Table
             // For existing records, merge submitted params with existing params
             // This preserves values from lazy-loaded sections that were never expanded
             if (!empty($array['id'])) {
-                $db    = $this->getDbo();
+                $db    = $this->getDatabase();
                 $query = $db->getQuery(true)
                     ->select($db->quoteName('params'))
                     ->from($db->quoteName('#__bsms_templates'))
@@ -264,9 +264,7 @@ class CwmtemplateTable extends Table
         $pk = $pk ?? $this->$k;
 
         if ((int) $pk === 1) {
-            $this->setError(Text::_('JBS_TPL_DEFAULT_ERROR'));
-
-            return false;
+            throw new \RuntimeException(Text::_('JBS_TPL_DEFAULT_ERROR'));
         }
 
         return parent::delete($pk);


### PR DESCRIPTION
## Summary
- Replaced `getError()`/`setError()` with proper exceptions across 6 admin models (CwmcommentModel, CwmmediafileModel, CwmmessageModel, CwmpodcastModel, CwmserieModel, CwmtemplateModel) and 1 table (CwmtemplateTable)
- Replaced `$this->_db` with `$this->getDatabase()` in CwmmediafileTable (6 occurrences)
- Replaced `getDbo()` with `getDatabase()` in CwmtemplateTable (1 occurrence)

These deprecated APIs have been deprecated since Joomla 1.7 (`getError`/`setError`) and Joomla 4.2 (`_db`/`getDbo`) and are removed in Joomla 7.

## Changes by file
| File | Pattern | Count |
|------|---------|-------|
| CwmmediafileModel | `$table->getError() ?:` removed | 6 |
| CwmmessageModel | `$table->getError() ?:` / `$row->getError()` removed | 5 |
| CwmcommentModel | `$table->getError()` load check + store/check patterns | 3 |
| CwmserieModel | `$table->getError()` load check + store/check patterns | 3 |
| CwmtemplateModel | `$tmplCurr->getError() ?:` removed | 1 |
| CwmpodcastModel | `$table->getError() ?:` removed | 1 |
| CwmtemplateTable | `setError()` → `throw RuntimeException` | 1 |
| CwmmediafileTable | `$this->_db` → `$this->getDatabase()` | 6 |
| CwmtemplateTable | `getDbo()` → `getDatabase()` | 1 |

## Test plan
- [ ] Edit and save a media file (exercises CwmmediafileModel save flow)
- [ ] Edit and save a message/sermon (exercises CwmmessageModel)
- [ ] Batch copy comments and series (exercises batchCopy in CwmcommentModel, CwmserieModel)
- [ ] Copy a template (exercises CwmtemplateModel::copy)
- [ ] Try to delete the default template (ID 1) — should show error message
- [ ] Check in a media file that was checked out (exercises CwmmediafileTable::checkIn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)