### PR TITLE
Migrate to Joomla 5/6 compatible APIs and MVC patterns

### DIFF
--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -109,7 +109,7 @@ class CwmadminController extends FormController
 
         $db   = Factory::getContainer()->get('DatabaseDriver');
         $msg  = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
-        $post = $this->input->post->get('jform', [], 'array');
+        $post = $this->getInput()->post->get('jform', [], 'array');
         $reg  = new Registry();
         $reg->loadArray($post['params']);
         $from = $reg->get('from', 'x');
@@ -165,7 +165,7 @@ class CwmadminController extends FormController
         }
 
         $db   = Factory::getContainer()->get('DatabaseDriver');
-        $post = $this->input->post->get('jform', [], 'array');
+        $post = $this->getInput()->post->get('jform', [], 'array');
         $reg  = new Registry();
         $reg->loadArray($post['params']);
         $from  = $reg->get('pFrom', 'x');
@@ -224,7 +224,7 @@ class CwmadminController extends FormController
             return;
         }
 
-        $post    = $this->input->post->get('jform', [], 'raw');
+        $post    = $this->getInput()->post->get('jform', [], 'raw');
         $decoded = json_decode($post['mediaimage'], true, 512, JSON_THROW_ON_ERROR);
         $db      = Factory::getContainer()->get('DatabaseDriver');
         $query   = $db->getQuery(true);
@@ -930,21 +930,22 @@ class CwmadminController extends FormController
         }
 
         // Name of an array 'jform' must match 'control' => 'jform' line in the model code
-        $data = $this->input->post->get('jform', [], 'array');
+        $data = $this->getInput()->post->get('jform', [], 'array');
 
         // This is validate() from the FormModel class, not the Form class
         // FormModel::validate() calls both Form::filter() and Form::validate() methods
         $validData = $model->validate($form, $data);
 
         if ($validData === false) {
-            // @todo getErrors() is used by Joomla's FormModel::validate() internally; remove when Joomla drops it
-            $errors = $model->getErrors();
+            // Get validation errors from the form directly (Joomla 6 compatible)
+            $form   = $model->getForm();
+            $errors = $form ? $form->getErrors() : [];
 
             foreach ($errors as $error) {
                 if ($error instanceof \Exception) {
                     $app->enqueueMessage($error->getMessage(), 'warning');
                 } else {
-                    $app->enqueueMessage($error, 'warning');
+                    $app->enqueueMessage((string) $error, 'warning');
                 }
             }
 

--- a/admin/src/Controller/CwmassetsController.php
+++ b/admin/src/Controller/CwmassetsController.php
@@ -97,7 +97,7 @@ class CwmassetsController extends BaseController
         $session    = Factory::getApplication()->getSession();
         $session->set('asset_stack', '', 'CWM');
         $session->set('checklists', $checklists, 'CWM');
-        $this->input->set('view', 'Cwmassets');
+        $this->getInput()->set('view', 'Cwmassets');
 
         $this->display(false);
     }
@@ -122,7 +122,7 @@ class CwmassetsController extends BaseController
         Cwmhelper::clearCache();
         $session = Factory::getApplication()->getSession();
         $session->set('asset_stack', '', 'CWM');
-        $this->input->set('view', 'Cwmassets');
+        $this->getInput()->set('view', 'Cwmassets');
         $this->display(false);
     }
 

--- a/admin/src/Controller/CwmlocationsController.php
+++ b/admin/src/Controller/CwmlocationsController.php
@@ -41,8 +41,8 @@ class CwmlocationsController extends AdminController
     public function saveOrderAjax(): void
     {
         // Get the input
-        $pks   = $this->input->post->get('cid', [], 'array');
-        $order = $this->input->post->get('order', [], 'array');
+        $pks   = $this->getInput()->post->get('cid', [], 'array');
+        $order = $this->getInput()->post->get('order', [], 'array');
 
         // Sanitize the input
         ArrayHelper::toInteger($pks);

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -208,8 +208,8 @@ class CwmmediafileController extends FormController
             }
         }
 
-        if ($this->input->getCmd('return') && parent::cancel($key)) {
-            $this->setRedirect(base64_decode($this->input->getCmd('return')));
+        if ($this->getInput()->getCmd('return') && parent::cancel($key)) {
+            $this->setRedirect(base64_decode($this->getInput()->getCmd('return')));
 
             return true;
         }
@@ -231,10 +231,10 @@ class CwmmediafileController extends FormController
      */
     protected function getRedirectToItemAppend($recordId = null, $urlVar = 'id'): string
     {
-        $tmpl    = $this->input->get('tmpl');
-        $layout  = $this->input->get('layout', 'edit', 'string');
-        $return  = $this->input->getCmd('return');
-        $options = $this->input->get('options');
+        $tmpl    = $this->getInput()->get('tmpl');
+        $layout  = $this->getInput()->get('layout', 'edit', 'string');
+        $return  = $this->getInput()->getCmd('return');
+        $options = $this->getInput()->get('options');
         $append  = '';
 
         // Setup redirect info.
@@ -310,8 +310,8 @@ class CwmmediafileController extends FormController
      */
     protected function postSaveHook($model, $validData = []): void
     {
-        $return = $this->input->getCmd('return');
-        $task   = $this->input->get('task');
+        $return = $this->getInput()->getCmd('return');
+        $task   = $this->getInput()->get('task');
 
         if ($return && $task !== 'apply') {
             Factory::getApplication()->enqueueMessage(Text::_('JBS_MED_SAVE'), 'message');

--- a/admin/src/Controller/CwmmessageController.php
+++ b/admin/src/Controller/CwmmessageController.php
@@ -128,7 +128,7 @@ class CwmmessageController extends FormController
         /** @var \CWM\Component\Proclaim\Administrator\Model\CwmtopicModel $model */
         $model = $this->getModel('Cwmtopic');
         $app   = Factory::getApplication();
-        $data  = $this->input->post->get('jform', [], 'array');
+        $data  = $this->getInput()->post->get('jform', [], 'array');
 
         // Get Tags - use topic_ids field (hidden input synced from fancy select)
         // Falls back to topics for backward compatibility
@@ -229,7 +229,7 @@ class CwmmessageController extends FormController
     {
         $recordId = (int)isset($data[$key]) ? $data[$key] : 0;
         $user     = Factory::getApplication()->getIdentity();
-        $userId   = $user->get('id');
+        $userId   = $user->id;
 
         // Check general edit permission first.
         if ($user->authorise('core.edit', 'com_proclaim.message.' . $recordId)) {

--- a/admin/src/Controller/CwmmessagesController.php
+++ b/admin/src/Controller/CwmmessagesController.php
@@ -41,8 +41,8 @@ class CwmmessagesController extends AdminController
     public function saveOrderAjax(): void
     {
         // Get the input
-        $pks   = $this->input->post->get('cid', [], 'array');
-        $order = $this->input->post->get('order', [], 'array');
+        $pks   = $this->getInput()->post->get('cid', [], 'array');
+        $order = $this->getInput()->post->get('order', [], 'array');
 
         // Sanitize the input
         ArrayHelper::toInteger($pks);

--- a/admin/src/Controller/CwmpodcastsController.php
+++ b/admin/src/Controller/CwmpodcastsController.php
@@ -187,7 +187,7 @@ class CwmpodcastsController extends AdminController
             return;
         }
 
-        $mediaId = $this->input->getInt('media_id', 0);
+        $mediaId = $this->getInput()->getInt('media_id', 0);
 
         if ($mediaId <= 0) {
             echo new JsonResponse(null, Text::_('JBS_PDC_INVALID_MEDIA_ID'), true);
@@ -262,7 +262,7 @@ class CwmpodcastsController extends AdminController
             return;
         }
 
-        $mediaId = $this->input->getInt('media_id', 0);
+        $mediaId = $this->getInput()->getInt('media_id', 0);
 
         if ($mediaId <= 0) {
             echo new JsonResponse(null, Text::_('JBS_PDC_INVALID_MEDIA_ID'), true);

--- a/admin/src/Controller/CwmseriesController.php
+++ b/admin/src/Controller/CwmseriesController.php
@@ -40,8 +40,8 @@ class CwmseriesController extends AdminController
      */
     public function saveOrderAjax(): void
     {
-        $pks   = $this->input->post->get('cid', [], 'array');
-        $order = $this->input->post->get('ordering', [], 'array');
+        $pks   = $this->getInput()->post->get('cid', [], 'array');
+        $order = $this->getInput()->post->get('ordering', [], 'array');
 
         // Sanitize the input
         ArrayHelper::toInteger($pks);

--- a/admin/src/Controller/CwmteachersController.php
+++ b/admin/src/Controller/CwmteachersController.php
@@ -40,8 +40,8 @@ class CwmteachersController extends AdminController
      */
     public function saveOrderAjax(): void
     {
-        $pks   = $this->input->post->get('cid', [], 'array');
-        $order = $this->input->post->get('order', [], 'array');
+        $pks   = $this->getInput()->post->get('cid', [], 'array');
+        $order = $this->getInput()->post->get('order', [], 'array');
 
         // Sanitize the input
         ArrayHelper::toInteger($pks);

--- a/admin/src/Controller/CwmtemplatesController.php
+++ b/admin/src/Controller/CwmtemplatesController.php
@@ -63,7 +63,7 @@ class CwmtemplatesController extends AdminController
 
         set_time_limit(300);
 
-        $userfile = $this->input->files->get('template_import');
+        $userfile = $this->getInput()->files->get('template_import');
         $app      = Factory::getApplication();
         $tc       = 0;
 

--- a/admin/src/Controller/DisplayController.php
+++ b/admin/src/Controller/DisplayController.php
@@ -63,7 +63,7 @@ class DisplayController extends BaseController
 
         // Guess the Text message prefix. Defaults to the option.
         if (empty($this->extension)) {
-            $this->extension = $this->input->get('extension', 'com_proclaim');
+            $this->extension = $this->getInput()->get('extension', 'com_proclaim');
         }
     }
 
@@ -81,9 +81,9 @@ class DisplayController extends BaseController
     public function display($cachable = false, $urlparams = []): static
     {
         // Set the default view name and format from the Request.
-        $vName   = $this->input->get('view', 'cwmcpanel');
-        $lName   = $this->input->get('layout', 'default', 'string');
-        $id      = $this->input->getInt('id');
+        $vName   = $this->getInput()->get('view', 'cwmcpanel');
+        $lName   = $this->getInput()->get('layout', 'default', 'string');
+        $id      = $this->getInput()->getInt('id');
 
         // Check for an edit form.
         if ($vName === 'cwmmessage' && $lName === 'edit' && !$this->checkEditId('com_proclaim.edit.cwmmessage', $id)) {

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -20,7 +20,6 @@ use CWM\Component\Proclaim\Administrator\Model\CwmadminModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
@@ -265,7 +264,10 @@ class CwmdbHelper
 
         if (!$done) {
             /** @var CwmadminModel $admin */
-            $admin = BaseDatabaseModel::getInstance('Cwmadmin', 'Model');
+            $admin = Factory::getApplication()
+                ->bootComponent('com_proclaim')
+                ->getMVCFactory()
+                ->createModel('Cwmadmin', 'Administrator');
             $admin->fix();
 
             return true;

--- a/admin/src/Helper/Cwmuploadscript.php
+++ b/admin/src/Helper/Cwmuploadscript.php
@@ -18,6 +18,8 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Content\AfterSaveEvent;
+use Joomla\CMS\Event\Content\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\MediaHelper;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -113,11 +115,18 @@ class Cwmuploadscript
             return ['data' => '', 'error' => 'The file can\'t be uploaded by types allowed'];
         }
 
-        // Trigger the onContentBeforeSave event.
+        // Trigger the onContentBeforeSave event via the event dispatcher (Joomla 5/6 compatible).
         $object_file = (object)$file;
-        $result      = $app->triggerEvent('onContentBeforeSave', ['com_proclaim.file', &$object_file, true]);
+        $dispatcher  = $app->getDispatcher();
+        $beforeEvent = new BeforeSaveEvent('onContentBeforeSave', [
+            'context' => 'com_proclaim.file',
+            'subject' => $object_file,
+            'isNew'   => true,
+            'data'    => [],
+        ]);
+        $dispatcher->dispatch('onContentBeforeSave', $beforeEvent);
 
-        if (\in_array(false, $result, true)) {
+        if (\in_array(false, $beforeEvent->getResult(), true)) {
             // There are some errors in the plugins
             return ['data' => '', 'error' => 'Plugin errors on upload'];
         }
@@ -126,8 +135,13 @@ class Cwmuploadscript
             return ['data' => '', 'error' => 'Could not upload'];
         }
 
-        // Trigger the onContentAfterSave event.
-        $app->triggerEvent('onContentAfterSave', ['com_proclaim.file', &$object_file, true]);
+        // Trigger the onContentAfterSave event via the event dispatcher (Joomla 5/6 compatible).
+        $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+            'context' => 'com_proclaim.file',
+            'subject' => $object_file,
+            'isNew'   => true,
+            'data'    => [],
+        ]));
 
         // Return Success
         return [

--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -26,6 +26,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Schema\ChangeSet;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Table\Extension as ExtensionTable;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Versioning\VersionableModelTrait;
 use Joomla\Registry\Registry;
@@ -338,7 +339,8 @@ class CwmadminModel extends AdminModel
      */
     public function fixUpdateVersion(): mixed
     {
-        $table = Table::getInstance('Extension');
+        $db    = Factory::getContainer()->get('DatabaseDriver');
+        $table = new ExtensionTable($db);
         $table->load($this->getExtentionId());
         $cache         = new Registry($table->manifest_cache);
         $updateVersion = $cache->get('version');
@@ -386,7 +388,8 @@ class CwmadminModel extends AdminModel
      */
     public function fixDefaultTextFilters(): mixed
     {
-        $table = Table::getInstance('Extension');
+        $db    = Factory::getContainer()->get('DatabaseDriver');
+        $table = new ExtensionTable($db);
         $table->load($table->find(['name' => 'com_proclaim']));
 
         // Check for empty $config and non-empty content filters
@@ -429,7 +432,8 @@ class CwmadminModel extends AdminModel
      */
     public function getUpdateVersion(): mixed
     {
-        $table = Table::getInstance('Extension');
+        $db    = Factory::getContainer()->get('DatabaseDriver');
+        $table = new ExtensionTable($db);
         $table->load($this->getExtentionId());
 
         return (new Registry($table->manifest_cache))->get('version');
@@ -482,7 +486,7 @@ class CwmadminModel extends AdminModel
 
         $db   = Factory::getContainer()->get('DatabaseDriver');
         $msg  = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
-        $post = $_POST['jform'];
+        $post = Factory::getApplication()->getInput()->post->get('jform', [], 'array');
         $reg  = new Registry();
         $reg->loadArray($post['params']);
         $from    = $reg->get('mtFrom', 'x');

--- a/admin/src/Model/CwmcommentModel.php
+++ b/admin/src/Model/CwmcommentModel.php
@@ -293,12 +293,12 @@ class CwmcommentModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmlocationModel.php
+++ b/admin/src/Model/CwmlocationModel.php
@@ -113,12 +113,12 @@ class CwmlocationModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -927,7 +927,7 @@ class CwmmediafileModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
 
             // Set ordering to the last item if not set
@@ -943,7 +943,7 @@ class CwmmediafileModel extends AdminModel
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -677,7 +677,7 @@ class CwmmessageModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
 
             // Set ordering to the last item if not set
@@ -694,7 +694,7 @@ class CwmmessageModel extends AdminModel
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 }

--- a/admin/src/Model/CwmmessagetypeModel.php
+++ b/admin/src/Model/CwmmessagetypeModel.php
@@ -117,7 +117,7 @@ class CwmmessagetypeModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
 
             // Set ordering to the last item if not set
@@ -133,7 +133,7 @@ class CwmmessagetypeModel extends AdminModel
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -128,12 +128,12 @@ class CwmpodcastModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -441,7 +441,7 @@ class CwmserieModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
 
             // Set ordering to the last item if not set
@@ -457,7 +457,7 @@ class CwmserieModel extends AdminModel
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
 
         if ($table->ordering == 0) {

--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -408,12 +408,12 @@ class CwmserverModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -418,7 +418,7 @@ class CwmteacherModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
 
             // Set ordering to the last item if not set
@@ -434,7 +434,7 @@ class CwmteacherModel extends AdminModel
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -203,12 +203,12 @@ class CwmtemplateModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Model/CwmtemplatecodeModel.php
+++ b/admin/src/Model/CwmtemplatecodeModel.php
@@ -231,12 +231,12 @@ class CwmtemplatecodeModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 }

--- a/admin/src/Model/CwmtopicModel.php
+++ b/admin/src/Model/CwmtopicModel.php
@@ -124,12 +124,12 @@ class CwmtopicModel extends AdminModel
         if (empty($table->id)) {
             // Set the values for a new record
             if (empty($table->created_by)) {
-                $table->created_by = $user->get('id');
+                $table->created_by = $user->id;
             }
         } else {
             // Set the values for existing records
             $table->modified    = $date->toSql();
-            $table->modified_by = $user->get('id');
+            $table->modified_by = $user->id;
         }
     }
 

--- a/admin/src/Table/CwmadminTable.php
+++ b/admin/src/Table/CwmadminTable.php
@@ -146,7 +146,7 @@ class CwmadminTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmcommentTable.php
+++ b/admin/src/Table/CwmcommentTable.php
@@ -202,7 +202,7 @@ class CwmcommentTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmlocationTable.php
+++ b/admin/src/Table/CwmlocationTable.php
@@ -222,7 +222,7 @@ class CwmlocationTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -278,7 +278,7 @@ class CwmmediafileTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -570,7 +570,7 @@ class CwmmessageTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -236,7 +236,7 @@ class CwmmessagetypeTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmpodcastTable.php
+++ b/admin/src/Table/CwmpodcastTable.php
@@ -417,7 +417,7 @@ class CwmpodcastTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmserieTable.php
+++ b/admin/src/Table/CwmserieTable.php
@@ -244,7 +244,7 @@ class CwmserieTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmserverTable.php
+++ b/admin/src/Table/CwmserverTable.php
@@ -243,7 +243,7 @@ class CwmserverTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmstudytopicsTable.php
+++ b/admin/src/Table/CwmstudytopicsTable.php
@@ -102,7 +102,7 @@ class CwmstudytopicsTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmteacherTable.php
+++ b/admin/src/Table/CwmteacherTable.php
@@ -209,7 +209,7 @@ class CwmteacherTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -254,7 +254,7 @@ class CwmtemplateTable extends Table
     public function store($updateNulls = false): bool
     {
         // Set default rules if not already set
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -263,7 +263,7 @@ class CwmtemplatecodeTable extends Table
             return false;
         }
 
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -231,7 +231,7 @@ class CwmtopicTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
-        if (!$this->_rules) {
+        if (!$this->getRules()) {
             $this->setRules(
                 '{"core.delete":[],"core.edit":[],"core.create":[],"core.edit.state":[],"core.edit.own":[]}'
             );

--- a/admin/tmpl/cwmteachers/default.php
+++ b/admin/tmpl/cwmteachers/default.php
@@ -28,7 +28,7 @@ $wa->useScript('table.columns')
 
 $app        = Factory::getApplication();
 $user       = $app->getIdentity();
-$userId     = $user->get('id');
+$userId     = $user->id;
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $archived   = $this->state->get('filter.published') == 2 ? true : false;

--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -14,11 +14,11 @@ namespace CWM\Component\Proclaim\Site\Controller;
 use CWM\Component\Proclaim\Administrator\Helper\CwmnotificationHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmdownload;
 use CWM\Component\Proclaim\Site\Model\CwmsermonModel;
+use Joomla\CMS\Captcha\Captcha;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Input\Input;
@@ -180,17 +180,27 @@ class CwmsermonController extends FormController
             $params->loadString($model->_template[0]->params);
         }
 
-        // Check captcha if enabled
+        // Check captcha if enabled (Joomla 5/6 compatible Captcha API)
         if ($params->get('use_captcha') > 0) {
-            PluginHelper::importPlugin('captcha');
-            $captchaResponse = $input->get('recaptcha_response_field', '', 'string');
-            $res             = $app->triggerEvent('onCheckAnswer', [$captchaResponse]);
+            $captchaPlugin = $params->get('captcha', $app->get('captcha', ''));
 
-            if (empty($res[0])) {
-                $app->enqueueMessage(Text::_('JBS_STY_INCORRECT_KEY'), 'error');
-                $this->redirectBack($input, $t);
+            if ($captchaPlugin) {
+                try {
+                    $captcha         = Captcha::getInstance($captchaPlugin);
+                    $captchaResponse = $input->get('recaptcha_response_field', '', 'string');
 
-                return;
+                    if (!$captcha->checkAnswer($captchaResponse)) {
+                        $app->enqueueMessage(Text::_('JBS_STY_INCORRECT_KEY'), 'error');
+                        $this->redirectBack($input, $t);
+
+                        return;
+                    }
+                } catch (\RuntimeException $e) {
+                    $app->enqueueMessage(Text::_('JBS_STY_INCORRECT_KEY'), 'error');
+                    $this->redirectBack($input, $t);
+
+                    return;
+                }
             }
         }
 
@@ -398,7 +408,7 @@ class CwmsermonController extends FormController
         $this->input = Factory::getApplication()->getInput();
 
         // Need to override the parent method completely.
-        $tmpl   = $this->input->get('tmpl');
+        $tmpl   = $this->getInput()->get('tmpl');
         $append = '';
 
         // Setup redirect info.

--- a/site/src/Controller/DisplayController.php
+++ b/site/src/Controller/DisplayController.php
@@ -16,9 +16,9 @@ namespace CWM\Component\Proclaim\Site\Controller;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Input\Input;
 
 /**
  * Component Controller
@@ -40,12 +40,12 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      */
     public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
-        // Contact frontpage Editor contacts proxying.
-        $this->input = Factory::getApplication()->getInput();
+        // Get input early to check view before parent construction.
+        $appInput = $input ?? Factory::getApplication()->getInput();
 
-        if ($this->input->get('view') === 'cwmlandingpage' && $this->input->get('layout') === 'modal') {
+        if ($appInput->get('view') === 'cwmlandingpage' && $appInput->get('layout') === 'modal') {
             $config['base_path'] = JPATH_ADMINISTRATOR . '/components';
-        } elseif ($this->input->get('view') === 'cwmsermons' && $this->input->get('layout') === 'modal') {
+        } elseif ($appInput->get('view') === 'cwmsermons' && $appInput->get('layout') === 'modal') {
             $config['base_path'] = JPATH_ADMINISTRATOR . '/components';
         }
 
@@ -72,25 +72,26 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
         Note, we are using a_id to avoid collisions with the router and the return page.
         Frontend is a bit messier than the backend.
         */
-        $id    = $this->input->getInt('a_id');
-        $vName = $this->input->getCmd('view', 'cwmlandingpage');
-        $this->input->set('view', $vName);
+        $input = $this->getInput();
+        $id    = $input->getInt('a_id');
+        $vName = $input->getCmd('view', 'cwmlandingpage');
+        $input->set('view', $vName);
 
-        $user = $this->app->getIdentity();
+        $user = $this->getApplication()->getIdentity();
 
         if (
             $vName === 'cwmpopup'
-            || $user->get('id')
-            || ($this->input->getMethod() === 'POST'
+            || $user->id
+            || ($input->getMethod() === 'POST'
                 && str_contains($vName, 'form'))
         ) {
             $cachable = false;
         }
 
         // Attempt to change MySQL for an error in a large select
-        $t = $this->input->get('t', '1', 'int');
+        $t = $input->get('t', '1', 'int');
 
-        $this->input->set('t', $t);
+        $input->set('t', $t);
 
         $safeurlparams = [
             'id'               => 'INT',

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -19,6 +19,10 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use CWM\Component\Proclaim\Administrator\Table\CwmtemplateTable;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Image\Image;
@@ -2502,26 +2506,30 @@ a2a_config.templates.email = {
         $offset = 0;
         PluginHelper::importPlugin('content');
 
-        // Run content plugins
-        $dispatcher            = Factory::getApplication();
+        // Run content plugins via the event dispatcher (Joomla 5/6 compatible)
+        $dispatcher            = Factory::getApplication()->getDispatcher();
         $contentEventArguments = [
             'context' => 'com_proclaim.sermon',
-            'subject' => &$item,
-            'params'  => &$params,
+            'subject' => $item,
+            'params'  => $params,
             'page'    => $offset,
         ];
 
-        $dispatcher->triggerEvent('onContentPrepare', $contentEventArguments);
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', $contentEventArguments));
 
-        $item->event                        = new \stdClass();
-        $results                            = $dispatcher->triggerEvent('onContentAfterTitle', $contentEventArguments);
-        $item->event->afterDisplayTitle     = trim(implode("\n", $results));
+        $item->event = new \stdClass();
 
-        $results                            = $dispatcher->triggerEvent('onContentBeforeDisplay', $contentEventArguments);
-        $item->event->beforeDisplayContent  = trim(implode("\n", $results));
+        $event = new AfterTitleEvent('onContentAfterTitle', $contentEventArguments);
+        $dispatcher->dispatch('onContentAfterTitle', $event);
+        $item->event->afterDisplayTitle = trim(implode("\n", $event->getResult()));
 
-        $results                            = $dispatcher->triggerEvent('onContentAfterDisplay', $contentEventArguments);
-        $item->event->afterDisplayContent   = trim(implode("\n", $results));
+        $event = new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments);
+        $dispatcher->dispatch('onContentBeforeDisplay', $event);
+        $item->event->beforeDisplayContent = trim(implode("\n", $event->getResult()));
+
+        $event = new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments);
+        $dispatcher->dispatch('onContentAfterDisplay', $event);
+        $item->event->afterDisplayContent = trim(implode("\n", $event->getResult()));
 
         return $item;
     }

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -15,6 +15,10 @@ namespace CWM\Component\Proclaim\Site\Helper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use CWM\Component\Proclaim\Administrator\Table\CwmtemplateTable;
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -450,26 +454,30 @@ class Cwmpagebuilder
         $offset = 0;
         PluginHelper::importPlugin('content');
 
-        // Run content plugins
-        $dispatcher            = Factory::getApplication();
+        // Run content plugins via the event dispatcher (Joomla 5/6 compatible)
+        $dispatcher            = Factory::getApplication()->getDispatcher();
         $contentEventArguments = [
             'context' => 'com_proclaim.sermon',
-            'subject' => &$item,
-            'params'  => &$params,
+            'subject' => $item,
+            'params'  => $params,
             'page'    => $offset,
         ];
 
-        $dispatcher->triggerEvent('onContentPrepare', $contentEventArguments);
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', $contentEventArguments));
 
-        $item->event                        = new \stdClass();
-        $results                            = $dispatcher->triggerEvent('onContentAfterTitle', $contentEventArguments);
-        $item->event->afterDisplayTitle     = trim(implode("\n", $results));
+        $item->event = new \stdClass();
 
-        $results                            = $dispatcher->triggerEvent('onContentBeforeDisplay', $contentEventArguments);
-        $item->event->beforeDisplayContent  = trim(implode("\n", $results));
+        $event = new AfterTitleEvent('onContentAfterTitle', $contentEventArguments);
+        $dispatcher->dispatch('onContentAfterTitle', $event);
+        $item->event->afterDisplayTitle = trim(implode("\n", $event->getResult()));
 
-        $results                            = $dispatcher->triggerEvent('onContentAfterDisplay', $contentEventArguments);
-        $item->event->afterDisplayContent   = trim(implode("\n", $results));
+        $event = new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments);
+        $dispatcher->dispatch('onContentBeforeDisplay', $event);
+        $item->event->beforeDisplayContent = trim(implode("\n", $event->getResult()));
+
+        $event = new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments);
+        $dispatcher->dispatch('onContentAfterDisplay', $event);
+        $item->event->afterDisplayContent = trim(implode("\n", $event->getResult()));
 
         return $item;
     }

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -286,7 +286,7 @@ class Cwmshowscripture
 
         // Fallback if nothing found
         if (empty($translations)) {
-            $obj = (object) ['abbreviation' => $version, 'name' => strtoupper($version), 'language' => $siteLang];
+            $obj          = (object) ['abbreviation' => $version, 'name' => strtoupper($version), 'language' => $siteLang];
             $translations = [$obj];
         }
 
@@ -315,7 +315,7 @@ class Cwmshowscripture
         ksort($otherGroup);
 
         // Build the searchable dropdown HTML
-        $messageId = (int) ($row->id ?? 0);
+        $messageId    = (int) ($row->id ?? 0);
         $siteLangName = self::$languageNames[$siteLang] ?? ucfirst($siteLang);
 
         // Find current version name for display

--- a/site/src/Model/CwmseriespodcastlistModel.php
+++ b/site/src/Model/CwmseriespodcastlistModel.php
@@ -51,8 +51,8 @@ class CwmseriespodcastlistModel extends ListModel
         }
 
         $user   = Factory::getApplication()->getIdentity();
-        $userId = $user->get('id');
-        $guest  = $user->get('guest');
+        $userId = $user->id;
+        $guest  = $user->guest;
         $groups = $user->getAuthorisedViewLevels();
 
         // Convert the parameter fields into objects.

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -261,8 +261,8 @@ class CwmsermonModel extends FormModel
                 $data->admin_params = Cwmparams::getAdmin()->params;
 
                 // Technically guest could edit an article, but lets not check that to improve performance a little.
-                if (!$user->get('guest')) {
-                    $userId = $user->get('id');
+                if (!$user->guest) {
+                    $userId = $user->id;
                     $asset  = 'com_proclaim.message.' . $data->id;
 
                     // Check general edit permission first.

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -108,8 +108,6 @@ class CwmsermonsModel extends ListModel
             ];
         }
 
-        $this->input = Factory::getApplication();
-
         parent::__construct($config);
     }
 
@@ -1071,9 +1069,10 @@ class CwmsermonsModel extends ListModel
                             }
 
                             if ((int)$filterid >= 1 && $filter === 'study.booknumber') {
-                                $book = $filterid;
-                                $chb  = $this->input->get('minChapt', '', 'int');
-                                $che  = $this->input->get('maxChapt', '', 'int');
+                                $book     = $filterid;
+                                $appInput = Factory::getApplication()->getInput();
+                                $chb      = $appInput->get('minChapt', '', 'int');
+                                $che      = $appInput->get('maxChapt', '', 'int');
 
                                 if ($chb && $che) {
                                     $query->where(

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -23,6 +23,7 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcastsubscribe;
 use CWM\Component\Proclaim\Site\Helper\Cwmrelatedstudies;
 use CWM\Component\Proclaim\Site\Helper\Cwmshowscripture;
 use CWM\Component\Proclaim\Site\Model\CwmsermonModel;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -279,9 +280,7 @@ class HtmlView extends BaseHtmlView
 
         // Check the view access to the article (the model has already computed the values).
         if (
-            $item->params->get('access-view') !== true && (($item->params->get('show_noauth') !== true && $user->get(
-                'guest'
-            )))
+            $item->params->get('access-view') !== true && (($item->params->get('show_noauth') !== true && $user->guest))
         ) {
             $app->enqueueMessage(Text::_('JERROR_ALERTNOAUTHOR'), 'error');
         }
@@ -358,33 +357,40 @@ class HtmlView extends BaseHtmlView
         }
 
         PluginHelper::importPlugin('content');
+        $dispatcher    = $app->getDispatcher();
         $article       = new \stdClass();
         $article->text = $this->item->scripture1;
-        $app->triggerEvent(
-            'onContentPrepare',
-            ['com_proclaim.sermons', & $article, & $this->item->params, null]
-        );
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+            'context' => 'com_proclaim.sermons',
+            'subject' => $article,
+            'params'  => $this->item->params,
+            'page'    => 0,
+        ]));
         $this->item->scripture1 = $article->text;
         $article->text          = $this->item->scripture2;
-        $app->triggerEvent(
-            'onContentPrepare',
-            ['com_proclaim.sermons', & $article, & $this->item->params, null]
-        );
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+            'context' => 'com_proclaim.sermons',
+            'subject' => $article,
+            'params'  => $this->item->params,
+            'page'    => 0,
+        ]));
         $this->item->scripture2 = $article->text;
         $article->text          = $this->item->studyintro;
-        $app->triggerEvent(
-            'onContentPrepare',
-            ['com_proclaim.sermons', & $article, & $this->item->params, null]
-        );
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+            'context' => 'com_proclaim.sermons',
+            'subject' => $article,
+            'params'  => $this->item->params,
+            'page'    => 0,
+        ]));
         $this->item->studyintro = $article->text;
         $article->text          = $this->item->secondary_reference;
-        $app->triggerEvent(
-            'onContentPrepare',
-            ['com_proclaim.sermons', & $article, & $this->item->params, null]
-        );
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+            'context' => 'com_proclaim.sermons',
+            'subject' => $article,
+            'params'  => $this->item->params,
+            'page'    => 0,
+        ]));
         $this->item->secondary_reference = $article->text;
-        $this->addHelperPath(JPATH_COMPONENT_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'helpers');
-        $this->loadHelper('params');
 
         // Get the podcast subscription
         HTMLHelper::_('stylesheet', 'media/css/podcast.css');
@@ -441,11 +447,13 @@ class HtmlView extends BaseHtmlView
                     break;
             }
 
-            $limitstart = (int)$app->input->get('limitstart', 'int');
-            $app->triggerEvent(
-                'onContentPrepare',
-                ['com_proclaim.sermon', & $article, & $this->item->params, $limitstart]
-            );
+            $limitstart = (int)$app->getInput()->get('limitstart', 0, 'int');
+            $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+                'context' => 'com_proclaim.sermon',
+                'subject' => $article,
+                'params'  => $this->item->params,
+                'page'    => $limitstart,
+            ]));
             $article->studytext    = $article->text;
             $this->item->studytext = $article->text;
         }


### PR DESCRIPTION
Replace deprecated Joomla APIs to ensure compatibility with Joomla 6:

- Replace $app->triggerEvent() with typed event classes and
  $app->getDispatcher()->dispatch() (ContentPrepareEvent, AfterTitleEvent,
  BeforeDisplayEvent, AfterDisplayEvent, BeforeSaveEvent, AfterSaveEvent)
- Replace Table::getInstance('Extension') with direct ExtensionTable
  instantiation
- Replace BaseDatabaseModel::getInstance() with MVCFactory->createModel()
- Replace $model->getErrors() with $form->getErrors() for validation
- Replace $user->get('id')/$user->get('guest') with direct property access
  ($user->id, $user->guest) across 17 files
- Replace $this->_rules with $this->getRules() in all 14 Table classes
- Replace $this->input-> with $this->getInput()-> in all controllers
- Replace Joomla\CMS\Input\Input with Joomla\Input\Input (removed in J6)
- Fix $this->input = Factory::getApplication() mis-assignment in
  CwmsermonsModel
- Fix $_POST direct access with proper Input API in CwmadminModel
- Remove deprecated $this->addHelperPath() call in HtmlView
- Replace legacy captcha triggerEvent with Captcha::getInstance() API

https://claude.ai/code/session_0166D4NhKi44RMNTRBRuAdvq