### PR TITLE
Add check-in/checkout support for all entity types

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -76,9 +76,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_comments`
     `asset_id`     INT(10) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'FK to the #__assets table.',
     `access`       INT(10) UNSIGNED NOT NULL DEFAULT '0',
     `language`     CHAR(7)          NOT NULL COMMENT 'The language code for the Comments.',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`),
     KEY `idx_study_published` (`study_id`, `published`, `comment_date`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -138,6 +141,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_locations`
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`),
     KEY `idx_published_access` (`published`, `access`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -206,9 +210,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_message_type`
     `created_by_alias` VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`         DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
-    KEY `idx_access` (`access`)
+    KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -258,9 +265,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_podcast`
     `created_by_alias`        VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`                DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`             INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`             INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time`        DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
-    KEY `idx_access` (`access`)
+    KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -292,9 +302,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_series`
     `created_by_alias` VARCHAR(255)                                     NOT NULL DEFAULT '',
     `modified`         DATETIME                                         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED                                 NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED                                 NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                                                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`),
     KEY `idx_createdby` (`created_by`),
     KEY `idx_published_access` (`published`, `access`),
     KEY `idx_teacher_published` (`teacher`, `published`)
@@ -323,9 +336,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_servers`
     `created_by_alias` VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`         DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
-    KEY `idx_access` (`access`)
+    KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -484,9 +500,12 @@ CREATE TABLE IF NOT EXISTS `#__bsms_teachers`
     `created_by_alias`  VARCHAR(255)                                     NOT NULL DEFAULT '',
     `modified`          DATETIME                                         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`       INT(10) UNSIGNED                                 NOT NULL DEFAULT '0',
+    `checked_out`       INT(10) UNSIGNED                                 NOT NULL DEFAULT 0,
+    `checked_out_time`  DATETIME                                                  DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`),
     KEY `idx_createdby` (`created_by`),
     KEY `idx_published_access` (`published`, `access`)
 ) ENGINE InnoDB
@@ -511,8 +530,11 @@ CREATE TABLE IF NOT EXISTS `#__bsms_templatecode`
     `created_by_alias` VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`         DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     `templatecode`     MEDIUMTEXT       NOT NULL,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    KEY `idx_checkout` (`checked_out`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -539,10 +561,13 @@ CREATE TABLE IF NOT EXISTS `#__bsms_templates`
     `created_by_alias` VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`         DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     `access`           INT(10) UNSIGNED NOT NULL DEFAULT '0',
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
-    KEY `idx_access` (`access`)
+    KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -579,12 +604,15 @@ CREATE TABLE IF NOT EXISTS `#__bsms_topics`
     `created_by_alias` VARCHAR(255)     NOT NULL DEFAULT '',
     `modified`         DATETIME         NOT NULL DEFAULT '0000-00-00 00:00:00',
     `modified_by`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    `checked_out`      INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `checked_out_time` DATETIME                  DEFAULT NULL,
     `asset_id`         INT(10) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'FK to the #__assets table.',
     `language`         CHAR(7)                   DEFAULT '*',
     `access`           INT(10) UNSIGNED NOT NULL DEFAULT '1',
     PRIMARY KEY (`id`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
+    KEY `idx_checkout` (`checked_out`),
     KEY `idx_published_access` (`published`, `access`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/admin/sql/updates/mysql/10.1.0-20260211.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260211.sql
@@ -1,0 +1,52 @@
+--
+-- Add checked_out and checked_out_time columns for check-in/check-out support
+--
+
+ALTER TABLE `#__bsms_teachers`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_series`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_topics`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_message_type`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_servers`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_podcast`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_templates`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_templatecode`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+ALTER TABLE `#__bsms_comments`
+    ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `language`,
+    ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`,
+    ADD KEY `idx_checkout` (`checked_out`);
+
+-- Add missing index to locations (columns already exist)
+ALTER TABLE `#__bsms_locations`
+    ADD KEY `idx_checkout` (`checked_out`);

--- a/admin/src/Controller/CwmmediafilesController.php
+++ b/admin/src/Controller/CwmmediafilesController.php
@@ -17,13 +17,8 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
-use CWM\Component\Proclaim\Administrator\Model\CwmmediafileModel;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\CMS\Router\Route;
-use Joomla\CMS\Session\Session;
 
 /**
  * MediaFiles list controller class
@@ -33,51 +28,6 @@ use Joomla\CMS\Session\Session;
  */
 class CwmmediafilesController extends AdminController
 {
-    /**
-     * Check in of one or more records.
-     *
-     * @return  bool  True on success
-     *
-     * @throws \Exception
-     * @since   7.0.0
-     */
-    public function checkin(): bool
-    {
-        // Check for request forgeries.
-        if (!Session::checkToken()) {
-            $this->setRedirect('index.php?option=com_proclaim&view=cwmmediafiles', Text::_('JINVALID_TOKEN'), 'error');
-
-            return false;
-        }
-
-        $ids = Factory::getApplication()->getInput()->post->get('cid', [], 'array');
-
-        /** @var CwmmediafileModel $model */
-        $model  = $this->getModel($name = 'Cwmmediafile', $prefix = 'Administrator', $config = ['ignore_request' => true]);
-        $return = $model->checkin($ids);
-
-        if ($return === false) {
-            // Checkin failed.
-            $message = Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', '');
-            $this->setRedirect(
-                Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false),
-                $message,
-                'error'
-            );
-
-            return false;
-        }
-
-        // Checkin succeeded.
-        $message = Text::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', \count($ids));
-        $this->setRedirect(
-            Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false),
-            $message
-        );
-
-        return true;
-    }
-
     /**
      * Proxy for getModel.
      *

--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -159,20 +159,6 @@ class CwmadminModel extends AdminModel
     }
 
     /**
-     * Method to check-out a row for editing.
-     *
-     * @param   null  $pk  The numeric id of the primary key.
-     *
-     * @return bool|int|null False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool|int|null
-    {
-        return $pk;
-    }
-
-    /**
      * Get Media Files
      *
      * @return mixed

--- a/admin/src/Model/CwmcommentModel.php
+++ b/admin/src/Model/CwmcommentModel.php
@@ -63,20 +63,6 @@ class CwmcommentModel extends AdminModel
     }
 
     /**
-     * Method to check-out a row for editing.
-     *
-     * @param   int  $pk  The numeric id of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): mixed
-    {
-        return $pk;
-    }
-
-    /**
      * Get the form data
      *
      * @param   array    $data      Data for the form.

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -168,6 +168,8 @@ class CwmcommentsModel extends ListModel
                         'comment.access',
                         'comment.language',
                         'comment.asset_id',
+                        'comment.checked_out',
+                        'comment.checked_out_time',
                     ]
                 ))
             )
@@ -226,6 +228,10 @@ class CwmcommentsModel extends ListModel
             'LEFT',
             $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('comment.access')
         );
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('comment.checked_out'));
 
         // Add the list ordering clause
         $orderCol  = $this->state->get('list.ordering', 'study.studytitle');

--- a/admin/src/Model/CwmlocationModel.php
+++ b/admin/src/Model/CwmlocationModel.php
@@ -72,20 +72,6 @@ class CwmlocationModel extends AdminModel
     }
 
     /**
-     * Method to check-out a row for editing.
-     *
-     * @param   ?int  $pk  The numeric id of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Method to get the data that should be injected in the form.
      *
      * @return  array    The default data is an empty array.

--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -196,7 +196,7 @@ class CwmlocationsModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                implode(', ', $db->qn(['location.id', 'location.published', 'location.access', 'location.location_text']))
+                implode(', ', $db->qn(['location.id', 'location.published', 'location.access', 'location.location_text', 'location.checked_out', 'location.checked_out_time']))
             )
         );
         $query->from($db->qn('#__bsms_locations', 'location'));
@@ -207,6 +207,10 @@ class CwmlocationsModel extends ListModel
             'LEFT',
             $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('location.access')
         );
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('location.checked_out'));
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -863,44 +863,6 @@ class CwmmediafileModel extends AdminModel
     }
 
     /**
-     * Method override to check in a record or an array of records
-     *
-     * @param   mixed  $pks  The ID of the primary key or an array of IDs
-     *
-     * @return  false|int  Boolean false if there is an error, otherwise the count of records checked in.
-     *
-     * @throws \Exception
-     * @since   12.2
-     */
-    public function checkin($pks = []): false|int
-    {
-        $pks   = (array)$pks;
-        $table = $this->getTable();
-        $count = 0;
-
-        if (empty($pks)) {
-            $pks = [(int)$this->getState('mediafile.id')];
-        }
-
-        // Check in all items.
-        foreach ($pks as $pk) {
-            if ($table->load($pk)) {
-                if ($table->checked_out > 0) {
-                    if (!parent::checkin($pk)) {
-                        return false;
-                    }
-
-                    $count++;
-                }
-            } else {
-                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_RECORD_NOT_FOUND'));
-            }
-        }
-
-        return $count;
-    }
-
-    /**
      * Method to test whether a record can be deleted.
      *
      * @param   object  $record  A record object.

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -413,20 +413,6 @@ class CwmmessageModel extends AdminModel
     }
 
     /**
-     * Method to check-out a row for editing.
-     *
-     * @param   int  $pk  The numeric id of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Saves the manually set order of records.
      *
      * @param   array  $pks    An array of primary key ids.

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -222,6 +222,8 @@ class CwmmessagesModel extends ListModel
                         'study.publish_up',
                         'study.publish_down',
                         'study.params',
+                        'study.checked_out',
+                        'study.checked_out_time',
                     ]
                 ))
             )
@@ -275,6 +277,10 @@ class CwmmessagesModel extends ListModel
             $db->qn('#__bsms_mediafiles', 'mediafile') . ' ON ' . $db->qn('mediafile.study_id') . ' = ' . $db->qn('study.id')
         );
         $query->group($db->qn('study.id'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('study.checked_out'));
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {

--- a/admin/src/Model/CwmmessagetypeModel.php
+++ b/admin/src/Model/CwmmessagetypeModel.php
@@ -52,20 +52,6 @@ class CwmmessagetypeModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   int  $pk  The numeric id of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Method to get a table object, load it if necessary.
      *
      * @param   string  $name     The table name. Optional.

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -202,12 +202,18 @@ class CwmmessagetypesModel extends ListModel
                         'messagetype.ordering',
                         'messagetype.access',
                         'messagetype.alias',
+                        'messagetype.checked_out',
+                        'messagetype.checked_out_time',
                     ]
                 ))
             )
         );
 
         $query->from($db->qn('#__bsms_message_type', 'messagetype'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('messagetype.checked_out'));
 
         // Filter by published state
         $published = $this->getState('filter.published');

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -70,20 +70,6 @@ class CwmpodcastModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   null  $pk  The numeric ID of the primary key.
-     *
-     * @return int|null False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): ?int
-    {
-        return (int)$pk;
-    }
-
-    /**
      * Method to get a table object, load it if necessary.
      *
      * @param   string  $name     The table name. Optional.

--- a/admin/src/Model/CwmpodcastsModel.php
+++ b/admin/src/Model/CwmpodcastsModel.php
@@ -158,6 +158,8 @@ class CwmpodcastsModel extends ListModel
                         'podcast.filename',
                         'podcast.language',
                         'podcast.access',
+                        'podcast.checked_out',
+                        'podcast.checked_out_time',
                     ]
                 ))
             )
@@ -177,6 +179,10 @@ class CwmpodcastsModel extends ListModel
                 'LEFT',
                 $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('podcast.access')
             );
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('podcast.checked_out'));
 
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -254,20 +254,6 @@ class CwmserieModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   int  $pk  The numeric ID of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Batch copy items to a new category or the current one.
      *
      * @param   int    $value     The new category.

--- a/admin/src/Model/CwmseriesModel.php
+++ b/admin/src/Model/CwmseriesModel.php
@@ -168,6 +168,8 @@ class CwmseriesModel extends ListModel
                     $db->quoteName('series.language'),
                     $db->quoteName('series.access'),
                     $db->quoteName('series.ordering'),
+                    $db->quoteName('series.checked_out'),
+                    $db->quoteName('series.checked_out_time'),
                 ])
             )
         )
@@ -184,7 +186,11 @@ class CwmseriesModel extends ListModel
         ->join('LEFT', $db->quoteName('#__languages', 'l'), $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('series.language'))
 
         // Join over the asset groups.
-        ->join('LEFT', '#__viewlevels AS ag ON ag.id = series.access');
+        ->join('LEFT', '#__viewlevels AS ag ON ag.id = series.access')
+
+        // Join over the users for the checked out user.
+        ->select($db->quoteName('uc.name', 'editor'))
+        ->join('LEFT', $db->quoteName('#__users', 'uc'), $db->quoteName('uc.id') . ' = ' . $db->quoteName('series.checked_out'));
 
         // Filter on the language.
         if ($language = $this->getState('filter.language')) {

--- a/admin/src/Model/CwmserversModel.php
+++ b/admin/src/Model/CwmserversModel.php
@@ -181,8 +181,12 @@ class CwmserversModel extends ListModel
         $query = $db->getQuery(true);
         $user  = Factory::getApplication()->getIdentity();
 
-        $query->select($this->getState('list.select', 'server.id, server.published, server.server_name, server.type'));
+        $query->select($this->getState('list.select', 'server.id, server.published, server.server_name, server.type, server.checked_out, server.checked_out_time'));
         $query->from($db->quoteName('#__bsms_servers', 'server'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->quoteName('uc.name', 'editor'))
+            ->join('LEFT', $db->quoteName('#__users', 'uc') . ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('server.checked_out'));
 
         // Filter by published state
         $published = $this->getState('filter.published');

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -156,20 +156,6 @@ class CwmteacherModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   int  $pk  The numeric id of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Method to validate the form data.
      *
      * @param   Form    $form   The form to validate against.

--- a/admin/src/Model/CwmteachersModel.php
+++ b/admin/src/Model/CwmteachersModel.php
@@ -166,6 +166,10 @@ class CwmteachersModel extends ListModel
             $db->qn('#__viewlevels', 'ag') . ' ON ' . $db->qn('ag.id') . ' = ' . $db->qn('teacher.access')
         );
 
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('teacher.checked_out'));
+
         // Filter by access level.
         if ($access = $this->getState('filter.access')) {
             $query->where($db->qn('teacher.access') . ' = ' . (int) $access);

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -145,20 +145,6 @@ class CwmtemplateModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   int  $pk  The numeric id of the primary key.
-     *
-     * @return  ?int  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): ?int
-    {
-        return $pk;
-    }
-
-    /**
      * Method to get a table object, load it if necessary.
      *
      * @param   string  $name     The table name. Optional.

--- a/admin/src/Model/CwmtemplatecodeModel.php
+++ b/admin/src/Model/CwmtemplatecodeModel.php
@@ -82,20 +82,6 @@ class CwmtemplatecodeModel extends AdminModel
     }
 
     /**
-     * Method to check-out a row for editing.
-     *
-     * @param   null  $pk  The numeric id of the primary key.
-     *
-     * @return bool|int|null False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool|int|null
-    {
-        return $pk;
-    }
-
-    /**
      * Get Type Language String
      *
      * @return ?string

--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -104,10 +104,16 @@ class CwmtemplatecodesModel extends ListModel
                     'templatecode.filename',
                     'templatecode.templatecode',
                     'templatecode.type',
+                    'templatecode.checked_out',
+                    'templatecode.checked_out_time',
                 ]))
             )
         );
         $query->from($db->quoteName('#__bsms_templatecode', 'templatecode'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->quoteName('uc.name', 'editor'))
+            ->join('LEFT', $db->quoteName('#__users', 'uc') . ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('templatecode.checked_out'));
 
         // Filter by search in filename or study title
         $search = $this->getState('filter.search');

--- a/admin/src/Model/CwmtemplatesModel.php
+++ b/admin/src/Model/CwmtemplatesModel.php
@@ -153,10 +153,14 @@ class CwmtemplatesModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                implode(', ', $db->qn(['template.id', 'template.published', 'template.title']))
+                implode(', ', $db->qn(['template.id', 'template.published', 'template.title', 'template.checked_out', 'template.checked_out_time']))
             )
         );
         $query->from($db->qn('#__bsms_templates', 'template'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('template.checked_out'));
 
         // Filter by published state
         $published = $this->getState('filter.published');

--- a/admin/src/Model/CwmtopicModel.php
+++ b/admin/src/Model/CwmtopicModel.php
@@ -66,20 +66,6 @@ class CwmtopicModel extends AdminModel
     }
 
     /**
-     * Method to check out a row for editing.
-     *
-     * @param   mixed  $pk  The numeric ID of the primary key.
-     *
-     * @return  bool  False on failure or error, true otherwise.
-     *
-     * @since   11.1
-     */
-    public function checkout($pk = null): bool
-    {
-        return true;
-    }
-
-    /**
      * Method to get a table object, load it if necessary.
      *
      * @param   string  $name     The table name. Optional.

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -135,10 +135,14 @@ class CwmtopicsModel extends ListModel
         $query->select(
             $this->getState(
                 'list.select',
-                implode(', ', $db->qn(['topic.id', 'topic.topic_text', 'topic.published'])) . ', ' . $db->qn('topic.params', 'topic_params')
+                implode(', ', $db->qn(['topic.id', 'topic.topic_text', 'topic.published', 'topic.checked_out', 'topic.checked_out_time'])) . ', ' . $db->qn('topic.params', 'topic_params')
             )
         );
         $query->from($db->qn('#__bsms_topics', 'topic'));
+
+        // Join over the users for the checked out user.
+        $query->select($db->qn('uc.name', 'editor'))
+            ->join('LEFT', $db->qn('#__users', 'uc') . ' ON ' . $db->qn('uc.id') . ' = ' . $db->qn('topic.checked_out'));
 
         // Filter by search in title.
         $search = $this->getState('filter.search');

--- a/admin/src/Table/CwmcommentTable.php
+++ b/admin/src/Table/CwmcommentTable.php
@@ -158,6 +158,22 @@ class CwmcommentTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmlocationTable.php
+++ b/admin/src/Table/CwmlocationTable.php
@@ -128,6 +128,22 @@ class CwmlocationTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -288,67 +288,6 @@ class CwmmediafileTable extends Table
     }
 
     /**
-     * Method to check a row in if the necessary properties/fields exist.  Checking
-     * a row in will allow other users the ability to edit the row.
-     *
-     * @param   mixed  $pk  An optional primary key value to check out.  If not set the instance property value is used.
-     *
-     * @return  bool  True on success.
-     *
-     * @throws  \UnexpectedValueException
-     * @since   11.1
-     * @link    http://docs.joomla.org/Table/checkIn
-     */
-    #[\Override]
-    public function checkIn($pk = null): bool
-    {
-        // If there is no checked_out or checked_out_time field, just return true.
-        if (!property_exists($this, 'checked_out') || !property_exists($this, 'checked_out_time')) {
-            return true;
-        }
-
-        if (\is_null($pk)) {
-            $pk = [];
-
-            foreach ($this->_tbl_keys as $key) {
-                $pk[$this->$key] = $this->$key;
-            }
-        } elseif (!\is_array($pk)) {
-            $pk = [$this->_tbl_key => $pk];
-        }
-
-        foreach ($this->_tbl_keys as $key) {
-            $pk[$key] = empty($pk[$key]) ? $this->$key : $pk[$key];
-
-            if ($pk[$key] === null) {
-                throw new \UnexpectedValueException('Null primary key not allowed.');
-            }
-        }
-
-        // Check the row in by primary key.
-        $db    = $this->getDatabase();
-        $query = $db->getQuery(true)
-            ->update($this->_tbl)
-            ->set($db->quoteName($this->getColumnAlias('checked_out')) . ' = 0')
-            ->set(
-                $db->quoteName($this->getColumnAlias('checked_out_time')) . ' = ' . $db->quote(
-                    $db->getNullDate()
-                )
-            );
-        $this->appendPrimaryKeys($query, $pk);
-        $db->setQuery($query);
-
-        // Check for a database error.
-        $db->execute();
-
-        // Set table values in the object.
-        $this->checked_out      = 0;
-        $this->checked_out_time = '';
-
-        return true;
-    }
-
-    /**
      * Method to compute the default name of the asset.
      * The default name is in the form `table_name.id`
      * where id is the value of the primary key of the table.

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -138,6 +138,22 @@ class CwmmessagetypeTable extends Table
     public ?string $message_type = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmpodcastTable.php
+++ b/admin/src/Table/CwmpodcastTable.php
@@ -316,6 +316,22 @@ class CwmpodcastTable extends Table
     public ?string $params = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmserieTable.php
+++ b/admin/src/Table/CwmserieTable.php
@@ -181,6 +181,22 @@ class CwmserieTable extends Table
     public int $podcast_show = 0;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmserverTable.php
+++ b/admin/src/Table/CwmserverTable.php
@@ -141,6 +141,22 @@ class CwmserverTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmteacherTable.php
+++ b/admin/src/Table/CwmteacherTable.php
@@ -108,6 +108,22 @@ class CwmteacherTable extends Table
     public ?string $teacher_thumbnail = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -160,6 +160,22 @@ class CwmtemplateTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Contractor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -109,6 +109,22 @@ class CwmtemplatecodeTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param     $db  DatabaseInterface connector object

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -132,6 +132,22 @@ class CwmtopicTable extends Table
     public ?int $modified_by = null;
 
     /**
+     * Checked out user ID
+     *
+     * @var int|null
+     * @since 10.1.0
+     */
+    public ?int $checked_out = null;
+
+    /**
+     * Checked out time
+     *
+     * @var string|null
+     * @since 10.1.0
+     */
+    public ?string $checked_out_time = null;
+
+    /**
      * Constructor
      *
      * @param   DatabaseDriver  $db  Database connector object

--- a/admin/src/View/Cwmcomments/HtmlView.php
+++ b/admin/src/View/Cwmcomments/HtmlView.php
@@ -150,6 +150,7 @@ class HtmlView extends BaseHtmlView
         if ($canDo->get('core.edit.state')) {
             $childBar->publish('cwmcomments.publish');
             $childBar->unpublish('cwmcomments.unpublish');
+            $childBar->checkin('cwmcomments.checkin')->listCheck(true);
 
             if ((int) $this->state->get('filter.published') !== ContentComponent::CONDITION_TRASHED) {
                 $childBar->trash('cwmcomments.trash');

--- a/admin/src/View/Cwmlocations/HtmlView.php
+++ b/admin/src/View/Cwmlocations/HtmlView.php
@@ -146,6 +146,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmlocations.publish');
             $childBar->unpublish('cwmlocations.unpublish');
             $childBar->archive('cwmlocations.archive');
+            $childBar->checkin('cwmlocations.checkin')->listCheck(true);
 
             if ((int) $this->state->get('filter.published') !== ContentComponent::CONDITION_TRASHED) {
                 $childBar->trash('cwmlocations.trash')->listCheck(true);

--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -202,6 +202,7 @@ class HtmlView extends BaseHtmlView
                 $childBar->publish('cwmmediafiles.publish');
                 $childBar->unpublish('cwmmediafiles.unpublish');
                 $childBar->archive('cwmmediafiles.archive');
+                $childBar->checkin('cwmmediafiles.checkin')->listCheck(true);
 
                 if ((int) $this->state->get('filter.published') !== ContentComponent::CONDITION_TRASHED) {
                     $childBar->trash('cwmmediafiles.trash')->listCheck(true);

--- a/admin/src/View/Cwmmessagetypes/HtmlView.php
+++ b/admin/src/View/Cwmmessagetypes/HtmlView.php
@@ -141,6 +141,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmmessagetypes.publish');
             $childBar->unpublish('cwmmessagetypes.unpublish');
             $childBar->archive('cwmmessagetypes.archive');
+            $childBar->checkin('cwmmessagetypes.checkin')->listCheck(true);
 
             if ((int) $this->state->get('filter.published') !== ContentComponent::CONDITION_TRASHED) {
                 $childBar->trash('cwmmessagetypes.trash')->listCheck(true);

--- a/admin/src/View/Cwmpodcasts/HtmlView.php
+++ b/admin/src/View/Cwmpodcasts/HtmlView.php
@@ -142,6 +142,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmpodcasts.publish')->listCheck(true);
             $childBar->unpublish('cwmpodcasts.unpublish')->listCheck(true);
             $childBar->archive('cwmpodcasts.archive')->listCheck(true);
+            $childBar->checkin('cwmpodcasts.checkin')->listCheck(true);
 
             if ($this->state->get('filter.published') != -2) {
                 $childBar->trash('cwmpodcasts.trash')->listCheck(true);

--- a/admin/src/View/Cwmseries/HtmlView.php
+++ b/admin/src/View/Cwmseries/HtmlView.php
@@ -176,6 +176,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmseries.publish');
             $childBar->unpublish('cwmseries.unpublish');
             $childBar->archive('cwmseries.archive');
+            $childBar->checkin('cwmseries.checkin')->listCheck(true);
 
             if ($canDo->get('core.edit.state')) {
                 $childBar->trash('cwmseries.trash');

--- a/admin/src/View/Cwmservers/HtmlView.php
+++ b/admin/src/View/Cwmservers/HtmlView.php
@@ -141,6 +141,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmservers.publish')->listCheck(true);
             $childBar->unpublish('cwmservers.unpublish')->listCheck(true);
             $childBar->archive('cwmservers.archive')->listCheck(true);
+            $childBar->checkin('cwmservers.checkin')->listCheck(true);
 
             if ($this->state->get('filter.published') != -2) {
                 $childBar->trash('cwmservers.trash')->listCheck(true);

--- a/admin/src/View/Cwmteachers/HtmlView.php
+++ b/admin/src/View/Cwmteachers/HtmlView.php
@@ -150,6 +150,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmteachers.publish');
             $childBar->unpublish('cwmteachers.unpublish');
             $childBar->archive('cwmteachers.archive');
+            $childBar->checkin('cwmteachers.checkin')->listCheck(true);
 
             if ((int) $this->state->get('filter.published') !== ProclaimComponent::CONDITION_TRASHED) {
                 $childBar->trash('cwmteachers.trash')->listCheck(true);

--- a/admin/src/View/Cwmtemplatecodes/HtmlView.php
+++ b/admin/src/View/Cwmtemplatecodes/HtmlView.php
@@ -161,6 +161,7 @@ class HtmlView extends BaseHtmlView
                 $childBar->publish('cwmtemplatecodes.publish');
                 $childBar->unpublish('cwmtemplatecodes.unpublish');
                 $childBar->archive('cwmtemplatecodes.archive');
+                $childBar->checkin('cwmtemplatecodes.checkin')->listCheck(true);
 
                 if ((int) $this->state->get('filter.published') !== ProclaimComponent::CONDITION_TRASHED) {
                     $childBar->trash('cwmtemplatecodes.trash')->listCheck(true);

--- a/admin/src/View/Cwmtemplates/HtmlView.php
+++ b/admin/src/View/Cwmtemplates/HtmlView.php
@@ -160,6 +160,7 @@ class HtmlView extends BaseHtmlView
         if ($this->canDo->get('core.edit.state')) {
             $childBar->publish('cwmtemplates.publish');
             $childBar->unpublish('cwmtemplates.unpublish');
+            $childBar->checkin('cwmtemplates.checkin')->listCheck(true);
             $childBar->trash('cwmtemplates.trash');
 
             // Add a batch button

--- a/admin/src/View/Cwmtopics/HtmlView.php
+++ b/admin/src/View/Cwmtopics/HtmlView.php
@@ -148,6 +148,7 @@ class HtmlView extends BaseHtmlView
             $childBar->publish('cwmtopics.publish');
             $childBar->unpublish('cwmtopics.unpublish');
             $childBar->archive('cwmtopics.archive', 'JTOOLBAR_ARCHIVE');
+            $childBar->checkin('cwmtopics.checkin')->listCheck(true);
 
             if ((int) $this->state->get('filter.published') !== ContentComponent::CONDITION_TRASHED) {
                 $childBar->trash('cwmtopics.trash')->listCheck(true);

--- a/admin/tmpl/cwmcomments/default.php
+++ b/admin/tmpl/cwmcomments/default.php
@@ -191,6 +191,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                         <?php
                         foreach ($this->items as $i => $item) :
                             $link       = Route::_('index.php?option=com_proclaim&task=cwmcomment.edit&id=' . (int)$item->id);
+                            $canCheckin  = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate  = $user->authorise('core.create');
                             $canEdit    = $user->authorise('core.edit', 'com_proclaim.comment.' . $item->id);
                             $canEditOwn = $user->authorise('core.edit.own', 'com_proclaim.comment.' . $item->id);
@@ -238,6 +240,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                                 </td>
                                 <td class="nowrap has-context" style="width:10%;">
                                     <div class="float-left">
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmcomments.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                         if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmlocations/default.php
+++ b/admin/tmpl/cwmlocations/default.php
@@ -130,6 +130,8 @@ if (empty($this->items)) : ?>
                     foreach ($this->items as $i => $item) :
                         $item->max_ordering = 0;
                         $ordering           = ($listOrder === 'location.ordering');
+                        $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                            || $item->checked_out == $userId || \is_null($item->checked_out);
                         $canCreate          = $user->authorise('core.create');
                         $canEdit            = $user->authorise('core.edit', 'com_proclaim.location.' . $item->id);
                         $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.location.' . $item->id);
@@ -154,6 +156,10 @@ if (empty($this->items)) : ?>
                             </td>
                             <td class="nowrap has-context">
                                 <div class="float-left">
+                                    <?php if ($item->checked_out) : ?>
+                                        <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                            $item->checked_out_time, 'cwmlocations.', $canCheckin); ?>
+                                    <?php endif; ?>
                                     <?php
                             if ($canEdit || $canEditOwn) : ?>
                                         <a href="<?php

--- a/admin/tmpl/cwmmessages/default.php
+++ b/admin/tmpl/cwmmessages/default.php
@@ -286,6 +286,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessages'); ?>" method="pos
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmmessages.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmmessagetypes/default.php
+++ b/admin/tmpl/cwmmessagetypes/default.php
@@ -105,6 +105,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessagetypes'); ?>" method=
                         <?php
                         foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0;
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.messagetype.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.messagetype.' . $item->id);
@@ -128,7 +130,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessagetypes'); ?>" method=
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
-
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmmessagetypes.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmpodcasts/default.php
+++ b/admin/tmpl/cwmpodcasts/default.php
@@ -128,6 +128,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmpodcasts'); ?>" method="pos
                         <?php
                         foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0; //??
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.podcast.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.podcast.' . $item->id);
@@ -153,7 +155,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmpodcasts'); ?>" method="pos
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
-
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmpodcasts.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmseries/default.php
+++ b/admin/tmpl/cwmseries/default.php
@@ -118,6 +118,8 @@ $saveOrder = $listOrder == $orderName;
                         <?php
                         foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0;
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.serie.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.serie.' . $item->id);
@@ -151,6 +153,10 @@ $saveOrder = $listOrder == $orderName;
                                     ) : Text::_('JUNDEFINED'); ?>
                                         <?php
                                         endif; ?>
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmseries.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                         if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -149,6 +149,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                         <?php
                         foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0;
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.cwmserver.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.cwmserver.' . $item->id);
@@ -173,7 +175,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
-
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmservers.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmteachers/default.php
+++ b/admin/tmpl/cwmteachers/default.php
@@ -151,6 +151,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmteachers'); ?>" method="pos
                         <?php
                         foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0;
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.teacher.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.teacher.' . $item->id);
@@ -175,6 +177,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmteachers'); ?>" method="pos
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmteachers.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmtemplatecodes/default.php
+++ b/admin/tmpl/cwmtemplatecodes/default.php
@@ -102,6 +102,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplatecodes'); ?>" method
                                 'index.php?option=com_proclaim&task=cwmtemplatecode.edit&id=' . (int)$item->id
                             );
                             $item->max_ordering = 0; //??
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.templatcode.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.templatecode.' . $item->id);
@@ -125,6 +127,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplatecodes'); ?>" method
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmtemplatecodes.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmtemplates/default.php
+++ b/admin/tmpl/cwmtemplates/default.php
@@ -108,6 +108,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplates'); ?>" method="po
                                 'index.php?option=com_proclaim&task=cwmtemplate.edit&id=' . (int)$item->id
                             );
                             $item->max_ordering = 0;
+                            $canCheckin          = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.template.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.template.' . $item->id);
@@ -131,7 +133,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplates'); ?>" method="po
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
-
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmtemplates.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/admin/tmpl/cwmtopics/default.php
+++ b/admin/tmpl/cwmtopics/default.php
@@ -105,6 +105,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtopics'); ?>" method="post"
                         <?php
                         foreach ($this->items as $i => $item) :
                             $link       = Route::_('index.php?option=com_proclaim&task=topic.edit&id=' . (int)$item->id);
+                            $canCheckin  = $user->authorise('core.manage', 'com_checkin')
+                                || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate  = $user->authorise('core.create');
                             $canEdit    = $user->authorise('core.edit', 'com_proclaim.topic.' . $item->id);
                             $canEditOwn = $user->authorise('core.edit.own', 'com_proclaim.topic.' . $item->id);
@@ -128,7 +130,10 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtopics'); ?>" method="post"
                                 </td>
                                 <td class="nowrap has-context">
                                     <div class="float-left">
-
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
+                                                $item->checked_out_time, 'cwmtopics.', $canCheckin); ?>
+                                        <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>
                                             <a href="<?php

--- a/tests/unit/Admin/Controller/CwmmediafilesControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmmediafilesControllerTest.php
@@ -24,21 +24,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class CwmmediafilesControllerTest extends ProclaimTestCase
 {
     /**
-     * Test checkin method signature
-     *
-     * @return void
-     * #[CoversClass(CwmmediafilesController::class)]::checkin
-     */
-    public function testCheckinMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmmediafilesController::class, 'checkin');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-    }
-
-    /**
      * Test getModel method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmadminModelTest.php
+++ b/tests/unit/Admin/Model/CwmadminModelTest.php
@@ -99,27 +99,6 @@ class CwmadminModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmadminModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmadminModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        // Return type is bool|int|null, which reflection might show differently
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getMediaFiles method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmcommentModelTest.php
+++ b/tests/unit/Admin/Model/CwmcommentModelTest.php
@@ -44,27 +44,6 @@ class CwmcommentModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmcommentModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmcommentModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('mixed', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getForm method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmlocationModelTest.php
+++ b/tests/unit/Admin/Model/CwmlocationModelTest.php
@@ -77,24 +77,4 @@ class CwmlocationModelTest extends ProclaimTestCase
         $this->assertTrue($params[1]->isOptional());
     }
 
-    /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmlocationModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmlocationModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
 }

--- a/tests/unit/Admin/Model/CwmmediafileModelTest.php
+++ b/tests/unit/Admin/Model/CwmmediafileModelTest.php
@@ -182,24 +182,4 @@ class CwmmediafileModelTest extends ProclaimTestCase
         $this->assertTrue($params[1]->isOptional());
     }
 
-    /**
-     * Test checkin method signature
-     *
-     * @return void
-     * #[CoversClass(CwmmediafileModel::class)]::checkin
-     */
-    public function testCheckinMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmmediafileModel::class, 'checkin');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        // Return type is false|int, which reflection might show differently
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pks', $params[0]->getName());
-        $this->assertParamTypeName('mixed', $params[0]);
-        $this->assertTrue($params[0]->isOptional());
-    }
 }

--- a/tests/unit/Admin/Model/CwmmessagetypeModelTest.php
+++ b/tests/unit/Admin/Model/CwmmessagetypeModelTest.php
@@ -49,27 +49,6 @@ class CwmmessagetypeModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmmessagetypeModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmmessagetypeModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getTable method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmpodcastModelTest.php
+++ b/tests/unit/Admin/Model/CwmpodcastModelTest.php
@@ -49,28 +49,6 @@ class CwmpodcastModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmpodcastModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmpodcastModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('int', $reflection);
-        $this->assertTrue($reflection->getReturnType()->allowsNull());
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getTable method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmserieModelTest.php
+++ b/tests/unit/Admin/Model/CwmserieModelTest.php
@@ -105,27 +105,6 @@ class CwmserieModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmserieModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmserieModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getTable method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmteacherModelTest.php
+++ b/tests/unit/Admin/Model/CwmteacherModelTest.php
@@ -71,27 +71,6 @@ class CwmteacherModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmteacherModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmteacherModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test validate method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmtemplateModelTest.php
+++ b/tests/unit/Admin/Model/CwmtemplateModelTest.php
@@ -113,28 +113,6 @@ class CwmtemplateModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmtemplateModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmtemplateModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('int', $reflection);
-        $this->assertTrue($reflection->getReturnType()->allowsNull());
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getTable method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmtemplatecodeModelTest.php
+++ b/tests/unit/Admin/Model/CwmtemplatecodeModelTest.php
@@ -49,27 +49,6 @@ class CwmtemplatecodeModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmtemplatecodeModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmtemplatecodeModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        // Return type is bool|int|null, which reflection might show differently
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getType method signature
      *
      * @return void

--- a/tests/unit/Admin/Model/CwmtopicModelTest.php
+++ b/tests/unit/Admin/Model/CwmtopicModelTest.php
@@ -49,27 +49,6 @@ class CwmtopicModelTest extends ProclaimTestCase
     }
 
     /**
-     * Test checkout method signature
-     *
-     * @return void
-     * #[CoversClass(CwmtopicModel::class)]::checkout
-     */
-    public function testCheckoutMethodSignature(): void
-    {
-        $reflection = new \ReflectionMethod(CwmtopicModel::class, 'checkout');
-
-        $this->assertFalse($reflection->isStatic());
-        $this->assertTrue($reflection->isPublic());
-        $this->assertReturnTypeName('bool', $reflection);
-
-        $params = $reflection->getParameters();
-        $this->assertCount(1, $params);
-        $this->assertEquals('pk', $params[0]->getName());
-        // No type hint in method signature for pk
-        $this->assertTrue($params[0]->isOptional());
-    }
-
-    /**
      * Test getTable method signature
      *
      * @return void


### PR DESCRIPTION
## Summary
- Enables Joomla's native record locking (check-in/checkout) across all 12 admin list views: messages, teachers, series, topics, locations, media files, message types, servers, podcasts, templates, template codes, and comments
- Adds `checked_out` and `checked_out_time` DB columns (with migration) to the 9 tables that were missing them; adds index to locations (columns already existed); studies and mediafiles already had columns
- Removes no-op `checkout()` stub overrides from all single-item models so Joomla's `AdminModel::checkout()` handles real locking
- Removes redundant custom `checkin()` from mediafiles controller/model/table — Joomla's built-in `AdminController` handles it natively

## Changes (71 files)
- **SQL**: Install schema updated for all 12 tables; migration `10.1.0-20260211.sql` adds columns to 9 tables + index to locations
- **Table classes**: `checked_out`/`checked_out_time` properties added to 10 tables (studies/mediafiles already had them)
- **List models**: All 12 select `checked_out`/`checked_out_time` and LEFT JOIN `#__users` for editor name
- **List views**: All 12 have `$childBar->checkin()` toolbar button
- **List templates**: All 12 show lock indicator via `HTMLHelper::_('jgrid.checkedout', ...)`
- **Tests**: Removed 12 tests for deleted checkout/checkin stubs; all 1051 tests pass

## Test plan
- [ ] Verify fresh install creates all `checked_out`/`checked_out_time` columns
- [ ] Verify update migration adds columns to existing installs
- [ ] Open a record for editing — verify lock icon appears in list view for other users
- [ ] Use toolbar "Check In" button — verify lock is released
- [ ] Verify `com_checkin` global check-in finds locked Proclaim records
- [ ] Run `composer test:unit` — all 1051 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)