### PR TITLE
refactor: extract inline JS/CSS to external files for CSP compliance

### DIFF
--- a/admin/src/Field/CwmcalendarField.php
+++ b/admin/src/Field/CwmcalendarField.php
@@ -67,36 +67,11 @@ class CwmcalendarField extends JoomlaCalendarField
             $html
         );
 
-        // Register the value-interceptor JS once per page
+        // Register the value-interceptor JS once per page (external file,
+        // no PHP data needed — the script targets [data-cwm-no-seconds] inputs)
         $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-        $wa->addInlineScript(
-            <<<'JS'
-            (function() {
-                if (window._cwmCalNoSec) return;
-                window._cwmCalNoSec = true;
-
-                var desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
-
-                document.querySelectorAll('[data-cwm-no-seconds] input[type="text"]').forEach(function(input) {
-                    Object.defineProperty(input, 'value', {
-                        get: function() {
-                            return desc.get.call(this);
-                        },
-                        set: function(v) {
-                            if (typeof v === 'string') {
-                                v = v.replace(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}):\d{2}$/, '$1');
-                            }
-                            desc.set.call(this, v);
-                        },
-                        configurable: true
-                    });
-                });
-            })();
-            JS,
-            ['position' => 'after'],
-            [],
-            ['core']
-        );
+        $wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
+        $wa->useScript('com_proclaim.cwm-calendar-noseconds');
 
         return $html;
     }

--- a/admin/src/Field/ServerField.php
+++ b/admin/src/Field/ServerField.php
@@ -79,6 +79,9 @@ class ServerField extends FormField
             }
 
             if (!isset($scriptSelect[$this->id])) {
+                // Inline: standard Joomla modal-fields proxy — each field instance
+                // needs its own jSelectServer_{id} function with a unique field ID
+                // baked in.  Too dynamic per-instance to extract.
                 $wa->addInlineScript(
                     "
 				window.jSelectServer_" . $this->id . " = function (id, title, object, url, language) {

--- a/admin/src/Field/TeacherListField.php
+++ b/admin/src/Field/TeacherListField.php
@@ -63,14 +63,10 @@ class TeacherListField extends ListField
             $this->layout = 'joomla.form.field.list-fancy-select';
 
             // Ensure the Choices.js dropdown is not clipped by parent containers
-            // and renders above adjacent subform rows.
-            Factory::getApplication()->getDocument()->getWebAssetManager()
-                ->addInlineStyle(
-                    '.subform-repeatable-group joomla-field-fancy-select .choices__list--dropdown,'
-                    . ' .subform-repeatable-group joomla-field-fancy-select .choices__list[aria-expanded] {'
-                    . ' z-index: 1050; }'
-                    . ' .subform-repeatable-group { overflow: visible !important; }'
-                );
+            // and renders above adjacent subform rows (rules live in topics-field.css).
+            $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+            $wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
+            $wa->useStyle('com_proclaim.topics-field');
         }
 
         return $result;

--- a/admin/src/Field/TopicsFormField.php
+++ b/admin/src/Field/TopicsFormField.php
@@ -208,114 +208,23 @@ class TopicsFormField extends FormField
      */
     protected function addFreeTaggingScript(array $allTopics): void
     {
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
-        $addItemText = Text::_('JBS_CMN_PRESS_ENTER_ADD', true);
+        $document = Factory::getApplication()->getDocument();
+        $wa       = $document->getWebAssetManager();
 
         // Create a map of existing topic names to IDs for duplicate detection
         $existingTopics = [];
+
         foreach ($allTopics as $topic) {
             $existingTopics[mb_strtolower($topic['text'])] = $topic['id'];
         }
-        $existingJson = json_encode($existingTopics, JSON_HEX_APOS | JSON_HEX_QUOT);
 
-        $script = "
-            document.addEventListener('DOMContentLoaded', function() {
-                const selectEl = document.getElementById('" . $this->id . "');
-                const hiddenInput = document.getElementById('" . $this->id . "_input');
-                if (!selectEl || !hiddenInput) return;
-
-                const fancySelect = selectEl.closest('joomla-field-fancy-select');
-                if (!fancySelect) return;
-
-                // Function to sync hidden input with current selections
-                function syncHiddenInput(choices) {
-                    // Get all selected items
-                    const items = choices.getValue();
-                    let values = [];
-
-                    if (Array.isArray(items)) {
-                        values = items.map(function(item) {
-                            return item.value || item;
-                        });
-                    } else if (items && items.value) {
-                        values = [items.value];
-                    }
-
-                    hiddenInput.value = values.join(',');
-                    console.log('Topics synced:', hiddenInput.value);
-                }
-
-                // Wait for Choices.js to initialize
-                const checkChoices = setInterval(function() {
-                    if (fancySelect.choicesInstance) {
-                        clearInterval(checkChoices);
-                        const choices = fancySelect.choicesInstance;
-                        const existingTopics = " . $existingJson . ";
-
-                        // Sync on any change event
-                        selectEl.addEventListener('change', function() {
-                            syncHiddenInput(choices);
-                        });
-
-                        // Also sync on addItem and removeItem events
-                        selectEl.addEventListener('addItem', function() {
-                            setTimeout(function() { syncHiddenInput(choices); }, 10);
-                        });
-                        selectEl.addEventListener('removeItem', function() {
-                            setTimeout(function() { syncHiddenInput(choices); }, 10);
-                        });
-
-                        // Sync before form submission
-                        const form = selectEl.closest('form');
-                        if (form) {
-                            form.addEventListener('submit', function() {
-                                syncHiddenInput(choices);
-                            });
-                        }
-
-                        // Listen for search/input to enable adding new items
-                        const inputEl = fancySelect.querySelector('input.choices__input');
-                        if (inputEl) {
-                            inputEl.addEventListener('keydown', function(e) {
-                                if (e.key === 'Enter') {
-                                    const value = this.value.trim();
-                                    if (value && !existingTopics[value.toLowerCase()]) {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-
-                                        // Add as new choice and select it
-                                        choices.setChoices([{
-                                            value: value,
-                                            label: value,
-                                            selected: true
-                                        }], 'value', 'label', false);
-
-                                        // Clear input and sync
-                                        this.value = '';
-                                        choices.hideDropdown();
-                                        setTimeout(function() { syncHiddenInput(choices); }, 10);
-                                    }
-                                }
-                            });
-
-                            // Show hint for adding new items
-                            inputEl.setAttribute('placeholder', '" . $addItemText . "');
-                            // Fix width to show full placeholder
-                            inputEl.style.width = '150px';
-                            inputEl.style.minWidth = '150px';
-                        }
-
-                        // Initial sync
-                        syncHiddenInput(choices);
-                    }
-                }, 100);
-
-                // Clear interval after 5 seconds to prevent memory leak
-                setTimeout(function() { clearInterval(checkChoices); }, 5000);
-            });
-        ";
-
-        $wa->addInlineScript($script);
+        // Pass dynamic data via script options; logic lives in external JS
+        $wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
+        $wa->useScript('com_proclaim.topics-free-tagging');
+        $document->addScriptOptions('com_proclaim.topicsField', [
+            'fieldId'        => $this->id,
+            'existingTopics' => $existingTopics,
+            'addItemText'    => Text::_('JBS_CMN_PRESS_ENTER_ADD', true),
+        ]);
     }
 }

--- a/admin/src/Field/UploadField.php
+++ b/admin/src/Field/UploadField.php
@@ -52,22 +52,11 @@ class UploadField extends FormField
         $handler = $this->getAttribute('handler');
         $token   = Session::getFormToken();
 
-        $wa->addInlineScript(
-            'document.addEventListener("DOMContentLoaded", function() {
-                if (typeof uploader === "undefined") { return; }
-                uploader.setOption("url", "index.php?option=com_proclaim&task=cwmmediafile.xhr&' . $token . '=1");
-                uploader.bind("BeforeUpload", function() {
-                    var pathEl = document.getElementById("jform_params_localFolder");
-                    var typeEl = document.getElementById("jform_serverType");
-                    uploader.setOption("multipart_params", {
-                        handler: "' . $handler . '",
-                        path: pathEl ? pathEl.value : "",
-                        type: typeEl ? typeEl.value : ""
-                    });
-                });
-                uploader.init();
-            });'
-        );
+        $wa->useScript('com_proclaim.upload-field');
+        $document->addScriptOptions('com_proclaim.uploadField', [
+            'url'     => 'index.php?option=com_proclaim&task=cwmmediafile.xhr&' . $token . '=1',
+            'handler' => $handler,
+        ]);
 
         $class    = $this->getAttribute('class') ? (string) $this->getAttribute('class') : '';
         $required = 'requires="' . $this->getAttribute('required') . '"';

--- a/admin/tmpl/cwmarchive/edit.php
+++ b/admin/tmpl/cwmarchive/edit.php
@@ -25,7 +25,13 @@ use Joomla\CMS\Session\Session;
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')
     ->useScript('form.validate')
+    ->useScript('com_proclaim.cwm-archive')
     ->useStyle('com_proclaim.general');
+
+$this->getDocument()->addScriptOptions('com_proclaim.archive', [
+    'token'   => Session::getFormToken(),
+    'backUrl' => Route::_('index.php?option=com_proclaim&view=cwmadmin', false),
+]);
 ?>
 
 <!-- Archive Progress Modal -->
@@ -123,126 +129,3 @@ $wa->useScript('keepalive')
         </div>
     </div>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const token = '<?php echo Session::getFormToken(); ?>';
-    const modal = document.getElementById('archive-progress-modal');
-    const progressBar = modal.querySelector('.progress-bar');
-    const statusText = modal.querySelector('.status-text');
-    const detailText = modal.querySelector('.detail-text');
-    const spinner = modal.querySelector('.operation-spinner');
-    const closeBtn = modal.querySelector('.btn-close-modal');
-    let bsModal = null;
-
-    // Update interval label when radio changes
-    const switchRadios = document.querySelectorAll('input[name="jform[switch]"]');
-    const intervalLabel = document.getElementById('interval-label');
-
-    switchRadios.forEach(function(radio) {
-        radio.addEventListener('change', function() {
-            const labels = {
-                'year': '<?php echo Text::_('JBS_CMN_YEARS'); ?>',
-                'month': '<?php echo Text::_('JBS_CMN_MONTHS'); ?>',
-                'day': '<?php echo Text::_('JBS_CMN_DAYS'); ?>'
-            };
-            intervalLabel.textContent = labels[this.value] || labels['year'];
-        });
-    });
-
-    // Archive button click
-    document.getElementById('btn-start-archive').addEventListener('click', function() {
-        const timeframe = document.getElementById('jform_timeframe').value;
-        const switchVal = document.querySelector('input[name="jform[switch]"]:checked')?.value || 'year';
-
-        if (!timeframe || timeframe < 1) {
-            Joomla.renderMessages({error: ['<?php echo Text::_('JBS_ARCHIVE_TIMEFRAME_REQUIRED', true); ?>']});
-            return;
-        }
-
-        // Confirm action
-        const intervalText = {
-            'year': '<?php echo Text::_('JBS_CMN_YEARS'); ?>',
-            'month': '<?php echo Text::_('JBS_CMN_MONTHS'); ?>',
-            'day': '<?php echo Text::_('JBS_CMN_DAYS'); ?>'
-        };
-        const confirmMsg = '<?php echo Text::_('JBS_ARCHIVE_CONFIRM', true); ?>'
-            .replace('%s', timeframe + ' ' + intervalText[switchVal]);
-
-        if (!confirm(confirmMsg)) {
-            return;
-        }
-
-        // Show modal
-        if (!bsModal) {
-            bsModal = new bootstrap.Modal(modal);
-        }
-        progressBar.style.width = '0%';
-        progressBar.textContent = '0%';
-        progressBar.classList.remove('bg-success', 'bg-danger');
-        progressBar.classList.add('progress-bar-animated');
-        statusText.textContent = '<?php echo Text::_('JBS_ADM_PROCESSING'); ?>';
-        detailText.textContent = '';
-        spinner.style.display = 'inline-block';
-        closeBtn.style.display = 'none';
-        bsModal.show();
-
-        // Start archive via AJAX
-        const url = 'index.php?option=com_proclaim&task=cwmadmin.doArchiveXHR&' + token + '=1' +
-            '&timeframe=' + encodeURIComponent(timeframe) +
-            '&switch=' + encodeURIComponent(switchVal);
-
-        progressBar.style.width = '50%';
-        progressBar.textContent = '50%';
-
-        fetch(url)
-            .then(response => response.json())
-            .then(data => {
-                progressBar.style.width = '100%';
-                progressBar.textContent = '100%';
-                progressBar.classList.remove('progress-bar-animated');
-                spinner.style.display = 'none';
-
-                if (data.success) {
-                    progressBar.classList.add('bg-success');
-                    statusText.textContent = '<?php echo Text::_('JBS_CMN_OPERATION_SUCCESSFUL'); ?>';
-                    detailText.innerHTML = data.message || '';
-                } else {
-                    progressBar.classList.add('bg-danger');
-                    statusText.textContent = '<?php echo Text::_('JBS_ADM_ERROR'); ?>';
-                    detailText.textContent = data.message || '';
-                }
-
-                closeBtn.style.display = 'inline-block';
-            })
-            .catch(error => {
-                progressBar.style.width = '100%';
-                progressBar.classList.remove('progress-bar-animated');
-                progressBar.classList.add('bg-danger');
-                spinner.style.display = 'none';
-                statusText.textContent = '<?php echo Text::_('JBS_ADM_ERROR'); ?>';
-                detailText.textContent = error.message;
-                closeBtn.style.display = 'inline-block';
-            });
-    });
-
-    // Close button
-    closeBtn.addEventListener('click', function() {
-        if (bsModal) {
-            bsModal.hide();
-        }
-    });
-
-    // Joomla submitbutton for toolbar
-    Joomla.submitbutton = function(task) {
-        if (task === 'cwmadmin.back' || task === 'administration.back') {
-            window.location.href = '<?php echo Route::_('index.php?option=com_proclaim&view=cwmadmin', false); ?>';
-            return;
-        }
-        var form = document.getElementById('adminForm');
-        if (document.formvalidator.isValid(form)) {
-            Joomla.submitform(task, form);
-        }
-    };
-});
-</script>

--- a/build/media_source/css/topics-field.css
+++ b/build/media_source/css/topics-field.css
@@ -21,3 +21,13 @@
 .proclaim-topics-field + .choices .choices__item {
     margin-right: 5px;
 }
+
+/* Ensure Choices.js dropdowns in subform rows are not clipped and
+   render above adjacent rows (used by TeacherListField searchable). */
+.subform-repeatable-group joomla-field-fancy-select .choices__list--dropdown,
+.subform-repeatable-group joomla-field-fancy-select .choices__list[aria-expanded] {
+    z-index: 1050;
+}
+.subform-repeatable-group {
+    overflow: visible !important;
+}

--- a/build/media_source/js/cwm-archive.es6.js
+++ b/build/media_source/js/cwm-archive.es6.js
@@ -1,0 +1,129 @@
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @since      10.2.0
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    'use strict';
+
+    const config = Joomla.getOptions('com_proclaim.archive') || {};
+    const token = config.token || '';
+    const backUrl = config.backUrl || 'index.php?option=com_proclaim&view=cwmadmin';
+
+    const modal = document.getElementById('archive-progress-modal');
+    const progressBar = modal.querySelector('.progress-bar');
+    const statusText = modal.querySelector('.status-text');
+    const detailText = modal.querySelector('.detail-text');
+    const spinner = modal.querySelector('.operation-spinner');
+    const closeBtn = modal.querySelector('.btn-close-modal');
+    let bsModal = null;
+
+    // Update interval label when radio changes
+    const switchRadios = document.querySelectorAll('input[name="jform[switch]"]');
+    const intervalLabel = document.getElementById('interval-label');
+
+    const intervalLabels = {
+        year: Joomla.Text._('JBS_CMN_YEARS'),
+        month: Joomla.Text._('JBS_CMN_MONTHS'),
+        day: Joomla.Text._('JBS_CMN_DAYS'),
+    };
+
+    switchRadios.forEach((radio) => {
+        radio.addEventListener('change', function () {
+            intervalLabel.textContent = intervalLabels[this.value] || intervalLabels.year;
+        });
+    });
+
+    // Archive button click
+    document.getElementById('btn-start-archive').addEventListener('click', () => {
+        const timeframe = document.getElementById('jform_timeframe').value;
+        const switchEl = document.querySelector('input[name="jform[switch]"]:checked');
+        const switchVal = switchEl ? switchEl.value : 'year';
+
+        if (!timeframe || timeframe < 1) {
+            Joomla.renderMessages({ error: [Joomla.Text._('JBS_ARCHIVE_TIMEFRAME_REQUIRED')] });
+            return;
+        }
+
+        // Confirm action
+        const confirmMsg = Joomla.Text._('JBS_ARCHIVE_CONFIRM')
+            .replace('%s', `${timeframe} ${intervalLabels[switchVal]}`);
+
+        if (!confirm(confirmMsg)) {
+            return;
+        }
+
+        // Show modal
+        if (!bsModal) {
+            bsModal = new bootstrap.Modal(modal);
+        }
+        progressBar.style.width = '0%';
+        progressBar.textContent = '0%';
+        progressBar.classList.remove('bg-success', 'bg-danger');
+        progressBar.classList.add('progress-bar-animated');
+        statusText.textContent = Joomla.Text._('JBS_ADM_PROCESSING');
+        detailText.textContent = '';
+        spinner.style.display = 'inline-block';
+        closeBtn.style.display = 'none';
+        bsModal.show();
+
+        // Start archive via AJAX
+        const url = `index.php?option=com_proclaim&task=cwmadmin.doArchiveXHR&${token}=1`
+            + `&timeframe=${encodeURIComponent(timeframe)}`
+            + `&switch=${encodeURIComponent(switchVal)}`;
+
+        progressBar.style.width = '50%';
+        progressBar.textContent = '50%';
+
+        fetch(url)
+            .then((response) => response.json())
+            .then((data) => {
+                progressBar.style.width = '100%';
+                progressBar.textContent = '100%';
+                progressBar.classList.remove('progress-bar-animated');
+                spinner.style.display = 'none';
+
+                if (data.success) {
+                    progressBar.classList.add('bg-success');
+                    statusText.textContent = Joomla.Text._('JBS_CMN_OPERATION_SUCCESSFUL');
+                    detailText.innerHTML = data.message || '';
+                } else {
+                    progressBar.classList.add('bg-danger');
+                    statusText.textContent = Joomla.Text._('JBS_ADM_ERROR');
+                    detailText.textContent = data.message || '';
+                }
+
+                closeBtn.style.display = 'inline-block';
+            })
+            .catch((error) => {
+                progressBar.style.width = '100%';
+                progressBar.classList.remove('progress-bar-animated');
+                progressBar.classList.add('bg-danger');
+                spinner.style.display = 'none';
+                statusText.textContent = Joomla.Text._('JBS_ADM_ERROR');
+                detailText.textContent = error.message;
+                closeBtn.style.display = 'inline-block';
+            });
+    });
+
+    // Close button
+    closeBtn.addEventListener('click', () => {
+        if (bsModal) {
+            bsModal.hide();
+        }
+    });
+
+    // Joomla submitbutton for toolbar
+    Joomla.submitbutton = (task) => {
+        if (task === 'cwmadmin.back' || task === 'administration.back') {
+            window.location.href = backUrl;
+            return;
+        }
+        const form = document.getElementById('adminForm');
+        if (document.formvalidator.isValid(form)) {
+            Joomla.submitform(task, form);
+        }
+    };
+});

--- a/build/media_source/js/cwm-calendar-noseconds.es6.js
+++ b/build/media_source/js/cwm-calendar-noseconds.es6.js
@@ -1,0 +1,38 @@
+/**
+ * CwmcalendarField — strips seconds from Joomla CalendarField display.
+ *
+ * The DB stores DATETIME with seconds, and Joomla's CalendarField always
+ * renders them. This script intercepts the input element's value setter via
+ * Object.defineProperty so every write (PHP, JS init, date pick) has seconds
+ * stripped.
+ *
+ * @package    Proclaim.Admin
+ * @subpackage Field
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @since      10.2.0
+ */
+(function () {
+    if (window._cwmCalNoSec) {
+        return;
+    }
+    window._cwmCalNoSec = true;
+
+    const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+
+    document.querySelectorAll('[data-cwm-no-seconds] input[type="text"]').forEach(function (input) {
+        Object.defineProperty(input, 'value', {
+            get() {
+                return desc.get.call(this);
+            },
+            set(val) {
+                let cleaned = val;
+                if (typeof cleaned === 'string') {
+                    cleaned = cleaned.replace(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}):\d{2}$/, '$1');
+                }
+                desc.set.call(this, cleaned);
+            },
+            configurable: true,
+        });
+    });
+})();

--- a/build/media_source/js/cwm-landing-toggle.es6.js
+++ b/build/media_source/js/cwm-landing-toggle.es6.js
@@ -1,0 +1,39 @@
+/**
+ * @package    Proclaim.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Show/hide toggle for landing page "show more" sections.
+ * Called from inline onclick attributes in landing page templates.
+ *
+ * @since 10.2.0
+ */
+
+/**
+ * Toggle visibility of a landing page section by ID or class name.
+ *
+ * @param {string} d  The element ID or class suffix to toggle
+ */
+window.ReverseDisplay2 = function ReverseDisplay2(d) {
+  const el = document.getElementById(d);
+
+  if (el) {
+    // Legacy/Table layout support
+    if (el.style.display === 'none') {
+      el.style.display = 'contents';
+    } else {
+      el.style.display = 'none';
+    }
+  } else {
+    // Grid layout support (class toggling)
+    const elements = document.getElementsByClassName(`landing-hidden-${d}`);
+
+    for (let i = 0; i < elements.length; i += 1) {
+      if (elements[i].style.display === 'none') {
+        elements[i].style.display = '';
+      } else {
+        elements[i].style.display = 'none';
+      }
+    }
+  }
+};

--- a/build/media_source/js/cwm-social-share.es6.js
+++ b/build/media_source/js/cwm-social-share.es6.js
@@ -1,0 +1,32 @@
+/**
+ * @package    Proclaim.Media
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Reads AddToAny social share configuration from Joomla script options
+ * and sets up the global a2a_config object.
+ *
+ * @since  10.2.0
+ */
+document.addEventListener('DOMContentLoaded', () => {
+    const opts = Joomla.getOptions('com_proclaim.socialShare');
+    if (!opts) {
+        return;
+    }
+
+    window.a2a_config = window.a2a_config || {};
+
+    a2a_config.onclick = 1;
+    a2a_config.num_services = 8;
+    a2a_config.thanks = { postShare: true, ad: false };
+
+    a2a_config.templates = a2a_config.templates || {};
+    a2a_config.templates.email = {
+        subject: '${title}',
+        body: (opts.description || 'Check out this message') + '\n\n${link}',
+    };
+
+    if (opts.linkUrl) {
+        a2a_config.linkurl_default = opts.linkUrl;
+    }
+});

--- a/build/media_source/js/topics-free-tagging.es6.js
+++ b/build/media_source/js/topics-free-tagging.es6.js
@@ -1,0 +1,119 @@
+/**
+ * Topics field — Choices.js free-tagging support.
+ *
+ * Reads configuration from Joomla.getOptions('com_proclaim.topicsField'):
+ *   - fieldId:        DOM id of the <select> element
+ *   - existingTopics: object mapping lowercase topic names to IDs
+ *   - addItemText:    placeholder text for the input
+ *
+ * @package    Proclaim.Admin
+ * @subpackage Field
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @since      10.2.0
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    const opts = Joomla.getOptions('com_proclaim.topicsField');
+    if (!opts) {
+        return;
+    }
+
+    const selectEl = document.getElementById(opts.fieldId);
+    const hiddenInput = document.getElementById(opts.fieldId + '_input');
+    if (!selectEl || !hiddenInput) {
+        return;
+    }
+
+    const fancySelect = selectEl.closest('joomla-field-fancy-select');
+    if (!fancySelect) {
+        return;
+    }
+
+    const existingTopics = opts.existingTopics || {};
+    const addItemText = opts.addItemText || '';
+
+    /**
+     * Sync hidden input with current Choices.js selections.
+     *
+     * @param {object} choices  The Choices.js instance
+     */
+    function syncHiddenInput(choices) {
+        const items = choices.getValue();
+        let values = [];
+
+        if (Array.isArray(items)) {
+            values = items.map(function (item) {
+                return item.value || item;
+            });
+        } else if (items && items.value) {
+            values = [items.value];
+        }
+
+        hiddenInput.value = values.join(',');
+    }
+
+    // Wait for Choices.js to initialise
+    const checkChoices = setInterval(function () {
+        if (!fancySelect.choicesInstance) {
+            return;
+        }
+
+        clearInterval(checkChoices);
+        const choices = fancySelect.choicesInstance;
+
+        // Sync on change, addItem, removeItem events
+        selectEl.addEventListener('change', function () {
+            syncHiddenInput(choices);
+        });
+        selectEl.addEventListener('addItem', function () {
+            setTimeout(function () { syncHiddenInput(choices); }, 10);
+        });
+        selectEl.addEventListener('removeItem', function () {
+            setTimeout(function () { syncHiddenInput(choices); }, 10);
+        });
+
+        // Sync before form submission
+        const form = selectEl.closest('form');
+        if (form) {
+            form.addEventListener('submit', function () {
+                syncHiddenInput(choices);
+            });
+        }
+
+        // Listen for Enter key to add new items
+        const inputEl = fancySelect.querySelector('input.choices__input');
+        if (inputEl) {
+            inputEl.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') {
+                    const value = this.value.trim();
+                    if (value && !existingTopics[value.toLowerCase()]) {
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        choices.setChoices([{
+                            value,
+                            label: value,
+                            selected: true,
+                        }], 'value', 'label', false);
+
+                        this.value = '';
+                        choices.hideDropdown();
+                        setTimeout(function () { syncHiddenInput(choices); }, 10);
+                    }
+                }
+            });
+
+            if (addItemText) {
+                inputEl.setAttribute('placeholder', addItemText);
+            }
+            inputEl.style.width = '150px';
+            inputEl.style.minWidth = '150px';
+        }
+
+        // Initial sync
+        syncHiddenInput(choices);
+    }, 100);
+
+    // Clear interval after 5 seconds to prevent memory leak
+    setTimeout(function () { clearInterval(checkChoices); }, 5000);
+});

--- a/build/media_source/js/upload-field.es6.js
+++ b/build/media_source/js/upload-field.es6.js
@@ -1,0 +1,36 @@
+/**
+ * Upload field — plupload initialisation.
+ *
+ * Reads configuration from Joomla.getOptions('com_proclaim.uploadField'):
+ *   - url:     the XHR upload endpoint (includes CSRF token)
+ *   - handler: the server handler identifier
+ *
+ * @package    Proclaim.Admin
+ * @subpackage Field
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @since      10.2.0
+ */
+/* global uploader */
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof uploader === 'undefined') {
+        return;
+    }
+
+    const opts = Joomla.getOptions('com_proclaim.uploadField');
+    if (!opts) {
+        return;
+    }
+
+    uploader.setOption('url', opts.url);
+    uploader.bind('BeforeUpload', function () {
+        const pathEl = document.getElementById('jform_params_localFolder');
+        const typeEl = document.getElementById('jform_serverType');
+        uploader.setOption('multipart_params', {
+            handler: opts.handler,
+            path: pathEl ? pathEl.value : '',
+            type: typeEl ? typeEl.value : '',
+        });
+    });
+    uploader.init();
+});

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -6,6 +6,18 @@
     "license": "GPL-2.0-or-later",
     "assets": [
         {
+            "name": "com_proclaim.cwm-archive",
+            "type": "script",
+            "uri": "com_proclaim/cwm-archive.min.js",
+            "dependencies": [
+                "core",
+                "bootstrap.modal"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
             "name": "com_proclaim.cwm-fetch",
             "type": "script",
             "uri": "com_proclaim/cwm-fetch.min.js",
@@ -691,6 +703,17 @@
             }
         },
         {
+            "name": "com_proclaim.cwm-landing-toggle",
+            "type": "script",
+            "uri": "com_proclaim/cwm-landing-toggle.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
             "name": "com_proclaim.sermon-filters",
             "type": "script",
             "uri": "com_proclaim/sermon-filters.min.js",
@@ -811,6 +834,17 @@
             }
         },
         {
+            "name": "com_proclaim.social-share",
+            "type": "script",
+            "uri": "com_proclaim/cwm-social-share.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
             "name": "com_proclaim.share",
             "type": "script",
             "uri": "com_proclaim/proclaim-share.min.js",
@@ -873,6 +907,39 @@
             "name": "com_proclaim.topics-field",
             "type": "style",
             "uri": "com_proclaim/topics-field.min.css"
+        },
+        {
+            "name": "com_proclaim.upload-field",
+            "type": "script",
+            "uri": "com_proclaim/upload-field.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
+            "name": "com_proclaim.cwm-calendar-noseconds",
+            "type": "script",
+            "uri": "com_proclaim/cwm-calendar-noseconds.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
+            "name": "com_proclaim.topics-free-tagging",
+            "type": "script",
+            "uri": "com_proclaim/topics-free-tagging.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
         }
     ]
 }

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -2860,24 +2860,18 @@ class Cwmlisting
 
         $doc = $app->getDocument();
 
-        // Note: ${link} and ${title} are AddToAny template placeholders (not PHP variables)
-        $escapedDesc = addslashes($data['description'] ?: 'Check out this message');
-        $config      = "var a2a_config = a2a_config || {};
-a2a_config.onclick = 1;
-a2a_config.num_services = 8;
-a2a_config.thanks = { postShare: true, ad: false };
-a2a_config.templates = a2a_config.templates || {};
-a2a_config.templates.email = {
-    subject: '\${title}',
-    body: '" . $escapedDesc . "\\n\\n\${link}'
-};";
+        $shareOptions = [
+            'description' => $data['description'] ?: 'Check out this message',
+        ];
 
         if ($data['imageUrl']) {
-            $config .= "\na2a_config.linkurl_default = '" . addslashes($data['link']) . "';";
+            $shareOptions['linkUrl'] = $data['link'];
         }
 
+        $doc->addScriptOptions('com_proclaim.socialShare', $shareOptions);
+
         $wa = $doc->getWebAssetManager();
-        $wa->addInlineScript($config);
+        $wa->useScript('com_proclaim.social-share');
 
         $wa->registerAndUseScript(
             'com_proclaim.addtoany',

--- a/site/src/View/Cwmlandingpage/HtmlView.php
+++ b/site/src/View/Cwmlandingpage/HtmlView.php
@@ -128,30 +128,7 @@ class HtmlView extends BaseHtmlView
         $this->landingData = $this->landing->getLandingData($this->params);
 
         // Add the show/hide javascript
-        $js = <<<JS
-    function ReverseDisplay2(d) {
-        var el = document.getElementById(d);
-        if (el) {
-            // Legacy/Table layout support
-            if (el.style.display == "none") {
-                el.style.display = "contents";
-            } else {
-                el.style.display = "none";
-            }
-        } else {
-            // Grid layout support (class toggling)
-            var elements = document.getElementsByClassName('landing-hidden-' + d);
-            for (var i = 0; i < elements.length; i++) {
-                if (elements[i].style.display == "none") {
-                    elements[i].style.display = "";
-                } else {
-                    elements[i].style.display = "none";
-                }
-            }
-        }
-    }
-JS;
-        $document->getWebAssetManager()->addInlineScript($js);
+        $document->getWebAssetManager()->useScript('com_proclaim.cwm-landing-toggle');
 
         parent::display($tpl);
     }


### PR DESCRIPTION
## Summary

Extracted 6 inline JavaScript blocks and 1 inline CSS block into external files loaded via Joomla's Web Asset Manager. Dynamic data is now passed through `addScriptOptions()` instead of PHP string injection.

### New external JS files
| File | Was | Source |
|------|-----|--------|
| `cwm-archive.es6.js` | 120-line `<script>` block | `admin/tmpl/cwmarchive/edit.php` |
| `cwm-landing-toggle.es6.js` | `addInlineScript()` heredoc | `site/src/View/Cwmlandingpage/HtmlView.php` |
| `cwm-social-share.es6.js` | `addInlineScript()` with a2a_config | `site/src/Helper/Cwmlisting.php` |
| `upload-field.es6.js` | `addInlineScript()` | `admin/src/Field/UploadField.php` |
| `cwm-calendar-noseconds.es6.js` | `addInlineScript()` IIFE | `admin/src/Field/CwmcalendarField.php` |
| `topics-free-tagging.es6.js` | `addInlineScript()` ~95 lines | `admin/src/Field/TopicsFormField.php` |

### CSS fix
- TeacherListField `addInlineStyle()` moved to existing `topics-field.css`

### Left as-is
- `ServerField.php` — per-instance modal proxy function (too dynamic, comment added)
- `Cwmpopup/HtmlView.php` — trivial `window.close()` one-liner

## Test plan
- [ ] Archive page — modal progress works
- [ ] Landing page — show/hide toggles work
- [ ] Social sharing — AddToAny buttons work on sermon detail
- [ ] Media file upload field — upload handler works
- [ ] Calendar field — seconds stripped correctly
- [ ] Topics field — free tagging and existing topic selection works
- [ ] Teacher subform — Choices.js dropdown not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)