### PR TITLE
fix: add missing org_name migration for teacher table

### DIFF
--- a/admin/sql/updates/mysql/10.3.0-20260322.sql
+++ b/admin/sql/updates/mysql/10.3.0-20260322.sql
@@ -111,3 +111,6 @@ WHERE `params` LIKE '%"fab %';
 UPDATE `#__bsms_templates`
 SET `params` = REPLACE(`params`, '"far ', '"fa-regular ')
 WHERE `params` LIKE '%"far %';
+
+-- Add organization name column to teachers table (issue #1198)
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `org_name` VARCHAR(255) DEFAULT NULL AFTER `title`;


### PR DESCRIPTION
## Summary
- Adds `ALTER TABLE` migration to create the `org_name` column on existing installs
- The column was present in fresh install SQL, Table class, form XML, and edit template — but no upgrade migration existed, so upgraded databases silently dropped organization data on save

Closes #1198

## Test plan
- [ ] On an existing install (upgraded from 10.2.x), verify the `org_name` column is added to `#__bsms_teachers` after running the update
- [ ] Save a teacher with an organization name — verify it persists after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)