### PR TITLE
Add persistent L2 cache to Cwmstats and filter dropdowns

### DIFF
--- a/admin/src/Lib/Cwmstats.php
+++ b/admin/src/Lib/Cwmstats.php
@@ -18,6 +18,8 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -59,6 +61,29 @@ class Cwmstats
     private static string $total_messages_end = '';
 
     /**
+     * Get a Joomla persistent cache controller for cross-request caching.
+     *
+     * @param   int  $lifetime  Cache lifetime in seconds.
+     *
+     * @return  CallbackController
+     *
+     * @since   10.1.0
+     */
+    private static function getPersistentCache(int $lifetime = 900): CallbackController
+    {
+        /** @var CallbackController $cache */
+        $cache = Factory::getContainer()
+            ->get(CacheControllerFactoryInterface::class)
+            ->createCacheController('callback', [
+                'defaultgroup' => 'com_proclaim',
+                'caching'      => true,
+            ]);
+        $cache->setLifeTime($lifetime);
+
+        return $cache;
+    }
+
+    /**
      * Total plays of media files per study
      *
      * @param   int  $id  ID number of study
@@ -93,7 +118,7 @@ class Cwmstats
      */
     public static function getTotalMessages(string $start = '', string $end = ''): int
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Delegate to CwmcountHelper for simple published count (no date filtering)
@@ -145,44 +170,50 @@ class Cwmstats
      */
     public static function getTotalTopics(string $start = '', string $end = ''): int
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
         $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
-        $key = 'totalTopics:' . $start . ':' . $end . ':' . $userKey;
+        $key     = 'totalTopics:' . $start . ':' . $end . ':' . $userKey;
 
         if (isset(self::$cache[$key])) {
             return self::$cache[$key];
         }
 
-        $db    = Factory::getContainer()->get('DatabaseDriver');
-        $query = $db->getQuery(true);
-        $query
-            ->select('COUNT(*)')
-            ->from($db->quoteName('#__bsms_studies', 's'))
-            ->leftJoin($db->quoteName('#__bsms_studytopics', 'st') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('st.study_id'))
-            ->leftJoin($db->quoteName('#__bsms_topics', 't') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.topic_id'))
-            ->where($db->quoteName('t.published') . ' = 1');
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user, $start, $end) {
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query
+                ->select('COUNT(*)')
+                ->from($db->quoteName('#__bsms_studies', 's'))
+                ->leftJoin($db->quoteName('#__bsms_studytopics', 'st') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('st.study_id'))
+                ->leftJoin($db->quoteName('#__bsms_topics', 't') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.topic_id'))
+                ->where($db->quoteName('t.published') . ' = 1');
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
-        }
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
+            }
 
-        if (!empty($start)) {
-            $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(' . $db->quote($start) . ')');
-        }
+            if (!empty($start)) {
+                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(' . $db->quote($start) . ')');
+            }
 
-        if (!empty($end)) {
-            $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(' . $db->quote($end) . ')');
-        }
+            if (!empty($end)) {
+                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(' . $db->quote($end) . ')');
+            }
 
-        $db->setQuery($query);
+            $db->setQuery($query);
 
-        self::$cache[$key] = (int) $db->loadResult();
+            return (int) $db->loadResult();
+        }, [], md5($key));
 
-        return self::$cache[$key];
+        self::$cache[$key] = $result;
+
+        return $result;
     }
 
     /**
@@ -194,44 +225,50 @@ class Cwmstats
      */
     public static function getTopStudies(): string
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
-        $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
+        $userKey  = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
         $cacheKey = 'topStudies:' . $userKey;
 
         if (isset(self::$cache[$cacheKey])) {
             return self::$cache[$cacheKey];
         }
 
-        $db    = Factory::getContainer()->get('DatabaseDriver');
-        $query = $db->getQuery(true);
-        $query
-            ->select($db->quoteName(['id', 'studytitle', 'studydate', 'hits', 'access']))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('published') . ' = 1')
-            ->where($db->quoteName('hits') . ' > 0');
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user) {
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query
+                ->select($db->quoteName(['id', 'studytitle', 'studydate', 'hits', 'access']))
+                ->from($db->quoteName('#__bsms_studies'))
+                ->where($db->quoteName('published') . ' = 1')
+                ->where($db->quoteName('hits') . ' > 0');
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('access'), $user->getAuthorisedViewLevels());
-        }
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('access'), $user->getAuthorisedViewLevels());
+            }
 
-        $query->order($db->quoteName('hits') . ' DESC');
-        $db->setQuery($query, 0, 5);
-        $results     = $db->loadObjectList();
-        $top_studies = '';
+            $query->order($db->quoteName('hits') . ' DESC');
+            $db->setQuery($query, 0, 5);
+            $rows        = $db->loadObjectList();
+            $top_studies = '';
 
-        foreach ($results as $result) {
-            $top_studies .= (int) $result->hits . ' ' . Text::_('JBS_CMN_HITS') .
-                ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $result->id . '">' .
-                htmlspecialchars($result->studytitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($result->studydate)) . '<br>';
-        }
+            foreach ($rows as $row) {
+                $top_studies .= (int) $row->hits . ' ' . Text::_('JBS_CMN_HITS') .
+                    ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $row->id . '">' .
+                    htmlspecialchars($row->studytitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($row->studydate)) . '<br>';
+            }
 
-        self::$cache[$cacheKey] = $top_studies;
+            return $top_studies;
+        }, [], md5($cacheKey));
 
-        return $top_studies;
+        self::$cache[$cacheKey] = $result;
+
+        return $result;
     }
 
     /**
@@ -255,51 +292,57 @@ class Cwmstats
      */
     public static function getTopThirtyDays(): string
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
-        $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
+        $userKey  = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
         $cacheKey = 'topThirtyDays:' . $userKey;
 
         if (isset(self::$cache[$cacheKey])) {
             return self::$cache[$cacheKey];
         }
 
-        $month      = mktime(0, 0, 0, (int) date("m") - 1, (int) date("d"), (int) date("Y"));
-        $last_month = date("Y-m-d 00:00:01", $month);
-        $db         = Factory::getContainer()->get('DatabaseDriver');
-        $query      = $db->getQuery(true);
-        $query
-            ->select($db->quoteName(['id', 'studytitle', 'studydate', 'hits', 'access']))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('published') . ' = 1')
-            ->where($db->quoteName('hits') . ' > 0')
-            ->where($db->quoteName('studydate') . ' > ' . $db->quote($last_month));
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user) {
+            $month      = mktime(0, 0, 0, (int) date("m") - 1, (int) date("d"), (int) date("Y"));
+            $last_month = date("Y-m-d 00:00:01", $month);
+            $db         = Factory::getContainer()->get('DatabaseDriver');
+            $query      = $db->getQuery(true);
+            $query
+                ->select($db->quoteName(['id', 'studytitle', 'studydate', 'hits', 'access']))
+                ->from($db->quoteName('#__bsms_studies'))
+                ->where($db->quoteName('published') . ' = 1')
+                ->where($db->quoteName('hits') . ' > 0')
+                ->where($db->quoteName('studydate') . ' > ' . $db->quote($last_month));
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('access'), $user->getAuthorisedViewLevels());
-        }
-
-        $query->order($db->quoteName('hits') . ' DESC');
-        $db->setQuery($query, 0, 5);
-        $results     = $db->loadObjectList();
-        $top_studies = '';
-
-        if (!$results) {
-            $top_studies = Text::_('JBS_CPL_NO_INFORMATION');
-        } else {
-            foreach ($results as $result) {
-                $top_studies .= (int) $result->hits . ' ' . Text::_('JBS_CMN_HITS') .
-                    ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $result->id . '">' .
-                    htmlspecialchars($result->studytitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($result->studydate)) . '<br>';
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('access'), $user->getAuthorisedViewLevels());
             }
-        }
 
-        self::$cache[$cacheKey] = $top_studies;
+            $query->order($db->quoteName('hits') . ' DESC');
+            $db->setQuery($query, 0, 5);
+            $rows        = $db->loadObjectList();
+            $top_studies = '';
 
-        return $top_studies;
+            if (!$rows) {
+                $top_studies = Text::_('JBS_CPL_NO_INFORMATION');
+            } else {
+                foreach ($rows as $row) {
+                    $top_studies .= (int) $row->hits . ' ' . Text::_('JBS_CMN_HITS') .
+                        ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $row->id . '">' .
+                        htmlspecialchars($row->studytitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($row->studydate)) . '<br>';
+                }
+            }
+
+            return $top_studies;
+        }, [], md5($cacheKey));
+
+        self::$cache[$cacheKey] = $result;
+
+        return $result;
     }
 
     /**
@@ -323,50 +366,56 @@ class Cwmstats
      */
     public static function getTopDownloads(): string
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
-        $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
+        $userKey  = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
         $cacheKey = 'topDownloads:' . $userKey;
 
         if (isset(self::$cache[$cacheKey])) {
             return self::$cache[$cacheKey];
         }
 
-        $db    = Factory::getContainer()->get('DatabaseDriver');
-        $query = $db->getQuery(true);
-        $query
-            ->select($db->quoteName(['mf.downloads']))
-            ->select($db->quoteName('s.id', 'sid'))
-            ->select($db->quoteName('s.studytitle', 'stitle'))
-            ->select($db->quoteName('s.studydate', 'sdate'))
-            ->select($db->quoteName('s.access', 'saccess'))
-            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('mf.study_id') . ' = ' . $db->quoteName('s.id'))
-            ->where($db->quoteName('mf.published') . ' = 1')
-            ->where($db->quoteName('mf.downloads') . ' > 0');
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user) {
+            $db    = Factory::getContainer()->get('DatabaseDriver');
+            $query = $db->getQuery(true);
+            $query
+                ->select($db->quoteName(['mf.downloads']))
+                ->select($db->quoteName('s.id', 'sid'))
+                ->select($db->quoteName('s.studytitle', 'stitle'))
+                ->select($db->quoteName('s.studydate', 'sdate'))
+                ->select($db->quoteName('s.access', 'saccess'))
+                ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
+                ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('mf.study_id') . ' = ' . $db->quoteName('s.id'))
+                ->where($db->quoteName('mf.published') . ' = 1')
+                ->where($db->quoteName('mf.downloads') . ' > 0');
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
-        }
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
+            }
 
-        $query->order($db->quoteName('mf.downloads') . ' DESC');
-        $db->setQuery($query, 0, 5);
-        $results     = $db->loadObjectList();
-        $top_studies = '';
+            $query->order($db->quoteName('mf.downloads') . ' DESC');
+            $db->setQuery($query, 0, 5);
+            $rows        = $db->loadObjectList();
+            $top_studies = '';
 
-        foreach ($results as $result) {
-            $top_studies .=
-                (int) $result->downloads . ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' .
-                (int) $result->sid . '">' . htmlspecialchars($result->stitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($result->sdate)) .
-                '<br>';
-        }
+            foreach ($rows as $row) {
+                $top_studies .=
+                    (int) $row->downloads . ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' .
+                    (int) $row->sid . '">' . htmlspecialchars($row->stitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($row->sdate)) .
+                    '<br>';
+            }
 
-        self::$cache[$cacheKey] = $top_studies;
+            return $top_studies;
+        }, [], md5($cacheKey));
 
-        return $top_studies;
+        self::$cache[$cacheKey] = $result;
+
+        return $result;
     }
 
     /**
@@ -378,56 +427,62 @@ class Cwmstats
      */
     public static function getDownloadsLastThreeMonths(): string
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
-        $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
+        $userKey  = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
         $cacheKey = 'downloadsLast3Months:' . $userKey;
 
         if (isset(self::$cache[$cacheKey])) {
             return self::$cache[$cacheKey];
         }
 
-        $month     = mktime(0, 0, 0, (int) date("m") - 3, (int) date("d"), (int) date("Y"));
-        $lastmonth = date("Y-m-d 00:00:01", $month);
-        $db        = Factory::getContainer()->get('DatabaseDriver');
-        $query     = $db->getQuery(true);
-        $query
-            ->select($db->quoteName(['mf.downloads']))
-            ->select($db->quoteName('s.id', 'sid'))
-            ->select($db->quoteName('s.studytitle', 'stitle'))
-            ->select($db->quoteName('s.studydate', 'sdate'))
-            ->select($db->quoteName('s.access', 'saccess'))
-            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('mf.study_id') . ' = ' . $db->quoteName('s.id'))
-            ->where($db->quoteName('mf.published') . ' = 1')
-            ->where($db->quoteName('mf.downloads') . ' > 0')
-            ->where($db->quoteName('mf.createdate') . ' > ' . $db->quote($lastmonth));
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user) {
+            $month     = mktime(0, 0, 0, (int) date("m") - 3, (int) date("d"), (int) date("Y"));
+            $lastmonth = date("Y-m-d 00:00:01", $month);
+            $db        = Factory::getContainer()->get('DatabaseDriver');
+            $query     = $db->getQuery(true);
+            $query
+                ->select($db->quoteName(['mf.downloads']))
+                ->select($db->quoteName('s.id', 'sid'))
+                ->select($db->quoteName('s.studytitle', 'stitle'))
+                ->select($db->quoteName('s.studydate', 'sdate'))
+                ->select($db->quoteName('s.access', 'saccess'))
+                ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
+                ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('mf.study_id') . ' = ' . $db->quoteName('s.id'))
+                ->where($db->quoteName('mf.published') . ' = 1')
+                ->where($db->quoteName('mf.downloads') . ' > 0')
+                ->where($db->quoteName('mf.createdate') . ' > ' . $db->quote($lastmonth));
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
-        }
-
-        $query->order($db->quoteName('mf.downloads') . ' DESC');
-        $db->setQuery($query, 0, 5);
-        $results     = $db->loadObjectList();
-        $top_studies = '';
-
-        if (!$results) {
-            $top_studies = Text::_('JBS_CPL_NO_INFORMATION');
-        } else {
-            foreach ($results as $result) {
-                $top_studies .= (int) $result->downloads . ' ' . Text::_('JBS_CMN_HITS') .
-                    ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $result->sid . '">' .
-                    htmlspecialchars($result->stitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($result->sdate)) . '<br>';
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
             }
-        }
 
-        self::$cache[$cacheKey] = $top_studies;
+            $query->order($db->quoteName('mf.downloads') . ' DESC');
+            $db->setQuery($query, 0, 5);
+            $rows        = $db->loadObjectList();
+            $top_studies = '';
 
-        return $top_studies;
+            if (!$rows) {
+                $top_studies = Text::_('JBS_CPL_NO_INFORMATION');
+            } else {
+                foreach ($rows as $row) {
+                    $top_studies .= (int) $row->downloads . ' ' . Text::_('JBS_CMN_HITS') .
+                        ' - <a href="index.php?option=com_proclaim&amp;task=message.edit&amp;id=' . (int) $row->sid . '">' .
+                        htmlspecialchars($row->stitle, ENT_QUOTES, 'UTF-8') . '</a> - ' . date('Y-m-d', strtotime($row->sdate)) . '<br>';
+                }
+            }
+
+            return $top_studies;
+        }, [], md5($cacheKey));
+
+        self::$cache[$cacheKey] = $result;
+
+        return $result;
     }
 
     /**
@@ -469,65 +524,71 @@ class Cwmstats
      */
     public static function getTopScore(): string
     {
-        $user = Factory::getApplication()->getIdentity();
+        $user    = Factory::getApplication()->getIdentity();
         $isAdmin = $user->authorise('core.admin');
 
         // Include user authorization in cache key for non-admin users
-        $userKey = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
+        $userKey  = $isAdmin ? 'admin' : implode(',', $user->getAuthorisedViewLevels());
         $cacheKey = 'topScore:' . $userKey;
 
         if (isset(self::$cache[$cacheKey])) {
             return self::$cache[$cacheKey];
         }
 
-        $admin  = Cwmparams::getAdmin();
-        $format = (int) $admin->params->get('format_popular', 0);
-        $db     = Factory::getContainer()->get('DatabaseDriver');
+        // L2: persistent cache across requests (TTL: 15 min)
+        $pc     = self::getPersistentCache();
+        $result = $pc->get(function () use ($isAdmin, $user) {
+            $admin  = Cwmparams::getAdmin();
+            $format = (int) $admin->params->get('format_popular', 0);
+            $db     = Factory::getContainer()->get('DatabaseDriver');
 
-        $query = $db->getQuery(true);
-        $query->select($db->quoteName(['s.id', 's.studytitle', 's.studydate', 's.hits', 's.access']))
-            ->select('SUM(' . $db->quoteName('mf.downloads') . ' + ' . $db->quoteName('mf.plays') . ') AS added')
-            ->from($db->quoteName('#__bsms_studies', 's'))
-            ->join('INNER', $db->quoteName('#__bsms_mediafiles', 'mf') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
-            ->where($db->quoteName('mf.published') . ' = 1');
+            $query = $db->getQuery(true);
+            $query->select($db->quoteName(['s.id', 's.studytitle', 's.studydate', 's.hits', 's.access']))
+                ->select('SUM(' . $db->quoteName('mf.downloads') . ' + ' . $db->quoteName('mf.plays') . ') AS added')
+                ->from($db->quoteName('#__bsms_studies', 's'))
+                ->join('INNER', $db->quoteName('#__bsms_mediafiles', 'mf') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
+                ->where($db->quoteName('mf.published') . ' = 1');
 
-        // Filter by access level for non-super-admin users (multi-campus isolation)
-        if (!$isAdmin) {
-            $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
-        }
+            // Filter by access level for non-super-admin users (multi-campus isolation)
+            if (!$isAdmin) {
+                $query->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels());
+            }
 
-        $query->group($db->quoteName(['s.id', 's.studytitle', 's.studydate', 's.hits', 's.access']))
-            ->order($db->qn('added') . ' DESC');
+            $query->group($db->quoteName(['s.id', 's.studytitle', 's.studydate', 's.hits', 's.access']))
+                ->order($db->qn('added') . ' DESC');
 
-        $db->setQuery($query, 0, 10); // Get more to account for re-sorting if hits are included
-        $results = $db->loadObjectList();
+            $db->setQuery($query, 0, 10); // Get more to account for re-sorting if hits are included
+            $rows = $db->loadObjectList();
 
-        $final = [];
+            $final = [];
 
-        foreach ($results as $result) {
-            $total = ($format < 1) ? ((int) $result->added + (int) $result->hits) : (int) $result->added;
-            $link  = ' <a href="' . Route::_('index.php?option=com_proclaim&task=message.edit&id=' . (int) $result->id) . '">' .
-                htmlspecialchars($result->studytitle, ENT_QUOTES, 'UTF-8') . '</a> ' . date('Y-m-d', strtotime($result->studydate)) . '<br>';
-            $final[] = ['total' => $total, 'link' => $link];
-        }
+            foreach ($rows as $row) {
+                $total   = ($format < 1) ? ((int) $row->added + (int) $row->hits) : (int) $row->added;
+                $link    = ' <a href="' . Route::_('index.php?option=com_proclaim&task=message.edit&id=' . (int) $row->id) . '">' .
+                    htmlspecialchars($row->studytitle, ENT_QUOTES, 'UTF-8') . '</a> ' . date('Y-m-d', strtotime($row->studydate)) . '<br>';
+                $final[] = ['total' => $total, 'link' => $link];
+            }
 
-        // Re-sort by total descending
-        usort($final, function ($a, $b) {
-            return $b['total'] <=> $a['total'];
-        });
+            // Re-sort by total descending
+            usort($final, function ($a, $b) {
+                return $b['total'] <=> $a['total'];
+            });
 
-        // Slice to top 5
-        $final = \array_slice($final, 0, 5);
+            // Slice to top 5
+            $final = \array_slice($final, 0, 5);
 
-        $top_score_table = '';
+            $top_score_table = '';
 
-        foreach ($final as $item) {
-            $top_score_table .= (string) $item['total'] . ' ' . $item['link'];
-        }
+            foreach ($final as $item) {
+                $top_score_table .= (string) $item['total'] . ' ' . $item['link'];
+            }
 
-        self::$cache[$cacheKey] = $top_score_table;
+            return $top_score_table;
+        }, [], md5($cacheKey));
 
-        return $top_score_table;
+        self::$cache[$cacheKey] = $result;
+
+        return $result;
     }
 
     /**

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -15,6 +15,8 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -84,6 +86,29 @@ class CwmsermonsModel extends ListModel
         } else {
             $this->filterCache = [];
         }
+    }
+
+    /**
+     * Get a Joomla persistent cache controller for cross-request caching.
+     *
+     * @param   int  $lifetime  Cache lifetime in seconds.
+     *
+     * @return  CallbackController
+     *
+     * @since   10.1.0
+     */
+    private function getPersistentCache(int $lifetime = 3600): CallbackController
+    {
+        /** @var CallbackController $cache */
+        $cache = Factory::getContainer()
+            ->get(CacheControllerFactoryInterface::class)
+            ->createCacheController('callback', [
+                'defaultgroup' => 'com_proclaim',
+                'caching'      => true,
+            ]);
+        $cache->setLifeTime($lifetime);
+
+        return $cache;
     }
 
     /**
@@ -250,20 +275,25 @@ class CwmsermonsModel extends ListModel
             return $this->filterCache['teachers'];
         }
 
-        $db    = $this->getDatabase();
-        $query = $db->getQuery(true);
-        $query->select($db->quoteName(['t.id', 't.teachername'], ['value', 'text']));
-        $query->from($db->quoteName('#__bsms_teachers', 't'));
-        $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('series.teacher'));
-        $query->group($db->quoteName('t.id'));
-        $query->order($db->quoteName('t.teachername') . ' ASC');
+        // L2: persistent cache across requests (TTL: 1 hour)
+        $pc     = $this->getPersistentCache();
+        $result = $pc->get(function () {
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true);
+            $query->select($db->quoteName(['t.id', 't.teachername'], ['value', 'text']));
+            $query->from($db->quoteName('#__bsms_teachers', 't'));
+            $query->select($db->quoteName('series.access'));
+            $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('series.teacher'));
+            $query->group($db->quoteName('t.id'));
+            $query->order($db->quoteName('t.teachername') . ' ASC');
+            $db->setQuery($query);
 
-        $db->setQuery($query);
+            return $db->loadObjectList();
+        }, [], 'filter_teachers');
 
-        $this->filterCache['teachers'] = $db->loadObjectList();
+        $this->filterCache['teachers'] = $result;
 
-        return $this->filterCache['teachers'];
+        return $result;
     }
 
     /**
@@ -278,20 +308,25 @@ class CwmsermonsModel extends ListModel
             return $this->filterCache['years'];
         }
 
-        $db    = $this->getDatabase();
-        $query = $db->getQuery(true);
-        $query->select('DISTINCT YEAR(' . $db->quoteName('s.studydate') . ') as value');
-        $query->select('YEAR(' . $db->quoteName('s.studydate') . ') as text');
-        $query->from($db->quoteName('#__bsms_studies', 's'));
-        $query->select($db->quoteName('series.access'));
-        $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('series.id'));
-        $query->order($db->quoteName('value'));
+        // L2: persistent cache across requests (TTL: 1 hour)
+        $pc     = $this->getPersistentCache();
+        $result = $pc->get(function () {
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true);
+            $query->select('DISTINCT YEAR(' . $db->quoteName('s.studydate') . ') as value');
+            $query->select('YEAR(' . $db->quoteName('s.studydate') . ') as text');
+            $query->from($db->quoteName('#__bsms_studies', 's'));
+            $query->select($db->quoteName('series.access'));
+            $query->join('INNER', $db->quoteName('#__bsms_series', 'series') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('series.id'));
+            $query->order($db->quoteName('value'));
+            $db->setQuery($query);
 
-        $db->setQuery($query);
+            return $db->loadObjectList();
+        }, [], 'filter_years');
 
-        $this->filterCache['years'] = $db->loadObjectList();
+        $this->filterCache['years'] = $result;
 
-        return $this->filterCache['years'];
+        return $result;
     }
 
     /**
@@ -307,36 +342,43 @@ class CwmsermonsModel extends ListModel
             return $this->filterCache['series'];
         }
 
-        $db    = $this->getDatabase();
-        $query = $db->getQuery(true);
-
-        $query->select($db->quoteName(['series.id', 'series.series_text', 'series.access'], ['value', 'text', 'access']));
-        $query->from($db->quoteName('#__bsms_series', 'series'));
-        $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.series_id') . ' = ' . $db->quoteName('series.id'));
-        $query->group($db->quoteName('series.id'));
-        $query->order($db->quoteName('series.series_text'));
-
-        $db->setQuery($query);
-        $items = $db->loadObjectList();
-
-        // Check permissions for this view by running through the records and removing those the user doesn't have permission to see
+        // User-aware cache key: users sharing the same access levels share the cached result
         $user   = $this->getCurrentUser();
         $groups = $user->getAuthorisedViewLevels();
-        $count  = \count($items);
 
-        if ($count > 0) {
-            foreach ($items as $i => $iValue) {
-                if ($iValue->access > 1) {
-                    if (!\in_array($iValue->access, $groups, true)) {
-                        unset($items[$i]);
+        // L2: persistent cache across requests (TTL: 1 hour)
+        $pc     = $this->getPersistentCache();
+        $result = $pc->get(function () use ($groups) {
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true);
+
+            $query->select($db->quoteName(['series.id', 'series.series_text', 'series.access'], ['value', 'text', 'access']));
+            $query->from($db->quoteName('#__bsms_series', 'series'));
+            $query->join('INNER', $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.series_id') . ' = ' . $db->quoteName('series.id'));
+            $query->group($db->quoteName('series.id'));
+            $query->order($db->quoteName('series.series_text'));
+
+            $db->setQuery($query);
+            $items = $db->loadObjectList();
+            $count = \count($items);
+
+            // Check permissions: remove series the current access group cannot see
+            if ($count > 0) {
+                foreach ($items as $i => $iValue) {
+                    if ($iValue->access > 1) {
+                        if (!\in_array($iValue->access, $groups, true)) {
+                            unset($items[$i]);
+                        }
                     }
                 }
             }
-        }
 
-        $this->filterCache['series'] = $items;
+            return $items;
+        }, [], md5('filter_series:' . implode(',', $groups)));
 
-        return $items;
+        $this->filterCache['series'] = $result;
+
+        return $result;
     }
 
     /**
@@ -351,23 +393,29 @@ class CwmsermonsModel extends ListModel
             return $this->filterCache['books'];
         }
 
-        $db    = $this->getDatabase();
-        $query = $db->getQuery(true);
+        // L2: persistent cache across requests (TTL: 1 hour)
+        $pc     = $this->getPersistentCache();
+        $result = $pc->get(function () {
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true);
 
-        $query->select($db->quoteName(['books.id', 'books.bookname', 'books.id'], ['value', 'text', 'value']));
-        $query->from($db->quoteName('#__bsms_books', 'books'));
-        $query->order($db->quoteName('books.booknumber'));
+            $query->select($db->quoteName(['books.id', 'books.bookname', 'books.id'], ['value', 'text', 'value']));
+            $query->from($db->quoteName('#__bsms_books', 'books'));
+            $query->order($db->quoteName('books.booknumber'));
 
-        $db->setQuery($query);
-        $books = $db->loadObjectList();
+            $db->setQuery($query);
+            $books = $db->loadObjectList();
 
-        foreach ($books as $book) {
-            $book->text = Text::_($book->text);
-        }
+            foreach ($books as $book) {
+                $book->text = Text::_($book->text);
+            }
 
-        $this->filterCache['books'] = $books;
+            return $books;
+        }, [], 'filter_books');
 
-        return $this->filterCache['books'];
+        $this->filterCache['books'] = $result;
+
+        return $result;
     }
 
     /**

--- a/tests/integration/Admin/Lib/CwmstatsCacheTest.php
+++ b/tests/integration/Admin/Lib/CwmstatsCacheTest.php
@@ -69,4 +69,29 @@ class CwmstatsCacheTest extends IntegrationTestCase
         $this->assertParamTypeName('int', $params[0]);
         $this->assertReturnTypeName('int', $ref);
     }
+
+    public function testPersistentCacheHelperExists(): void
+    {
+        $ref = new \ReflectionClass(Cwmstats::class);
+        $this->assertTrue($ref->hasMethod('getPersistentCache'), 'getPersistentCache() method must exist');
+
+        $method = $ref->getMethod('getPersistentCache');
+        $this->assertTrue($method->isStatic(), 'getPersistentCache() must be static');
+        $this->assertTrue($method->isPrivate(), 'getPersistentCache() must be private');
+
+        $params = $method->getParameters();
+        $this->assertCount(1, $params, 'getPersistentCache() must accept one parameter (lifetime)');
+        $this->assertEquals('lifetime', $params[0]->getName());
+        $this->assertTrue($params[0]->isOptional(), 'lifetime must be optional');
+        $this->assertEquals(900, $params[0]->getDefaultValue(), 'Default TTL must be 900 seconds');
+    }
+
+    public function testPersistentCacheReturnTypeIsCallbackController(): void
+    {
+        $ref    = new \ReflectionMethod(Cwmstats::class, 'getPersistentCache');
+        $return = $ref->getReturnType();
+
+        $this->assertNotNull($return, 'getPersistentCache() must declare a return type');
+        $this->assertStringContainsString('CallbackController', (string) $return);
+    }
 }


### PR DESCRIPTION
## Summary

- **Cwmstats** — 6 admin dashboard stat methods now use a Joomla `CallbackController` persistent cache (L2, 15 min TTL) on top of the existing in-memory L1 cache. Methods: `getTotalTopics`, `getTopStudies`, `getTopThirtyDays`, `getTopDownloads`, `getDownloadsLastThreeMonths`, `getTopScore`.
- **CwmsermonsModel** — 4 filter dropdown methods now use L2 persistent cache (1 hour TTL): `getTeachers`, `getYears`, `getSeries`, `getBooks`. `getSeries` uses a user-aware cache key to preserve existing PHP-side access filtering for multi-campus deployments.
- No new invalidation logic needed — all 12 admin models already call `cleanCache('com_proclaim')` on every save/delete, clearing both cache groups automatically.
- Adds 2 integration tests verifying `getPersistentCache()` helper signature and return type.

## Test plan

- [ ] 270 PHPUnit tests pass (`composer test`)
- [ ] PHP syntax clean (`composer lint:syntax`)
- [ ] Load admin dashboard — stats display correctly
- [ ] Save a message record — reload dashboard, stats reflect the change (cache invalidated by model's `cleanCache()`)
- [ ] Clear cache via Asset Tools tab — works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)