### PR TITLE
fix: remove redundant controller overrides and fix edit() return bug

### DIFF
--- a/admin/src/Controller/CwmcommentController.php
+++ b/admin/src/Controller/CwmcommentController.php
@@ -64,21 +64,6 @@ class CwmcommentController extends FormController
     }
 
     /**
-     * Method override to check if you can add a new record.
-     *
-     * @param   array  $data  An array of input data.
-     *
-     * @return  bool
-     *
-     * @since   1.6
-     */
-    protected function allowAdd($data = []): bool
-    {
-        // In the absence of better information, revert to the component permissions.
-        return parent::allowAdd();
-    }
-
-    /**
      * Method override to check if you can edit an existing record.
      *
      * @param   array   $data  An array of input data.

--- a/admin/src/Controller/CwmlocationController.php
+++ b/admin/src/Controller/CwmlocationController.php
@@ -113,9 +113,6 @@ class CwmlocationController extends FormController
      */
     public function batch($model = null): bool
     {
-        $this->checkToken();
-
-        // Preset the redirect
         $this->setRedirect(
             Route::_('index.php?option=com_proclaim&view=cwmlocations' . $this->getRedirectToListAppend(), false)
         );

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -99,7 +99,7 @@ class CwmmediafileController extends FormController
             $app->setUserState('com_proclaim.edit.mediafile.server_id', null);
         }
 
-        return true;
+        return $result;
     }
 
     /**

--- a/admin/src/Controller/CwmpodcastController.php
+++ b/admin/src/Controller/CwmpodcastController.php
@@ -84,9 +84,6 @@ class CwmpodcastController extends FormController
      */
     public function batch($model = null): bool
     {
-        $this->checkToken();
-
-        // Preset the redirect
         $this->setRedirect(
             Route::_('index.php?option=com_proclaim&view=cwmpodcasts' . $this->getRedirectToListAppend(), false)
         );

--- a/admin/src/Controller/CwmserieController.php
+++ b/admin/src/Controller/CwmserieController.php
@@ -117,22 +117,6 @@ class CwmserieController extends FormController
     }
 
     /**
-     * Method override to check if you can add a new record.
-     *
-     * @param   array  $data  An array of input data.
-     *
-     * @return  bool
-     *
-     * @since   1.6
-     */
-    protected function allowAdd($data = []): bool
-    {
-        $allow = null;
-
-        return $allow ?? parent::allowAdd();
-    }
-
-    /**
      * Method override to check if you can edit an existing record.
      *
      * @param   array   $data  An array of input data.

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -204,9 +204,6 @@ class CwmserverController extends FormController
      */
     public function batch($model = null): bool
     {
-        $this->checkToken();
-
-        // Preset the redirect
         $this->setRedirect(
             Route::_('index.php?option=com_proclaim&view=cwmservers' . $this->getRedirectToListAppend(), false)
         );

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -911,17 +911,12 @@ class CwmmigrationHelper
      * @return  int
      *
      * @since   10.1.0
+     *
+     * @deprecated Use CwmlocationHelper::getPublishedLocationCount() instead. Will be removed in 11.0.
      */
     public static function getPublishedLocationCount(): int
     {
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->getQuery(true)
-            ->select('COUNT(*)')
-            ->from($db->quoteName('#__bsms_locations'))
-            ->where($db->quoteName('published') . ' = 1');
-        $db->setQuery($query);
-
-        return (int) $db->loadResult();
+        return CwmlocationHelper::getPublishedLocationCount();
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Remove redundant `allowAdd()`** from CwmserieController and CwmcommentController — just called parent with no extra logic
- **Remove redundant `checkToken()`** from `batch()` in Location, Podcast, and Server controllers — parent::batch() already calls it
- **Fix `edit()` return bug** in CwmmediafileController — was always returning `true` instead of actual result from parent
- **Deprecate duplicate** `getPublishedLocationCount()` in CwmmigrationHelper — delegates to CwmlocationHelper

7 files, -49 lines net.

## Test plan

- [ ] Batch operations work on all entity list views
- [ ] Media file edit/cancel navigation works correctly
- [ ] Series and Comment create (allowAdd) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)