### PR TITLE
feat: expand lint:js scope to include test files

### DIFF
--- a/build/eslint.config.mjs
+++ b/build/eslint.config.mjs
@@ -82,6 +82,8 @@ export default defineConfig([
         files: ['tests/**/*.js', 'tests/**/*.mjs'],
         rules: {
             'no-undef': 'off',
+            // Test files access mock.calls[n] frequently; nested destructuring hurts readability
+            'prefer-destructuring': 'off',
         },
     },
 ]);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report build/reports/e2e",
-    "lint:js": "eslint --config build/eslint.config.mjs --max-warnings=0 build/media_source/js/"
+    "lint:js": "eslint --config build/eslint.config.mjs --max-warnings=0 build/media_source/js/ tests/js/ tests/e2e/"
   },
   "dependencies": {
     "chart.js": "^4.5.1",

--- a/tests/js/cwmadmin-batch-footers.test.js
+++ b/tests/js/cwmadmin-batch-footers.test.js
@@ -16,7 +16,7 @@ const BATCH_FILES = [
 ];
 
 describe('Admin Batch Files', () => {
-    BATCH_FILES.forEach(({ name, file, task }) => {
+    BATCH_FILES.forEach(({ file, task }) => {
         describe(`${file.split('/').pop()}`, () => {
             describe('Batch Functionality', () => {
                 let mockSubmitForm;

--- a/tests/js/fancybox.test.js
+++ b/tests/js/fancybox.test.js
@@ -58,7 +58,7 @@ describe('fancybox.es6.js', () => {
         });
 
         test('should bind with Carousel and Toolbar options', () => {
-            const bindOptions = mockFancybox.bind.mock.calls[0][1];
+            const [, bindOptions] = mockFancybox.bind.mock.calls[0];
             expect(bindOptions.Carousel).toEqual({ infinite: false });
             expect(bindOptions.Toolbar.display.right).toContain('close');
         });

--- a/tests/js/scripture-switcher.test.js
+++ b/tests/js/scripture-switcher.test.js
@@ -13,8 +13,8 @@
 const SOURCE_FILE = 'build/media_source/js/scripture-switcher.es6.js';
 
 // Track DOMContentLoaded handlers for cleanup
-var capturedDclHandler = null;
-var origAddEventListener = document.addEventListener.bind(document);
+let capturedDclHandler = null;
+const origAddEventListener = document.addEventListener.bind(document);
 
 /**
  * Build the DOM fixtures for the searchable scripture switcher.
@@ -24,15 +24,14 @@ var origAddEventListener = document.addEventListener.bind(document);
  * @param {Object} opts  Configuration options
  * @returns {void}
  */
-function setupDOM(opts) {
-    opts = opts || {};
-    var currentVersion = opts.currentVersion || 'kjv';
-    var bodyText = opts.bodyText || '<p><sup>1</sup> In the beginning God created...</p>';
-    var copyrightText = opts.copyrightText || 'Public Domain';
+function setupDOM(opts = {}) {
+    const currentVersion = opts.currentVersion || 'kjv';
+    const bodyText = opts.bodyText || '<p><sup>1</sup> In the beginning God created...</p>';
+    const copyrightText = opts.copyrightText || 'Public Domain';
 
     // Build the scripture container with switcher inside .scripture-text
     // All content is static test fixture data
-    var html = '<div class="scripture-container scripture-visible">'
+    const html = '<div class="scripture-container scripture-visible">'
         + '<div class="scripture-text">'
         + '<div class="scripture-body">' + bodyText + '</div>'
         + '<div class="scripture-copyright">' + copyrightText + '</div>'
@@ -136,15 +135,15 @@ afterEach(function () {
 // --- Initialization tests ---
 describe('scripture-switcher initialization', function () {
     test('sets _currentVersion from data-current-version', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
-        var switcher = document.querySelector('.scripture-searchable-switcher');
+        const switcher = document.querySelector('.scripture-searchable-switcher');
         expect(switcher._currentVersion).toBe('kjv');
     });
 
     test('caches initial content at init time', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch, {
             currentVersion: 'kjv',
             bodyText: '<p>Initial KJV text</p>'
@@ -152,7 +151,7 @@ describe('scripture-switcher initialization', function () {
 
         // The cache is internal (WeakMap), but we can verify by clicking KJV
         // and confirming no fetch is made
-        var kjvItem = document.querySelector('[data-value="kjv"]');
+        const kjvItem = document.querySelector('[data-value="kjv"]');
         kjvItem.click();
 
         expect(mockFetch).not.toHaveBeenCalled();
@@ -162,26 +161,26 @@ describe('scripture-switcher initialization', function () {
 // --- Same-version short-circuit ---
 describe('same-version short-circuit', function () {
     test('clicking the currently displayed version does not trigger fetch', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
-        var kjvItem = document.querySelector('[data-value="kjv"]');
+        const kjvItem = document.querySelector('[data-value="kjv"]');
         kjvItem.click();
 
         expect(mockFetch).not.toHaveBeenCalled();
     });
 
     test('clicking same version closes the menu', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
         // Open menu first
-        var toggle = document.querySelector('.scripture-dropdown-toggle');
+        const toggle = document.querySelector('.scripture-dropdown-toggle');
         toggle.click();
         expect(document.querySelector('.scripture-dropdown-menu').style.display).toBe('flex');
 
         // Click KJV (already active)
-        var kjvItem = document.querySelector('[data-value="kjv"]');
+        const kjvItem = document.querySelector('[data-value="kjv"]');
         kjvItem.click();
 
         expect(document.querySelector('.scripture-dropdown-menu').style.display).toBe('none');
@@ -192,7 +191,7 @@ describe('same-version short-circuit', function () {
 // --- Successful fetch commits UI ---
 describe('successful fetch', function () {
     test('updates body, dropdown text, and select only after success', async function () {
-        var mockFetch = jest.fn().mockResolvedValue({
+        const mockFetch = jest.fn().mockResolvedValue({
             ok: true,
             text: function () {
                 return Promise.resolve(JSON.stringify({
@@ -208,15 +207,15 @@ describe('successful fetch', function () {
         });
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
 
         // Wait for async fetch to complete
         await new Promise(function (r) { setTimeout(r, 50); });
 
-        var body = document.querySelector('.scripture-body');
-        var toggleText = document.querySelector('.scripture-dropdown-text');
-        var select = document.querySelector('.scripture-version-select');
+        const body = document.querySelector('.scripture-body');
+        const toggleText = document.querySelector('.scripture-dropdown-text');
+        const select = document.querySelector('.scripture-version-select');
 
         expect(body.textContent).toContain('ESV passage text');
         expect(toggleText.textContent).toBe('English Standard Version');
@@ -224,9 +223,9 @@ describe('successful fetch', function () {
     });
 
     test('caches successful fetch for instant restore', async function () {
-        var callCount = 0;
-        var mockFetch = jest.fn().mockImplementation(function () {
-            callCount++;
+        let callCount = 0;
+        const mockFetch = jest.fn().mockImplementation(function () {
+            callCount += 1;
             return Promise.resolve({
                 ok: true,
                 text: function () {
@@ -245,13 +244,13 @@ describe('successful fetch', function () {
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
         // First: click ESV
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
         await new Promise(function (r) { setTimeout(r, 50); });
         expect(callCount).toBe(1);
 
         // Switch back to KJV (cached from init)
-        var kjvItem = document.querySelector('[data-value="kjv"]');
+        const kjvItem = document.querySelector('[data-value="kjv"]');
         kjvItem.click();
         await new Promise(function (r) { setTimeout(r, 50); });
         // No additional fetch because KJV was cached at init
@@ -264,7 +263,7 @@ describe('successful fetch', function () {
         expect(callCount).toBe(1);
 
         // Verify ESV content is displayed
-        var body = document.querySelector('.scripture-body');
+        const body = document.querySelector('.scripture-body');
         expect(body.textContent).toContain('ESV passage text');
     });
 });
@@ -272,7 +271,7 @@ describe('successful fetch', function () {
 // --- Failure rollback ---
 describe('failure rollback', function () {
     test('restores original content and shows error banner on failure', async function () {
-        var mockFetch = jest.fn().mockResolvedValue({
+        const mockFetch = jest.fn().mockResolvedValue({
             ok: true,
             text: function () {
                 return Promise.resolve(JSON.stringify({
@@ -290,50 +289,50 @@ describe('failure rollback', function () {
             copyrightText: 'Public Domain'
         });
 
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
 
         // Wait for fetch + retries (non-retryable so should be fast)
         await new Promise(function (r) { setTimeout(r, 100); });
 
         // Original content restored
-        var body = document.querySelector('.scripture-body');
+        const body = document.querySelector('.scripture-body');
         expect(body.textContent).toContain('Original KJV text');
 
         // Dropdown text NOT changed (was never committed)
-        var toggleText = document.querySelector('.scripture-dropdown-text');
+        const toggleText = document.querySelector('.scripture-dropdown-text');
         expect(toggleText.textContent).toBe('King James Version');
 
         // Error banner shown
-        var banner = document.querySelector('.scripture-error-banner');
+        const banner = document.querySelector('.scripture-error-banner');
         expect(banner).not.toBeNull();
         expect(banner.className).toContain('alert-warning');
 
         // Banner has retry button
-        var retryBtn = banner.querySelector('.scripture-retry-banner-btn');
+        const retryBtn = banner.querySelector('.scripture-retry-banner-btn');
         expect(retryBtn).not.toBeNull();
 
         // Banner has diagnostic details
-        var details = banner.querySelector('details');
+        const details = banner.querySelector('details');
         expect(details).not.toBeNull();
         expect(details.textContent).toContain('ESV');
         expect(details.textContent).toContain('api_bible');
     });
 
     test('dropdown text and select are never changed on failure', async function () {
-        var mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));
+        const mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
 
         // Wait for retries to exhaust
         await new Promise(function (r) { setTimeout(r, 200); });
 
-        var toggleText = document.querySelector('.scripture-dropdown-text');
+        const toggleText = document.querySelector('.scripture-dropdown-text');
         expect(toggleText.textContent).toBe('King James Version');
 
-        var select = document.querySelector('.scripture-version-select');
+        const select = document.querySelector('.scripture-version-select');
         expect(select.value).toBe('kjv');
     });
 });
@@ -341,9 +340,9 @@ describe('failure rollback', function () {
 // --- Error banner ---
 describe('error banner', function () {
     test('error banner is removed when new fetch starts', async function () {
-        var callNum = 0;
-        var mockFetch = jest.fn().mockImplementation(function () {
-            callNum++;
+        let callNum = 0;
+        const mockFetch = jest.fn().mockImplementation(function () {
+            callNum += 1;
             if (callNum <= 1) {
                 // First call (ESV) fails non-retryable
                 return Promise.resolve({
@@ -378,29 +377,29 @@ describe('error banner', function () {
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
         // First attempt — fails, shows banner
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
         await new Promise(function (r) { setTimeout(r, 100); });
 
-        var banner = document.querySelector('.scripture-error-banner');
+        const banner = document.querySelector('.scripture-error-banner');
         expect(banner).not.toBeNull();
 
         // Click NIV — existing banner should be removed during loading
-        var nivItem = document.querySelector('[data-value="niv"]');
+        const nivItem = document.querySelector('[data-value="niv"]');
         nivItem.click();
 
         // Wait for NIV fetch to succeed — banner from ESV should be gone
         await new Promise(function (r) { setTimeout(r, 100); });
-        var bannerAfterNiv = document.querySelector('.scripture-error-banner');
+        const bannerAfterNiv = document.querySelector('.scripture-error-banner');
         expect(bannerAfterNiv).toBeNull();
 
         // NIV content should be displayed
-        var body = document.querySelector('.scripture-body');
+        const body = document.querySelector('.scripture-body');
         expect(body.textContent).toContain('NIV text');
     });
 
     test('banner includes diagnostic details section', async function () {
-        var mockFetch = jest.fn().mockResolvedValue({
+        const mockFetch = jest.fn().mockResolvedValue({
             ok: true,
             text: function () {
                 return Promise.resolve(JSON.stringify({
@@ -414,14 +413,14 @@ describe('error banner', function () {
         });
         setupModule(mockFetch, { currentVersion: 'kjv' });
 
-        var esvItem = document.querySelector('[data-value="esv"]');
+        const esvItem = document.querySelector('[data-value="esv"]');
         esvItem.click();
         await new Promise(function (r) { setTimeout(r, 100); });
 
-        var banner = document.querySelector('.scripture-error-banner');
+        const banner = document.querySelector('.scripture-error-banner');
         expect(banner).not.toBeNull();
 
-        var details = banner.querySelector('details');
+        const details = banner.querySelector('details');
         expect(details).not.toBeNull();
         expect(details.textContent).toContain('API key expired');
         expect(details.textContent).toContain('api_bible');
@@ -432,11 +431,11 @@ describe('error banner', function () {
 // --- Menu interaction ---
 describe('menu interaction', function () {
     test('toggle opens and closes the menu', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch);
 
-        var toggle = document.querySelector('.scripture-dropdown-toggle');
-        var menu = document.querySelector('.scripture-dropdown-menu');
+        const toggle = document.querySelector('.scripture-dropdown-toggle');
+        const menu = document.querySelector('.scripture-dropdown-menu');
 
         // Initially closed
         expect(menu.style.display).toBe('none');
@@ -453,10 +452,10 @@ describe('menu interaction', function () {
     });
 
     test('items get tabindex for keyboard navigation', function () {
-        var mockFetch = jest.fn();
+        const mockFetch = jest.fn();
         setupModule(mockFetch);
 
-        var items = document.querySelectorAll('.scripture-dropdown-item');
+        const items = document.querySelectorAll('.scripture-dropdown-item');
         items.forEach(function (item) {
             expect(item.getAttribute('tabindex')).toBe('0');
         });

--- a/tests/js/scripture-tooltip.test.js
+++ b/tests/js/scripture-tooltip.test.js
@@ -127,7 +127,7 @@ describe('scripture-tooltip.es6.js', () => {
 
     describe('Keyboard interaction', () => {
         test('should respond to Escape key', () => {
-            const { mockPopoverInstance } = setupModule();
+            setupModule();
             const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
 
             document.body.dispatchEvent(event);

--- a/tests/js/series-scroll.test.js
+++ b/tests/js/series-scroll.test.js
@@ -10,10 +10,8 @@
  * unit testing purposes, not from external input.
  */
 
-const SOURCE_FILE = 'build/media_source/js/series-scroll.es6.js';
-
-var capturedDclHandler = null;
-var origAddEventListener = document.addEventListener.bind(document);
+let capturedDclHandler = null;
+const origAddEventListener = document.addEventListener.bind(document);
 
 function captureAndRequire(path) {
     document.addEventListener = function (type, handler, options) {
@@ -155,17 +153,17 @@ describe('series-scroll.es6.js', () => {
         }
 
         test('should show initial counter on page load', () => {
-            var mockFetch = jest.fn();
+            const mockFetch = jest.fn();
             setupLoadMore(mockFetch);
 
-            var counter = document.getElementById('proclaim-item-counter');
+            const counter = document.getElementById('proclaim-item-counter');
             expect(counter.textContent).toContain('Showing');
             expect(counter.textContent).toContain('2');
             expect(counter.textContent).toContain('10');
         });
 
         test('should append items on Load More click', async () => {
-            var mockFetch = jest.fn().mockResolvedValue({
+            const mockFetch = jest.fn().mockResolvedValue({
                 ok: true,
                 json: function () {
                     return Promise.resolve({
@@ -182,12 +180,12 @@ describe('series-scroll.es6.js', () => {
 
             setupLoadMore(mockFetch);
 
-            var list = document.getElementById('proclaim-series-list');
-            var listing = list.querySelector('.proclaim-listing');
+            const list = document.getElementById('proclaim-series-list');
+            const listing = list.querySelector('.proclaim-listing');
             // 2 proclaim-item divs
             expect(listing.querySelectorAll(':scope > .proclaim-item').length).toBe(2);
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
@@ -200,7 +198,7 @@ describe('series-scroll.es6.js', () => {
         });
 
         test('should hide button when all items loaded', async () => {
-            var mockFetch = jest.fn().mockResolvedValue({
+            const mockFetch = jest.fn().mockResolvedValue({
                 ok: true,
                 json: function () {
                     return Promise.resolve({
@@ -216,14 +214,14 @@ describe('series-scroll.es6.js', () => {
 
             setupLoadMore(mockFetch, { totalItems: 3 });
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var container = document.getElementById('proclaim-load-more');
+            const container = document.getElementById('proclaim-load-more');
             expect(container.style.display).toBe('none');
         });
     });
@@ -279,7 +277,7 @@ describe('series-scroll.es6.js', () => {
         }
 
         test('should pause after threshold and show Load More', async () => {
-            var mockFetch = jest.fn().mockResolvedValue({
+            const mockFetch = jest.fn().mockResolvedValue({
                 ok: true,
                 json: function () {
                     return Promise.resolve({
@@ -295,8 +293,8 @@ describe('series-scroll.es6.js', () => {
 
             setupInfinite(mockFetch, { scrollThreshold: 2 });
 
-            var observer = IntersectionObserver._lastInstance;
-            var loadMoreContainer = document.getElementById('proclaim-load-more');
+            const observer = IntersectionObserver._lastInstance;
+            const loadMoreContainer = document.getElementById('proclaim-load-more');
 
             // Initially hidden
             expect(loadMoreContainer.style.display).toBe('none');
@@ -317,7 +315,7 @@ describe('series-scroll.es6.js', () => {
         });
 
         test('should include credentials in fetch requests', async () => {
-            var mockFetch = jest.fn().mockResolvedValue({
+            const mockFetch = jest.fn().mockResolvedValue({
                 ok: true,
                 json: function () {
                     return Promise.resolve({
@@ -333,12 +331,12 @@ describe('series-scroll.es6.js', () => {
 
             setupInfinite(mockFetch);
 
-            var observer = IntersectionObserver._lastInstance;
+            const observer = IntersectionObserver._lastInstance;
             mockFetch.mockClear();
             observer.trigger([{ isIntersecting: true }]);
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var fetchOpts = mockFetch.mock.calls[0][1];
+            const [, fetchOpts] = mockFetch.mock.calls[0];
             expect(fetchOpts.credentials).toBe('same-origin');
         });
     });

--- a/tests/js/sermon-filters.test.js
+++ b/tests/js/sermon-filters.test.js
@@ -12,8 +12,8 @@
 
 // Track DOMContentLoaded handlers so we can clean them up between tests.
 // jest.resetModules() does NOT remove event listeners from `document`.
-var capturedDclHandler = null;
-var origAddEventListener = document.addEventListener.bind(document);
+let capturedDclHandler = null;
+const origAddEventListener = document.addEventListener.bind(document);
 
 /**
  * Helper: set up the full DOM + mocks needed for the sermon-filters module.
@@ -23,9 +23,9 @@ var origAddEventListener = document.addEventListener.bind(document);
  * @param {Object}   extraOpts  Additional options to merge into sermonFilters config
  */
 function setupModule(fetchMock, extraOpts) {
-    var paginationStyle = (extraOpts && extraOpts.paginationStyle) || 'pagination';
+    const paginationStyle = (extraOpts && extraOpts.paginationStyle) || 'pagination';
 
-    var html = '<div id="proclaim-main-content">' +
+    let html = '<div id="proclaim-main-content">' +
             '<form id="adminForm">' +
                 '<input name="filter_search" type="text" value="" />' +
                 '<select name="filter_teacher">' +
@@ -50,7 +50,7 @@ function setupModule(fetchMock, extraOpts) {
     }
 
     if (paginationStyle === 'loadmore' || paginationStyle === 'infinite') {
-        var hideBtn = (paginationStyle === 'infinite') ? ' style="display:none"' : '';
+        const hideBtn = (paginationStyle === 'infinite') ? ' style="display:none"' : '';
         html += '<div class="proclaim-load-more" id="proclaim-load-more"' + hideBtn + '>' +
                     '<button type="button" class="btn btn-outline-primary">Load More</button>' +
                 '</div>';
@@ -229,7 +229,7 @@ describe('sermon-filters.es6.js', () => {
         });
 
         test('should initialize when all requirements are met', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch);
 
             expect(window.history.replaceState).toHaveBeenCalledWith(
@@ -242,11 +242,11 @@ describe('sermon-filters.es6.js', () => {
 
     describe('Standard Pagination Mode', () => {
         test('should trigger AJAX fetch on form submit', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch);
             mockFetch.mockClear();
 
-            var form = document.getElementById('adminForm');
+            const form = document.getElementById('adminForm');
             form.dispatchEvent(new Event('submit', { cancelable: true }));
 
             await new Promise(function (r) { setTimeout(r, 0); });
@@ -254,37 +254,37 @@ describe('sermon-filters.es6.js', () => {
 
             expect(mockFetch).toHaveBeenCalled();
 
-            var fetchUrl = mockFetch.mock.calls[0][0];
+            const [fetchUrl] = mockFetch.mock.calls[0];
             expect(fetchUrl).toContain('task=cwmsermons.filterAjax');
         });
 
         test('should include CSRF token in request', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch);
             mockFetch.mockClear();
 
-            var form = document.getElementById('adminForm');
+            const form = document.getElementById('adminForm');
             form.dispatchEvent(new Event('submit', { cancelable: true }));
 
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var fetchUrl = mockFetch.mock.calls[0][0];
+            const [fetchUrl] = mockFetch.mock.calls[0];
             expect(fetchUrl).toContain('testtoken=1');
         });
 
         test('should update listing content after successful fetch', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch);
             mockFetch.mockClear();
 
-            var form = document.getElementById('adminForm');
+            const form = document.getElementById('adminForm');
             form.dispatchEvent(new Event('submit', { cancelable: true }));
 
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var list = document.getElementById('proclaim-sermon-list');
+            const list = document.getElementById('proclaim-sermon-list');
             expect(list.innerHTML).toContain('New Item 1');
             expect(list.querySelector('.proclaim-listing')).not.toBeNull();
         });
@@ -294,11 +294,11 @@ describe('sermon-filters.es6.js', () => {
         test('should debounce search input by 350ms', () => {
             jest.useFakeTimers();
 
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch);
-            var baselineCount = mockFetch.mock.calls.length;
+            const baselineCount = mockFetch.mock.calls.length;
 
-            var searchInput = document.querySelector('input[name="filter_search"]');
+            const searchInput = document.querySelector('input[name="filter_search"]');
 
             searchInput.value = 'G';
             searchInput.dispatchEvent(new Event('input'));
@@ -319,36 +319,36 @@ describe('sermon-filters.es6.js', () => {
 
     describe('Load More Mode', () => {
         test('should show initial counter on page load', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
 
-            var counter = document.getElementById('proclaim-item-counter');
+            const counter = document.getElementById('proclaim-item-counter');
             expect(counter.textContent).toContain('Showing');
             expect(counter.textContent).toContain('2');
             expect(counter.textContent).toContain('10');
         });
 
         test('should show Load More button when in loadmore mode', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
 
-            var btn = document.getElementById('proclaim-load-more');
+            const btn = document.getElementById('proclaim-load-more');
             expect(btn).not.toBeNull();
             expect(btn.querySelector('button')).not.toBeNull();
         });
 
         test('should append items on Load More click', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
 
-            var list = document.getElementById('proclaim-sermon-list');
-            var listing = list.querySelector('.proclaim-listing');
+            const list = document.getElementById('proclaim-sermon-list');
+            const listing = list.querySelector('.proclaim-listing');
             // 2 proclaim-item divs
             expect(listing.querySelectorAll(':scope > .proclaim-item').length).toBe(2);
 
             mockFetch.mockClear();
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
@@ -360,61 +360,61 @@ describe('sermon-filters.es6.js', () => {
         });
 
         test('should update counter after load', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 10, pagesTotal: 5 }));
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 10, pagesTotal: 5 }));
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
             mockFetch.mockClear();
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var counter = document.getElementById('proclaim-item-counter');
+            const counter = document.getElementById('proclaim-item-counter');
             expect(counter.textContent).toContain('Showing');
         });
 
         test('should hide Load More when all items loaded', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 2, pagesTotal: 1 }));
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 2, pagesTotal: 1 }));
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
             mockFetch.mockClear();
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var container = document.getElementById('proclaim-load-more');
+            const container = document.getElementById('proclaim-load-more');
             expect(container.style.display).toBe('none');
 
-            var counter = document.getElementById('proclaim-item-counter');
+            const counter = document.getElementById('proclaim-item-counter');
             expect(counter.textContent).toContain('All items loaded');
         });
 
         test('should reset to replace mode on filter change', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
 
             // First, do a load more to accumulate
             mockFetch.mockClear();
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var list = document.getElementById('proclaim-sermon-list');
-            var listing = list.querySelector('.proclaim-listing');
+            const list = document.getElementById('proclaim-sermon-list');
+            const listing = list.querySelector('.proclaim-listing');
             // 4 proclaim-item divs after append
             expect(listing.querySelectorAll(':scope > .proclaim-item').length).toBe(4);
 
             // Now change a filter — should replace, not append
             mockFetch.mockClear();
-            var select = document.querySelector('select[name="filter_teacher"]');
+            const select = document.querySelector('select[name="filter_teacher"]');
             select.value = '5';
             select.dispatchEvent(new Event('change'));
 
@@ -429,14 +429,14 @@ describe('sermon-filters.es6.js', () => {
 
     describe('Infinite Scroll Mode', () => {
         test('should create IntersectionObserver when in infinite mode', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'infinite' });
 
             expect(IntersectionObserver._lastInstance).toBeDefined();
         });
 
         test('should not show pagination containers in infinite mode', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'infinite' });
 
             expect(document.getElementById('proclaim-pagination-top')).toBeNull();
@@ -444,41 +444,41 @@ describe('sermon-filters.es6.js', () => {
         });
 
         test('should have sentinel element for intersection', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'infinite' });
 
-            var sentinel = document.getElementById('proclaim-scroll-sentinel');
+            const sentinel = document.getElementById('proclaim-scroll-sentinel');
             expect(sentinel).not.toBeNull();
         });
 
         test('should show counter element', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'infinite' });
 
-            var counter = document.getElementById('proclaim-item-counter');
+            const counter = document.getElementById('proclaim-item-counter');
             expect(counter).not.toBeNull();
         });
 
         test('should have Load More button hidden initially in infinite mode', () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'infinite' });
 
-            var container = document.getElementById('proclaim-load-more');
+            const container = document.getElementById('proclaim-load-more');
             expect(container).not.toBeNull();
             expect(container.style.display).toBe('none');
         });
 
         test('should include credentials in fetch requests', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
             setupModule(mockFetch, { paginationStyle: 'loadmore' });
             mockFetch.mockClear();
 
-            var btn = document.querySelector('#proclaim-load-more button');
+            const btn = document.querySelector('#proclaim-load-more button');
             btn.click();
 
             await new Promise(function (r) { setTimeout(r, 0); });
 
-            var fetchOpts = mockFetch.mock.calls[0][1];
+            const [, fetchOpts] = mockFetch.mock.calls[0];
             expect(fetchOpts.credentials).toBe('same-origin');
             expect(fetchOpts.headers['Accept']).toBe('application/json');
         });
@@ -487,11 +487,11 @@ describe('sermon-filters.es6.js', () => {
     describe('Infinite Scroll Threshold', () => {
         test('should pause auto-scroll after threshold pages and show Load More button', async () => {
             // threshold=2 means after 2 auto-loaded pages, pause
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
             setupModule(mockFetch, { paginationStyle: 'infinite', scrollThreshold: 2 });
 
-            var observer = IntersectionObserver._lastInstance;
-            var loadMoreContainer = document.getElementById('proclaim-load-more');
+            const observer = IntersectionObserver._lastInstance;
+            const loadMoreContainer = document.getElementById('proclaim-load-more');
 
             // Initially hidden
             expect(loadMoreContainer.style.display).toBe('none');
@@ -515,11 +515,11 @@ describe('sermon-filters.es6.js', () => {
         });
 
         test('should resume auto-scroll after manual Load More click', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
             setupModule(mockFetch, { paginationStyle: 'infinite', scrollThreshold: 1 });
 
-            var observer = IntersectionObserver._lastInstance;
-            var loadMoreContainer = document.getElementById('proclaim-load-more');
+            const observer = IntersectionObserver._lastInstance;
+            const loadMoreContainer = document.getElementById('proclaim-load-more');
 
             // Trigger one auto-load to reach threshold
             observer.trigger([{ isIntersecting: true }]);
@@ -529,7 +529,7 @@ describe('sermon-filters.es6.js', () => {
             expect(loadMoreContainer.style.display).toBe('');
 
             // Click Load More — should resume
-            var btn = loadMoreContainer.querySelector('button');
+            const btn = loadMoreContainer.querySelector('button');
             btn.click();
             await new Promise(function (r) { setTimeout(r, 0); });
             await new Promise(function (r) { setTimeout(r, 0); });
@@ -540,14 +540,14 @@ describe('sermon-filters.es6.js', () => {
         });
 
         test('should not pause when threshold is 0 (unlimited)', async () => {
-            var mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse({ total: 20, pagesTotal: 10 }));
             setupModule(mockFetch, { paginationStyle: 'infinite', scrollThreshold: 0 });
 
-            var observer = IntersectionObserver._lastInstance;
-            var loadMoreContainer = document.getElementById('proclaim-load-more');
+            const observer = IntersectionObserver._lastInstance;
+            const loadMoreContainer = document.getElementById('proclaim-load-more');
 
             // Auto-load many pages — should never show button
-            for (var i = 0; i < 5; i++) {
+            for (let i = 0; i < 5; i++) {
                 observer.trigger([{ isIntersecting: true }]);
                 await new Promise(function (r) { setTimeout(r, 0); });
                 await new Promise(function (r) { setTimeout(r, 0); });
@@ -563,17 +563,17 @@ describe('sermon-filters.es6.js', () => {
             jest.spyOn(console, 'warn').mockImplementation(function () {});
 
             // All fetch calls fail (no fetch happens during init)
-            var mockFetch = jest.fn()
+            const mockFetch = jest.fn()
                 .mockRejectedValue(new TypeError('Network error'));
 
             setupModule(mockFetch);
 
-            var form = document.getElementById('adminForm');
+            const form = document.getElementById('adminForm');
             form.submit = jest.fn();
 
             form.dispatchEvent(new Event('submit', { cancelable: true }));
 
-            for (var i = 0; i < 10; i++) {
+            for (let i = 0; i < 10; i++) {
                 await new Promise(function (r) { setTimeout(r, 10); });
             }
 

--- a/tests/js/template-lazyload.test.js
+++ b/tests/js/template-lazyload.test.js
@@ -70,7 +70,7 @@ describe('template-lazyload.es6.js', () => {
 
             // The "show" accordion should trigger a fetch
             expect(global.fetch).toHaveBeenCalled();
-            const fetchUrl = global.fetch.mock.calls[0][0];
+            const [fetchUrl] = global.fetch.mock.calls[0];
             expect(fetchUrl).toContain('fieldset=study_details');
             expect(fetchUrl).toContain('id=42');
         });
@@ -90,7 +90,7 @@ describe('template-lazyload.es6.js', () => {
             await new Promise(resolve => setTimeout(resolve, 0));
 
             expect(global.fetch).toHaveBeenCalled();
-            const fetchUrl = global.fetch.mock.calls[0][0];
+            const [fetchUrl] = global.fetch.mock.calls[0];
             expect(fetchUrl).toContain('fieldset=messages_list');
         });
 


### PR DESCRIPTION
## Summary

- Expands `npm run lint:js` from only `build/media_source/js/` to also cover `tests/js/` and `tests/e2e/`, creating a consistent quality gate across all hand-written JS
- Fixed 145 ESLint issues in test files (132 auto-fixed, 13 manual)
- Added `prefer-destructuring: off` override for test files — nested destructuring on `mock.calls[0][1]` hurts readability without benefit
- Build tooling scripts (`rollup.config.js`, `jest.config.js`, `build-css.js`) are CommonJS Node scripts with a different runtime — intentionally excluded

## What changed

| Scope | Before | After |
|-------|--------|-------|
| `build/media_source/js/` (46 files) | ✅ | ✅ |
| `tests/js/` (11 test files) | ❌ | ✅ |
| `tests/e2e/` (8 Playwright specs) | ❌ | ✅ |
| `build/*.js` (Node tooling) | ❌ | ❌ (intentional) |

## Test plan

- [x] `npm run lint:js` → 0 errors, 0 warnings
- [x] `npm test` → 150/150 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)