### PR TITLE
Wrap raw SQL identifiers with quoteName()

### DIFF
--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -98,21 +98,28 @@ class CwmtemplatecodesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                'templatecode.id, templatecode.published, templatecode.filename, templatecode.templatecode, templatecode.type'
+                implode(', ', $db->quoteName([
+                    'templatecode.id',
+                    'templatecode.published',
+                    'templatecode.filename',
+                    'templatecode.templatecode',
+                    'templatecode.type',
+                ]))
             )
         );
-        $query->from('`#__bsms_templatecode` AS templatecode');
+        $query->from($db->quoteName('#__bsms_templatecode', 'templatecode'));
 
         // Filter by search in filename or study title
         $search = $this->getState('filter.search');
 
         if (!empty($search)) {
             if (stripos($search, 'id:') === 0) {
-                $query->where('podcast.id = ' . (int)substr($search, 3));
+                $query->where($db->quoteName('templatecode.id') . ' = ' . (int)substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
                 $query->where(
-                    '(templatecode.filename LIKE ' . $search . ' OR templatecode.templatecode LIKE ' . $search . ')'
+                    '(' . $db->quoteName('templatecode.filename') . ' LIKE ' . $search
+                    . ' OR ' . $db->quoteName('templatecode.templatecode') . ' LIKE ' . $search . ')'
                 );
             }
         }
@@ -121,15 +128,15 @@ class CwmtemplatecodesModel extends ListModel
         $published = $this->getState('filter.published');
 
         if (is_numeric($published)) {
-            $query->where('templatecode.published = ' . (int)$published);
+            $query->where($db->quoteName('templatecode.published') . ' = ' . (int)$published);
         } elseif ($published === '') {
-            $query->where('(templatecode.published = 0 OR templatecode.published = 1)');
+            $query->where('(' . $db->quoteName('templatecode.published') . ' = 0 OR ' . $db->quoteName('templatecode.published') . ' = 1)');
         }
 
         // Add the list ordering clause
         $orderCol  = $this->state->get('list.ordering', 'templatecode.filename');
         $orderDirn = $this->state->get('list.direction', 'ASC');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        $query->order($db->quoteName($orderCol) . ' ' . $db->escape($orderDirn));
 
         return $query;
     }

--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -309,7 +309,7 @@ final class Proclaim extends Adapter implements SubscriberInterface
     protected function seriesAccessChange(Table $row): void
     {
         $query = clone $this->getStateQuery();
-        $query->where('s.id = ' . (int) $row->id);
+        $query->where($this->db->quoteName('s.id') . ' = ' . (int) $row->id);
 
         // Get the access level.
         $this->db->setQuery($query);
@@ -345,7 +345,7 @@ final class Proclaim extends Adapter implements SubscriberInterface
          */
         foreach ($pks as $pk) {
             $query = clone $this->getStateQuery();
-            $query->where('s.id = ' . (int) $pk);
+            $query->where($this->db->quoteName('s.id') . ' = ' . (int) $pk);
 
             // Get the published states.
             $this->db->setQuery($query);

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -247,24 +247,38 @@ class Cwmpagebuilder
         $groups = implode(',', $user->getAuthorisedViewLevels());
 
         $query = $db->getQuery(true);
+        $nullDateQuoted = $db->quote($db->getNullDate());
+        $query->select(implode(', ', $db->quoteName([
+            'study.id', 'study.published', 'study.studydate', 'study.studytitle',
+            'study.booknumber', 'study.chapter_begin', 'study.verse_begin',
+            'study.chapter_end', 'study.verse_end', 'study.hits', 'study.alias',
+            'study.studyintro', 'study.teacher_id', 'study.secondary_reference',
+            'study.booknumber2', 'study.location_id',
+        ])));
+        // Use studydate as fallback for modified
         $query->select(
-            'study.id, study.published, study.studydate, study.studytitle, study.booknumber, study.chapter_begin,
-		                study.verse_begin, study.chapter_end, study.verse_end, study.hits, study.alias, study.studyintro,
-		                study.teacher_id, study.secondary_reference, study.booknumber2, study.location_id, ' .
-            // Use created if modified is 0
-            'CASE WHEN study.modified = ' . $db->quote(
-                $db->getNullDate()
-            ) . ' THEN study.studydate ELSE study.modified END as modified, ' .
-            'study.modified_by, uam.name as modified_by_name,' .
-            // Use created if publish_up is 0
-            'CASE WHEN study.publish_up = ' . $db->quote(
-                $db->getNullDate()
-            ) . ' THEN study.studydate ELSE study.publish_up END as publish_up,' .
-            'study.publish_down,
-		                study.series_id, study.download_id, study.thumbnailm, study.thumbhm, study.thumbwm,
-		                study.access, study.user_name, study.user_id, study.studynumber, study.chapter_begin2, study.chapter_end2,
-		                study.verse_end2, study.verse_begin2, ' . $query->length('study.studytext') . ' AS readmore ,'
-            . ' CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END as slug '
+            'CASE WHEN ' . $db->quoteName('study.modified') . ' = ' . $nullDateQuoted
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.modified')
+            . ' END AS ' . $db->quoteName('modified')
+        );
+        $query->select($db->quoteName('study.modified_by') . ', ' . $db->quoteName('uam.name', 'modified_by_name'));
+        // Use studydate as fallback for publish_up
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.publish_up') . ' = ' . $nullDateQuoted
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.publish_up')
+            . ' END AS ' . $db->quoteName('publish_up')
+        );
+        $query->select(implode(', ', $db->quoteName([
+            'study.publish_down', 'study.series_id', 'study.download_id',
+            'study.thumbnailm', 'study.thumbhm', 'study.thumbwm',
+            'study.access', 'study.user_name', 'study.user_id', 'study.studynumber',
+            'study.chapter_begin2', 'study.chapter_end2', 'study.verse_end2', 'study.verse_begin2',
+        ])));
+        $query->select($query->length($db->quoteName('study.studytext')) . ' AS ' . $db->quoteName('readmore'));
+        $query->select(
+            'CASE WHEN CHAR_LENGTH(' . $db->quoteName('study.alias') . ') THEN CONCAT_WS('
+            . $db->quote(':') . ', ' . $db->quoteName('study.id') . ', ' . $db->quoteName('study.alias')
+            . ') ELSE ' . $db->quoteName('study.id') . ' END AS ' . $db->quoteName('slug')
         );
         $query->from($db->quoteName('#__bsms_studies', 'study'));
 
@@ -393,8 +407,8 @@ class Cwmpagebuilder
                 'com_proclaim'
             ))
         ) {
-            $query->where('(study.publish_up = ' . $nullDate . ' OR study.publish_up <= ' . $nowDate . ')')
-                ->where('(study.publish_down = ' . $nullDate . ' OR study.publish_down >= ' . $nowDate . ')');
+            $query->where('(' . $db->quoteName('study.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_up') . ' <= ' . $nowDate . ')')
+                ->where('(' . $db->quoteName('study.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_down') . ' >= ' . $nowDate . ')');
         }
 
         // Filter by language

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -119,22 +119,40 @@ class CwmseriesdisplayModel extends ItemModel
         $query->select(
             $this->getState(
                 'list.select',
-                'study.id, study.published, study.studydate, study.studytitle, study.booknumber, study.chapter_begin,
-		                study.verse_begin, study.chapter_end, study.verse_end, study.hits, study.alias, study.studyintro,
-		                study.teacher_id, study.secondary_reference, study.booknumber2, study.location_id, ' .
-                // Use created if modified is 0
-                'CASE WHEN study.modified = ' . $db->quote($nullDate) .
-                ' THEN study.studydate ELSE study.modified END AS modified, ' .
-                'study.modified_by, user_name AS modified_by_name,' .
-                // Use created if publish_up is 0
-                'CASE WHEN study.publish_up = ' . $db->quote($nullDate) .
-                ' THEN study.studydate ELSE study.publish_up END AS publish_up,' .
-                'study.publish_down,
-		                study.series_id, study.download_id, study.thumbnailm, study.thumbhm, study.thumbwm,
-		                study.access, study.user_name, study.user_id, study.studynumber, study.chapter_begin2, study.chapter_end2,
-		                study.verse_end2, study.verse_begin2, ' . $query->length('study.studytext') . ' AS readmore,'
+                implode(', ', $db->quoteName([
+                    'study.id', 'study.published', 'study.studydate', 'study.studytitle',
+                    'study.booknumber', 'study.chapter_begin', 'study.verse_begin',
+                    'study.chapter_end', 'study.verse_end', 'study.hits', 'study.alias',
+                    'study.studyintro', 'study.teacher_id', 'study.secondary_reference',
+                    'study.booknumber2', 'study.location_id',
+                ]))
             )
-            . ' CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END AS slug '
+        );
+        $quotedNullDate = $db->quote($nullDate);
+        // Use studydate as fallback for modified
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.modified') . ' = ' . $quotedNullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.modified')
+            . ' END AS ' . $db->quoteName('modified')
+        );
+        $query->select($db->quoteName('study.modified_by') . ', ' . $db->quoteName('study.user_name', 'modified_by_name'));
+        // Use studydate as fallback for publish_up
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.publish_up') . ' = ' . $quotedNullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.publish_up')
+            . ' END AS ' . $db->quoteName('publish_up')
+        );
+        $query->select(implode(', ', $db->quoteName([
+            'study.publish_down', 'study.series_id', 'study.download_id',
+            'study.thumbnailm', 'study.thumbhm', 'study.thumbwm',
+            'study.access', 'study.user_name', 'study.user_id', 'study.studynumber',
+            'study.chapter_begin2', 'study.chapter_end2', 'study.verse_end2', 'study.verse_begin2',
+        ])));
+        $query->select($query->length($db->quoteName('study.studytext')) . ' AS ' . $db->quoteName('readmore'));
+        $query->select(
+            'CASE WHEN CHAR_LENGTH(' . $db->quoteName('study.alias') . ') THEN CONCAT_WS('
+            . $db->quote(':') . ', ' . $db->quoteName('study.id') . ', ' . $db->quoteName('study.alias')
+            . ') ELSE ' . $db->quoteName('study.id') . ' END AS ' . $db->quoteName('slug')
         );
         $query->from($db->quoteName('#__bsms_studies', 'study'));
 

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -122,22 +122,40 @@ class CwmseriespodcastdisplayModel extends ItemModel
         $query->select(
             $this->getState(
                 'list.select',
-                'study.id, study.published, study.studydate, study.studytitle, study.booknumber, study.chapter_begin,
-		                study.verse_begin, study.chapter_end, study.verse_end, study.hits, study.alias, study.studyintro,
-		                study.teacher_id, study.secondary_reference, study.booknumber2, study.location_id, ' .
-                // Use created if modified is 0
-                'CASE WHEN study.modified = ' . $db->quote($nullDate) .
-                ' THEN study.studydate ELSE study.modified END AS modified, ' .
-                'study.modified_by, user_name AS modified_by_name,' .
-                // Use created if publish_up is 0
-                'CASE WHEN study.publish_up = ' . $db->quote($nullDate) .
-                ' THEN study.studydate ELSE study.publish_up END AS publish_up,' .
-                'study.publish_down,
-		                study.series_id, study.download_id, study.thumbnailm, study.thumbhm, study.thumbwm,
-		                study.access, study.user_name, study.user_id, study.studynumber, study.chapter_begin2, study.chapter_end2,
-		                study.verse_end2, study.verse_begin2,' . ' ' . $query->length('study.studytext') . ' AS readmore,'
+                implode(', ', $db->quoteName([
+                    'study.id', 'study.published', 'study.studydate', 'study.studytitle',
+                    'study.booknumber', 'study.chapter_begin', 'study.verse_begin',
+                    'study.chapter_end', 'study.verse_end', 'study.hits', 'study.alias',
+                    'study.studyintro', 'study.teacher_id', 'study.secondary_reference',
+                    'study.booknumber2', 'study.location_id',
+                ]))
             )
-            . ' CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END AS slug '
+        );
+        $quotedNullDate = $db->quote($nullDate);
+        // Use studydate as fallback for modified
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.modified') . ' = ' . $quotedNullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.modified')
+            . ' END AS ' . $db->quoteName('modified')
+        );
+        $query->select($db->quoteName('study.modified_by') . ', ' . $db->quoteName('study.user_name', 'modified_by_name'));
+        // Use studydate as fallback for publish_up
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.publish_up') . ' = ' . $quotedNullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.publish_up')
+            . ' END AS ' . $db->quoteName('publish_up')
+        );
+        $query->select(implode(', ', $db->quoteName([
+            'study.publish_down', 'study.series_id', 'study.download_id',
+            'study.thumbnailm', 'study.thumbhm', 'study.thumbwm',
+            'study.access', 'study.user_name', 'study.user_id', 'study.studynumber',
+            'study.chapter_begin2', 'study.chapter_end2', 'study.verse_end2', 'study.verse_begin2',
+        ])));
+        $query->select($query->length($db->quoteName('study.studytext')) . ' AS ' . $db->quoteName('readmore'));
+        $query->select(
+            'CASE WHEN CHAR_LENGTH(' . $db->quoteName('study.alias') . ') THEN CONCAT_WS('
+            . $db->quote(':') . ', ' . $db->quoteName('study.id') . ', ' . $db->quoteName('study.alias')
+            . ') ELSE ' . $db->quoteName('study.id') . ' END AS ' . $db->quoteName('slug')
         );
         $query->from($db->quoteName('#__bsms_studies', 'study'));
 

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -95,7 +95,10 @@ class CwmsermonModel extends FormModel
                 $query->select(
                     $this->getState(
                         'item.select',
-                        's.*,CASE WHEN CHAR_LENGTH(s.alias) THEN CONCAT_WS(\':\', s.id, s.alias) ELSE s.id END as slug'
+                        $db->quoteName('s') . '.*,'
+                        . 'CASE WHEN CHAR_LENGTH(' . $db->quoteName('s.alias') . ') THEN CONCAT_WS('
+                        . $db->quote(':') . ', ' . $db->quoteName('s.id') . ', ' . $db->quoteName('s.alias')
+                        . ') ELSE ' . $db->quoteName('s.id') . ' END AS ' . $db->quoteName('slug')
                     )
                 );
                 $query->from($db->quoteName('#__bsms_studies', 's'));
@@ -200,8 +203,8 @@ class CwmsermonModel extends FormModel
 
                     $nowDate = $db->quote($date->toSql());
 
-                    $query->where('(s.publish_up = ' . $nullDate . ' OR s.publish_up <= ' . $nowDate . ')')
-                        ->where('(s.publish_down = ' . $nullDate . ' OR s.publish_down >= ' . $nowDate . ')');
+                    $query->where('(' . $db->quoteName('s.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('s.publish_up') . ' <= ' . $nowDate . ')')
+                        ->where('(' . $db->quoteName('s.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('s.publish_down') . ' >= ' . $nowDate . ')');
                 }
 
                 // Implement View Level Access

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -534,26 +534,43 @@ class CwmsermonsModel extends ListModel
         $groups = $user->getAuthorisedViewLevels();
         $db     = $this->getDatabase();
         $query  = parent::getListQuery();
+        $nullDate = $db->quote($db->getNullDate());
         $query->select(
             $this->getState(
                 'list.select',
-                'study.id, study.published, study.studydate, study.studytitle, study.booknumber, study.chapter_begin,
-		                study.verse_begin, study.chapter_end, study.verse_end, study.hits, study.alias, study.studyintro,
-		                study.teacher_id, study.secondary_reference, study.booknumber2, study.location_id, study.studytext, study.params, ' .
-                // Use created if modified is 0
-                'CASE WHEN study.modified = ' . $db->quote(
-                    $db->getNullDate()
-                ) . ' THEN study.studydate ELSE study.modified END as modified, ' .
-                'study.modified_by, uam.name as modified_by_name,' .
-                // Use created if publish_up is 0
-                'CASE WHEN study.publish_up = ' . $db->quote(
-                    $db->getNullDate()
-                ) . ' THEN study.studydate ELSE study.publish_up END as publish_up,' .
-                'study.publish_down,
-		                study.series_id, study.download_id, study.thumbnailm, study.thumbhm, study.thumbwm,
-		                study.access, study.user_name, study.user_id, study.studynumber, study.chapter_begin2, study.chapter_end2,
-		                study.verse_end2, study.verse_begin2, ' . ' ' . $query->length('study.studytext') . ' AS readmore'
-            ) . ', CASE WHEN CHAR_LENGTH(study.alias) THEN CONCAT_WS(\':\', study.id, study.alias) ELSE study.id END as slug '
+                implode(', ', $db->quoteName([
+                    'study.id', 'study.published', 'study.studydate', 'study.studytitle',
+                    'study.booknumber', 'study.chapter_begin', 'study.verse_begin',
+                    'study.chapter_end', 'study.verse_end', 'study.hits', 'study.alias',
+                    'study.studyintro', 'study.teacher_id', 'study.secondary_reference',
+                    'study.booknumber2', 'study.location_id', 'study.studytext', 'study.params',
+                ]))
+            )
+        );
+        // Use studydate as fallback for modified
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.modified') . ' = ' . $nullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.modified')
+            . ' END AS ' . $db->quoteName('modified')
+        );
+        $query->select($db->quoteName('study.modified_by') . ', ' . $db->quoteName('uam.name', 'modified_by_name'));
+        // Use studydate as fallback for publish_up
+        $query->select(
+            'CASE WHEN ' . $db->quoteName('study.publish_up') . ' = ' . $nullDate
+            . ' THEN ' . $db->quoteName('study.studydate') . ' ELSE ' . $db->quoteName('study.publish_up')
+            . ' END AS ' . $db->quoteName('publish_up')
+        );
+        $query->select(implode(', ', $db->quoteName([
+            'study.publish_down', 'study.series_id', 'study.download_id',
+            'study.thumbnailm', 'study.thumbhm', 'study.thumbwm',
+            'study.access', 'study.user_name', 'study.user_id', 'study.studynumber',
+            'study.chapter_begin2', 'study.chapter_end2', 'study.verse_end2', 'study.verse_begin2',
+        ])));
+        $query->select($query->length($db->quoteName('study.studytext')) . ' AS ' . $db->quoteName('readmore'));
+        $query->select(
+            'CASE WHEN CHAR_LENGTH(' . $db->quoteName('study.alias') . ') THEN CONCAT_WS('
+            . $db->quote(':') . ', ' . $db->quoteName('study.id') . ', ' . $db->quoteName('study.alias')
+            . ') ELSE ' . $db->quoteName('study.id') . ' END AS ' . $db->quoteName('slug')
         );
         $query->from($db->quoteName('#__bsms_studies', 'study'));
 
@@ -690,9 +707,8 @@ class CwmsermonsModel extends ListModel
         }
         $query->where('(' . $db->quoteName('series.published') . ' = 1 OR ' . $db->quoteName('study.series_id') . ' <= 0)');
 
-        // Define null and now dates
-        $nullDate = $db->quote($db->getNullDate());
-        $nowDate  = $db->quote((new Date())->toSql());
+        // Define now date for publish filter
+        $nowDate = $db->quote((new Date())->toSql());
 
         // Filter by start and end dates.
         if (
@@ -701,8 +717,8 @@ class CwmsermonsModel extends ListModel
                 'com_proclaim'
             ))
         ) {
-            $query->where('(study.publish_up = ' . $nullDate . ' OR study.publish_up <= ' . $nowDate . ')')
-                ->where('(study.publish_down = ' . $nullDate . ' OR study.publish_down >= ' . $nowDate . ')');
+            $query->where('(' . $db->quoteName('study.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_up') . ' <= ' . $nowDate . ')')
+                ->where('(' . $db->quoteName('study.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_down') . ' >= ' . $nowDate . ')');
         }
 
         // Begin the filters for menu items
@@ -1005,7 +1021,7 @@ class CwmsermonsModel extends ListModel
                         $subquery = '(';
 
                         foreach ($filtervalue as $filterid) {
-                            $where2[] = $filter . ' = ' . (int)$filterid;
+                            $where2[] = $db->quoteName($filter) . ' = ' . (int)$filterid;
                         }
 
                         $subquery .= implode(' OR ', $where2);
@@ -1019,7 +1035,7 @@ class CwmsermonsModel extends ListModel
                                     $$filterid = $this->getState($filter);
                                 }
 
-                                $query->where($filter . ' = ' . (int)$filterid);
+                                $query->where($db->quoteName($filter) . ' = ' . (int)$filterid);
                             }
 
                             if ((int)$filterid >= 1 && $filter === 'study.booknumber') {
@@ -1029,24 +1045,24 @@ class CwmsermonsModel extends ListModel
 
                                 if ($chb && $che) {
                                     $query->where(
-                                        '(study.booknumber = ' . (int)$book .
-                                        ' AND study.chapter_begin >= ' . (int)$chb .
-                                        ' AND study.chapter_end <= ' . (int)$che . ')' .
-                                        'OR study.booknumber2 = ' . (int)$book
+                                        '(' . $db->quoteName('study.booknumber') . ' = ' . (int)$book .
+                                        ' AND ' . $db->quoteName('study.chapter_begin') . ' >= ' . (int)$chb .
+                                        ' AND ' . $db->quoteName('study.chapter_end') . ' <= ' . (int)$che . ')' .
+                                        ' OR ' . $db->quoteName('study.booknumber2') . ' = ' . (int)$book
                                     );
                                 } elseif ($chb) {
                                     $query->where(
-                                        '(study.booknumber = ' . (int)$book . ' AND study.chapter_begin > = ' .
-                                        (int)$chb . ') OR study.booknumber2 = ' . (int)$book
+                                        '(' . $db->quoteName('study.booknumber') . ' = ' . (int)$book . ' AND ' . $db->quoteName('study.chapter_begin') . ' >= ' .
+                                        (int)$chb . ') OR ' . $db->quoteName('study.booknumber2') . ' = ' . (int)$book
                                     );
                                 } elseif ($che) {
                                     $query->where(
-                                        '(study.booknumber = ' . (int)$book . ' AND study.chapter_end <= ' .
-                                        $che . ') OR study.booknumber2 = ' . (int)$book
+                                        '(' . $db->quoteName('study.booknumber') . ' = ' . (int)$book . ' AND ' . $db->quoteName('study.chapter_end') . ' <= ' .
+                                        (int)$che . ') OR ' . $db->quoteName('study.booknumber2') . ' = ' . (int)$book
                                     );
                                 } else {
                                     $query->where(
-                                        '(study.booknumber = ' . (int)$book . ' OR study.booknumber2 = ' . (int)$book . ')'
+                                        '(' . $db->quoteName('study.booknumber') . ' = ' . (int)$book . ' OR ' . $db->quoteName('study.booknumber2') . ' = ' . (int)$book . ')'
                                     );
                                 }
                             }


### PR DESCRIPTION
## Summary
- Wraps all bare SQL column/table names with `$db->quoteName()` across 7 files for SQL injection safety and cross-database compatibility
- Breaks large monolithic `$query->select()` calls into multiple readable calls with proper identifier quoting
- Fixes bug in `CwmtemplatecodesModel` where search-by-ID filter referenced wrong table alias (`podcast.id` → `templatecode.id`)
- Replaces escaped single-quote colon literals (`\':\''`) with `$db->quote(':')` in CONCAT_WS expressions

## Files changed
| File | Changes |
|------|---------|
| `admin/src/Model/CwmtemplatecodesModel.php` | SELECT, FROM, WHERE, ORDER clauses + bug fix |
| `plugins/finder/proclaim/src/Extension/Proclaim.php` | 2 WHERE clauses in series state/access methods |
| `site/src/Model/CwmsermonModel.php` | SELECT slug + WHERE publish dates |
| `site/src/Model/CwmsermonsModel.php` | Large SELECT block + WHERE publish dates + filter loop |
| `site/src/Model/CwmseriesdisplayModel.php` | Large SELECT block |
| `site/src/Model/CwmseriespodcastdisplayModel.php` | Large SELECT block |
| `site/src/Helper/Cwmpagebuilder.php` | Large SELECT block + WHERE publish dates |

## Test plan
- [ ] Verify sermon list page loads correctly (exercises CwmsermonsModel, Cwmpagebuilder)
- [ ] Verify single sermon detail page loads (exercises CwmsermonModel)
- [ ] Verify series display page loads (exercises CwmseriesdisplayModel)
- [ ] Verify template codes list loads in admin (exercises CwmtemplatecodesModel)
- [ ] Verify Smart Search indexing works (exercises finder plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)