### PR TITLE
Improve media files list view layout

### DIFF
--- a/admin/src/Model/CwmmediafilesModel.php
+++ b/admin/src/Model/CwmmediafilesModel.php
@@ -273,6 +273,7 @@ class CwmmediafilesModel extends ListModel
 
         // Join over servers
         $query->select($db->qn('server.type', 'serverType'));
+        $query->select($db->qn('server.server_name', 'server_name'));
         $query->join(
             'LEFT',
             $db->qn('#__bsms_servers', 'server') . ' ON ' . $db->qn('server.id') . ' = ' . $db->qn('mediafile.server_id')

--- a/admin/tmpl/cwmmediafiles/default.php
+++ b/admin/tmpl/cwmmediafiles/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Default
  *
@@ -16,6 +17,7 @@
 use Joomla\CMS\Button\PublishedButton;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
@@ -32,9 +34,12 @@ $user      = $this->getCurrentUser();
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$archived  = $this->state->get('filter.published') == 2 ? true : false;
-$trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder === 'mediafile.ordering';
+$columns   = 9;
+
+if (Multilanguage::isEnabled()) {
+    $columns++;
+}
 
 if ($saveOrder && !empty($this->items)) {
     $saveOrderingUrl = 'index.php?option=com_proclaim&task=cwmmediafiles.saveOrderAjax&tmpl=component&' . Session::getFormToken() . '=1';
@@ -45,36 +50,27 @@ if ($saveOrder && !empty($this->items)) {
     <div class="row">
         <div class="col-md-12">
             <div id="j-main-container" class="j-main-container">
-                <?php
-                echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
-                <?php
-                if (empty($this->items)) : ?>
+                <?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
+                <?php if (empty($this->items)) : ?>
                     <div class="alert alert-info">
                         <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+                                class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+                        <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
                     </div>
                 <?php else : ?>
-                    <table class="table itemList" id="mediafileList">
+                    <table class="table" id="mediafileList">
                         <caption class="visually-hidden">
-                            <?php
-                            echo Text::_('JBS_STY_TABLE_CAPTION'); ?>,
-                            <span id="orderedBy"><?php
-                                echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-                            <span id="filteredBy"><?php
-                                echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+                            <?php echo Text::_('JBS_STY_TABLE_CAPTION'); ?>,
+                            <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+                            <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
                         </caption>
                         <thead>
                         <tr>
-                            <th class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo HTMLHelper::_('grid.checkall'); ?>
+                            <th scope="col" class="w-1 text-center">
+                                <?php echo HTMLHelper::_('grid.checkall'); ?>
                             </th>
                             <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo HTMLHelper::_(
+                                <?php echo HTMLHelper::_(
                                     'searchtools.sort',
                                     '',
                                     'mediafile.ordering',
@@ -83,12 +79,11 @@ if ($saveOrder && !empty($this->items)) {
                                     null,
                                     'asc',
                                     'JGRID_HEADING_ORDERING',
-                                    'icon-sort'
+                                    'icon-menu-2'
                                 ); ?>
                             </th>
-                            <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo HTMLHelper::_(
+                            <th scope="col" class="w-1 text-center">
+                                <?php echo HTMLHelper::_(
                                     'searchtools.sort',
                                     'JPUBLISHED',
                                     'mediafile.published',
@@ -96,13 +91,11 @@ if ($saveOrder && !empty($this->items)) {
                                     $listOrder
                                 ); ?>
                             </th>
-                            <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo Text::_('JBS_MED_RESOURCE_NAME'); ?>
-                            </th>
                             <th scope="col" style="min-width:100px">
-                                <?php
-                                echo HTMLHelper::_(
+                                <?php echo Text::_('JBS_MED_RESOURCE_NAME'); ?>
+                            </th>
+                            <th scope="col">
+                                <?php echo HTMLHelper::_(
                                     'searchtools.sort',
                                     'JBS_CMN_STUDY_TITLE',
                                     'study.studytitle',
@@ -110,13 +103,11 @@ if ($saveOrder && !empty($this->items)) {
                                     $listOrder
                                 ); ?>
                             </th>
-                            <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo Text::_('JBS_MED_MEDIA_TYPE'); ?>
+                            <th scope="col" class="w-10 d-none d-md-table-cell">
+                                <?php echo Text::_('JBS_CMN_SERVER'); ?>
                             </th>
-                            <th scope="col" class="w-1 d-none d-md-table-cell text-center">
-                                <?php
-                                echo HTMLHelper::_(
+                            <th scope="col" class="w-10 d-none d-md-table-cell text-center">
+                                <?php echo HTMLHelper::_(
                                     'searchtools.sort',
                                     'JBS_MED_CREATE_DATE',
                                     'mediafile.createdate',
@@ -124,193 +115,151 @@ if ($saveOrder && !empty($this->items)) {
                                     $listOrder
                                 ); ?>
                             </th>
-                            <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo HTMLHelper::_(
-                                    'searchtools.sort',
-                                    'JBS_MED_ACCESS',
-                                    'mediafile.access',
-                                    $listDirn,
-                                    $listOrder
-                                ); ?>
+                            <th scope="col" class="w-10 d-none d-md-table-cell text-center">
+                                <?php echo Text::_('JBS_MED_MEDIA_FILES_STATS'); ?>
                             </th>
-                            <th scope="col" class="w-1 text-center d-none d-md-table-cell">
-                                <?php
-                                echo Text::_('JBS_MED_MEDIA_FILES_STATS'); ?>
-                            </th>
+                            <?php if (Multilanguage::isEnabled()) : ?>
+                                <th scope="col" class="w-10 d-none d-md-table-cell">
+                                    <?php echo HTMLHelper::_(
+                                        'searchtools.sort',
+                                        'JGRID_HEADING_LANGUAGE',
+                                        'mediafile.language',
+                                        $listDirn,
+                                        $listOrder
+                                    ); ?>
+                                </th>
+                            <?php endif; ?>
                             <th scope="col" class="w-3 d-none d-lg-table-cell">
                                 <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'mediafile.id', $listDirn, $listOrder); ?>
                             </th>
                         </tr>
                         </thead>
+                        <tfoot>
+                        <tr>
+                            <td colspan="<?php echo $columns; ?>"></td>
+                        </tr>
+                        </tfoot>
                         <tbody<?php if ($saveOrder) :
                             ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php
                         endif; ?>>
-                        <?php
-                        foreach ($this->items as $i => $item) :
+                        <?php foreach ($this->items as $i => $item) :
                             $item->max_ordering = 0;
-                            $canCheckin         = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canEdit            = $user->authorise('core.edit', 'com_proclaim.mediafile.' . $item->id);
-                            $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.mediafile.' . $item->id);
-                            $canChange          = $user->authorise('core.edit.state', 'com_proclaim.mediafile.' . $item->id);
-                            $label              = $this->escape($item->serverConfig->name->__toString()) . ' - ';
-                            $label .= $this->escape(
-                                $item->params[$item->serverConfig->config->media_resource->__toString()]
-                            )
-                                ? $item->serverConfig->config->media_resource->__toString() : 'mediacode';
+                            $canCheckin  = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || \is_null($item->checked_out);
+                            $canEdit     = $user->authorise('core.edit', 'com_proclaim.mediafile.' . $item->id);
+                            $canEditOwn  = $user->authorise('core.edit.own', 'com_proclaim.mediafile.' . $item->id);
+                            $canChange   = $user->authorise('core.edit.state', 'com_proclaim.mediafile.' . $item->id);
+
+                            // Get the resource identifier (filename, URL, etc.)
+                            $resourceKey = 'filename';
+                            if ($item->serverConfig && isset($item->serverConfig->config->media_resource)) {
+                                $resourceKey = $item->serverConfig->config->media_resource->__toString();
+                            }
+                            $resourceValue = $item->params->get($resourceKey, '');
                             ?>
-                            <tr class="row<?php
-                            echo $i % 2; ?>" data-draggable-group="<?php
-                            echo $item->study_id ?>">
+                            <tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->study_id; ?>">
                                 <td class="text-center">
-                                    <?php
-                                    echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $label); ?>
+                                    <?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $this->escape($resourceValue ?: $item->id)); ?>
                                 </td>
                                 <td class="text-center d-none d-md-table-cell">
                                     <?php
                                     $iconClass = '';
-                            if (!$canChange) {
-                                $iconClass = ' inactive';
-                            } elseif (!$saveOrder) {
-                                $iconClass = ' inactive tip-top hasTooltip" title="' . HTMLHelper::tooltipText(
-                                    'JORDERINGDISABLED'
-                                );
-                            }
-                            ?>
+                                    if (!$canChange) {
+                                        $iconClass = ' inactive';
+                                    } elseif (!$saveOrder) {
+                                        $iconClass = ' inactive" title="' . HTMLHelper::tooltipText('JORDERINGDISABLED');
+                                    }
+                                    ?>
                                     <span class="sortable-handler<?php echo $iconClass ?>">
                                         <span class="icon-ellipsis-v" aria-hidden="true"></span>
                                     </span>
                                     <?php if ($canChange && $saveOrder) : ?>
                                         <input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden"/>
-                                    <?php
-                                    endif; ?>
+                                    <?php endif; ?>
                                 </td>
-                                <td class="text-center d-none d-md-table-cell">
+                                <td class="text-center">
                                     <?php
                                     $options = [
                                         'task_prefix' => 'cwmmediafiles.',
                                         'disabled'    => !$canChange,
                                         'id'          => 'state-' . $item->id,
                                     ];
-                            echo (new PublishedButton())->render((int) $item->published, $i, $options);
-                            ?>
+                                    echo (new PublishedButton())->render((int) $item->published, $i, $options);
+                                    ?>
                                 </td>
                                 <td class="nowrap has-context">
-                                    <div class="float-left">
-                                        <?php
-                                if ($item->checked_out) : ?>
-                                            <?php
-                                    echo HTMLHelper::_(
-                                        'jgrid.checkedout',
-                                        $i,
-                                        $item->editor,
-                                        $item->checked_out_time,
-                                        'cwmmediafiles.',
-                                        $canCheckin
-                                    ); ?>
-                                        <?php
-                                endif; ?>
-                                        <?php
-                                if ($item->language === '*'): ?>
-                                            <?php
-                                    $language = Text::alt('JALL', 'language'); ?>
-                                        <?php else: ?>
-                                            <?php
-                                    $language = $item->language_title ? $this->escape(
-                                        $item->language_title
-                                    ) : Text::_('JUNDEFINED'); ?>
-                                        <?php
-                                        endif; ?>
-                                        <?php
-                                        if ($canEdit || $canEditOwn) : ?>
-                                            <a href="<?php
-                                            echo Route::_(
-                                                'index.php?option=com_proclaim&task=cwmmediafile.edit&id=' . (int)$item->id
+                                    <div>
+                                        <?php if ($item->checked_out) : ?>
+                                            <?php echo HTMLHelper::_(
+                                                'jgrid.checkedout',
+                                                $i,
+                                                $item->editor,
+                                                $item->checked_out_time,
+                                                'cwmmediafiles.',
+                                                $canCheckin
+                                            ); ?>
+                                        <?php endif; ?>
+                                        <?php if ($canEdit || $canEditOwn) : ?>
+                                            <a href="<?php echo Route::_(
+                                                'index.php?option=com_proclaim&task=cwmmediafile.edit&id=' . (int) $item->id
                                             ); ?>">
-                                                <span class="label float-left"><?php
-                                                    echo $this->escape($label); ?></span>
+                                                <?php echo $this->escape($resourceValue ?: Text::_('JBS_MED_RESOURCE_NAME')); ?>
                                             </a>
                                         <?php else : ?>
-                                            <span
-                                                    title="<?php
-                                                    echo Text::sprintf(
-                                                        'JFIELD_ALIAS_LABEL',
-                                                        $this->escape($item->alias)
-                                                    ); ?>">
-										<?php
-                                        echo $label; ?>
-				                    </span>
-                                        <?php
-                                        endif; ?>
-                                    </div>
-                                    <div class="clearfix"></div>
-                                    <div class="float-left">
-                                        <a href="<?php
-                                        echo Route::_(
-                                            'index.php?option=com_proclaim&task=cwmmediafile.edit&id=' . (int)$item->id
-                                        ); ?>">
-                                            <?php
-                                            echo $this->escape(
-                                                $item->params[$item->serverConfig->config->media_resource->__toString()]
-                                            ); ?>
-                                        </a>
+                                            <?php echo $this->escape($resourceValue ?: Text::_('JBS_MED_RESOURCE_NAME')); ?>
+                                        <?php endif; ?>
                                     </div>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <?php
-                                    echo $this->escape($item->studytitle); ?>
+                                    <?php echo $this->escape($item->studytitle); ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <?php
-                                    echo $this->escape($item->serverConfig->name->__toString()); ?>
-                                </td>
-                                <td class="small d-none d-md-table-cell">
-                                    <?php
-                                    echo HTMLHelper::_('date', $item->createdate, Text::_('DATE_FORMAT_LC4')); ?>
-                                </td>
-                                <td class="small d-none d-md-table-cell">
-                                    <?php
-                                    echo $this->escape($item->access_level); ?>
+                                    <?php if (!empty($item->server_name)) : ?>
+                                        <?php echo $this->escape($item->server_name); ?>
+                                        <br/>
+                                        <span class="badge bg-secondary"><?php echo $this->escape(ucfirst($item->serverType ?? 'legacy')); ?></span>
+                                    <?php else : ?>
+                                        <span class="text-muted fst-italic"><?php echo Text::_('JNONE'); ?></span>
+                                    <?php endif; ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell text-center">
-                                    <?php
-                                    echo $this->escape($item->plays); ?>
-                                    / <?php
-                                    echo $this->escape($item->downloads); ?>
+                                    <?php echo HTMLHelper::_('date', $item->createdate, Text::_('DATE_FORMAT_LC4')); ?>
                                 </td>
+                                <td class="d-none d-md-table-cell text-center">
+                                    <span class="badge bg-info"><?php echo Text::sprintf('JBS_CMN_PLAYS', (int) $item->plays); ?></span>
+                                    <br/>
+                                    <span class="badge bg-info"><?php echo Text::sprintf('JBS_CMN_DOWNLOADS', (int) $item->downloads); ?></span>
+                                </td>
+                                <?php if (Multilanguage::isEnabled()) : ?>
+                                    <td class="small d-none d-md-table-cell">
+                                        <?php echo LayoutHelper::render('joomla.content.language', $item); ?>
+                                    </td>
+                                <?php endif; ?>
                                 <td class="d-none d-lg-table-cell">
                                     <?php echo (int) $item->id; ?>
                                 </td>
                             </tr>
-                        <?php
-                        endforeach; ?>
+                        <?php endforeach; ?>
                         </tbody>
                     </table>
 
-                    <?php
-                    echo $this->pagination->getListFooter(); ?>
+                    <?php echo $this->pagination->getListFooter(); ?>
 
-                    <?php
-                    // Load the batch processing form.?>
-                    <?php
-                    if ($user->authorise('core.create', 'com_proclaim')
+                    <?php if (
+                        $user->authorise('core.create', 'com_proclaim')
                         && $user->authorise('core.edit', 'com_proclaim')
                         && $user->authorise('core.edit.state', 'com_proclaim')
                     ) : ?>
-                        <?php
-                        echo HTMLHelper::_(
+                        <?php echo HTMLHelper::_(
                             'bootstrap.renderModal',
                             'collapseModal',
                             [
-                                    'title'  => Text::_('JBS_CMN_BATCH_OPTIONS'),
-                                    'footer' => $this->loadTemplate('batch_footer'),
-                                ],
+                                'title'  => Text::_('JBS_CMN_BATCH_OPTIONS'),
+                                'footer' => $this->loadTemplate('batch_footer'),
+                            ],
                             $this->loadTemplate('batch_body')
                         ); ?>
-                    <?php
-                    endif; ?>
-                <?php
-                endif; ?>
+                    <?php endif; ?>
+                <?php endif; ?>
                 <input type="hidden" name="task" value=""/>
                 <input type="hidden" name="boxchecked" value="0"/>
                 <?php echo HTMLHelper::_('form.token'); ?>


### PR DESCRIPTION
## Summary
- Rewrites the admin media files list template to match the messages list view patterns
- Replaces fragile XML `serverConfig` label construction with clean resource name links from params
- Adds Server column showing server name with type badge (e.g., "YouTube" + `Youtube` badge)
- Uses styled `badge bg-info` for Plays/Downloads stats (consistent with messages view)
- Adds `<tfoot>`, dynamic column count, and multilanguage column support
- Removes unused Access column (available via filters) and legacy `float-left`/`clearfix` markup
- Adds `server.server_name` to model query for direct DB access

## Test plan
- [ ] Verify media files list displays correctly with resource name links, server badges, and stats badges
- [ ] Verify ordering drag-and-drop still works
- [ ] Verify check-in/checkout lock indicators display correctly
- [ ] Verify pagination works
- [ ] Verify search and filter tools work
- [ ] Run `composer lint:syntax` — 0 errors
- [ ] Run `composer test:unit` — 1051 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)