### PR TITLE
refactor: extract 4 reusable layouts from 40+ duplicated template blocks

### DIFF
--- a/admin/layouts/edit/permissions_tab.php
+++ b/admin/layouts/edit/permissions_tab.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Reusable permissions tab layout for edit views.
+ *
+ * @package    Proclaim.Administrator
+ * @subpackage Layout
+ *
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Expected $displayData keys:
+ *   'form'    - Joomla\CMS\Form\Form instance
+ *   'canDo'   - CMSObject with permission flags
+ *   'tabName' - (optional) tab set name, defaults to 'myTab'
+ */
+
+$form    = $displayData['form'];
+$canDo   = $displayData['canDo'];
+$tabName = $displayData['tabName'] ?? 'myTab';
+
+if (!$canDo->get('core.admin')) {
+    return;
+}
+?>
+<?php echo HTMLHelper::_('uitab.addTab', $tabName, 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
+<div class="row">
+    <div class="col-lg-12">
+        <?php echo $form->getInput('rules'); ?>
+    </div>
+</div>
+<?php echo HTMLHelper::_('uitab.endTab'); ?>

--- a/admin/layouts/edit/publish_tab.php
+++ b/admin/layouts/edit/publish_tab.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Reusable publishing/metadata tab layout for edit views.
+ *
+ * @package    Proclaim.Administrator
+ * @subpackage Layout
+ *
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * @var mixed $displayData The view object (HtmlView instance).
+ *                         Optional key 'tabName' can be passed as array: ['view' => $this, 'tabName' => 'myTab']
+ */
+
+// Support both direct view object and array with options
+if (\is_array($displayData)) {
+    $view    = $displayData['view'];
+    $tabName = $displayData['tabName'] ?? 'myTab';
+} else {
+    $view    = $displayData;
+    $tabName = 'myTab';
+}
+
+?>
+<?php echo HTMLHelper::_('uitab.addTab', $tabName, 'publish', Text::_('JBS_STY_PUBLISH')); ?>
+<div class="row">
+    <div class="col-lg-12">
+        <?php echo LayoutHelper::render('joomla.edit.publishingdata', $view); ?>
+    </div>
+</div>
+<?php echo HTMLHelper::_('uitab.endTab'); ?>

--- a/admin/layouts/html/batch/footer.php
+++ b/admin/layouts/html/batch/footer.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Shared batch modal footer layout.
+ *
+ * Expects $displayData['submitTask'] — the controller task for the batch
+ * (e.g. 'cwmmessage.batch').
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$submitTask = $displayData['submitTask'] ?? '';
+?>
+<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+    <?php echo Text::_('JCANCEL'); ?>
+</button>
+<button type="submit" id="batch-submit-button-id" class="btn btn-success" data-submit-task="<?php echo htmlspecialchars($submitTask, ENT_QUOTES, 'UTF-8'); ?>">
+    <?php echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/admin/layouts/html/empty_state.php
+++ b/admin/layouts/html/empty_state.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Reusable empty-state alert layout.
+ *
+ * @var   array  $displayData  Optional keys:
+ *                             - 'message' (string) Language key; defaults to JGLOBAL_NO_MATCHING_RESULTS
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$message = $displayData['message'] ?? 'JGLOBAL_NO_MATCHING_RESULTS';
+?>
+<div class="alert alert-info">
+    <span class="icon-info-circle" aria-hidden="true"></span><span
+            class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+    <?php echo Text::_($message); ?>
+</div>

--- a/admin/tmpl/cwmcomment/edit.php
+++ b/admin/tmpl/cwmcomment/edit.php
@@ -17,6 +17,7 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var CWM\Component\Proclaim\Administrator\View\Cwmcomment\HtmlView $this */
@@ -62,20 +63,7 @@ echo Route::_('index.php?option=com_proclaim&layout=edit&id=' . (int)$this->item
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_CMN_FIELDSET_RULES')); ?>
-            <div class="row">
-                <fieldset>
-                    <?php
-                    echo $this->form->getInput('rules'); ?>
-                </fieldset>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
         <input type="hidden" name="task" value=""/>
         <input type="hidden" name="return" value="<?php
         echo $input->getCmd('return'); ?>"/>

--- a/admin/tmpl/cwmcomments/default.php
+++ b/admin/tmpl/cwmcomments/default.php
@@ -72,13 +72,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                                echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                     <?php else : ?>
                     <table class="table table-striped itemlist" id="comments">
                         <caption class="visually-hidden">

--- a/admin/tmpl/cwmcomments/default_batch_footer.php
+++ b/admin/tmpl/cwmcomments/default_batch_footer.php
@@ -14,21 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmcomments\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$published = $this->state->get('filter.published');
-
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmcomment.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmcomment.batch']);

--- a/admin/tmpl/cwmlocation/edit.php
+++ b/admin/tmpl/cwmlocation/edit.php
@@ -61,28 +61,9 @@ echo Route::_('index.php?option=com_proclaim&layout=' . $currentLayout . '&id=' 
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <?php
         echo HTMLHelper::_('uitab.endTabSet'); ?>

--- a/admin/tmpl/cwmlocations/default.php
+++ b/admin/tmpl/cwmlocations/default.php
@@ -64,10 +64,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmlocations'); ?>" method="po
 ?>
             <?php
 if (empty($this->items)) : ?>
-                <div class="alert alert-no-items">
-                    <?php
-        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                </div>
+                <?php echo LayoutHelper::render('html.empty_state'); ?>
             <?php else : ?>
                 <table class="table table-striped adminlist" id="locationsList">
                     <thead>

--- a/admin/tmpl/cwmlocations/default_batch_footer.php
+++ b/admin/tmpl/cwmlocations/default_batch_footer.php
@@ -14,20 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmlocations\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$published = $this->state->get('filter.published');
-
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmlocation.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmlocation.batch']);

--- a/admin/tmpl/cwmlocations/modal.php
+++ b/admin/tmpl/cwmlocations/modal.php
@@ -63,12 +63,7 @@ if (!empty($editor)) {
 
         <?php
         if (empty($this->items)) : ?>
-            <div class="alert alert-info">
-                <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php
-                    echo Text::_('INFO'); ?></span>
-                <?php
-                echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-            </div>
+            <?php echo LayoutHelper::render('html.empty_state'); ?>
             <?php else : ?>
             <table class="table table-sm">
                 <caption class="visually-hidden">

--- a/admin/tmpl/cwmmediafile/edit.php
+++ b/admin/tmpl/cwmmediafile/edit.php
@@ -166,28 +166,9 @@ echo 'index.php?option=com_proclaim&view=cwmmediafile&layout=edit&id=' . (int)$t
         </div>
         <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <?php
         echo HTMLHelper::_('uitab.endTabSet'); ?>

--- a/admin/tmpl/cwmmediafiles/default.php
+++ b/admin/tmpl/cwmmediafiles/default.php
@@ -56,11 +56,7 @@ if ($saveOrder && !empty($this->items)) {
             <div id="j-main-container" class="j-main-container">
                 <?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-                        <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table" id="mediafileList">
                         <caption class="visually-hidden">

--- a/admin/tmpl/cwmmediafiles/default_batch_footer.php
+++ b/admin/tmpl/cwmmediafiles/default_batch_footer.php
@@ -14,16 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmmediafiles\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmmediafile.batch'>
-    <?php echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmmediafile.batch']);

--- a/admin/tmpl/cwmmessage/edit.php
+++ b/admin/tmpl/cwmmessage/edit.php
@@ -423,18 +423,7 @@ echo Route::_(
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php
-                echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <!-- Hidden fields -->
         <?php

--- a/admin/tmpl/cwmmessages/default.php
+++ b/admin/tmpl/cwmmessages/default.php
@@ -99,11 +99,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessages'); ?>" method="pos
                         </a>
                     </div>
                     <?php else: ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-                        <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                     <?php endif; ?>
                 <?php else : ?>
                     <table class="table" id="messagesList">

--- a/admin/tmpl/cwmmessages/default_batch_footer.php
+++ b/admin/tmpl/cwmmessages/default_batch_footer.php
@@ -14,16 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmmessages\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmmessage.batch'>
-    <?php echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmmessage.batch']);

--- a/admin/tmpl/cwmmessages/modal.php
+++ b/admin/tmpl/cwmmessages/modal.php
@@ -61,13 +61,7 @@ if (!empty($editor)) {
 
         <?php
         if (empty($this->items)) : ?>
-            <div class="alert alert-info">
-                <span class="icon-info-circle" aria-hidden="true"></span><span
-                        class="visually-hidden"><?php
-                        echo Text::_('INFO'); ?></span>
-                <?php
-                echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-            </div>
+            <?php echo LayoutHelper::render('html.empty_state'); ?>
             <?php else : ?>
             <table class="table table-sm">
                 <caption class="visually-hidden">

--- a/admin/tmpl/cwmmessagetype/edit.php
+++ b/admin/tmpl/cwmmessagetype/edit.php
@@ -58,28 +58,9 @@ echo Route::_('index.php?option=com_proclaim&layout=edit&id=' . (int)$this->item
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <?php
         echo HTMLHelper::_('uitab.endTabSet'); ?>

--- a/admin/tmpl/cwmmessagetypes/default.php
+++ b/admin/tmpl/cwmmessagetypes/default.php
@@ -47,13 +47,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessagetypes'); ?>" method=
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="messagetypeslist">
                         <thead>

--- a/admin/tmpl/cwmmessagetypes/default_batch_footer.php
+++ b/admin/tmpl/cwmmessagetypes/default_batch_footer.php
@@ -14,19 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmmediafiles\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmmessagetype.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmmessagetype.batch']);

--- a/admin/tmpl/cwmpodcast/edit.php
+++ b/admin/tmpl/cwmpodcast/edit.php
@@ -278,23 +278,9 @@ $wa->addInlineScript(
         <?php endif; ?>
         <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php if ($this->canDo->get('core.admin')) : ?>
-            <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <div class="col-lg-12">
-                    <?php echo $this->form->getInput('rules'); ?>
-                </div>
-            </div>
-            <?php echo HTMLHelper::_('uitab.endTab'); ?>
-        <?php endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
     </div>

--- a/admin/tmpl/cwmpodcasts/default.php
+++ b/admin/tmpl/cwmpodcasts/default.php
@@ -50,13 +50,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmpodcasts'); ?>" method="pos
                 <?php echo Cwmstats::getPodcastTaskState(); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table table-striped adminlist" id="podcasts">
                         <thead>

--- a/admin/tmpl/cwmpodcasts/default_batch_footer.php
+++ b/admin/tmpl/cwmpodcasts/default_batch_footer.php
@@ -14,18 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmpodcasts\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmpodcast.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmpodcast.batch']);

--- a/admin/tmpl/cwmserie/edit.php
+++ b/admin/tmpl/cwmserie/edit.php
@@ -70,16 +70,7 @@ echo Route::_('index.php?option=com_proclaim&layout=' . $currentLayout . '&id=' 
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
         <?php if (!empty($this->item->id) && $this->item->id > 0) : ?>
         <?php
@@ -143,20 +134,7 @@ echo Route::_('index.php?option=com_proclaim&layout=' . $currentLayout . '&id=' 
         <?php echo HTMLHelper::_('uitab.endTab'); ?>
         <?php endif; ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_CMN_FIELDSET_RULES')); ?>
-            <fieldset id="fieldset-rules" class="options-form">
-                <div>
-                <?php
-                echo $this->form->getInput('rules'); ?>
-                </div>
-            </fieldset>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <input type="hidden" name="task" value=""/>
         <input type="hidden" name="return" value="<?php

--- a/admin/tmpl/cwmseries/default.php
+++ b/admin/tmpl/cwmseries/default.php
@@ -55,13 +55,7 @@ if (str_contains($listOrder, 'publish_up')) {
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="seriesList">
                         <thead>

--- a/admin/tmpl/cwmseries/default_batch_footer.php
+++ b/admin/tmpl/cwmseries/default_batch_footer.php
@@ -14,21 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmseries\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$published = $this->state->get('filter.published');
-
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmserie.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmserie.batch']);

--- a/admin/tmpl/cwmseries/modal.php
+++ b/admin/tmpl/cwmseries/modal.php
@@ -63,13 +63,7 @@ if (!empty($editor)) {
     echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
     <?php
     if (empty($this->items)) : ?>
-        <div class="alert alert-info">
-            <span class="icon-info-circle" aria-hidden="true"></span><span
-                    class="visually-hidden"><?php
-                    echo Text::_('INFO'); ?></span>
-            <?php
-            echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-        </div>
+        <?php echo LayoutHelper::render('html.empty_state'); ?>
         <?php else : ?>
         <table class="table table-sm">
             <caption class="visually-hidden">

--- a/admin/tmpl/cwmserver/edit.php
+++ b/admin/tmpl/cwmserver/edit.php
@@ -169,17 +169,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmserver&layout=' . $currentL
             endif; ?>
             <?php
         endif; ?>
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
         <input type="hidden" name="task" value=""/>
         <input type="hidden" name="return" value="<?php
         echo $input->getBase64('return'); ?>"/>

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -85,13 +85,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="messagesList">
                         <caption class="visually-hidden">

--- a/admin/tmpl/cwmservers/default_batch_footer.php
+++ b/admin/tmpl/cwmservers/default_batch_footer.php
@@ -14,18 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmservers\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmserver.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmserver.batch']);

--- a/admin/tmpl/cwmservers/modal.php
+++ b/admin/tmpl/cwmservers/modal.php
@@ -45,13 +45,7 @@ $onclick   = $this->escape($function);
         echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
         <?php
         if (empty($this->items)) : ?>
-            <div class="alert alert-info">
-                <span class="icon-info-circle" aria-hidden="true"></span><span
-                        class="visually-hidden"><?php
-                        echo Text::_('INFO'); ?></span>
-                <?php
-                echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-            </div>
+            <?php echo LayoutHelper::render('html.empty_state'); ?>
             <?php else : ?>
             <table class="table table-sm">
                 <caption class="visually-hidden">

--- a/admin/tmpl/cwmservers/types.php
+++ b/admin/tmpl/cwmservers/types.php
@@ -17,6 +17,7 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
 $app = Factory::getApplication();
@@ -74,10 +75,7 @@ $typeIcons = [
 ?>
 <div class="container-fluid p-3">
     <?php if (empty($this->types)) : ?>
-        <div class="alert alert-info">
-            <span class="icon-info-circle" aria-hidden="true"></span>
-            <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-        </div>
+        <?php echo LayoutHelper::render('html.empty_state'); ?>
     <?php else : ?>
         <h6 class="text-body-secondary mb-3"><?php echo Text::_('JBS_CMN_SELECT_SERVERTYPE'); ?></h6>
         <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">

--- a/admin/tmpl/cwmteacher/edit.php
+++ b/admin/tmpl/cwmteacher/edit.php
@@ -228,24 +228,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
         <?php endif; ?>
 
         <?php // ===== Publishing Tab =====?>
-        <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php // ===== Permissions Tab =====?>
-        <?php if ($this->canDo->get('core.admin')) : ?>
-        <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_CMN_FIELDSET_RULES')); ?>
-        <fieldset id="fieldset-rules" class="options-form">
-            <div>
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-        </fieldset>
-        <?php echo HTMLHelper::_('uitab.endTab'); ?>
-        <?php endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <input type="hidden" name="task" value=""/>
         <input type="hidden" name="return" value="<?php echo $input->getBase64('return'); ?>"/>

--- a/admin/tmpl/cwmteachers/default.php
+++ b/admin/tmpl/cwmteachers/default.php
@@ -53,13 +53,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmteachers'); ?>" method="pos
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="teachers">
                         <caption class="visually-hidden">

--- a/admin/tmpl/cwmteachers/default_batch_footer.php
+++ b/admin/tmpl/cwmteachers/default_batch_footer.php
@@ -14,21 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmteachers\HtmlView $this */
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$published = $this->state->get('filter.published');
-
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmteacher.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmteacher.batch']);

--- a/admin/tmpl/cwmteachers/modal.php
+++ b/admin/tmpl/cwmteachers/modal.php
@@ -58,13 +58,7 @@ if (!empty($editor)) {
         echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
         <?php
         if (empty($this->items)) : ?>
-            <div class="alert alert-info">
-                <span class="icon-info-circle" aria-hidden="true"></span><span
-                        class="visually-hidden"><?php
-                        echo Text::_('INFO'); ?></span>
-                <?php
-                echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-            </div>
+            <?php echo LayoutHelper::render('html.empty_state'); ?>
             <?php else : ?>
             <table class="table table-sm">
                 <caption class="visually-hidden">

--- a/admin/tmpl/cwmtemplate/edit.php
+++ b/admin/tmpl/cwmtemplate/edit.php
@@ -414,18 +414,7 @@ endforeach;
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php
-echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <input type="hidden" name="task" value=""/>
         <?php echo HTMLHelper::_('form.token'); ?>

--- a/admin/tmpl/cwmtemplatecode/edit.php
+++ b/admin/tmpl/cwmtemplatecode/edit.php
@@ -212,28 +212,9 @@ echo Route::_('index.php?option=com_proclaim&layout=edit&id=' . (int)$this->item
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
 
         <input type="hidden" name="task" value=""/>
         <?php

--- a/admin/tmpl/cwmtemplatecodes/default.php
+++ b/admin/tmpl/cwmtemplatecodes/default.php
@@ -49,13 +49,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplatecodes'); ?>" method
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                                echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                     <?php else : ?>
                     <table class="table itemList" id="templatecodes">
                         <thead>

--- a/admin/tmpl/cwmtemplates/default.php
+++ b/admin/tmpl/cwmtemplates/default.php
@@ -47,13 +47,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplates'); ?>" method="po
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="templatelist">
                         <thead>

--- a/admin/tmpl/cwmtemplates/default_batch_footer.php
+++ b/admin/tmpl/cwmtemplates/default_batch_footer.php
@@ -14,18 +14,8 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-/** @var CWM\Component\Proclaim\Administrator\View\Cwmtemplates\HtmlView $this */
+use Joomla\CMS\Layout\LayoutHelper;
 
-use Joomla\CMS\Language\Text;
+$this->getDocument()->getWebAssetManager()->useScript('com_proclaim.cwmadmin-batch-footer');
 
-$wa = $this->getDocument()->getWebAssetManager();
-$wa->useScript('com_proclaim.cwmadmin-batch-footer');
-?>
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-    <?php
-    echo Text::_('JCANCEL'); ?>
-</button>
-<button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='cwmtemplate.batch'>
-    <?php
-    echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+echo LayoutHelper::render('html.batch.footer', ['submitTask' => 'cwmtemplate.batch']);

--- a/admin/tmpl/cwmtopic/edit.php
+++ b/admin/tmpl/cwmtopic/edit.php
@@ -83,28 +83,9 @@ if (str_starts_with($string, 'JBS')) { ?>
         <?php
         echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'publish', Text::_('JBS_STY_PUBLISH')); ?>
-        <div class="row">
-            <div class="col-lg-12">
-                <?php
-echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php echo LayoutHelper::render('edit.publish_tab', $this); ?>
 
-        <?php
-        if ($this->canDo->get('core.admin')) : ?>
-            <?php
-            echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('JBS_ADM_ADMIN_PERMISSIONS')); ?>
-            <div class="row">
-                <?php echo $this->form->getInput('rules'); ?>
-            </div>
-            <?php
-            echo HTMLHelper::_('uitab.endTab'); ?>
-            <?php
-        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
         <?php
         echo $this->form->getInput('id'); ?>
         <?php

--- a/admin/tmpl/cwmtopics/default.php
+++ b/admin/tmpl/cwmtopics/default.php
@@ -47,13 +47,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtopics'); ?>" method="post"
                 echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
                 <?php
                 if (empty($this->items)) : ?>
-                    <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span
-                                class="visually-hidden"><?php
-                            echo Text::_('INFO'); ?></span>
-                        <?php
-                        echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-                    </div>
+                    <?php echo LayoutHelper::render('html.empty_state'); ?>
                 <?php else : ?>
                     <table class="table itemList" id="topics">
                         <thead>


### PR DESCRIPTION
## Summary

Extracted 4 reusable Joomla layouts from duplicate template blocks across 40+ files. Net result: **210 lines added, 464 removed** (-254 lines).

### New layouts

| Layout | Replaces | Files Updated |
|--------|----------|---------------|
| `edit/permissions_tab.php` | Admin permissions tab with rules input | 12 edit views |
| `edit/publish_tab.php` | Publishing data tab | 8 edit views |
| `html/empty_state.php` | "No matching results" alert | 18 list/modal views |
| `html/batch/footer.php` | Batch modal Cancel/Process buttons | 10 list views |

### What was NOT extracted
- `cwmmessage/edit.php` publish tab — has extra meta fields
- `cwmserver/edit.php` publish tab — in sidebar, not its own tab
- Batch body forms — too entity-specific

## Test plan
- [ ] All edit views show Permissions tab for super admin
- [ ] All edit views show Publishing tab with correct dates
- [ ] All list views show "No matching results" when filtered empty
- [ ] All batch modals show Cancel/Process buttons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)