### PR TITLE
Fix series podcast display N+1 query pattern

### DIFF
--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -929,8 +929,8 @@ class Cwmlisting
         $data = '';
 
         // Build image CSS class: always include img-fluid for responsive images, plus any custom class
-        $customImgClass = isset($row->custom) && !str_contains($row->custom, 'style=') ? $row->custom : '';
-        $imgClass = trim('img-fluid' . ($customImgClass !== '' ? ' ' . $customImgClass : ''));
+        $customImgClass    = isset($row->custom) && !str_contains($row->custom, 'style=') ? $row->custom : '';
+        $imgClass          = trim('img-fluid' . ($customImgClass !== '' ? ' ' . $customImgClass : ''));
         $classAppliedToImg = false;
 
         // Match the data in $item to a row/col in $row->name

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -1029,6 +1029,96 @@ class Cwmmedia
     }
 
     /**
+     * Get multiple media rows in a single query (batch version of getMediaRows2).
+     *
+     * Uses WHERE IN(...) to load all requested media files at once,
+     * avoiding the N+1 query pattern.
+     *
+     * @param   int[]  $ids  Array of media file IDs
+     *
+     * @return array  Associative array keyed by media file ID
+     *
+     * @throws \Exception
+     * @since 10.1.0
+     */
+    public function getMediaRowsBatch(array $ids): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        // Deduplicate and sanitise
+        $ids = array_unique(array_map('intval', $ids));
+        $ids = array_filter($ids, static fn ($id) => $id > 0);
+
+        if (empty($ids)) {
+            return [];
+        }
+
+        $db    = Factory::getContainer()->get('DatabaseDriver');
+        $query = $db->getQuery(true);
+        $query->select(
+            $db->quoteName('#__bsms_mediafiles') . '.*, ' . $db->quoteName('#__bsms_servers.params', 'sparams') . ','
+            . $db->quoteName('s.studyintro') . ', ' . $db->quoteName('s.series_id') . ', '
+            . $db->quoteName('s.studytitle') . ', ' . $db->quoteName('s.studydate') . ', '
+            . $db->quoteName('s.teacher_id') . ', ' . $db->quoteName('s.booknumber') . ', '
+            . $db->quoteName('s.chapter_begin') . ', ' . $db->quoteName('s.chapter_end') . ', '
+            . $db->quoteName('s.verse_begin') . ', ' . $db->quoteName('s.verse_end') . ', '
+            . $db->quoteName('t.teachername') . ', ' . $db->quoteName('t.teacher_thumbnail') . ', '
+            . $db->quoteName('t.teacher_image') . ', '
+            . $db->quoteName('t.teacher_thumbnail', 'thumb') . ', '
+            . $db->quoteName('t.image') . ', ' . $db->quoteName('t.id', 'tid') . ', '
+            . $db->quoteName('s.id', 'sid') . ', '
+            . $db->quoteName('se.id', 'seriesid') . ', ' . $db->quoteName('se.series_text') . ', '
+            . $db->quoteName('se.series_thumbnail')
+        )
+            ->from($db->quoteName('#__bsms_mediafiles'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_servers') . ' ON ('
+                . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_studies', 's') . ' ON ('
+                . $db->quoteName('s.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_study_teachers', 'stj') . ' ON ('
+                . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
+                . ' AND ' . $db->quoteName('stj.ordering') . ' = 0)'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_teachers', 't') . ' ON ('
+                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_series', 'se') . ' ON ('
+                . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id') . ')'
+            )
+            ->whereIn($db->quoteName('#__bsms_mediafiles.id'), $ids)
+            ->where($db->quoteName('#__bsms_mediafiles.published') . ' IN (1, 2)')
+            ->where(
+                $db->quoteName('#__bsms_mediafiles.language') . ' IN ('
+                . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ',' . $db->quote('*') . ')'
+            )
+            ->order($db->quoteName('ordering') . ' ASC');
+        $db->setQuery($query);
+        $rows = $db->loadObjectList();
+
+        $result = [];
+
+        foreach ($rows as $media) {
+            $reg = new Registry();
+            $reg->loadString($media->sparams);
+            $sparams      = $reg->toObject();
+            $media->spath = $sparams->path ?? '';
+
+            $result[$media->id] = $media;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get Media info Row2
      *
      * @param   int  $id  ID of Row

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -42,6 +42,15 @@ class CwmseriespodcastdisplayModel extends ItemModel
     protected string $context = 'com_proclaim.podcastdisplay';
 
     /**
+     * Cached studies query (avoids rebuilding for getTotal).
+     *
+     * @var  QueryInterface|null
+     *
+     * @since 10.1.0
+     */
+    private ?QueryInterface $studiesQuery = null;
+
+    /**
      * Method to get study data.
      *
      * @param   int  $pk  The ID of the study.
@@ -291,8 +300,12 @@ class CwmseriespodcastdisplayModel extends ItemModel
      */
     public function getStudies(): array
     {
-        $db              = $this->getDatabase();
-        $query           = $this->getStudiesQuery();
+        $db    = $this->getDatabase();
+        $query = $this->getStudiesQuery();
+
+        // Cache the query so getTotal() can clone it
+        $this->studiesQuery = $query;
+
         $template_params = Cwmparams::getTemplateparams();
         $t_params        = $template_params->params;
 
@@ -320,8 +333,12 @@ class CwmseriespodcastdisplayModel extends ItemModel
      */
     public function getTotal(): int
     {
-        $db    = $this->getDatabase();
-        $query = $this->getStudiesQuery();
+        $db = $this->getDatabase();
+
+        // Reuse the cached query from getStudies() if available, otherwise build fresh
+        $query = $this->studiesQuery !== null
+            ? clone $this->studiesQuery
+            : $this->getStudiesQuery();
 
         $query->clear('select')->clear('order')->clear('limit')->clear('offset');
         $query->select('COUNT(DISTINCT ' . $db->quoteName('study.id') . ')');

--- a/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
+++ b/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
@@ -136,21 +136,35 @@ class HtmlView extends BaseHtmlView
         $media = [];
 
         if ($studies) {
-            foreach ($studies as $s => $study) {
-                $medias   = !empty($study->mids) ? explode(',', $study->mids) : [];
-                $jbsMedia = new Cwmmedia();
+            // Collect all media IDs from every study into one flat array
+            $allMediaIds = [];
 
-                foreach ($medias as $i => $extraMedia) {
-                    $rowMedia = $jbsMedia->getMediaRows2((int)$extraMedia);
+            foreach ($studies as $study) {
+                if (!empty($study->mids)) {
+                    foreach (explode(',', $study->mids) as $mid) {
+                        $mid = (int) $mid;
 
-                    if ($rowMedia) {
-                        $reg = new Registry();
-                        $reg->loadString($rowMedia->params);
-                        $rowParams = $reg;
-
-                        if (str_ends_with($rowParams->get('filename', ''), '.mp3')) {
-                            $media[] = $rowMedia;
+                        if ($mid > 0) {
+                            $allMediaIds[] = $mid;
                         }
+                    }
+                }
+            }
+
+            if ($allMediaIds) {
+                // Single batch query replaces N+1 individual queries
+                $jbsMedia    = new Cwmmedia();
+                $batchResult = $jbsMedia->getMediaRowsBatch($allMediaIds);
+
+                foreach ($batchResult as $rowMedia) {
+                    $reg = new Registry();
+                    $reg->loadString($rowMedia->params);
+
+                    if (str_ends_with($reg->get('filename', ''), '.mp3')) {
+                        // Pre-parse Registry objects so the template doesn't recreate them
+                        $rowMedia->sparams = new Registry($rowMedia->sparams);
+                        $rowMedia->params  = $reg;
+                        $media[]           = $rowMedia;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add `getMediaRowsBatch()` to `Cwmmedia` helper — single `WHERE IN(...)` query replacing N individual `getMediaRows2()` calls
- Replace nested N+1 loop in `HtmlView` with flat ID collection + single batch call + `.mp3` filter + pre-parsed Registry objects
- Cache studies query in model so `getTotal()` clones it instead of rebuilding from scratch

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| DB queries (20 studies, 3 media each) | ~62 (1 studies + 60 media + 1 count) | ~3 (1 studies + 1 media batch + 1 count) |
| Registry creation in template | 2 per media item | 0 (pre-parsed in view) |
| Query construction | 2x full build | 1 build + 1 clone |

## Test plan
- [ ] Load a series podcast page on j5-dev/j6-dev — media files display correctly
- [ ] Verify pagination still works
- [ ] Verify audio player "Listen" links still function
- [ ] `composer test` — all 250 PHP tests pass
- [ ] `composer lint:syntax` — no syntax errors
- [ ] `composer lint:fix` — code style clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)