### PR TITLE
fix: fix local media browser to show all file types and wire upload_extensions config

### DIFF
--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -18,6 +18,8 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Local;
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmuploadscript;
+use CWM\Component\Proclaim\Site\Helper\Cwmmedia;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -326,11 +328,12 @@ class CWMAddonLocal extends CWMAddon
             return ['success' => false, 'error' => 'Directory not found'];
         }
 
-        // Extension filters
-        $audioExts = ['mp3', 'm4a', 'ogg', 'oga', 'wav', 'flac', 'aac', 'wma'];
-        $videoExts = ['mp4', 'm4v', 'webm', 'ogv', 'mov', 'avi', 'mkv', 'wmv'];
-        $docExts   = ['pdf', 'doc', 'docx', 'ppt', 'pptx'];
-        $allExts   = array_merge($audioExts, $videoExts, $docExts);
+        // Extension filters — read from Proclaim config, categorized via Cwmmedia::getMimetypes()
+        $categories = $this->getExtensionsByCategory();
+        $audioExts  = $categories['audio'];
+        $videoExts  = $categories['video'];
+        $docExts    = $categories['doc'];
+        $allExts    = array_merge($audioExts, $videoExts, $docExts);
 
         // Determine which extensions to show
         $allowedExts = match ($filter) {
@@ -420,6 +423,69 @@ class CWMAddonLocal extends CWMAddon
             'currentPath' => $currentRel,
             'parentPath'  => $parentPath,
             'basePath'    => $basePath,
+        ];
+    }
+
+    /**
+     * Categorize allowed file extensions into audio, video, and document groups.
+     *
+     * Reads the `upload_extensions` param from Proclaim component configuration and
+     * cross-references with Cwmmedia::getMimetypes() to sort extensions by MIME category.
+     * Falls back to sensible defaults when the param is missing or a category is empty.
+     *
+     * @return  array{audio: string[], video: string[], doc: string[]}
+     *
+     * @since   10.1.0
+     */
+    protected function getExtensionsByCategory(): array
+    {
+        $defaultAudio = ['mp3', 'm4a', 'ogg', 'oga', 'wav', 'flac', 'aac', 'wma'];
+        $defaultVideo = ['mp4', 'm4v', 'webm', 'ogv', 'mov', 'avi', 'mkv', 'wmv'];
+        $defaultDoc   = ['pdf', 'doc', 'docx', 'ppt', 'pptx'];
+
+        $uploadExtensions = ComponentHelper::getParams('com_proclaim')
+            ->get('upload_extensions', '');
+
+        if (empty($uploadExtensions)) {
+            return ['audio' => $defaultAudio, 'video' => $defaultVideo, 'doc' => $defaultDoc];
+        }
+
+        // Build a flat extension→MIME map from the pipe-separated pattern keys in getMimetypes()
+        $mimeMap = [];
+
+        foreach ((new Cwmmedia())->getMimetypes() as $pattern => $mime) {
+            foreach (explode('|', $pattern) as $ext) {
+                $mimeMap[strtolower(trim($ext))] = $mime;
+            }
+        }
+
+        $audio = [];
+        $video = [];
+        $doc   = [];
+
+        foreach (explode(',', $uploadExtensions) as $raw) {
+            $ext = strtolower(trim($raw));
+
+            if (empty($ext)) {
+                continue;
+            }
+
+            $mime = $mimeMap[$ext] ?? '';
+
+            if (str_starts_with($mime, 'audio/')) {
+                $audio[] = $ext;
+            } elseif (str_starts_with($mime, 'video/')) {
+                $video[] = $ext;
+            } elseif (!empty($mime) && !str_starts_with($mime, 'image/')) {
+                // application/*, text/* → document; images excluded (not media files)
+                $doc[] = $ext;
+            }
+        }
+
+        return [
+            'audio' => $audio ?: $defaultAudio,
+            'video' => $video ?: $defaultVideo,
+            'doc'   => $doc ?: $defaultDoc,
         ];
     }
 

--- a/admin/src/Addons/Servers/Local/local.xml
+++ b/admin/src/Addons/Servers/Local/local.xml
@@ -82,9 +82,6 @@
                    label="JBS_MED_CHOOSE_MIMETYPE" description="JBS_MED_CHOOSE_MIMETYPE_DESC"
                    class="inputbox" default="">
             </field>
-            <field name="mime_type" type="MimeType" extension="com_proclaim"
-                   label="JBS_MED_CHOOSE_MIMETYPE" description="JBS_MED_CHOOSE_MIMETYPE_DESC"
-                   class="inputbox"/>
         </fieldset>
         <fieldset name="parameters" label="JBS_ADDON_LOCAL_PARAMETERS">
             <field name="autostart" type="list"

--- a/admin/src/Addons/Servers/Local/media.xml
+++ b/admin/src/Addons/Servers/Local/media.xml
@@ -7,7 +7,7 @@
                    type="Media"
                    label="JBS_MED_FILENAME"
                    description="JBS_MED_USE_FILENAME_AS_PATH"
-                   directory="/images/biblestudy/media/"
+                   directory="biblestudy/media"
                    types="images,audios,videos,documents"
                    required="true"/>
             <field name="local_browse_btn"

--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -79,6 +79,22 @@ class Cwmhtml
     }
 
     /**
+     * Method to get the player field options.
+     *
+     * @return  array  The field option objects.
+     *
+     * @since   10.1.0
+     */
+    public static function playerlist(): array
+    {
+        return [
+            (object) ['value' => 0, 'text' => Text::_('JBS_CMN_DIRECT_LINK')],
+            (object) ['value' => 1, 'text' => Text::_('JBS_CMN_USE_INTERNAL_PLAYER')],
+            (object) ['value' => 8, 'text' => Text::_('JBS_CMN_USE_EMBED_CODE')],
+        ];
+    }
+
+    /**
      * Display a batch widget for the popup selector.
      *
      * @return  string  The necessary HTML for the widget.


### PR DESCRIPTION
## Summary

- **Fix Joomla media picker directory** (`media.xml`): Changed `directory="/images/biblestudy/media/"` to `directory="biblestudy/media"`. Joomla's `MediaField::getLayoutData()` resolves the directory against `JPATH_SITE/images/` — the leading `/` and `images/` prefix caused a double-path (`images//images/biblestudy/media/`), `is_dir()` returned false, and the picker fell back to the images root showing only images.
- **Wire `upload_extensions` config to LocalBrowser** (`CWMAddonLocal.php`): Replaced hardcoded audio/video/doc extension arrays with `getExtensionsByCategory()` which reads the `upload_extensions` param from Proclaim component configuration and categorizes via `Cwmmedia::getMimetypes()` MIME-prefix matching (`audio/`, `video/`, `application/`+`text/`). Falls back to the same defaults if the param is empty or a category would be empty after filtering.
- **Remove duplicate `mime_type` field** (`local.xml`): Identical field was defined twice in the `media_type` fieldset — removed the second declaration.
- **Add `Cwmhtml::playerlist()`** (`Cwmhtml.php`): Missing static method referenced by `admin/layouts/html/batch/players.php` for the batch player selection widget.

## Test plan

- [ ] Create a new Local server media file record; click the filename field's Joomla media picker — confirm it opens to `images/biblestudy/media/` (not the images root) and shows audio/video/document tabs
- [ ] Select an MP3 or MP4 via the picker; confirm the filename field is populated with a clean path and the record saves/plays correctly on the frontend
- [ ] Open the LocalBrowser (Browse Local Files button); confirm it lists audio, video, and document files per the `upload_extensions` config
- [ ] Change `upload_extensions` in Proclaim config → verify LocalBrowser respects the change
- [ ] Open a batch operation modal with a player selection; confirm no PHP error (playerlist method now exists)
- [ ] `composer test` — 388 PHPUnit tests pass
- [ ] `npm test` — 150 Jest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)