### PR TITLE
Optimize sermon detail page server response time

### DIFF
--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -228,30 +228,22 @@ class Cwmrelatedstudies
      */
     private function scoreByBooks(object $db, int $studyId, array $groups): void
     {
-        // Collect book numbers from junction table
+        // Collect book numbers from both junction table and legacy column in one query
         $query = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('booknumber'))
             ->from($db->quoteName('#__bsms_study_scriptures'))
             ->where($db->quoteName('study_id') . ' = ' . $studyId)
-            ->where($db->quoteName('booknumber') . ' > 0');
+            ->where($db->quoteName('booknumber') . ' > 0')
+            ->union(
+                $db->getQuery(true)
+                    ->select($db->quoteName('booknumber'))
+                    ->from($db->quoteName('#__bsms_studies'))
+                    ->where($db->quoteName('id') . ' = ' . $studyId)
+                    ->where($db->quoteName('booknumber') . ' > 0')
+            );
 
         $db->setQuery($query);
-        $bookNumbers = array_map('intval', $db->loadColumn() ?: []);
-
-        // Also get the legacy booknumber from the studies table
-        $query = $db->getQuery(true)
-            ->select($db->quoteName('booknumber'))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('id') . ' = ' . $studyId);
-
-        $db->setQuery($query);
-        $legacyBook = (int) $db->loadResult();
-
-        if ($legacyBook > 0) {
-            $bookNumbers[] = $legacyBook;
-        }
-
-        $bookNumbers = array_unique(array_filter($bookNumbers));
+        $bookNumbers = array_unique(array_filter(array_map('intval', $db->loadColumn() ?: [])));
 
         if (empty($bookNumbers)) {
             return;
@@ -318,36 +310,30 @@ class Cwmrelatedstudies
             return;
         }
 
-        // Get params for all published studies (excluding self)
-        $query = $db->getQuery(true)
-            ->select($db->quoteName(['id', 'params']))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('id') . ' != ' . $studyId)
-            ->where($db->quoteName('published') . ' = 1')
-            ->where($db->quoteName('access') . ' IN (' . implode(',', $groups) . ')')
-            ->where($db->quoteName('params') . ' IS NOT NULL')
-            ->where($db->quoteName('params') . ' != ' . $db->quote(''))
-            ->where($db->quoteName('params') . ' != ' . $db->quote('{}'));
+        // Use SQL LIKE matching to avoid loading all studies into PHP.
+        // Each keyword match adds 1 point. We run one query per keyword
+        // but only return IDs (no heavy params deserialization).
+        foreach ($keys as $key) {
+            $key = trim($key);
 
-        $db->setQuery($query);
-        $studies = $db->loadObjectList();
-
-        foreach ($studies as $study) {
-            $sparams    = new Registry($study->params);
-            $compareStr = (string) $sparams->get('metakey');
-
-            if (empty($compareStr)) {
+            if ($key === '') {
                 continue;
             }
 
-            $compareKeys = array_filter(array_map('trim', explode(',', $compareStr)));
-            $overlap     = \count(array_intersect(
-                array_map('strtolower', $keys),
-                array_map('strtolower', $compareKeys)
-            ));
+            $escaped = $db->quote('%' . $db->escape($key, true) . '%');
+            $query   = $db->getQuery(true)
+                ->select($db->quoteName('id'))
+                ->from($db->quoteName('#__bsms_studies'))
+                ->where($db->quoteName('id') . ' != ' . $studyId)
+                ->where($db->quoteName('published') . ' = 1')
+                ->where($db->quoteName('access') . ' IN (' . implode(',', $groups) . ')')
+                ->where($db->quoteName('params') . ' LIKE ' . $escaped);
 
-            if ($overlap > 0) {
-                $this->addScore((int) $study->id, $overlap);
+            $db->setQuery($query);
+            $ids = $db->loadColumn();
+
+            foreach ($ids as $id) {
+                $this->addScore((int) $id, 1);
             }
         }
     }

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -354,20 +354,26 @@ class Cwmshowscripture
         // Detect the site's active language (ISO 2-letter code)
         $siteLang = substr(Factory::getApplication()->getLanguage()->getTag(), 0, 2);
 
-        // Collect translations from DB with language info
-        $translations = [];
+        // Collect translations from DB with language info (cached per-request)
+        static $translationsCache = null;
 
-        try {
-            $db    = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-            $query = $db->getQuery(true)
-                ->select($db->quoteName(['abbreviation', 'name', 'language']))
-                ->from($db->quoteName('#__bsms_bible_translations'))
-                ->order($db->quoteName('language') . ' ASC, ' . $db->quoteName('name') . ' ASC');
-            $db->setQuery($query);
-            $translations = $db->loadObjectList() ?: [];
-        } catch (\Exception $e) {
-            // DB not available
+        if ($translationsCache === null) {
+            $translationsCache = [];
+
+            try {
+                $db    = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+                $query = $db->getQuery(true)
+                    ->select($db->quoteName(['abbreviation', 'name', 'language']))
+                    ->from($db->quoteName('#__bsms_bible_translations'))
+                    ->order($db->quoteName('language') . ' ASC, ' . $db->quoteName('name') . ' ASC');
+                $db->setQuery($query);
+                $translationsCache = $db->loadObjectList() ?: [];
+            } catch (\Exception $e) {
+                // DB not available
+            }
         }
+
+        $translations = $translationsCache;
 
         // Fallback if nothing found
         if (empty($translations)) {

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -413,18 +413,18 @@ class HtmlView extends BaseHtmlView
             $windowopen = "window.open(this.href,this.target,'width=800,height=500,scrollbars=1');return false;";
         }
 
-        // Added database queries from the default template - moved here instead
-        $database = Factory::getContainer()->get('DatabaseDriver');
-        $query    = $database->getQuery(true);
-        $query->select($database->quoteName('id'))
-            ->from($database->quoteName('#__menu'))
-            ->where(
-                $database->quoteName('link') . ' = '
-                . $database->quote('index.php?option=com_proclaim&view=cwmsermons')
-            )
-            ->where($database->quoteName('published') . ' = 1');
-        $database->setQuery($query);
-        $menuid       = $database->loadResult();
+        // Find the messages list menu item via Joomla's cached menu API
+        $menuid = null;
+        $menu   = $app->getMenu();
+
+        foreach ($menu->getItems('component', 'com_proclaim') as $menuItem) {
+            if (isset($menuItem->query['view']) && $menuItem->query['view'] === 'cwmsermons'
+                && $menuItem->published === 1) {
+                $menuid = $menuItem->id;
+                break;
+            }
+        }
+
         $this->menuid = $menuid;
 
         if ($this->getLayout() === 'pagebreak') {


### PR DESCRIPTION
## Summary

- **Related Studies book scoring**: Merged two separate DB queries (junction table + legacy column) into a single `UNION` query, eliminating a round-trip
- **Related Studies keyword scoring**: Replaced loading all published studies into PHP and deserializing every `params` JSON blob with per-keyword `LIKE` queries that return only matching IDs — avoids `O(n)` Registry instantiation
- **Bible translations query**: Added static request-scope cache to `buildBibleVersionSwitcher()` so the translations table is queried once per page load instead of once per scripture reference
- **Menu item lookup**: Replaced raw DB query for the messages list menu item with Joomla's `$app->getMenu()->getItems()` API, which uses Joomla's built-in menu cache

## Test plan

- [ ] Open a sermon detail page with Related Messages enabled — verify related studies still display correctly with scores
- [ ] Verify Bible version switcher dropdown still populates with all available translations
- [ ] Confirm "Back to Messages" link still resolves the correct menu item ID
- [ ] Check sermon detail pages with multiple scripture references — translations query should only fire once
- [ ] Test with studies that have metakey overlap — related studies should still appear ranked by relevance

🤖 Generated with [Claude Code](https://claude.com/claude-code)