### PR TITLE
build(deps): upgrade intl-tel-input 26.x → 28.x

### DIFF
--- a/build/build-assets.js
+++ b/build/build-assets.js
@@ -120,15 +120,15 @@ console.log('  Copied fancybox (from node_modules)');
 
 // intl-tel-input — CSS, JS, and flag images
 copyFile(
-    path.join(nodeModules, 'intl-tel-input/build/css/intlTelInput.min.css'),
+    path.join(nodeModules, 'intl-tel-input/dist/css/intlTelInput.min.css'),
     path.join(mediaBase, 'vendor/intl-tel-input/css/intlTelInput.min.css')
 );
 copyFile(
-    path.join(nodeModules, 'intl-tel-input/build/js/intlTelInputWithUtils.min.js'),
+    path.join(nodeModules, 'intl-tel-input/dist/js/intlTelInputWithUtils.min.js'),
     path.join(mediaBase, 'vendor/intl-tel-input/js/intlTelInputWithUtils.min.js')
 );
 copyDir(
-    path.join(nodeModules, 'intl-tel-input/build/img'),
+    path.join(nodeModules, 'intl-tel-input/dist/img'),
     path.join(mediaBase, 'vendor/intl-tel-input/img')
 );
 console.log('  Copied intl-tel-input (from node_modules)');

--- a/build/media_source/js/phone-input.es6.js
+++ b/build/media_source/js/phone-input.es6.js
@@ -25,11 +25,16 @@
             nationalMode: true,
             formatAsYouType: true,
             autoPlaceholder: 'aggressive',
-            showSelectedDialCode: true,
+            // Pin to false: preserves the current "flag only" look. v28 flipped
+            // the default to true; the previous code passed showSelectedDialCode
+            // which v26 silently ignored, so production has always rendered
+            // without the dial code beside the flag.
+            separateDialCode: false,
             containerClass: 'iti--proclaim',
             countrySearch: true,
-            // Put common church-ministry countries first
-            preferredCountries: ['us', 'ca', 'gb', 'au', 'nz', 'za', 'ph', 'in', 'br', 'mx', 'de', 'kr', 'ng'],
+            // Put common church-ministry countries first.
+            // (Renamed from preferredCountries in v25; required from v28.)
+            countryOrder: ['us', 'ca', 'gb', 'au', 'nz', 'za', 'ph', 'in', 'br', 'mx', 'de', 'kr', 'ng'],
         };
 
         const options = { ...defaults, ...opts };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fancyapps/ui": "^6.1.11",
         "chart.js": "^4.5.1",
         "core-js": "^3.48.0",
-        "intl-tel-input": "^26.5.1"
+        "intl-tel-input": "^28.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.28.6",
@@ -5459,13 +5459,10 @@
       "license": "ISC"
     },
     "node_modules/intl-tel-input": {
-      "version": "26.9.2",
-      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-26.9.2.tgz",
-      "integrity": "sha512-40v/uBlE7Wpg3Dz79T1AaE9eH66D86fCXucnI8UVCayypG91lBDyoXLXb7WAQuAdjLtB2+OuTJtlihjByWYL1g==",
-      "license": "MIT",
-      "workspaces": [
-        "site"
-      ]
+      "version": "28.0.4",
+      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-28.0.4.tgz",
+      "integrity": "sha512-7uRoetfwFHJ0+H3V+ptg/PaqEDeDy9AeFmUG2X+9Xs2Nev+A4w7SAdy492YpMffq9104XKS1P7G4ZXEa+bFOOQ==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@fancyapps/ui": "^6.1.11",
     "chart.js": "^4.5.1",
     "core-js": "^3.48.0",
-    "intl-tel-input": "^26.5.1"
+    "intl-tel-input": "^28.0.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.3",


### PR DESCRIPTION
Closes #1211.

## Summary

`intl-tel-input` was pinned at `^26.5.1` (installed 26.9.2). v28.0.4 is two majors ahead. Small, well-contained upgrade — one consumer (`build/media_source/js/phone-input.es6.js`, ~80 LOC) and three asset-copy paths in `build-assets.js`.

## Changes

- **`package.json`** — bump to `^28.0.0` (locked at 28.0.4).
- **`build/build-assets.js`** — three asset paths from `intl-tel-input/build/...` → `intl-tel-input/dist/...` (v27 directory rename).
- **`build/media_source/js/phone-input.es6.js`**:
    - `showSelectedDialCode` → `separateDialCode` (the real v28 option; 26.x was silently ignoring `showSelectedDialCode` and emitting the *"Unknown option 'showSelectedDialCode'. Ignoring."* console warning that appeared in your earlier teacher-edit logs).
    - **Pinned `separateDialCode: false`** to preserve current "flag only" UX. v28 flipped the default to `true`; production has always rendered without the dial code beside the flag because of the broken-option-name issue above. Pinning explicit means a future v28 default flip won't change the look on us.
    - `preferredCountries` → `countryOrder` (rename in v25, required from v28; 26.x was also silently ignoring our old name — the second console warning the user saw).
- **`package-lock.json`** — routine refresh from `npm install`.

## Verification

- [x] `npm outdated`: `intl-tel-input` no longer listed
- [x] `npm run build`: clean; bundled JS header confirms `v28.0.4`
- [x] `npm test`: 229/229 Jest pass
- [x] Manual smoke test on Teacher edit form: flag picker renders, `formatAsYouType` works, number persists in international format on save, no `Unknown option` console warnings.

## What didn't need attention

- `nationalMode: true` — already explicitly set, so v28's default-flip of `nationalMode` (true → false) doesn't affect us.
- `iti.isValidNumber()` / `iti.getNumber()` — APIs unchanged across v27/v28; called synchronously in form-submit handler. Smoke test confirmed save round-trip works.
- Framework wrappers — we use vanilla; v28's move to scoped packages (`@intl-tel-input/react` etc.) doesn't apply.

## Test plan

- [x] Open a teacher edit page; phone field shows the US flag and dropdown.
- [x] Click the flag → country search box appears, country list with flags renders, common countries (US, CA, GB, AU, NZ, ZA, PH, IN, BR, MX, DE, KR, NG) sit at the top.
- [x] Type a phone number; placeholder formats aggressively as you type.
- [x] Save the teacher; reload; number persists in international format.
- [x] DevTools console — no `Unknown option` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)