### PR TITLE
fix: YouTube poller concurrent fetch guard and versions.json update

### DIFF
--- a/build/media_source/js/mod-youtube-status.es6.js
+++ b/build/media_source/js/mod-youtube-status.es6.js
@@ -259,6 +259,7 @@
         }
 
         let pollTimer;
+        let fetchInFlight = false;
 
         function schedulePoll() {
             currentInterval = getBackoffInterval();
@@ -286,11 +287,20 @@
                 return;
             }
 
+            // Guard against overlapping fetches from rapid visibility changes
+            if (fetchInFlight) {
+                return;
+            }
+
+            fetchInFlight = true;
+
             fetch(ajaxUrl, {method: 'GET', headers: {'Accept': 'application/json'}})
                 .then(function (response) {
                     return response.json();
                 })
                 .then(function (data) {
+                    fetchInFlight = false;
+
                     if (!data.success) {
                         return;
                     }
@@ -359,6 +369,7 @@
                     schedulePoll();
                 })
                 .catch(function () {
+                    fetchInFlight = false;
                     unchangedCount += 1;
                     schedulePoll();
                 });

--- a/build/versions.json
+++ b/build/versions.json
@@ -1,20 +1,20 @@
 {
     "_comment": "Development version tracking - semantic versioning: major.minor.patch",
-    "_updated": "2026-03-09",
+    "_updated": "2026-03-15",
 
     "current": {
-        "version": "10.1.0",
+        "version": "10.2.0",
         "description": "Last stable release (from GitHub releases)"
     },
 
     "next": {
-        "patch": "10.1.1",
-        "minor": "10.2.0",
+        "patch": "10.2.1",
+        "minor": "10.3.0",
         "major": "11.0.0"
     },
 
     "active_development": {
-        "version": "10.2.0",
+        "version": "10.3.0",
         "description": "Use this for @since tags and migrations"
     },
 


### PR DESCRIPTION
## Summary

- **YouTube module poller** — added `fetchInFlight` guard to prevent overlapping status fetches when users rapidly switch tabs (visibility changes could trigger concurrent fetches)
- **versions.json** — updated to reflect 10.2.0 release: current=10.2.0, next patch=10.2.1, next minor=10.3.0, active development=10.3.0
- **Addon browsers** (item 1 from scan) — investigated and confirmed the cloneNode pattern is intentionally defensive, not a bug. No changes needed.

## Test plan

- [ ] YouTube module polls correctly without duplicate requests when switching tabs rapidly
- [ ] versions.json values are correct for next development cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)