### PR TITLE
feat: add teacher organization name to frontend rendering

### DIFF
--- a/admin/forms/template.xml
+++ b/admin/forms/template.xml
@@ -1035,6 +1035,16 @@
                    description="JBS_TPL_CUSTOMCLASS_DESC"/>
             <field name="tsteacher-titlelinktype" type="TeacherLinkOptions" default="0" label="JBS_TPL_TYPE_OF_LINK"
                    description="JBS_TPL_TYPE_OF_LINK_DESC"/>
+            <field name="tsteacherorgnamerow" type="RowOptions" size="1" default="0" label="JBS_TCH_ORG_NAME"
+                   description="JBS_TPL_ROW_DESC"/>
+            <field name="tsteacherorgnamecol" type="SpanOptions" default="1" label="JBS_TPL_COLUMN"
+                   description="JBS_TPL_COLUMN_DESC"/>
+            <field name="tsteacherorgnamecolspan" type="SpanOptions" default="0" label="JBS_TPL_COLSPAN"
+                   description="JBS_TPL_COLSPAN_DESC"/>
+            <field name="tsteacherorgnameelement" type="ElementOptions" default="0" translate="true" multiple="false"
+                   label="JBS_TPL_ELEMENT" description="JBS_TPL_ELEMENT_DESC"/>
+            <field name="tsteacherorgnamecustom" type="text" size="100" label="JBS_TPL_CUSTOMCLASS"
+                   description="JBS_TPL_CUSTOMCLASS_DESC"/>
             <field name="tsteachercardrow" type="RowOptions" size="1" default="0" label="JBS_CMN_TEACHER_CARD"
                    description="JBS_TPL_ROW_DESC"/>
             <field name="tsteachercardcol" type="SpanOptions" default="1" label="JBS_TPL_COLUMN"
@@ -1246,6 +1256,16 @@
                    description="JBS_TPL_CUSTOMCLASS_DESC"/>
             <field name="tdteacher-titlelinktype" type="TeacherLinkOptions" default="0" label="JBS_TPL_TYPE_OF_LINK"
                    description="JBS_TPL_TYPE_OF_LINK_DESC"/>
+            <field name="tdteacherorgnamerow" type="RowOptions" size="1" default="0" label="JBS_TCH_ORG_NAME"
+                   description="JBS_TPL_ROW_DESC"/>
+            <field name="tdteacherorgnamecol" type="SpanOptions" default="1" label="JBS_TPL_COLUMN"
+                   description="JBS_TPL_COLUMN_DESC"/>
+            <field name="tdteacherorgnamecolspan" type="SpanOptions" default="0" label="JBS_TPL_COLSPAN"
+                   description="JBS_TPL_COLSPAN_DESC"/>
+            <field name="tdteacherorgnameelement" type="ElementOptions" default="0" translate="true" multiple="false"
+                   label="JBS_TPL_ELEMENT" description="JBS_TPL_ELEMENT_DESC"/>
+            <field name="tdteacherorgnamecustom" type="text" size="100" label="JBS_TPL_CUSTOMCLASS"
+                   description="JBS_TPL_CUSTOMCLASS_DESC"/>
             <field name="tdteachercardrow" type="RowOptions" size="1" default="0" label="JBS_CMN_TEACHER_CARD"
                    description="JBS_TPL_ROW_DESC"/>
             <field name="tdteachercardcol" type="SpanOptions" default="1" label="JBS_TPL_COLUMN"

--- a/admin/src/Field/CustomField.php
+++ b/admin/src/Field/CustomField.php
@@ -89,6 +89,7 @@ class CustomField extends FormField
         '{{length}}'           => 'JBS_CMN_DURATION',
         '{{series}}'           => 'JBS_CMN_SERIES',
         '{{series_thumbnail}}' => 'JBS_CMN_SERIES_THUMBNAIL',
+        '{{teacherorgname}}'   => 'JBS_TCH_ORG_NAME',
     ];
 
     /**

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -137,7 +137,7 @@ class Cwmlisting
             'hits', 'downloads', 'studynumber', 'topic', 'locations', 'jbsmedia', 'messagetype',
             'thumbnail', 'teacherimage', 'teacheremail', 'teacherweb', 'teacherphone', 'teacherfb', 'teachertw',
             'teacherblog', 'teachershort', 'teacherlong', 'teacheraddress', 'teacherlink1',
-            'teacherlink2', 'teacherlink3', 'teacherlargeimage', 'teacherallinone',
+            'teacherlink2', 'teacherlink3', 'teacherlargeimage', 'teacherallinone', 'teacherorgname',
         ];
 
         foreach ($standardParams as $paramName) {
@@ -1143,6 +1143,14 @@ class Cwmlisting
                     $data = Text::_('JBS_TCH_PHONE');
                 } else {
                     (isset($item->phone) ? $data = '<a href="tel:' . preg_replace('/[^0-9]/', '', $item->phone) . '" target="_blank">' . $item->phone . '</a>' : $data);
+                }
+                break;
+
+            case $extra . 'teacherorgname':
+                if ($header === 1) {
+                    $data = Text::_('JBS_TCH_ORG_NAME');
+                } else {
+                    $data = trim($item->teacherorgname ?? $item->org_name ?? '');
                 }
                 break;
 
@@ -2620,8 +2628,9 @@ class Cwmlisting
             '{{bookname}}'    => $row->bookname ?? '',
             '{{hits}}'        => $row->hits ?? '',
             '{{location}}'    => $row->location_text ?? '',
-            '{{plays}}'       => $row->totalplays ?? '',
-            '{{downloads}}'   => $row->totaldownloads ?? '',
+            '{{plays}}'            => $row->totalplays ?? '',
+            '{{downloads}}'        => $row->totaldownloads ?? '',
+            '{{teacherorgname}}'   => $row->teacherorgname ?? $row->org_name ?? '',
         ];
 
         $label = str_replace(array_keys($replacements), array_values($replacements), $label);

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -345,6 +345,7 @@ class Cwmpagebuilder
         $query->select(
             $db->quoteName('teacher.teachername', 'teachername') . ', '
             . $db->quoteName('teacher.title', 'teachertitle') . ', '
+            . $db->quoteName('teacher.org_name', 'teacherorgname') . ', '
             . $db->quoteName('teacher.teacher_thumbnail', 'thumb')
         );
         $query->join(


### PR DESCRIPTION
## Summary

Exposes the teacher `org_name` field on frontend views so visitors can see the organization, not just schema.org crawlers.

### Changes
- **Cwmpagebuilder.php** — add `org_name` to teacher query SELECT (aliased as `teacherorgname`)
- **Cwmlisting.php** — add `teacherorgname` to standard params, rendering case, and `{{teacherorgname}}` template code substitution
- **template.xml** — Layout Editor fields for both `ts` (teacher list) and `td` (teacher detail) contexts
- **CustomField.php** — add `{{teacherorgname}}` to template code picker

### Display locations
- Layout Editor: drag-and-drop element in teacher list and teacher detail contexts
- Template codes: `{{teacherorgname}}` available in custom template text fields
- Falls back gracefully — blank org_name renders nothing

## Test plan

- [x] Open template editor → teacher elements show "Organization" option
- [ ] Add teacherorgname element to a teacher context → renders org_name on frontend
- [ ] Use `{{teacherorgname}}` in a custom template field → substitutes correctly
- [ ] Teacher with no org_name → element renders empty (no errors)
- [x] All 538 PHPUnit tests pass
- [x] PHP syntax clean

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)