### PR TITLE
Fix security vulnerabilities: XSS, open redirect, path traversal, IDOR

### DIFF
--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -21,11 +21,11 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmaiHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmalias;
 use CWM\Component\Proclaim\Administrator\Helper\CwmcsvimportHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
-use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmdescriptionHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmImageCleanup;
 use CWM\Component\Proclaim\Administrator\Helper\CwmImageMigration;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmthumbnail;
 use CWM\Component\Proclaim\Administrator\Helper\CwmupgradeHelper;
@@ -42,6 +42,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Folder;
 use Joomla\Registry\Registry;
@@ -2153,10 +2154,10 @@ class CwmadminController extends FormController
             }
 
             echo json_encode([
-                'success'  => true,
-                'count'    => $total,
-                'counts'   => $counts,
-                'message'  => $message,
+                'success' => true,
+                'count'   => $total,
+                'counts'  => $counts,
+                'message' => $message,
             ], JSON_THROW_ON_ERROR);
         } catch (\Exception $e) {
             echo json_encode([
@@ -2194,7 +2195,8 @@ class CwmadminController extends FormController
             }
         }
 
-        $redirect = $return ? base64_decode($return) : 'index.php?option=com_proclaim';
+        $decoded  = $return ? base64_decode($return) : '';
+        $redirect = ($decoded && Uri::isInternal($decoded)) ? $decoded : 'index.php?option=com_proclaim';
         $app->redirect($redirect);
     }
 

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -162,7 +162,7 @@ class CwmmediafileController extends FormController
             $app = Factory::getApplication();
             $app->close();
         } else {
-            throw new \RuntimeException(Text::sprintf('Handler: "' . $handler . '" does not exist!'), 404);
+            throw new \RuntimeException(Text::sprintf('Handler: "%s" does not exist!', htmlspecialchars($handler, ENT_QUOTES, 'UTF-8')), 404);
         }
     }
 
@@ -244,8 +244,14 @@ class CwmmediafileController extends FormController
             }
         }
 
-        if ($this->input->getCmd('return') && parent::cancel($key)) {
-            $this->setRedirect(base64_decode($this->input->getCmd('return')));
+        $return = $this->input->getCmd('return');
+
+        if ($return && parent::cancel($key)) {
+            $decoded = base64_decode($return);
+
+            if ($decoded && Uri::isInternal($decoded)) {
+                $this->setRedirect($decoded);
+            }
 
             return true;
         }
@@ -532,8 +538,12 @@ class CwmmediafileController extends FormController
         $task   = $this->input->get('task');
 
         if ($return && $task !== 'apply') {
-            Factory::getApplication()->enqueueMessage(Text::_('JBS_MED_SAVE'), 'message');
-            $this->setRedirect(base64_decode($return));
+            $decoded = base64_decode($return);
+
+            if ($decoded && Uri::isInternal($decoded)) {
+                Factory::getApplication()->enqueueMessage(Text::_('JBS_MED_SAVE'), 'message');
+                $this->setRedirect($decoded);
+            }
         }
     }
 

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -477,7 +477,8 @@ class Cwmrestore
 
         // Build the appropriate paths
         $config   = Factory::getApplication()->getConfig();
-        $tmp_dest = $config->get('tmp_path') . '/' . $userFile['name'];
+        $safeName = File::makeSafe($userFile['name']);
+        $tmp_dest = $config->get('tmp_path') . '/' . basename($safeName);
         $tmp_src  = $userFile['tmp_name'];
 
         // Move an uploaded file.

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -38,10 +38,10 @@ $wa->useScript('core')
 
 $msg   = '';
 $input = Factory::getApplication()->getInput();
-$msg   = $input->get('msg');
+$msg   = $input->getString('msg', '');
 
 if ($msg) {
-    echo $msg;
+    echo htmlspecialchars($msg, ENT_QUOTES, 'UTF-8');
 }
 
 $simple = Cwmhelper::getSimpleView();

--- a/site/src/Controller/CwmsermonsController.php
+++ b/site/src/Controller/CwmsermonsController.php
@@ -18,6 +18,7 @@ use CWM\Component\Proclaim\Site\Helper\Cwmmedia;
 use CWM\Component\Proclaim\Site\Model\CwmsermonsModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -66,9 +67,14 @@ class CwmsermonsController extends BaseController
         CwmanalyticsHelper::logEvent('play', 0, $id);
 
         // Now the hit has been updated will redirect to the url.
-        $return = $app->getInput()->get('return');
-        $return = base64_decode($return);
-        $app->redirect($return);
+        $return = $app->getInput()->getBase64('return', '');
+        $return = $return ? base64_decode($return) : '';
+
+        if ($return && Uri::isInternal($return)) {
+            $app->redirect($return);
+        } else {
+            $app->redirect('index.php');
+        }
     }
 
     /**

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -77,13 +77,22 @@ class Cwmdownload
                 $db->quoteName('#__bsms_servers') . ' ON ('
                 . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
             )
-            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid);
+            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid)
+            ->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
         $db->setQuery($query, 0, 1);
 
         $media = $db->loadObject();
 
         if (!$media) {
             $this->sendError($app, 404, 'Media not found');
+        }
+
+        // Verify the current user has the required access level
+        $user         = $app->getIdentity();
+        $accessLevels = $user->getAuthorisedViewLevels();
+
+        if (isset($media->access) && !\in_array((int) $media->access, $accessLevels, true)) {
+            $this->sendError($app, 403, 'Access denied');
         }
 
         // Increment download count after validation
@@ -145,7 +154,8 @@ class Cwmdownload
 
         header('Content-Description: File Transfer');
         header('Content-Type: application/octet-stream');
-        header('Content-Disposition: attachment; filename="' . basename($params->get('filename')) . '"');
+        $safeFilename = preg_replace('/[^\w.\-]/', '_', basename($params->get('filename')));
+        header('Content-Disposition: attachment; filename="' . $safeFilename . '"');
         header('Expires: 0');
         header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
         header('Cache-Control: private', false);

--- a/site/tmpl/cwmseriespodcastdisplay/default.php
+++ b/site/tmpl/cwmseriespodcastdisplay/default.php
@@ -88,16 +88,16 @@ $CWMedia = new Cwmmedia();
                                 ); ?>
                                 <td>
                                     <?php
-                                    echo stripslashes($item->studytitle); ?>
+                                    echo htmlspecialchars(stripslashes($item->studytitle), ENT_QUOTES, 'UTF-8'); ?>
                                 </td>
                                 <td>
                                     <?php
                                     echo HTMLHelper::Date($item->createdate); ?>
                                 </td>
                                 <td>
-                                    <a href="javascript:loadVideo('<?php
-                                    echo $path1; ?>', '<?php
-                                    echo $item->series_thumbnail; ?>')">
+                                    <a href="javascript:loadVideo(<?php
+                                    echo htmlspecialchars(json_encode($path1), ENT_QUOTES, 'UTF-8'); ?>, <?php
+                                    echo htmlspecialchars(json_encode($item->series_thumbnail), ENT_QUOTES, 'UTF-8'); ?>)">
                                         <?php
                                         echo Text::_('JBS_CMN_LISTEN'); ?>
                                     </a>

--- a/site/tmpl/cwmsermon/default_commentsform.php
+++ b/site/tmpl/cwmsermon/default_commentsform.php
@@ -83,7 +83,7 @@ if (!$this->item->id) {
                                     </span>
                                 </div>
                                 <div class="comment-text">
-                                    <?php echo $comment->comment_text; ?>
+                                    <?php echo htmlspecialchars($comment->comment_text, ENT_QUOTES, 'UTF-8'); ?>
                                 </div>
                             </div>
                         <?php endforeach; ?>


### PR DESCRIPTION
Summary
	∙	Reflected XSS in admin cpanel: user-supplied msg query parameter was echoed without escaping
	∙	Stored XSS in comment display: comment_text rendered without htmlspecialchars()
	∙	XSS in JavaScript context: variables injected into javascript: href without proper encoding in podcast template
	∙	Open redirect in 3 controllers: base64-decoded return parameter used in redirects without Uri::isInternal() validation
	∙	Path traversal in backup restore: uploaded filename used in path without File::makeSafe() / basename() sanitization
	∙	IDOR on media downloads: media files served by ID without checking published status or user access levels
	∙	Header injection: Content-Disposition filename not sanitized
	∙	Error message XSS: user-supplied handler name concatenated into exception message without escaping
Test plan
	∙	All 538 PHPUnit tests pass (0 failures)
	∙	PHP syntax check passes (0 errors in 1252 files)
	∙	Verify admin cpanel ?msg=<script>alert(1)</script> no longer executes JS
	∙	Verify comment text with HTML is displayed escaped
	∙	Verify redirect with external base64-encoded URL falls back to internal route
	∙	Verify media download returns 403 for unauthorized access levels
	∙	Verify backup restore rejects filenames with path traversal characters