### PR TITLE
refactor: extract duplicated option-source fields into reusable Field classes

### DIFF
--- a/admin/forms/template.xml
+++ b/admin/forms/template.xml
@@ -136,34 +136,14 @@
             </field>
         </fieldset>
         <fieldset name="VERSES" label="JBS_TPL_DISPLAY_DEFAULTS">
-            <field name="show_verses" type="list" default="0"
-                   label="JBS_TPL_VERSES_SHOW_VERSES" description="JBS_TPL_VERSES_SHOW_VERSES_DESC">
-                <option value="0">JBS_TPL_SHOW_ONLY_CHAPTERS</option>
-                <option value="1">JBS_TPL_SHOW_VERSES_AND_CHAPTERS</option>
-                <option value="2">JBS_TPL_SHOW_ONLY_BOOKS</option>
-            </field>
-            <field name="scripture_separator" type="list" default="middot"
-                   label="JBS_TPL_SCRIPTURE_SEPARATOR" description="JBS_TPL_SCRIPTURE_SEPARATOR_DESC">
-                <option value="newline">JBS_TPL_SEPARATOR_STACKED</option>
-                <option value="middot">JBS_TPL_SEPARATOR_MIDDOT</option>
-                <option value="pipe">JBS_TPL_SEPARATOR_PIPE</option>
-                <option value="semicolon">JBS_TPL_SEPARATOR_SEMICOLON</option>
-            </field>
+            <field name="show_verses" type="ShowVerses" default="0"
+                   label="JBS_TPL_VERSES_SHOW_VERSES" description="JBS_TPL_VERSES_SHOW_VERSES_DESC"/>
+            <field name="scripture_separator" type="ScriptureSeparator" default="middot"
+                   label="JBS_TPL_SCRIPTURE_SEPARATOR" description="JBS_TPL_SCRIPTURE_SEPARATOR_DESC"/>
             <field name="stylesheet" type="text" size="50" default=""
                    label="JBS_TPL_VERSES_STYLESHEET" description="JBS_TPL_VERSES_STYLESHEET_DESC"/>
-            <field name="date_format" type="list" default="2"
-                   label="JBS_TPL_VERSES_DATE_FORMAT" description="JBS_TPL_VERSES_DATE_FORMAT_DESC">
-                <option value="0">JBS_TPL_DATE_FORMAT_MMM_D_YYYY</option>
-                <option value="1">JBS_TPL_DATE_FORMAT_MMM_D</option>
-                <option value="2">JBS_TPL_DATE_FORMAT_M_D_YYYY</option>
-                <option value="3">JBS_TPL_DATE_FORMAT_M_D</option>
-                <option value="4">JBS_TPL_DATE_FORMAT_WD_MMMM_D_YYYY</option>
-                <option value="5">JBS_TPL_DATE_FORMAT_MMMM_D_YYYY</option>
-                <option value="6">JBS_TPL_DATE_FORMAT_D_MMMM_YYYY</option>
-                <option value="7">JBS_TPL_DATE_FORMAT_D_M_YYYY</option>
-                <option value="8">JBS_TPL_DATE_FORMAT_USE_GLOBAL</option>
-                <option value="9">JBS_TPL_DATE_FORMAT_YYYY_MM_DD</option>
-            </field>
+            <field name="date_format" type="DateFormat" default="2"
+                   label="JBS_TPL_VERSES_DATE_FORMAT" description="JBS_TPL_VERSES_DATE_FORMAT_DESC"/>
             <field name="custom_date_format" type="text" size="25" default=""
                    label="JBS_TPL_VERSES_CUSTOM_DATE_FORMAT" description="JBS_TPL_VERSES_CUSTOM_DATE_FORMAT_DESC"/>
         </fieldset>

--- a/admin/src/Field/DateFormatField.php
+++ b/admin/src/Field/DateFormatField.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Field;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Date format dropdown — single source of truth for date display options.
+ *
+ * Used in template.xml and mod_proclaim.xml.
+ *
+ * @package  Proclaim.Admin
+ * @since    10.2.0
+ */
+class DateFormatField extends ListField
+{
+    /**
+     * The field type.
+     *
+     * @var  string
+     *
+     * @since 10.2.0
+     */
+    protected $type = 'DateFormat';
+
+    /**
+     * Get the field options.
+     *
+     * @return  array  Array of HTMLHelper option objects
+     *
+     * @since   10.2.0
+     */
+    protected function getOptions(): array
+    {
+        $options   = parent::getOptions();
+        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_DATE_FORMAT_MMM_D_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_DATE_FORMAT_MMM_D'));
+        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_DATE_FORMAT_M_D_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_DATE_FORMAT_M_D'));
+        $options[] = HTMLHelper::_('select.option', '4', Text::_('JBS_TPL_DATE_FORMAT_WD_MMMM_D_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '5', Text::_('JBS_TPL_DATE_FORMAT_MMMM_D_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '6', Text::_('JBS_TPL_DATE_FORMAT_D_MMMM_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '7', Text::_('JBS_TPL_DATE_FORMAT_D_M_YYYY'));
+        $options[] = HTMLHelper::_('select.option', '8', Text::_('JBS_TPL_DATE_FORMAT_USE_GLOBAL'));
+        $options[] = HTMLHelper::_('select.option', '9', Text::_('JBS_TPL_DATE_FORMAT_YYYY_MM_DD'));
+
+        return $options;
+    }
+}

--- a/admin/src/Field/ScriptureSeparatorField.php
+++ b/admin/src/Field/ScriptureSeparatorField.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Field;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Scripture separator dropdown — single source of truth for separator options.
+ *
+ * Used in template.xml and mod_proclaim.xml.
+ *
+ * @package  Proclaim.Admin
+ * @since    10.2.0
+ */
+class ScriptureSeparatorField extends ListField
+{
+    /**
+     * The field type.
+     *
+     * @var  string
+     *
+     * @since 10.2.0
+     */
+    protected $type = 'ScriptureSeparator';
+
+    /**
+     * Get the field options.
+     *
+     * @return  array  Array of HTMLHelper option objects
+     *
+     * @since   10.2.0
+     */
+    protected function getOptions(): array
+    {
+        $options   = parent::getOptions();
+        $options[] = HTMLHelper::_('select.option', 'newline', Text::_('JBS_TPL_SEPARATOR_STACKED'));
+        $options[] = HTMLHelper::_('select.option', 'middot', Text::_('JBS_TPL_SEPARATOR_MIDDOT'));
+        $options[] = HTMLHelper::_('select.option', 'pipe', Text::_('JBS_TPL_SEPARATOR_PIPE'));
+        $options[] = HTMLHelper::_('select.option', 'semicolon', Text::_('JBS_TPL_SEPARATOR_SEMICOLON'));
+
+        return $options;
+    }
+}

--- a/admin/src/Field/ShowVersesField.php
+++ b/admin/src/Field/ShowVersesField.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Field;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Show Verses dropdown — single source of truth for verse display options.
+ *
+ * Used in template.xml and mod_proclaim.xml.
+ *
+ * @package  Proclaim.Admin
+ * @since    10.2.0
+ */
+class ShowVersesField extends ListField
+{
+    /**
+     * The field type.
+     *
+     * @var  string
+     *
+     * @since 10.2.0
+     */
+    protected $type = 'ShowVerses';
+
+    /**
+     * Get the field options.
+     *
+     * @return  array  Array of HTMLHelper option objects
+     *
+     * @since   10.2.0
+     */
+    protected function getOptions(): array
+    {
+        $options   = parent::getOptions();
+        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_SHOW_ONLY_CHAPTERS'));
+        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_SHOW_VERSES_AND_CHAPTERS'));
+        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_SHOW_ONLY_BOOKS'));
+
+        return $options;
+    }
+}

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -302,31 +302,12 @@
                 <!-- Option-source fields used by the Layout Editor settings modal.
                      These are not displayed; they exist so that scriptoptions.php
                      can extract the dropdown choices via $form->getField(). -->
-                <field name="show_verses" type="list" default="0" hidden="true"
-                       label="JBS_TPL_VERSES_SHOW_VERSES">
-                    <option value="0">JBS_TPL_SHOW_ONLY_CHAPTERS</option>
-                    <option value="1">JBS_TPL_SHOW_VERSES_AND_CHAPTERS</option>
-                    <option value="2">JBS_TPL_SHOW_ONLY_BOOKS</option>
-                </field>
-                <field name="scripture_separator" type="list" default="middot" hidden="true"
-                       label="JBS_TPL_SCRIPTURE_SEPARATOR">
-                    <option value="newline">JBS_TPL_SEPARATOR_STACKED</option>
-                    <option value="middot">JBS_TPL_SEPARATOR_MIDDOT</option>
-                    <option value="pipe">JBS_TPL_SEPARATOR_PIPE</option>
-                    <option value="semicolon">JBS_TPL_SEPARATOR_SEMICOLON</option>
-                </field>
-                <field name="date_format" type="list" default="2" hidden="true"
-                       label="JBS_TPL_VERSES_DATE_FORMAT">
-                    <option value="0">JBS_TPL_DATE_FORMAT_MMM_D_YYYY</option>
-                    <option value="1">JBS_TPL_DATE_FORMAT_MMM_D</option>
-                    <option value="2">JBS_TPL_DATE_FORMAT_M_D_YYYY</option>
-                    <option value="3">JBS_TPL_DATE_FORMAT_M_D</option>
-                    <option value="4">JBS_TPL_DATE_FORMAT_WD_MMMM_D_YYYY</option>
-                    <option value="5">JBS_TPL_DATE_FORMAT_MMMM_D_YYYY</option>
-                    <option value="6">JBS_TPL_DATE_FORMAT_D_MMMM_YYYY</option>
-                    <option value="7">JBS_TPL_DATE_FORMAT_D_M_YYYY</option>
-                    <option value="8">JBS_TPL_DATE_FORMAT_USE_GLOBAL</option>
-                </field>
+                <field name="show_verses" type="ShowVerses" default="0" hidden="true"
+                       label="JBS_TPL_VERSES_SHOW_VERSES"/>
+                <field name="scripture_separator" type="ScriptureSeparator" default="middot" hidden="true"
+                       label="JBS_TPL_SCRIPTURE_SEPARATOR"/>
+                <field name="date_format" type="DateFormat" default="2" hidden="true"
+                       label="JBS_TPL_VERSES_DATE_FORMAT"/>
                 <!-- Hidden fields for layout data storage - managed by Layout Editor -->
                 <field name="scripturesrow" type="hidden" default="0"/>
                 <field name="scripturescol" type="hidden" default="1"/>


### PR DESCRIPTION
## Summary

- Created 3 new custom Field classes: `ShowVersesField`, `ScriptureSeparatorField`, `DateFormatField` — single source of truth for dropdown options
- Updated `template.xml` and `mod_proclaim.xml` to reference custom field types instead of duplicating inline `<option>` elements
- Fixed `mod_proclaim.xml` missing the YYYY-MM-DD date format option (`value="9"`)

## Test plan

- [ ] Verify template editor shows correct dropdown options for show_verses, scripture_separator, date_format
- [ ] Verify mod_proclaim module config shows correct options
- [ ] Verify Layout Editor settings modal still loads options correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)