### PR TITLE
fix(captions): VttUploadField self-registers JS language keys

### DIFF
--- a/admin/src/Field/VttUploadField.php
+++ b/admin/src/Field/VttUploadField.php
@@ -163,5 +163,16 @@ class VttUploadField extends FormField
             'uploadUrl'   => $uploadUrl,
             'downloadUrl' => $downloadUrl,
         ]);
+
+        // Register the language keys this field's JS consumes via
+        // Joomla.Text._(). Joomla.Text._() returns the raw key string when
+        // a key is unregistered (truthy), so a `Joomla.Text._('K') || 'fallback'`
+        // pattern in the JS would silently print the raw key instead of the
+        // fallback. Register here rather than relying on the host template
+        // calling CwmlangHelper::registerAllForJs() — this field is self-contained.
+        $existing                              = $doc->getScriptOptions('joomla.jtext') ?: [];
+        $existing['JBS_MED_VTT_UPLOADING']     = Text::_('JBS_MED_VTT_UPLOADING');
+        $existing['JBS_MED_VTT_UPLOAD_FAILED'] = Text::_('JBS_MED_VTT_UPLOAD_FAILED');
+        $doc->addScriptOptions('joomla.jtext', $existing, false);
     }
 }


### PR DESCRIPTION
Targets `epic/1210-captions` — fix discovered during the Joomla coding-standards audit on the JS file touched by epic #1210. Will be picked up by integration PR #1232 automatically.

## Problem

The VTT upload JS uses the `Joomla.Text._('KEY') || 'fallback'` pattern at lines 24-25 of `build/media_source/js/cwm-vtt-upload.es6.js`:

```js
const uploadingTxt = Joomla.Text._('JBS_MED_VTT_UPLOADING') || 'Uploading…';
const failedTxt    = Joomla.Text._('JBS_MED_VTT_UPLOAD_FAILED') || 'Upload failed';
```

`Joomla.Text._()` returns the **raw key string** (truthy) when a key is unregistered, so the `|| 'fallback'` never fires. Users would see literal `"JBS_MED_VTT_UPLOADING"` in the spinner during upload.

The precondition `CwmlangHelper::registerAllForJs()` holds for most admin templates but **not** for `admin/tmpl/cwmmediafile/edit.php` — the primary host of `VttUploadField` — confirmed by `grep`.

## Fix

Make the field self-contained by merging its two consumed keys into the `joomla.jtext` script options block during asset registration:

```php
$existing                              = $doc->getScriptOptions('joomla.jtext') ?: [];
$existing['JBS_MED_VTT_UPLOADING']     = Text::_('JBS_MED_VTT_UPLOADING');
$existing['JBS_MED_VTT_UPLOAD_FAILED'] = Text::_('JBS_MED_VTT_UPLOAD_FAILED');
$doc->addScriptOptions('joomla.jtext', $existing, false);
```

- No template-level wiring required
- Idempotent — no behavior change for templates that already register all keys
- Pattern matches `CwmlangHelper::registerAllForJs()` (per-key merge into existing options)

## Test plan
- [x] `composer lint` — clean
- [x] `npm test --testPathPatterns=cwm-vtt-upload` — 7/7 Jest tests still green
- [ ] Manual: open the cwmmediafile edit form, click Browse, pick a file → confirm spinner shows "Uploading…" not "JBS_MED_VTT_UPLOADING"

🤖 Generated with [Claude Code](https://claude.com/claude-code)