### PR TITLE
feat: first-time adoption of cwm-build-tools v0.4 dev-environment commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
     "ext-fileinfo": "*"
   },
   "require-dev": {
+    "cwm/build-tools": "^0.4@alpha",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "phan/phan": "^5.4",
@@ -94,6 +95,12 @@
     "symfony/polyfill-php80": "*",
     "symfony/polyfill-php81": "*"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools"
+    }
+  ],
   "extra": {
     "branch-alias": {
       "dev-master": "2.x-dev"
@@ -105,7 +112,7 @@
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Api Tests,Integration Admin Table Tests'",
     "test:js": "npm test",
     "test:all": ["@test", "@test:js"],
-    "lint:syntax": "php build/proclaim_build.php lint-syntax",
+    "lint:syntax": "find admin/src site/src libraries/lib_cwmscripture/src modules plugins -type f -name '*.php' -print0 2>/dev/null | xargs -0 -n 1 -P 8 php -l > /dev/null",
     "lint": "php-cs-fixer fix --dry-run --diff",
     "lint:fix": "php-cs-fixer fix",
     "check": ["@lint:syntax", "@lint", "@test"],
@@ -113,13 +120,13 @@
     "build:assets": "npm ci && npm run build",
     "build:bridge": "cd build/migration-bridge && zip -r ../packages/proclaim_bridge_v1.0.0.zip proclaim_bridge.xml script.php index.html",
     "build:full": ["@check:all", "@build"],
-    "setup": "php build/proclaim_build.php setup",
-    "joomla-install": "php build/proclaim_build.php install-joomla",
-    "joomla-latest": "php build/proclaim_build.php joomla-latest",
-    "symlink": "php build/proclaim_build.php link",
-    "symlink:check": "php build/proclaim_build.php check",
-    "verify": "php build/proclaim_build.php verify",
-    "clean": "php build/proclaim_build.php clean",
+    "setup": "cwm-setup",
+    "joomla-install": "cwm-joomla-install",
+    "joomla-latest": "cwm-joomla-latest",
+    "link": "cwm-link",
+    "link-check": "cwm-link-check",
+    "verify": "cwm-verify",
+    "clean": "cwm-clean",
     "build": "php build/proclaim_build.php build",
     "package": "php build/proclaim_build.php package",
     "version": "php build/bump.php",

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -1,0 +1,67 @@
+{
+    "_comment": "Per-project config for cwm-build-tools. The headline extension is com_proclaim; the package wrapper bundles the component plus four modules, six plugins, and the lib_cwmscripture submodule. ARS IDs and announcement bullets directory match the legacy build/ artifacts the Proclaim-specific scripts already use.",
+    "extension": {
+        "type": "component",
+        "name": "com_proclaim"
+    },
+    "manifests": {
+        "package": "build/pkg_proclaim.xml",
+        "extensions": [
+            { "type": "component", "path": "proclaim.xml" },
+
+            { "type": "module", "path": "modules/site/mod_proclaim/mod_proclaim.xml" },
+            { "type": "module", "path": "modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml" },
+            { "type": "module", "path": "modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml" },
+            { "type": "module", "path": "modules/admin/mod_proclaimicon/mod_proclaimicon.xml" },
+
+            { "type": "plugin", "path": "plugins/finder/proclaim/proclaim.xml" },
+            { "type": "plugin", "path": "plugins/schemaorg/proclaim/proclaim.xml" },
+            { "type": "plugin", "path": "plugins/system/proclaim/proclaim.xml" },
+            { "type": "plugin", "path": "plugins/task/proclaim/proclaim.xml" },
+            { "type": "plugin", "path": "plugins/webservices/proclaim/proclaim.xml" },
+            { "type": "plugin", "path": "plugins/content/scripturelinks/scripturelinks.xml" },
+
+            { "type": "library", "path": "libraries/lib_cwmscripture/cwmscripture.xml" }
+        ]
+    },
+    "build": {
+        "_comment": "Project-specific package assembly still lives in build/proclaim_build.php — that script knows how to bundle the component + library + plugin submodules into pkg_proclaim. Replace once the generic cwm PackageBuilder lands (Phase 4).",
+        "command": "php build/proclaim_build.php package",
+        "outputGlob": "build/pkg_proclaim-*.zip"
+    },
+    "ars": {
+        "endpoint": "https://www.christianwebministries.org",
+        "categoryId": 0,
+        "updateStreamId": 0,
+        "environments": ["45", "46", "48", "49", "50"],
+        "tokenItem": "CWM ARS API Token",
+        "tokenVault": "CWM",
+        "itemDescription": "CWM Proclaim — sermon, study and Bible-study management for Joomla 5/6, including the Proclaim component, four site/admin modules, the Smart Search adapter, schema.org / system / task / webservices plugins, and the bundled CWM Scripture library."
+    },
+    "github": {
+        "owner": "Joomla-Bible-Study",
+        "repo": "Proclaim",
+        "releaseBranch": "main"
+    },
+    "changelog": {
+        "file": "build/proclaim-changelog.xml",
+        "url":  "https://raw.githubusercontent.com/Joomla-Bible-Study/Proclaim/main/build/proclaim-changelog.xml"
+    },
+    "dev": {
+        "_comment": "Drives cwm-link / cwm-link-check / cwm-clean / cwm-verify against the developer's local Joomla install(s). Auto-derive picks up admin/site/media + every module/plugin/library from manifests.extensions[]. The internalLinks block replaces the gitignored mirror symlinks (proclaim.xml, proclaim.script.php) the legacy build/proclaim_build.php created in admin/.",
+        "internalLinks": [
+            { "source": "proclaim.xml",        "link": "admin/proclaim.xml" },
+            { "source": "proclaim.script.php", "link": "admin/proclaim.script.php" }
+        ],
+        "links": [
+            {
+                "source": "admin/language/en-GB/en-GB.com_proclaim.ini",
+                "target": "{joomlaPath}/administrator/language/en-GB/en-GB.com_proclaim.ini"
+            },
+            {
+                "source": "admin/language/en-GB/en-GB.com_proclaim.sys.ini",
+                "target": "{joomlaPath}/administrator/language/en-GB/en-GB.com_proclaim.sys.ini"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Wire Proclaim into the shared toolchain for the dev-environment surface — the part [cwm-build-tools v0.4.0-alpha](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v0.4.0-alpha) was lifted from this repo's `build/proclaim_build.php` in the first place.

## Changes

- Add `cwm/build-tools ^0.4@alpha` to `require-dev`, with the matching VCS `repositories` block (Packagist registration is deferred; consumers pull straight from GitHub for now).
- Introduce **`cwm-build.config.json`** declaring the component, four modules, six plugins, and the `lib_cwmscripture` submodule. Auto-derive generates the standard symlink set; the `dev:` block carries the `internalLinks` (`admin/proclaim.xml`, `admin/proclaim.script.php`) and the language-file overrides that don't fall out of derivation.
- Swap the dev-command composer scripts to `cwm-*` binaries: `setup`, `joomla-install`, `joomla-latest`, `link` (was `symlink`), `link-check` (was `symlink:check`), `verify`, `clean`.
- Replace `lint:syntax`'s `php build/proclaim_build.php lint-syntax` with a generic find/xargs over the same source dirs.

## What stays

- `build/proclaim_build.php` left in place — still owns project-specific package assembly (`build`, `package`) plus a few helpers cwm-build-tools doesn't cover yet. Phase 4 `PackageBuilder` will retire the rest.
- Release plumbing (`release.sh`, `ars-release.sh`, `generate-changelog-entry.sh`) keeps using the local copies — those ARE the upstream donors `cwm-build-tools`' versions were lifted from. Not worth churning until a benchmark demands it.
- `build.dist.properties` stays as the per-developer template; the flat `builder.joomla_paths=` layout is still recognised by the new `PropertiesReader`'s legacy compat path. Existing `build.properties` files keep working without edits.

## Test plan

- [ ] `composer install` resolves `cwm/build-tools ^0.4@alpha` from the new VCS repository entry.
- [ ] `composer setup` walks the wizard (existing `build.properties` values come through as defaults via the legacy compat path).
- [ ] `composer link` creates symlinks for: component admin/site/media, all four modules, all six plugins (incl. `plugins/content/scripturelinks`), the lib_cwmscripture library + its `media/lib_cwmscripture` mirror + the manifest stub under `administrator/manifests/libraries/`, plus the two language-file overrides and the two internal mirrors (`admin/proclaim.xml`, `admin/proclaim.script.php`).
- [ ] `composer link-check` reports clean after `link`.
- [ ] `composer verify` connects to each install's DB; libraries / plugins auto-insert with `--fix`.
- [ ] `composer clean` removes every dev symlink.
- [ ] `composer build` and `composer package` (still calling `proclaim_build.php`) produce `com_proclaim-*.zip` and `pkg_proclaim-*.zip` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)