### PR TITLE
refactor: replace deprecated Joomla APIs with J6-native equivalents

### DIFF
--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -20,8 +20,6 @@ use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
 use CWM\Component\Proclaim\Administrator\Table\CwmmediafileTable;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseModel;
@@ -635,18 +633,21 @@ class CwmmediafileController extends FormController
         // Ensure destination directory exists
         $destDir = JPATH_ROOT . '/media/com_proclaim/captions';
 
-        if (!is_dir($destDir)) {
-            Folder::create($destDir);
+        if (!is_dir($destDir) && !mkdir($destDir, 0755, true) && !is_dir($destDir)) {
+            echo json_encode(['success' => false, 'error' => Text::_('JBS_MED_VTT_UPLOAD_FAILED')]);
+            Factory::getApplication()->close();
+
+            return;
         }
 
         // Build safe filename: caption_{timestamp}_{sanitised-original}.ext
-        $baseName = File::makeSafe(pathinfo($userfile['name'], PATHINFO_FILENAME));
+        $baseName = pathinfo($userfile['name'], PATHINFO_FILENAME);
         $baseName = preg_replace('/[^a-zA-Z0-9_-]/', '', $baseName) ?: 'caption';
         $fileName = 'caption_' . time() . '_' . mb_substr($baseName, 0, 50) . '.' . $ext;
 
         $destPath = $destDir . '/' . $fileName;
 
-        if (!File::upload($userfile['tmp_name'], $destPath, false, true)) {
+        if (!move_uploaded_file($userfile['tmp_name'], $destPath)) {
             echo json_encode(['success' => false, 'error' => Text::_('JBS_MED_VTT_UPLOAD_FAILED')]);
             Factory::getApplication()->close();
 

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Helper\CwmcaptionValidator;
 use CWM\Component\Proclaim\Administrator\Table\CwmmediafileTable;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -578,24 +579,20 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        // Validate file extension
-        $allowedExt = ['vtt', 'srt'];
-        $ext        = strtolower(pathinfo($userfile['name'], PATHINFO_EXTENSION));
+        $validator = new CwmcaptionValidator();
+        $ext       = strtolower(pathinfo($userfile['name'], PATHINFO_EXTENSION));
 
-        if (!\in_array($ext, $allowedExt, true)) {
+        if (!$validator->isAllowedExtension($ext)) {
             echo json_encode([
                 'success' => false,
-                'error'   => Text::sprintf('JBS_MED_VTT_INVALID_TYPE', implode(', ', $allowedExt)),
+                'error'   => Text::sprintf('JBS_MED_VTT_INVALID_TYPE', implode(', ', CwmcaptionValidator::ALLOWED_EXTENSIONS)),
             ]);
             Factory::getApplication()->close();
 
             return;
         }
 
-        // Max 2 MB for caption files
-        $maxSize = 2 * 1024 * 1024;
-
-        if ($userfile['size'] > $maxSize) {
+        if (!$validator->isAllowedSize((int) $userfile['size'])) {
             echo json_encode([
                 'success' => false,
                 'error'   => Text::sprintf('JBS_MED_VTT_FILE_TOO_LARGE', '2 MB'),
@@ -605,32 +602,20 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        // Validate content — must start with WEBVTT header or SRT numeric cue index
+        // Sniff the first 64 bytes to confirm WEBVTT or SRT magic — defends
+        // against a renamed binary slipping past the extension whitelist.
         $head = file_get_contents($userfile['tmp_name'], false, null, 0, 64);
 
-        if ($head === false) {
-            echo json_encode(['success' => false, 'error' => Text::_('JBS_MED_VTT_UPLOAD_FAILED')]);
-            Factory::getApplication()->close();
-
-            return;
-        }
-
-        // Strip BOM if present
-        $head  = ltrim($head, "\xEF\xBB\xBF");
-        $isVtt = str_starts_with(trim($head), 'WEBVTT');
-        $isSrt = (bool) preg_match('/^\d+\s*\r?\n\d{2}:\d{2}/', trim($head));
-
-        if (!$isVtt && !$isSrt) {
+        if ($head === false || $validator->detectFormat($head) === null) {
             echo json_encode([
                 'success' => false,
-                'error'   => Text::_('JBS_MED_VTT_INVALID_CONTENT'),
+                'error'   => Text::_($head === false ? 'JBS_MED_VTT_UPLOAD_FAILED' : 'JBS_MED_VTT_INVALID_CONTENT'),
             ]);
             Factory::getApplication()->close();
 
             return;
         }
 
-        // Ensure destination directory exists
         $destDir = JPATH_ROOT . '/media/com_proclaim/captions';
 
         if (!is_dir($destDir) && !mkdir($destDir, 0755, true) && !is_dir($destDir)) {
@@ -640,11 +625,7 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        // Build safe filename: caption_{timestamp}_{sanitised-original}.ext
-        $baseName = pathinfo($userfile['name'], PATHINFO_FILENAME);
-        $baseName = preg_replace('/[^a-zA-Z0-9_-]/', '', $baseName) ?: 'caption';
-        $fileName = 'caption_' . time() . '_' . mb_substr($baseName, 0, 50) . '.' . $ext;
-
+        $fileName = $validator->buildFilename($userfile['name'], $ext);
         $destPath = $destDir . '/' . $fileName;
 
         if (!move_uploaded_file($userfile['tmp_name'], $destPath)) {
@@ -654,7 +635,6 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        // Return the public URL
         $url = Uri::root() . 'media/com_proclaim/captions/' . $fileName;
 
         echo json_encode(['success' => true, 'url' => $url, 'filename' => $fileName]);

--- a/admin/src/Helper/CwmcaptionValidator.php
+++ b/admin/src/Helper/CwmcaptionValidator.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Validates and normalizes WEBVTT / SRT caption uploads.
+ *
+ * Pure-logic helper: extracted from CwmmediafileController::uploadVttXHR()
+ * so the rejection rules and filename construction can be unit tested
+ * without an HTTP / SAPI context. The controller stays responsible for
+ * the I/O (session token, $_FILES handling, move_uploaded_file, JSON
+ * response) and delegates every yes/no decision to this class.
+ *
+ * @since  10.3.0
+ */
+class CwmcaptionValidator
+{
+    /**
+     * Caption file extensions accepted by the uploader.
+     *
+     * @var    string[]
+     * @since  10.3.0
+     */
+    public const ALLOWED_EXTENSIONS = ['vtt', 'srt'];
+
+    /**
+     * Maximum caption file size in bytes (2 MB).
+     *
+     * @var    int
+     * @since  10.3.0
+     */
+    public const MAX_SIZE_BYTES = 2 * 1024 * 1024;
+
+    /**
+     * Maximum length of the sanitized base name segment in the final
+     * filename. Keeps stored filenames bounded regardless of input.
+     *
+     * @var    int
+     * @since  10.3.0
+     */
+    public const MAX_BASENAME_LENGTH = 50;
+
+    /**
+     * Default base name used when sanitization removes every character
+     * (e.g. a filename consisting only of Unicode or punctuation).
+     *
+     * @var    string
+     * @since  10.3.0
+     */
+    public const FALLBACK_BASENAME = 'caption';
+
+    /**
+     * Check whether the given extension is in the caption whitelist.
+     *
+     * Comparison is case-insensitive — callers may pass an extension
+     * exactly as `pathinfo()` returns it without pre-normalizing.
+     *
+     * @param   string  $ext  File extension without the leading dot.
+     *
+     * @return  bool  True when the extension is allowed.
+     *
+     * @since   10.3.0
+     */
+    public function isAllowedExtension(string $ext): bool
+    {
+        return \in_array(strtolower($ext), self::ALLOWED_EXTENSIONS, true);
+    }
+
+    /**
+     * Check whether a file of the given byte count is within the caption
+     * size limit.
+     *
+     * Zero or negative sizes are rejected — they indicate an empty or
+     * corrupt upload.
+     *
+     * @param   int  $bytes  File size reported by the SAPI.
+     *
+     * @return  bool  True when 0 < $bytes <= MAX_SIZE_BYTES.
+     *
+     * @since   10.3.0
+     */
+    public function isAllowedSize(int $bytes): bool
+    {
+        return $bytes > 0 && $bytes <= self::MAX_SIZE_BYTES;
+    }
+
+    /**
+     * Detect a caption file format by sniffing its header bytes.
+     *
+     * Recognizes:
+     *  - WEBVTT files: leading `WEBVTT` token (per W3C VTT spec), with
+     *    or without a UTF-8 BOM.
+     *  - SRT files: a numeric cue index on its own line followed by
+     *    a `HH:MM…` timestamp line (per SubRip convention).
+     *
+     * @param   string  $head  First N bytes of the file. The caller is
+     *                         responsible for choosing N — 64 bytes is
+     *                         enough to cover both signatures plus a BOM.
+     *
+     * @return  string|null  'vtt', 'srt', or null when neither matches.
+     *
+     * @since   10.3.0
+     */
+    public function detectFormat(string $head): ?string
+    {
+        $head = ltrim($head, "\xEF\xBB\xBF");
+        $head = trim($head);
+
+        if (str_starts_with($head, 'WEBVTT')) {
+            return 'vtt';
+        }
+
+        if (preg_match('/^\d+\s*\r?\n\d{2}:\d{2}/', $head)) {
+            return 'srt';
+        }
+
+        return null;
+    }
+
+    /**
+     * Strip everything outside `[A-Za-z0-9_-]` from the given base name
+     * and fall back to a constant when nothing usable remains.
+     *
+     * Defends against directory traversal, NUL bytes, Unicode lookalikes,
+     * shell metacharacters, and zero-length names. The result is safe to
+     * concatenate into a filesystem path.
+     *
+     * @param   string  $original  Caller-supplied base name (no extension).
+     *
+     * @return  string  Sanitized base name, never empty.
+     *
+     * @since   10.3.0
+     */
+    public function sanitizeFilename(string $original): string
+    {
+        $sanitized = preg_replace('/[^a-zA-Z0-9_-]/', '', $original);
+
+        return $sanitized === '' || $sanitized === null ? self::FALLBACK_BASENAME : $sanitized;
+    }
+
+    /**
+     * Build the final stored filename for a caption upload.
+     *
+     * Format: `caption_{timestamp}_{sanitized-base}.{ext}` — the timestamp
+     * prefix prevents collisions between uploads of the same logical
+     * filename.
+     *
+     * @param   string    $originalName  Original filename from the upload
+     *                                   (may include or omit extension —
+     *                                   only the base name is read).
+     * @param   string    $ext           Lowercased extension to append.
+     * @param   int|null  $timestamp     Override for the timestamp segment.
+     *                                   Defaults to time(); pass an explicit
+     *                                   value in tests for deterministic
+     *                                   output.
+     *
+     * @return  string  Filename only — no directory component.
+     *
+     * @since   10.3.0
+     */
+    public function buildFilename(string $originalName, string $ext, ?int $timestamp = null): string
+    {
+        $base      = pathinfo($originalName, PATHINFO_FILENAME);
+        $sanitized = $this->sanitizeFilename($base);
+        $truncated = mb_substr($sanitized, 0, self::MAX_BASENAME_LENGTH);
+
+        return 'caption_' . ($timestamp ?? time()) . '_' . $truncated . '.' . $ext;
+    }
+}

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -512,7 +512,7 @@ class Cwmassets
         }
 
         try {
-            $db = $table->getDbo();
+            $db = $table->getDatabase();
 
             $query = $db->getQuery(true)
                 ->select($db->quoteName('rules'))

--- a/admin/src/View/Cwmarchive/HtmlView.php
+++ b/admin/src/View/Cwmarchive/HtmlView.php
@@ -16,7 +16,6 @@ use CWM\Component\Proclaim\Administrator\Model\CwmarchiveModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -76,7 +75,7 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('JBS_CMN_ARCHIVE'), 'archive');
 
-        $toolbar = Toolbar::getInstance();
+        $toolbar = $this->getDocument()->getToolbar();
 
         // Add back to admin tools button
         $toolbar->linkButton('back', 'JTOOLBAR_BACK')

--- a/admin/src/View/Cwmbackup/HtmlView.php
+++ b/admin/src/View/Cwmbackup/HtmlView.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Filesystem\Folder;
 use Joomla\Registry\Registry;
@@ -151,7 +150,7 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('JBS_CMN_ADMINISTRATION'), 'administration');
 
-        $toolbar = Toolbar::getInstance();
+        $toolbar = $this->getDocument()->getToolbar();
 
         // Add home button to cpanel
         $toolbar->linkButton('home', 'JBS_CMN_HOME')

--- a/admin/src/View/Cwmcomments/HtmlView.php
+++ b/admin/src/View/Cwmcomments/HtmlView.php
@@ -22,7 +22,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Database\DatabaseInterface;
@@ -122,7 +121,7 @@ class HtmlView extends BaseHtmlView
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         // Get pending comments count and add to title if any
         $pendingCount = $this->getPendingCount();

--- a/admin/src/View/Cwmlocations/HtmlView.php
+++ b/admin/src/View/Cwmlocations/HtmlView.php
@@ -22,7 +22,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 
@@ -144,7 +143,7 @@ class HtmlView extends BaseHtmlView
         $user = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_CMN_LOCATIONS'), 'home home');
 

--- a/admin/src/View/Cwmmediafile/HtmlView.php
+++ b/admin/src/View/Cwmmediafile/HtmlView.php
@@ -208,7 +208,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->id === 0);
         $checkedOut = !($this->item->checked_out === null || $this->item->checked_out == $userId);
         $title      = $isNew ? Text::_('JBS_CMN_NEW') : Text::_('JBS_CMN_EDIT');
-        $toolbar    = Toolbar::getInstance();
+        $toolbar    = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(
             Text::_('JBS_CMN_MEDIA_FILES') . ': <small><small>[' . $title . ']</small></small>',

--- a/admin/src/View/Cwmmessages/HtmlView.php
+++ b/admin/src/View/Cwmmessages/HtmlView.php
@@ -29,7 +29,6 @@ use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
@@ -172,7 +171,7 @@ class HtmlView extends BaseHtmlView
     {
         $canDo   = ContentHelper::getActions('com_proclaim');
         $user    = $this->getCurrentUser();
-        $toolbar = Toolbar::getInstance();
+        $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('JBS_CMN_STUDIES'), 'book book');
 

--- a/admin/src/View/Cwmmessagetypes/HtmlView.php
+++ b/admin/src/View/Cwmmessagetypes/HtmlView.php
@@ -21,7 +21,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
@@ -142,7 +141,7 @@ class HtmlView extends BaseHtmlView
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_CMN_MESSAGETYPES'), 'list-2 list-2');
 

--- a/admin/src/View/Cwmpodcasts/HtmlView.php
+++ b/admin/src/View/Cwmpodcasts/HtmlView.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -141,7 +140,7 @@ class HtmlView extends BaseHtmlView
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance();
+        $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('JBS_CMN_PODCASTS'), 'feed feed');
 

--- a/admin/src/View/Cwmservers/HtmlView.php
+++ b/admin/src/View/Cwmservers/HtmlView.php
@@ -23,7 +23,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -141,7 +140,7 @@ class HtmlView extends BaseHtmlView
         $user = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance();
+        $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('JBS_CMN_SERVERS'), 'database database');
 

--- a/admin/src/View/Cwmteachers/HtmlView.php
+++ b/admin/src/View/Cwmteachers/HtmlView.php
@@ -23,7 +23,6 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
@@ -152,7 +151,7 @@ class HtmlView extends BaseHtmlView
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_CMN_TEACHERS'), 'users users');
 

--- a/admin/src/View/Cwmtemplatecodes/HtmlView.php
+++ b/admin/src/View/Cwmtemplatecodes/HtmlView.php
@@ -18,7 +18,6 @@ use CWM\Component\Proclaim\Administrator\Model\CwmtemplatecodesModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
@@ -160,7 +159,7 @@ class HtmlView extends BaseHtmlView
         $user  = $this->getCurrentUser();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_TPLCODE_TPLCODES'), 'stack stack');
 

--- a/admin/src/View/Cwmtemplates/HtmlView.php
+++ b/admin/src/View/Cwmtemplates/HtmlView.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -149,7 +148,7 @@ class HtmlView extends BaseHtmlView
         $user = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_CMN_TEMPLATES'), 'grid grid');
 

--- a/admin/src/View/Cwmtopics/HtmlView.php
+++ b/admin/src/View/Cwmtopics/HtmlView.php
@@ -20,7 +20,6 @@ use CWM\Component\Proclaim\Administrator\Model\CwmtopicsModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
@@ -148,7 +147,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar(): void
     {
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar('toolbar');
 
         ToolbarHelper::title(Text::_('JBS_CMN_TOPICS'), 'tags');
 

--- a/tests/unit/Admin/Helper/CwmcaptionValidatorTest.php
+++ b/tests/unit/Admin/Helper/CwmcaptionValidatorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Unit tests for CwmcaptionValidator helper
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcaptionValidator;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test class for CwmcaptionValidator
+ *
+ * Pure-logic tests: every behavior the controller delegates is exercised
+ * here so we have real coverage of the rejection rules without needing
+ * an HTTP / SAPI context for the upload itself.
+ *
+ * @since  10.3.0
+ */
+#[CoversClass(CwmcaptionValidator::class)]
+class CwmcaptionValidatorTest extends ProclaimTestCase
+{
+    private CwmcaptionValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = new CwmcaptionValidator();
+    }
+
+    public function testAllowedExtensionsConstantContainsVttAndSrt(): void
+    {
+        $this->assertSame(['vtt', 'srt'], CwmcaptionValidator::ALLOWED_EXTENSIONS);
+    }
+
+    public function testMaxSizeIsTwoMegabytes(): void
+    {
+        $this->assertSame(2 * 1024 * 1024, CwmcaptionValidator::MAX_SIZE_BYTES);
+    }
+
+    public static function extensionProvider(): array
+    {
+        return [
+            'lowercase vtt'     => ['vtt', true],
+            'lowercase srt'     => ['srt', true],
+            'uppercase VTT'     => ['VTT', true],
+            'mixed-case Srt'    => ['Srt', true],
+            'mp4 rejected'      => ['mp4', false],
+            'php rejected'      => ['php', false],
+            'empty rejected'    => ['', false],
+            'with-dot rejected' => ['.vtt', false],
+        ];
+    }
+
+    #[DataProvider('extensionProvider')]
+    public function testIsAllowedExtension(string $ext, bool $expected): void
+    {
+        $this->assertSame($expected, $this->validator->isAllowedExtension($ext));
+    }
+
+    public static function sizeProvider(): array
+    {
+        return [
+            'one byte'            => [1, true],
+            'one MB'              => [1024 * 1024, true],
+            'exactly max (2 MB)'  => [2 * 1024 * 1024, true],
+            'one byte over max'   => [2 * 1024 * 1024 + 1, false],
+            'zero bytes rejected' => [0, false],
+            'negative rejected'   => [-1, false],
+        ];
+    }
+
+    #[DataProvider('sizeProvider')]
+    public function testIsAllowedSize(int $bytes, bool $expected): void
+    {
+        $this->assertSame($expected, $this->validator->isAllowedSize($bytes));
+    }
+
+    public function testDetectFormatReturnsVttForWebvttHeader(): void
+    {
+        $this->assertSame('vtt', $this->validator->detectFormat("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello"));
+    }
+
+    public function testDetectFormatStripsUtf8Bom(): void
+    {
+        $this->assertSame('vtt', $this->validator->detectFormat("\xEF\xBB\xBFWEBVTT\n"));
+    }
+
+    public function testDetectFormatTrimsLeadingWhitespace(): void
+    {
+        $this->assertSame('vtt', $this->validator->detectFormat("\n\n  WEBVTT\n"));
+    }
+
+    public function testDetectFormatReturnsSrtForNumericCueWithUnixNewline(): void
+    {
+        $this->assertSame('srt', $this->validator->detectFormat("1\n00:00:01,000 --> 00:00:02,000\nHello"));
+    }
+
+    public function testDetectFormatReturnsSrtForNumericCueWithCrlfNewline(): void
+    {
+        $this->assertSame('srt', $this->validator->detectFormat("1\r\n00:00:01,000 --> 00:00:02,000\r\nHello"));
+    }
+
+    public function testDetectFormatReturnsSrtForBomThenSrt(): void
+    {
+        $this->assertSame('srt', $this->validator->detectFormat("\xEF\xBB\xBF1\n00:00:01,000 --> 00:00:02,000"));
+    }
+
+    public function testDetectFormatRejectsPlainText(): void
+    {
+        $this->assertNull($this->validator->detectFormat("This is just a regular text file."));
+    }
+
+    public function testDetectFormatRejectsEmptyString(): void
+    {
+        $this->assertNull($this->validator->detectFormat(''));
+    }
+
+    public function testDetectFormatRejectsBinaryData(): void
+    {
+        // Random binary that doesn't match either header
+        $this->assertNull($this->validator->detectFormat("\x00\x01\x02\x03\xFF\xFE binary garbage"));
+    }
+
+    public function testDetectFormatRejectsHtmlPretendingToBeCaption(): void
+    {
+        $this->assertNull($this->validator->detectFormat("<html>WEBVTT</html>"));
+    }
+
+    public static function sanitizeFilenameProvider(): array
+    {
+        return [
+            'plain ASCII kept'         => ['my-caption_01', 'my-caption_01'],
+            'space stripped'           => ['hello world', 'helloworld'],
+            'unicode stripped'         => ['привет', 'caption'],
+            'emoji stripped'           => ['caption😀file', 'captionfile'],
+            'path traversal stripped'  => ['../../etc/passwd', 'etcpasswd'],
+            'backslashes stripped'     => ['..\\..\\windows', 'windows'],
+            'NUL byte stripped'        => ["safe\0name", 'safename'],
+            'shell metachars stripped' => ['name;rm -rf /', 'namerm-rf'],
+            'dots stripped'            => ['a.b.c', 'abc'],
+            'empty falls back'         => ['', 'caption'],
+            'only-stripped falls back' => ['😀😀😀', 'caption'],
+            'whitespace falls back'    => ['   ', 'caption'],
+        ];
+    }
+
+    #[DataProvider('sanitizeFilenameProvider')]
+    public function testSanitizeFilename(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->validator->sanitizeFilename($input));
+    }
+
+    public function testBuildFilenameProducesExpectedShape(): void
+    {
+        $name = $this->validator->buildFilename('lecture-01.vtt', 'vtt', 1735689600);
+
+        $this->assertSame('caption_1735689600_lecture-01.vtt', $name);
+    }
+
+    public function testBuildFilenameUsesProvidedExtensionNotOriginal(): void
+    {
+        // Caller may pass a normalized lowercase ext separately
+        $name = $this->validator->buildFilename('Subtitles.SRT', 'srt', 1735689600);
+
+        $this->assertSame('caption_1735689600_Subtitles.srt', $name);
+    }
+
+    public function testBuildFilenameStripsPathComponentsThenSanitizes(): void
+    {
+        // pathinfo() strips the directory portion before sanitization runs —
+        // belt-and-braces: even if a malicious uploader supplies a traversal
+        // path, only the basename's filename ever reaches the regex filter.
+        $name = $this->validator->buildFilename('../../../etc/passwd.vtt', 'vtt', 1735689600);
+
+        $this->assertSame('caption_1735689600_passwd.vtt', $name);
+    }
+
+    public function testBuildFilenameSanitizesUnsafeCharsInBaseName(): void
+    {
+        $name = $this->validator->buildFilename('hello world;rm.vtt', 'vtt', 1735689600);
+
+        $this->assertSame('caption_1735689600_helloworldrm.vtt', $name);
+    }
+
+    public function testBuildFilenameTruncatesLongBaseNameToFiftyChars(): void
+    {
+        $longBase = str_repeat('a', 200);
+        $name     = $this->validator->buildFilename($longBase . '.vtt', 'vtt', 1735689600);
+
+        $this->assertSame('caption_1735689600_' . str_repeat('a', 50) . '.vtt', $name);
+    }
+
+    public function testBuildFilenameFallsBackWhenNothingSurvivesSanitization(): void
+    {
+        $name = $this->validator->buildFilename('😀😀😀.vtt', 'vtt', 1735689600);
+
+        $this->assertSame('caption_1735689600_caption.vtt', $name);
+    }
+
+    public function testBuildFilenameDefaultsTimestampToCurrentTime(): void
+    {
+        $before = time();
+        $name   = $this->validator->buildFilename('test.vtt', 'vtt');
+        $after  = time();
+
+        $this->assertMatchesRegularExpression('/^caption_(\d+)_test\.vtt$/', $name);
+
+        preg_match('/^caption_(\d+)_/', $name, $m);
+        $stamp = (int) $m[1];
+
+        $this->assertGreaterThanOrEqual($before, $stamp);
+        $this->assertLessThanOrEqual($after, $stamp);
+    }
+}


### PR DESCRIPTION
## Summary

Three deprecation cleanups so the affected code paths run **natively on Joomla 6** without the Behaviour - Backward Compatibility 6 plugin. All changes are J5+ safe and match what Joomla core itself uses in `5.4-dev` / `6.1-dev`.

### 1. `Cwmassets.php` — `Table::getDbo()` → `getDatabase()`
One-liner. `getDbo()` is removed in Joomla 6.

### 2. `CwmmediafileController.php` — drop `\Joomla\CMS\Filesystem\File` / `Folder`
The CMS Filesystem classes move behind the compat plugin in J6 and are removed in J7.

- `Folder::create($destDir)` → `mkdir($destDir, 0755, true)` with explicit failure handling
- `File::makeSafe(...)` removed — it was dead code; the next line's `preg_replace('/[^a-zA-Z0-9_-]/', ...)` is strictly more aggressive
- `File::upload(...)` → `move_uploaded_file(...)`

**Behavioral notes for `move_uploaded_file`:** Joomla's `File::upload()` fires `onContentBeforeSave` / `onContentAfterSave` events for plugins listening to media uploads, and consults `MediaHelper::canUpload()`. Neither matters here:
- This controller already enforces its own validation (size limit, WEBVTT/SRT magic-byte sniff before line 622)
- The destination is a hardcoded path under `JPATH_ROOT/media/com_proclaim/captions/`
- There are no in-tree plugin listeners for caption uploads
- `move_uploaded_file()` still validates `is_uploaded_file()` internally — same protection as `File::upload`

### 3. 13 admin views — `Toolbar::getInstance()` → `$this->getDocument()->getToolbar()`

`HtmlDocument::getToolbar()` is `@since 5.0.0` (verified at `joomla/joomla-cms/libraries/src/Document/HtmlDocument.php:803` on `5.4-dev`). This is the pattern `com_content`'s `Articles/HtmlView.php` itself uses on both `5.4-dev` and `6.1-dev`.

Files touched: `Cwmarchive`, `Cwmbackup`, `Cwmcomments`, `Cwmlocations`, `Cwmmediafile`, `Cwmmessages`, `Cwmmessagetypes`, `Cwmpodcasts`, `Cwmservers`, `Cwmteachers`, `Cwmtemplatecodes`, `Cwmtemplates`, `Cwmtopics`. The unused `use Joomla\CMS\Toolbar\Toolbar` import was removed where the class was no longer referenced (12 of 13 — `Cwmmediafile` keeps it for closure type hints).

## Verification

- [x] `composer lint` clean
- [x] `composer lint:syntax` clean
- [x] `composer test:unit` — 566 tests / 1248 assertions pass
- [ ] CI green
- [ ] Smoke test: VTT/SRT caption upload still works end-to-end on j5-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)