### PR TITLE
fix: LocalBrowser reads upload path from Proclaim config; actionable error on missing dir

### DIFF
--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -288,21 +288,20 @@ class CWMAddonLocal extends CWMAddon
         $db->setQuery($query);
         $serverParams = $db->loadResult();
 
-        $reg      = new Registry($serverParams ?: '{}');
-        $basePath = $reg->get('path', 'images/biblestudy/media');
-        $basePath = trim($basePath, '/');
+        // Use Proclaim's configured upload path (set in component config → Upload Path field).
+        // The server params Registry has no 'path' key — we always fell through to the hardcoded
+        // default before. Now we read the actual admin-configured value instead.
+        $uploadPath = ComponentHelper::getParams('com_proclaim')->get('uploadpath', '/images/biblestudy/media/');
+        $basePath   = trim($uploadPath, '/');
 
         // Build absolute base path
         $absBase = Path::clean(JPATH_SITE . '/' . $basePath);
 
         if (!is_dir($absBase)) {
             return [
-                'success'     => true,
-                'files'       => [],
-                'folders'     => [],
-                'currentPath' => $basePath,
-                'parentPath'  => null,
-                'basePath'    => $basePath,
+                'success' => false,
+                'error'   => 'Media directory not found: ' . $basePath
+                    . '. Create the directory on the server or update Upload Path in Proclaim → Configuration.',
             ];
         }
 
@@ -534,9 +533,8 @@ class CWMAddonLocal extends CWMAddon
         $db->setQuery($query);
         $serverParams = $db->loadResult();
 
-        $reg      = new Registry($serverParams ?: '{}');
-        $basePath = $reg->get('path', 'images/biblestudy/media');
-        $basePath = trim($basePath, '/');
+        $uploadPath = ComponentHelper::getParams('com_proclaim')->get('uploadpath', '/images/biblestudy/media/');
+        $basePath   = trim($uploadPath, '/');
 
         // Build absolute path for the source file
         $absBase = Path::clean(JPATH_SITE . '/' . $basePath);


### PR DESCRIPTION
## Summary

- **Read upload path from Proclaim config** (`handleBrowseFilesAction` + `handleCopyFileAction`): Both methods were calling `$reg->get('path', 'images/biblestudy/media')` on the server's params Registry, but Local server params only store `delete_files` — the `'path'` key never exists. Both methods always used the hardcoded fallback. Now reads `ComponentHelper::getParams('com_proclaim')->get('uploadpath', '/images/biblestudy/media/')` to respect whatever the admin configured in Proclaim → Configuration → Upload Path.
- **Actionable error when directory is missing**: Changed the `!is_dir($absBase)` early-return from `success: true` with empty arrays (silent blank grid) to `success: false` with a descriptive error message telling the admin to create the directory or update the Upload Path setting.

## Test plan

- [ ] Open a Local server media file record → click Browse Files
- [ ] If the configured upload path directory exists: confirm files are listed
- [ ] If the directory doesn't exist: confirm modal shows "Media directory not found: ..." error instead of blank grid
- [ ] Update Upload Path in Proclaim → Configuration to a non-default path → confirm LocalBrowser uses the new path
- [ ] `composer test` — 388 PHPUnit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)