### PR TITLE
Potential fix for code scanning alert no. 51: Double escaping or unescaping

### DIFF
--- a/build/media_source/js/message-wizard.es6.js
+++ b/build/media_source/js/message-wizard.es6.js
@@ -183,10 +183,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Strip HTML tags for preview using regex (no DOM parsing needed)
         let introPreview = introText.replace(/<[^>]*>/g, '');
-        // Decode common HTML entities
-        introPreview = introPreview.replace(/&amp;/g, '&').replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#039;/g, "'")
-            .replace(/&nbsp;/g, ' ');
+
+        // Decode HTML entities using DOM to avoid double-unescaping issues
+        const decodeHtml = (str) => {
+            const d = document.createElement('textarea');
+            d.innerHTML = str;
+
+            return d.value;
+        };
+
+        introPreview = decodeHtml(introPreview);
         introPreview = introPreview.substring(0, 200);
 
         const escHtml = (str) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Joomla-Bible-Study/Proclaim/security/code-scanning/51](https://github.com/Joomla-Bible-Study/Proclaim/security/code-scanning/51)

In general, to fix double-unescaping issues when decoding HTML entities, avoid manually chaining `.replace` calls that touch `&amp;` before other entities. Either (1) decode `&amp;` last if you keep the manual approach, or (2) use a standard, well-tested decoding mechanism such as the browser’s DOM parsing (setting `innerHTML` and reading `textContent`), which handles entity decoding correctly and avoids ordering bugs.

The best minimal-impact fix here is to replace the manual `.replace` chain on `introPreview` with a small helper that safely decodes HTML entities using the DOM. That way, we remove the incorrect order problem entirely without changing functionality: we still decode common entities, but we rely on the browser’s parser. Concretely, in `build/media_source/js/message-wizard.es6.js` around lines 184–190, we should (a) add a local function `decodeHtml` (similar in style to the existing `escHtml` helper) and (b) replace the current `introPreview = introPreview.replace(...).replace(...);` chain with `introPreview = decodeHtml(introPreview);`. No external imports are needed; this uses `document.createElement`, which is already available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
