### PR TITLE
feat: interactive transcript panel with VTT parsing, seek, and search

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -1705,6 +1705,7 @@ JBS_MED_TRACK_URL_DESC="URL to a WebVTT (.vtt) subtitle file. Upload via Media M
 JBS_MED_TRACK_KIND="Kind"
 JBS_MED_TRACK_CAPTIONS="Captions (includes sound effects)"
 JBS_MED_TRACK_SUBTITLES="Subtitles (dialogue only)"
+JBS_MED_TRANSCRIPT_SEARCH="Search transcript…"
 JBS_MED_VTT_BROWSE="Browse"
 JBS_MED_VTT_UPLOAD="Upload a VTT or SRT file"
 JBS_MED_VTT_UPLOADING="Uploading…"

--- a/admin/src/Service/HTML/CWMHtml5Inline.php
+++ b/admin/src/Service/HTML/CWMHtml5Inline.php
@@ -209,6 +209,16 @@ class CWMHtml5Inline
 
         $render .= "</div>";
 
+        // Interactive transcript panel — renders from the first caption/subtitle track
+        if (!empty($subtitleTracks)) {
+            $firstTrack    = (object) $subtitleTracks[0];
+            $transcriptSrc = htmlspecialchars($firstTrack->src ?? '', ENT_QUOTES, 'UTF-8');
+
+            if (!empty($transcriptSrc)) {
+                $render .= '<div data-transcript-src="' . $transcriptSrc . '"></div>';
+            }
+        }
+
         return $render;
     }
 

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
 
 /**
@@ -323,6 +324,9 @@ class CwmmediafileTable extends Table
         // Attempt physical file deletion — never block DB deletion
         $this->deletePhysicalFile();
 
+        // Clean up locally stored caption/subtitle VTT files
+        $this->deleteCaptionFiles();
+
         return parent::delete($pk);
     }
 
@@ -383,6 +387,69 @@ class CwmmediafileTable extends Table
         } catch (\Exception $e) {
             Log::add(
                 'Media file #' . ($this->id ?? '?') . ': physical file deletion failed — ' . $e->getMessage(),
+                Log::WARNING,
+                'com_proclaim'
+            );
+        }
+    }
+
+    /**
+     * Delete locally stored caption/subtitle VTT files for this media record.
+     *
+     * Only deletes files under media/com_proclaim/captions/ or media/biblestudy/subtitles/
+     * to avoid removing external URLs or files managed by other systems.
+     *
+     * @return  void
+     *
+     * @since   10.3.0
+     */
+    private function deleteCaptionFiles(): void
+    {
+        try {
+            $mediaParams    = new Registry($this->params ?: '{}');
+            $subtitleTracks = $mediaParams->get('subtitle_tracks', []);
+
+            if (empty($subtitleTracks)) {
+                return;
+            }
+
+            foreach ($subtitleTracks as $track) {
+                $track = (object) $track;
+                $src   = $track->src ?? '';
+
+                if (empty($src)) {
+                    continue;
+                }
+
+                // Only delete local files managed by Proclaim
+                if (
+                    !str_contains($src, 'media/com_proclaim/captions/')
+                    && !str_contains($src, 'media/biblestudy/subtitles/')
+                ) {
+                    continue;
+                }
+
+                // Resolve to absolute path and verify it's within JPATH_ROOT
+                $absPath = JPATH_ROOT . '/' . ltrim($src, '/');
+                $absPath = Path::clean($absPath);
+
+                if (!str_starts_with($absPath, Path::clean(JPATH_ROOT . '/media/'))) {
+                    continue;
+                }
+
+                if (file_exists($absPath)) {
+                    @unlink($absPath);
+
+                    Log::add(
+                        'Media file #' . ($this->id ?? '?') . ': deleted caption file ' . $src,
+                        Log::INFO,
+                        'com_proclaim'
+                    );
+                }
+            }
+        } catch (\Exception $e) {
+            Log::add(
+                'Media file #' . ($this->id ?? '?') . ': caption cleanup failed — ' . $e->getMessage(),
                 Log::WARNING,
                 'com_proclaim'
             );

--- a/build/media_source/css/cwm-transcript.css
+++ b/build/media_source/css/cwm-transcript.css
@@ -1,0 +1,82 @@
+/**
+ * Interactive transcript panel styles
+ *
+ * @package  Proclaim
+ * @since    10.3.0
+ */
+
+.cwm-transcript-panel {
+    margin-top: 1rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.375rem;
+    background: var(--bs-body-bg, #fff);
+    overflow: hidden;
+}
+
+.cwm-transcript-search {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+    background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+.cwm-transcript-cues {
+    max-height: 300px;
+    overflow-y: auto;
+    scroll-behavior: smooth;
+}
+
+.cwm-transcript-cue {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    border-bottom: 1px solid var(--bs-border-color-translucent, rgba(0, 0, 0, 0.05));
+    transition: background-color 0.15s ease;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.cwm-transcript-cue:last-child {
+    border-bottom: none;
+}
+
+.cwm-transcript-cue:hover {
+    background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+.cwm-transcript-cue.active {
+    background: var(--bs-primary-bg-subtle, #cfe2ff);
+    font-weight: 600;
+}
+
+.cwm-transcript-time {
+    flex-shrink: 0;
+    width: 3.5rem;
+    color: var(--bs-secondary-color, #6c757d);
+    font-variant-numeric: tabular-nums;
+    font-size: 0.8rem;
+    padding-top: 0.1rem;
+}
+
+.cwm-transcript-text {
+    flex: 1;
+    color: var(--bs-body-color, #212529);
+}
+
+.cwm-transcript-cue mark {
+    background: var(--bs-warning-bg-subtle, #fff3cd);
+    padding: 0 0.125rem;
+    border-radius: 0.125rem;
+}
+
+/* Print: show full transcript without scroll */
+@media print {
+    .cwm-transcript-cues {
+        max-height: none;
+        overflow: visible;
+    }
+
+    .cwm-transcript-search {
+        display: none;
+    }
+}

--- a/build/media_source/js/cwm-transcript.es6.js
+++ b/build/media_source/js/cwm-transcript.es6.js
@@ -1,0 +1,288 @@
+/**
+ * Interactive transcript panel — parses VTT files and renders a scrollable,
+ * clickable, searchable transcript synced to media playback.
+ *
+ * Looks for elements with `data-transcript-src` (VTT URL) and a sibling
+ * media player (video/audio or YouTube iframe) to bind to.
+ *
+ * @package  Proclaim
+ * @since    10.3.0
+ */
+(() => {
+    'use strict';
+
+    /**
+     * Parse a VTT timestamp (HH:MM:SS.mmm or MM:SS.mmm) into seconds.
+     *
+     * @param {string} timestamp  VTT timestamp string
+     * @returns {number}  Time in seconds
+     */
+    function parseVttTime(timestamp) {
+        const parts = timestamp.trim().split(':');
+        let seconds = 0;
+
+        if (parts.length === 3) {
+            seconds += parseFloat(parts[0]) * 3600;
+            seconds += parseFloat(parts[1]) * 60;
+            seconds += parseFloat(parts[2]);
+        } else if (parts.length === 2) {
+            seconds += parseFloat(parts[0]) * 60;
+            seconds += parseFloat(parts[1]);
+        }
+
+        return seconds;
+    }
+
+    /**
+     * Format seconds as MM:SS for display.
+     *
+     * @param {number} seconds
+     * @returns {string}
+     */
+    function formatTime(seconds) {
+        const m = Math.floor(seconds / 60);
+        const s = Math.floor(seconds % 60);
+
+        return m + ':' + String(s).padStart(2, '0');
+    }
+
+    /**
+     * Parse a WebVTT file string into an array of cue objects.
+     *
+     * @param {string} vttText  Raw VTT file content
+     * @returns {Array<{start: number, end: number, text: string}>}
+     */
+    function parseVtt(vttText) {
+        const cues = [];
+        // Normalize line endings and split into blocks
+        const blocks = vttText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n\n');
+
+        for (const block of blocks) {
+            const lines = block.trim().split('\n');
+
+            // Find the timestamp line (contains ' --> ')
+            let tsIndex = -1;
+
+            for (let i = 0; i < lines.length; i += 1) {
+                if (lines[i].includes(' --> ')) {
+                    tsIndex = i;
+                    break;
+                }
+            }
+
+            if (tsIndex === -1) {
+                continue;
+            }
+
+            const tsParts = lines[tsIndex].split(' --> ');
+
+            if (tsParts.length < 2) {
+                continue;
+            }
+
+            // Strip position/alignment settings from end timestamp
+            const endRaw = tsParts[1].split(/\s/)[0];
+            const start = parseVttTime(tsParts[0]);
+            const end = parseVttTime(endRaw);
+
+            // Text is everything after the timestamp line, strip VTT tags
+            const text = lines.slice(tsIndex + 1).join(' ')
+                .replace(/<[^>]+>/g, '')
+                .trim();
+
+            if (text) {
+                cues.push({ start, end, text });
+            }
+        }
+
+        return cues;
+    }
+
+    /**
+     * Seek a media element or YouTube iframe to the given time.
+     *
+     * @param {HTMLElement} container  Player wrapper element
+     * @param {number}      seconds   Target time
+     */
+    function seekTo(container, seconds) {
+        const iframe = container.querySelector('iframe[src*="youtube.com"]');
+
+        if (iframe) {
+            iframe.contentWindow.postMessage(JSON.stringify({
+                event: 'command',
+                func: 'seekTo',
+                args: [seconds, true],
+            }), '*');
+
+            return;
+        }
+
+        const media = container.querySelector('video, audio');
+
+        if (media) {
+            media.currentTime = seconds;
+            media.play();
+        }
+    }
+
+    /**
+     * Build and attach the interactive transcript panel for a player.
+     *
+     * @param {HTMLElement} wrapper    Element with data-transcript-src
+     * @param {Array}       cues       Parsed VTT cues
+     * @param {HTMLElement} playerEl   The player container (for seek)
+     */
+    function buildTranscriptPanel(wrapper, cues, playerEl) {
+        const panel = document.createElement('div');
+        panel.className = 'cwm-transcript-panel';
+
+        // Search bar
+        const searchWrap = document.createElement('div');
+        searchWrap.className = 'cwm-transcript-search';
+
+        const searchInput = document.createElement('input');
+        searchInput.type = 'search';
+        searchInput.className = 'form-control form-control-sm';
+        searchInput.placeholder = Joomla.Text._('JBS_MED_TRANSCRIPT_SEARCH') || 'Search transcript...';
+        searchInput.setAttribute('aria-label', searchInput.placeholder);
+        searchWrap.appendChild(searchInput);
+        panel.appendChild(searchWrap);
+
+        // Cue list
+        const listEl = document.createElement('div');
+        listEl.className = 'cwm-transcript-cues';
+        listEl.setAttribute('role', 'list');
+
+        cues.forEach((cue, idx) => {
+            const cueEl = document.createElement('div');
+            cueEl.className = 'cwm-transcript-cue';
+            cueEl.setAttribute('role', 'listitem');
+            cueEl.dataset.index = idx;
+            cueEl.dataset.start = cue.start;
+            cueEl.dataset.end = cue.end;
+            cueEl.innerHTML = '<span class="cwm-transcript-time">' + formatTime(cue.start)
+                + '</span> <span class="cwm-transcript-text">' + cue.text + '</span>';
+
+            cueEl.addEventListener('click', () => {
+                seekTo(playerEl, cue.start);
+            });
+
+            listEl.appendChild(cueEl);
+        });
+
+        panel.appendChild(listEl);
+        wrapper.appendChild(panel);
+
+        // Active cue tracking via HTML5 timeupdate
+        const media = playerEl.querySelector('video, audio');
+
+        if (media) {
+            let lastActive = -1;
+
+            media.addEventListener('timeupdate', () => {
+                const t = media.currentTime;
+                let activeIdx = -1;
+
+                for (let i = cues.length - 1; i >= 0; i -= 1) {
+                    if (t >= cues[i].start && t < cues[i].end) {
+                        activeIdx = i;
+                        break;
+                    }
+                }
+
+                if (activeIdx === lastActive) {
+                    return;
+                }
+
+                lastActive = activeIdx;
+                const items = listEl.querySelectorAll('.cwm-transcript-cue');
+
+                items.forEach((item, idx) => {
+                    item.classList.toggle('active', idx === activeIdx);
+                });
+
+                // Auto-scroll to keep active cue visible
+                if (activeIdx >= 0 && items[activeIdx]) {
+                    items[activeIdx].scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'nearest',
+                    });
+                }
+            });
+        }
+
+        // Search/filter
+        let debounceTimer;
+
+        searchInput.addEventListener('input', () => {
+            clearTimeout(debounceTimer);
+
+            debounceTimer = setTimeout(() => {
+                const query = searchInput.value.toLowerCase().trim();
+                const items = listEl.querySelectorAll('.cwm-transcript-cue');
+
+                items.forEach((item) => {
+                    const textEl = item.querySelector('.cwm-transcript-text');
+                    const original = cues[parseInt(item.dataset.index, 10)].text;
+
+                    if (!query) {
+                        item.style.display = '';
+                        textEl.innerHTML = original;
+
+                        return;
+                    }
+
+                    const lower = original.toLowerCase();
+
+                    if (lower.includes(query)) {
+                        item.style.display = '';
+                        // Highlight matches
+                        const regex = new RegExp('(' + query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+                        textEl.innerHTML = original.replace(regex, '<mark>$1</mark>');
+                    } else {
+                        item.style.display = 'none';
+                    }
+                });
+            }, 200);
+        });
+    }
+
+    // Initialize all transcript panels on the page
+    document.querySelectorAll('[data-transcript-src]').forEach((wrapper) => {
+        const vttUrl = wrapper.dataset.transcriptSrc;
+
+        if (!vttUrl) {
+            return;
+        }
+
+        // Find the player container — look for sibling or parent with media/iframe
+        const playerEl = wrapper.closest('.media.playhit')
+            || wrapper.previousElementSibling
+            || wrapper.parentElement.querySelector('.media.playhit, [data-chapters]');
+
+        if (!playerEl) {
+            return;
+        }
+
+        fetch(vttUrl)
+            .then((r) => {
+                if (!r.ok) {
+                    return '';
+                }
+
+                return r.text();
+            })
+            .then((text) => {
+                if (!text || !text.includes('WEBVTT')) {
+                    return;
+                }
+
+                const cues = parseVtt(text);
+
+                if (cues.length > 0) {
+                    buildTranscriptPanel(wrapper, cues, playerEl);
+                }
+            })
+            .catch(() => { /* VTT fetch failed — transcript not shown */ });
+    });
+})();

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -151,6 +151,22 @@
             }
         },
         {
+            "name": "com_proclaim.cwm-transcript",
+            "type": "script",
+            "uri": "com_proclaim/cwm-transcript.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
+            "name": "com_proclaim.cwm-transcript-css",
+            "type": "style",
+            "uri": "com_proclaim/cwm-transcript.css"
+        },
+        {
             "name": "com_proclaim.admin-youtube-log",
             "type": "script",
             "uri": "com_proclaim/admin-youtube-log.min.js",

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -501,6 +501,8 @@ class HtmlView extends BaseHtmlView
         if (empty($this->print)) {
             $wa->useScript('com_proclaim.cwm-player-chapters');
             $wa->useStyle('com_proclaim.cwm-chapters');
+            $wa->useScript('com_proclaim.cwm-transcript');
+            $wa->useStyle('com_proclaim.cwm-transcript-css');
         }
 
         // Load scripture tooltip assets (per-element controlled; JS is a no-op

--- a/tests/js/cwm-transcript.test.js
+++ b/tests/js/cwm-transcript.test.js
@@ -1,0 +1,286 @@
+/**
+ * Tests for cwm-transcript.es6.js
+ * Interactive transcript panel — VTT parsing, rendering, seek, search
+ *
+ * @package  Proclaim.Tests
+ * @since    10.3.0
+ */
+
+describe('cwm-transcript', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = '';
+
+        // Ensure Joomla.Text._ is available (setup.js only defines JText)
+        global.Joomla = {
+            ...global.Joomla,
+            Text: { _: jest.fn((key) => key) },
+        };
+
+        // jsdom doesn't implement scrollIntoView
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    // Sample VTT content for testing
+    const sampleVtt = `WEBVTT
+
+1
+00:00:00.000 --> 00:00:05.000
+Welcome to today's message.
+
+2
+00:00:05.000 --> 00:00:12.000
+We're going to be looking at Romans chapter 8.
+
+3
+00:00:12.000 --> 00:00:20.000
+This is one of the most encouraging passages in all of Scripture.`;
+
+    /**
+     * Flush microtasks so fetch().then().then() chains resolve.
+     * The transcript module uses fetch().then(r.text()).then(parse+render),
+     * so we need to flush multiple microtask levels.
+     */
+    async function flush() {
+        for (let i = 0; i < 20; i += 1) {
+            await Promise.resolve();
+        }
+        await new Promise((r) => setTimeout(r, 100));
+        for (let i = 0; i < 10; i += 1) {
+            await Promise.resolve();
+        }
+    }
+
+    function setupWithVtt(vttContent) {
+        // Mock fetch to return the VTT content
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(vttContent),
+            }),
+        );
+
+        document.body.innerHTML = `
+            <div class="media playhit" data-id="1">
+                <audio src="test.mp3" controls></audio>
+            </div>
+            <div data-transcript-src="/media/captions/test.vtt"></div>
+        `;
+
+        require('../../build/media_source/js/cwm-transcript.es6.js');
+    }
+
+    describe('VTT parsing', () => {
+        test('parses VTT cues and renders transcript panel', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const panel = document.querySelector('.cwm-transcript-panel');
+            expect(panel).not.toBeNull();
+
+            const cues = panel.querySelectorAll('.cwm-transcript-cue');
+            expect(cues.length).toBe(3);
+        });
+
+        test('renders timestamps in MM:SS format', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const times = document.querySelectorAll('.cwm-transcript-time');
+            expect(times[0].textContent).toBe('0:00');
+            expect(times[1].textContent).toBe('0:05');
+            expect(times[2].textContent).toBe('0:12');
+        });
+
+        test('renders cue text content', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const texts = document.querySelectorAll('.cwm-transcript-text');
+            expect(texts[0].textContent).toContain('Welcome');
+            expect(texts[1].textContent).toContain('Romans chapter 8');
+        });
+
+        test('does not render panel when VTT fetch fails', async () => {
+            global.fetch = jest.fn(() => Promise.resolve({ ok: false, text: () => Promise.resolve('') }));
+
+            document.body.innerHTML = `
+                <div class="media playhit" data-id="1"><audio src="t.mp3"></audio></div>
+                <div data-transcript-src="/bad.vtt"></div>
+            `;
+
+            require('../../build/media_source/js/cwm-transcript.es6.js');
+            await flush();
+
+            expect(document.querySelector('.cwm-transcript-panel')).toBeNull();
+        });
+
+        test('does not render panel for non-VTT content', async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({ ok: true, text: () => Promise.resolve('Not a VTT file') }),
+            );
+
+            document.body.innerHTML = `
+                <div class="media playhit" data-id="1"><audio src="t.mp3"></audio></div>
+                <div data-transcript-src="/bad.txt"></div>
+            `;
+
+            require('../../build/media_source/js/cwm-transcript.es6.js');
+            await flush();
+
+            expect(document.querySelector('.cwm-transcript-panel')).toBeNull();
+        });
+
+        test('handles VTT with hour timestamps', async () => {
+            const vttWithHours = `WEBVTT
+
+1
+01:15:30.000 --> 01:16:00.000
+Late in the sermon.`;
+
+            setupWithVtt(vttWithHours);
+            await flush();
+
+            const time = document.querySelector('.cwm-transcript-time');
+            expect(time.textContent).toBe('75:30');
+        });
+
+        test('strips VTT formatting tags from text', async () => {
+            const vttWithTags = `WEBVTT
+
+1
+00:00:00.000 --> 00:00:05.000
+This has <b>bold</b> and <i>italic</i> tags.`;
+
+            setupWithVtt(vttWithTags);
+            await flush();
+
+            const text = document.querySelector('.cwm-transcript-text');
+            expect(text.textContent).toBe('This has bold and italic tags.');
+        });
+    });
+
+    describe('click to seek', () => {
+        test('clicking a cue sets currentTime on audio element', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const cues = document.querySelectorAll('.cwm-transcript-cue');
+            cues[1].click();
+
+            const audio = document.querySelector('audio');
+            expect(audio.currentTime).toBe(5);
+            expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+        });
+    });
+
+    describe('active cue tracking', () => {
+        test('highlights active cue during playback', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const audio = document.querySelector('audio');
+            const cues = document.querySelectorAll('.cwm-transcript-cue');
+
+            // Simulate playback at 7 seconds (within cue 2: 5-12s)
+            Object.defineProperty(audio, 'currentTime', { value: 7, writable: true });
+            audio.dispatchEvent(new Event('timeupdate'));
+
+            expect(cues[0].classList.contains('active')).toBe(false);
+            expect(cues[1].classList.contains('active')).toBe(true);
+            expect(cues[2].classList.contains('active')).toBe(false);
+        });
+    });
+
+    describe('search/filter', () => {
+        test('filters cues by search text', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const searchInput = document.querySelector('.cwm-transcript-search input');
+            searchInput.value = 'romans';
+            searchInput.dispatchEvent(new Event('input'));
+
+            // Wait for debounce
+            await new Promise((r) => setTimeout(r, 300));
+
+            const cues = document.querySelectorAll('.cwm-transcript-cue');
+            // Cue 2 contains "Romans" — should be visible
+            expect(cues[1].style.display).toBe('');
+            // Others should be hidden
+            expect(cues[0].style.display).toBe('none');
+            expect(cues[2].style.display).toBe('none');
+        });
+
+        test('highlights matching text with <mark> tags', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const searchInput = document.querySelector('.cwm-transcript-search input');
+            searchInput.value = 'romans';
+            searchInput.dispatchEvent(new Event('input'));
+            await new Promise((r) => setTimeout(r, 300));
+
+            const text = document.querySelectorAll('.cwm-transcript-text')[1];
+            expect(text.innerHTML).toContain('<mark>');
+            expect(text.innerHTML).toContain('Romans');
+        });
+
+        test('clears filter when search is emptied', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const searchInput = document.querySelector('.cwm-transcript-search input');
+
+            // First filter
+            searchInput.value = 'romans';
+            searchInput.dispatchEvent(new Event('input'));
+            await new Promise((r) => setTimeout(r, 300));
+
+            // Then clear
+            searchInput.value = '';
+            searchInput.dispatchEvent(new Event('input'));
+            await new Promise((r) => setTimeout(r, 300));
+
+            const cues = document.querySelectorAll('.cwm-transcript-cue');
+            cues.forEach((cue) => {
+                expect(cue.style.display).toBe('');
+            });
+        });
+    });
+
+    describe('no player found', () => {
+        test('does not render when no sibling player exists', async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({ ok: true, text: () => Promise.resolve(sampleVtt) }),
+            );
+
+            document.body.innerHTML = '<div data-transcript-src="/test.vtt"></div>';
+
+            require('../../build/media_source/js/cwm-transcript.es6.js');
+            await flush();
+
+            expect(document.querySelector('.cwm-transcript-panel')).toBeNull();
+        });
+    });
+
+    describe('accessibility', () => {
+        test('cue list has role="list" and items have role="listitem"', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            expect(document.querySelector('.cwm-transcript-cues').getAttribute('role')).toBe('list');
+            document.querySelectorAll('.cwm-transcript-cue').forEach((cue) => {
+                expect(cue.getAttribute('role')).toBe('listitem');
+            });
+        });
+
+        test('search input has aria-label', async () => {
+            setupWithVtt(sampleVtt);
+            await flush();
+
+            const input = document.querySelector('.cwm-transcript-search input');
+            expect(input.getAttribute('aria-label')).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- **Interactive transcript panel** — automatically renders below HTML5 players when a subtitle/caption track is available
- **VTT parser** — extracts cues from WebVTT files (timestamps + text), strips formatting tags
- **Click-to-seek** — clicking any transcript line seeks the player to that timestamp
- **Active cue highlighting** — current cue highlighted during playback with auto-scroll
- **Search/filter** — text input filters transcript lines with match highlighting (`<mark>` tags)
- **Caption file cleanup** — locally stored VTT files deleted when media record is deleted (path traversal guarded)
- **15 new Jest tests** covering parsing, seek, tracking, search, accessibility, and edge cases

## Files changed

| File | Change |
|------|--------|
| `build/media_source/js/cwm-transcript.es6.js` | New — VTT parser, transcript UI, sync |
| `build/media_source/css/cwm-transcript.css` | New — theme-aware panel styles |
| `admin/src/Service/HTML/CWMHtml5Inline.php` | Add `data-transcript-src` attribute |
| `admin/src/Table/CwmmediafileTable.php` | Add `deleteCaptionFiles()` cleanup on delete |
| `site/src/View/Cwmsermon/HtmlView.php` | Register transcript JS/CSS assets |
| `media/joomla.asset.json` | Register new assets |
| `admin/language/en-GB/en-GB.com_proclaim.ini` | Add `JBS_MED_TRANSCRIPT_SEARCH` string |
| `tests/js/cwm-transcript.test.js` | New — 15 tests |

## Test plan

- [ ] Upload a VTT caption file to a media file with HTML5 audio/video
- [ ] View the sermon detail page — transcript panel should render below the player
- [ ] Click a transcript line — player should seek to that timestamp
- [ ] During playback, active cue should highlight and auto-scroll
- [ ] Type in search box — transcript filters and highlights matches
- [ ] Delete a media file — associated VTT files should be cleaned up from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)