### PR TITLE
chore(js): ESLint cleanup — auto-fix + globals + ignore minified vendor

### DIFF
--- a/build/media_source/js/addon-youtube-browser.es6.js
+++ b/build/media_source/js/addon-youtube-browser.es6.js
@@ -253,9 +253,8 @@
 
             // Get study title for auto-search
             const studyTitleField = document.getElementById('jform_study_id_name');
-            let studyTitle = '';
             if (studyTitleField && studyTitleField.value) {
-                studyTitle = studyTitleField.value;
+                const studyTitle = studyTitleField.value;
                 // Skip if it's the placeholder text
                 if (studyTitle.indexOf('Select') === -1 && studyTitle.indexOf('select') === -1) {
                     this.searchQuery = studyTitle;

--- a/build/media_source/js/cwm-landing-toggle.es6.js
+++ b/build/media_source/js/cwm-landing-toggle.es6.js
@@ -18,32 +18,32 @@
  * Hidden:  <div data-proclaim-section="sectionId" data-proclaim-hidden>
  */
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-proclaim-toggle]').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      e.preventDefault();
-      const sectionId = btn.dataset.proclaimToggle;
-      const expanded = btn.getAttribute('aria-expanded') === 'true';
+    document.querySelectorAll('[data-proclaim-toggle]').forEach((btn) => {
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const sectionId = btn.dataset.proclaimToggle;
+            const expanded = btn.getAttribute('aria-expanded') === 'true';
 
-      // Toggle all hidden items in this section
-      document.querySelectorAll(
-        `[data-proclaim-section="${sectionId}"][data-proclaim-hidden]`
-      ).forEach((el) => {
-        el.classList.toggle('proclaim-landing--hidden');
-      });
+            // Toggle all hidden items in this section
+            document.querySelectorAll(
+                `[data-proclaim-section="${sectionId}"][data-proclaim-hidden]`
+            ).forEach((el) => {
+                el.classList.toggle('proclaim-landing--hidden');
+            });
 
-      // Update ARIA state
-      btn.setAttribute('aria-expanded', String(!expanded));
+            // Update ARIA state
+            btn.setAttribute('aria-expanded', String(!expanded));
 
-      // Update button text
-      const showText = btn.dataset.proclaimShowText;
-      const hideText = btn.dataset.proclaimHideText;
-      const label = btn.querySelector('.proclaim-landing__toggle-label');
+            // Update button text
+            const showText = btn.dataset.proclaimShowText;
+            const hideText = btn.dataset.proclaimHideText;
+            const label = btn.querySelector('.proclaim-landing__toggle-label');
 
-      if (showText && hideText && label) {
-        label.textContent = expanded ? showText : hideText;
-      }
+            if (showText && hideText && label) {
+                label.textContent = expanded ? showText : hideText;
+            }
+        });
     });
-  });
 });
 
 /**
@@ -54,23 +54,23 @@ document.addEventListener('DOMContentLoaded', () => {
  * @deprecated 10.3.0 Use data-proclaim-toggle attributes instead
  */
 window.ReverseDisplay2 = function ReverseDisplay2(d) {
-  const el = document.getElementById(d);
+    const el = document.getElementById(d);
 
-  if (el) {
-    if (el.style.display === 'none') {
-      el.style.display = 'contents';
+    if (el) {
+        if (el.style.display === 'none') {
+            el.style.display = 'contents';
+        } else {
+            el.style.display = 'none';
+        }
     } else {
-      el.style.display = 'none';
-    }
-  } else {
-    const elements = document.getElementsByClassName(`landing-hidden-${d}`);
+        const elements = document.getElementsByClassName(`landing-hidden-${d}`);
 
-    for (let i = 0; i < elements.length; i += 1) {
-      if (elements[i].style.display === 'none') {
-        elements[i].style.display = '';
-      } else {
-        elements[i].style.display = 'none';
-      }
+        for (let i = 0; i < elements.length; i += 1) {
+            if (elements[i].style.display === 'none') {
+                elements[i].style.display = '';
+            } else {
+                elements[i].style.display = 'none';
+            }
+        }
     }
-  }
 };

--- a/build/media_source/js/cwm-transcript.es6.js
+++ b/build/media_source/js/cwm-transcript.es6.js
@@ -81,7 +81,7 @@
             }
 
             // Strip position/alignment settings from end timestamp
-            const endRaw = tsParts[1].split(/\s/)[0];
+            const [endRaw] = tsParts[1].split(/\s/);
             const start = parseVttTime(tsParts[0]);
             const end = parseVttTime(endRaw);
 

--- a/build/media_source/js/cwm-youtube-tracks.es6.js
+++ b/build/media_source/js/cwm-youtube-tracks.es6.js
@@ -323,14 +323,14 @@
 
         const resultContainer = document.getElementById('cwm-youtube-tracks-result');
 
-        var chaptersBtn = document.getElementById('cwm-import-chapters-btn');
+        const chaptersBtn = document.getElementById('cwm-import-chapters-btn');
         if (chaptersBtn) {
             chaptersBtn.addEventListener('click', function () {
                 handleImportChapters(resultContainer);
             });
         }
 
-        var captionsBtn = document.getElementById('cwm-list-captions-btn');
+        const captionsBtn = document.getElementById('cwm-list-captions-btn');
         if (captionsBtn) {
             captionsBtn.addEventListener('click', function () {
                 handleListCaptions(resultContainer);

--- a/build/media_source/js/message-ai-assist.es6.js
+++ b/build/media_source/js/message-ai-assist.es6.js
@@ -564,7 +564,7 @@
                     text.textContent = pulseMessages[pulseIndex % pulseMessages.length];
                 }
 
-                pulseIndex++;
+                pulseIndex += 1;
             }, 8000);
         }, lastDelay + 5000);
         timers.push(pulseStart);

--- a/build/media_source/js/message-wizard.es6.js
+++ b/build/media_source/js/message-wizard.es6.js
@@ -132,20 +132,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return el ? el.value.trim() : '';
         };
 
-        const getSelectedText = (id) => {
-            const el = document.getElementById(id);
-
-            if (!el) {
-                return '';
-            }
-
-            if (el.selectedIndex >= 0 && el.options[el.selectedIndex]) {
-                return el.options[el.selectedIndex].text;
-            }
-
-            return el.value || '';
-        };
-
         // Gather teachers from subform
         const teacherNames = [];
         document.querySelectorAll('[name*="[teacher_id]"]').forEach((sel) => {

--- a/build/media_source/js/setup-wizard.es6.js
+++ b/build/media_source/js/setup-wizard.es6.js
@@ -12,391 +12,391 @@
 'use strict';
 
 (function () {
-  const config = window.ProcSetupWizard || {};
-  const token = config.token || '';
-  const baseUrl = config.baseUrl || '';
-  const presets = config.presets || {};
+    const config = window.ProcSetupWizard || {};
+    const token = config.token || '';
+    const baseUrl = config.baseUrl || '';
+    const presets = config.presets || {};
 
-  let currentStep = 1;
-  const totalSteps = 5;
+    let currentStep = 1;
+    const totalSteps = 5;
 
-  function esc(str) {
-    const el = document.createElement('span');
-    el.textContent = String(str);
-    return el.innerHTML;
-  }
+    function esc(str) {
+        const el = document.createElement('span');
+        el.textContent = String(str);
+        return el.innerHTML;
+    }
 
-  // DOM references
-  const progressBar = document.getElementById('wizard-progress-bar');
-  const prevBtn = document.getElementById('wizard-prev-btn');
-  const nextBtn = document.getElementById('wizard-next-btn');
-  const applyBtn = document.getElementById('wizard-apply-btn');
-  const dismissBtn = document.getElementById('wizard-dismiss-btn');
-  const reviewSummary = document.getElementById('wizard-review-summary');
+    // DOM references
+    const progressBar = document.getElementById('wizard-progress-bar');
+    const prevBtn = document.getElementById('wizard-prev-btn');
+    const nextBtn = document.getElementById('wizard-next-btn');
+    const applyBtn = document.getElementById('wizard-apply-btn');
+    const dismissBtn = document.getElementById('wizard-dismiss-btn');
+    const reviewSummary = document.getElementById('wizard-review-summary');
 
-  /**
+    /**
    * Navigate to a specific step.
    *
    * @param {number} step  Step number (1-5).
    */
-  function goToStep(step) {
-    if (step < 1 || step > totalSteps) return;
+    function goToStep(step) {
+        if (step < 1 || step > totalSteps) return;
 
-    // Hide all steps
-    document.querySelectorAll('.wizard-step').forEach(el => {
-      el.classList.add('d-none');
-      el.classList.remove('active');
-    });
+        // Hide all steps
+        document.querySelectorAll('.wizard-step').forEach(el => {
+            el.classList.add('d-none');
+            el.classList.remove('active');
+        });
 
-    // Show target step
-    const target = document.querySelector(`.wizard-step[data-step="${step}"]`);
-    if (target) {
-      target.classList.remove('d-none');
-      target.classList.add('active');
+        // Show target step
+        const target = document.querySelector(`.wizard-step[data-step="${step}"]`);
+        if (target) {
+            target.classList.remove('d-none');
+            target.classList.add('active');
+        }
+
+        currentStep = step;
+
+        // Update progress bar
+        const pct = Math.round((step / totalSteps) * 100);
+        progressBar.style.width = pct + '%';
+        progressBar.setAttribute('aria-valuenow', pct);
+
+        // Update step labels
+        document.querySelectorAll('.wizard-step-label').forEach(label => {
+            const labelStep = parseInt(label.dataset.step, 10);
+            label.classList.remove('bg-success', 'bg-secondary');
+            label.classList.add(labelStep <= step ? 'bg-success' : 'bg-secondary');
+        });
+
+        // Button visibility
+        prevBtn.classList.toggle('d-none', step === 1);
+        nextBtn.classList.toggle('d-none', step === totalSteps);
+        applyBtn.classList.toggle('d-none', step !== totalSteps);
+        dismissBtn.classList.toggle('d-none', step === totalSteps);
+
+        // Build review summary on last step
+        if (step === totalSteps) {
+            buildReview();
+        }
+
+        // Update next button state
+        updateNextButton();
     }
 
-    currentStep = step;
-
-    // Update progress bar
-    const pct = Math.round((step / totalSteps) * 100);
-    progressBar.style.width = pct + '%';
-    progressBar.setAttribute('aria-valuenow', pct);
-
-    // Update step labels
-    document.querySelectorAll('.wizard-step-label').forEach(label => {
-      const labelStep = parseInt(label.dataset.step, 10);
-      label.classList.remove('bg-success', 'bg-secondary');
-      label.classList.add(labelStep <= step ? 'bg-success' : 'bg-secondary');
-    });
-
-    // Button visibility
-    prevBtn.classList.toggle('d-none', step === 1);
-    nextBtn.classList.toggle('d-none', step === totalSteps);
-    applyBtn.classList.toggle('d-none', step !== totalSteps);
-    dismissBtn.classList.toggle('d-none', step === totalSteps);
-
-    // Build review summary on last step
-    if (step === totalSteps) {
-      buildReview();
-    }
-
-    // Update next button state
-    updateNextButton();
-  }
-
-  /**
+    /**
    * Check if the current step is valid and enable/disable Next.
    */
-  function updateNextButton() {
-    let valid = true;
+    function updateNextButton() {
+        let valid = true;
 
-    if (currentStep === 1) {
-      valid = document.getElementById('wizard-ministry-style').value !== '';
-    } else if (currentStep === 2) {
-      valid = document.getElementById('wizard-org-name').value.trim() !== '';
+        if (currentStep === 1) {
+            valid = document.getElementById('wizard-ministry-style').value !== '';
+        } else if (currentStep === 2) {
+            valid = document.getElementById('wizard-org-name').value.trim() !== '';
+        }
+
+        nextBtn.disabled = !valid;
     }
 
-    nextBtn.disabled = !valid;
-  }
-
-  /**
+    /**
    * Apply preset defaults when a ministry style is selected (Step 1).
    *
    * @param {string} styleKey  Preset key.
    */
-  function applyPresetDefaults(styleKey) {
-    const preset = presets[styleKey];
-    if (!preset) return;
+    function applyPresetDefaults(styleKey) {
+        const preset = presets[styleKey];
+        if (!preset) return;
 
-    // Update content toggles (Step 3)
-    const seriesEl = document.getElementById('wizard-use-series');
-    const topicsEl = document.getElementById('wizard-use-topics');
-    const locationsEl = document.getElementById('wizard-use-locations');
+        // Update content toggles (Step 3)
+        const seriesEl = document.getElementById('wizard-use-series');
+        const topicsEl = document.getElementById('wizard-use-topics');
+        const locationsEl = document.getElementById('wizard-use-locations');
 
-    if (seriesEl) seriesEl.checked = preset.use_series !== false;
-    if (topicsEl) topicsEl.checked = preset.use_topics === true;
-    if (locationsEl) locationsEl.checked = preset.use_locations === true;
+        if (seriesEl) seriesEl.checked = preset.use_series !== false;
+        if (topicsEl) topicsEl.checked = preset.use_topics === true;
+        if (locationsEl) locationsEl.checked = preset.use_locations === true;
 
-    // Show/hide conditional sections based on style
-    const simpleOpts = document.getElementById('wizard-simple-options');
-    const campusNote = document.getElementById('wizard-campus-note');
-    const podcastSection = document.getElementById('wizard-podcast-section');
-    const locationDetails = document.getElementById('wizard-location-details');
+        // Show/hide conditional sections based on style
+        const simpleOpts = document.getElementById('wizard-simple-options');
+        const campusNote = document.getElementById('wizard-campus-note');
+        const podcastSection = document.getElementById('wizard-podcast-section');
+        const locationDetails = document.getElementById('wizard-location-details');
 
-    if (simpleOpts) simpleOpts.classList.toggle('d-none', styleKey !== 'simple');
-    if (campusNote) campusNote.classList.toggle('d-none', styleKey !== 'multi_campus');
-    if (podcastSection) podcastSection.classList.toggle('d-none', styleKey === 'simple');
-    if (locationDetails) locationDetails.classList.toggle('d-none', styleKey === 'simple');
+        if (simpleOpts) simpleOpts.classList.toggle('d-none', styleKey !== 'simple');
+        if (campusNote) campusNote.classList.toggle('d-none', styleKey !== 'multi_campus');
+        if (podcastSection) podcastSection.classList.toggle('d-none', styleKey === 'simple');
+        if (locationDetails) locationDetails.classList.toggle('d-none', styleKey === 'simple');
 
-    // Comments default: off for simple, on for full/multi
-    const commentsEl = document.getElementById('wizard-enable-comments');
-    if (commentsEl) commentsEl.checked = styleKey !== 'simple';
-  }
+        // Comments default: off for simple, on for full/multi
+        const commentsEl = document.getElementById('wizard-enable-comments');
+        if (commentsEl) commentsEl.checked = styleKey !== 'simple';
+    }
 
-  /**
+    /**
    * Show/hide media-specific config panels based on radio selection.
    */
-  function updateMediaConfig() {
-    const selected = document.querySelector('input[name="wizard-media"]:checked')?.value || 'local';
-    const ytConfig = document.getElementById('wizard-youtube-config');
-    const vimeoConfig = document.getElementById('wizard-vimeo-config');
+    function updateMediaConfig() {
+        const selected = document.querySelector('input[name="wizard-media"]:checked')?.value || 'local';
+        const ytConfig = document.getElementById('wizard-youtube-config');
+        const vimeoConfig = document.getElementById('wizard-vimeo-config');
 
-    if (ytConfig) ytConfig.classList.toggle('d-none', selected !== 'youtube');
-    if (vimeoConfig) vimeoConfig.classList.toggle('d-none', selected !== 'vimeo');
-  }
+        if (ytConfig) ytConfig.classList.toggle('d-none', selected !== 'youtube');
+        if (vimeoConfig) vimeoConfig.classList.toggle('d-none', selected !== 'vimeo');
+    }
 
-  /**
+    /**
    * Collect all wizard data from form fields.
    *
    * @returns {Object}  Wizard data payload.
    */
-  function collectData() {
-    const style = document.getElementById('wizard-ministry-style').value;
-    const media = document.querySelector('input[name="wizard-media"]:checked')?.value || 'local';
+    function collectData() {
+        const style = document.getElementById('wizard-ministry-style').value;
+        const media = document.querySelector('input[name="wizard-media"]:checked')?.value || 'local';
 
-    const bibleProvider = document.querySelector('input[name="wizard-bible-provider"]:checked')?.value || 'getbible';
+        const bibleProvider = document.querySelector('input[name="wizard-bible-provider"]:checked')?.value || 'getbible';
 
-    const data = {
-      ministry_style: style,
-      org_name: document.getElementById('wizard-org-name').value.trim(),
-      teacher_name: document.getElementById('wizard-teacher-name')?.value.trim() || '',
-      default_bible_version: document.getElementById('wizard-bible-version').value,
-      uploadpath: document.getElementById('wizard-upload-path').value.trim(),
-      provider_getbible: bibleProvider === 'getbible' ? 1 : 0,
-      provider_api_bible: bibleProvider === 'apibible' ? 1 : 0,
-      api_bible_api_key: document.getElementById('wizard-apibible-key')?.value.trim() || '',
-      metadesc: document.getElementById('wizard-metadesc')?.value.trim() || '',
-      primary_media: media,
-      create_sample_content: document.getElementById('wizard-sample-content').checked,
-      use_default_images: document.getElementById('wizard-default-images')?.checked || false,
-      enable_ai: document.getElementById('wizard-enable-ai').checked,
-      ai_voice: document.getElementById('wizard-ai-voice')?.value || 'third_person',
-      enable_podcast: document.getElementById('wizard-enable-podcast')?.checked || false,
-      enable_backup: document.getElementById('wizard-enable-backup')?.checked || false,
-      enable_comments: document.getElementById('wizard-enable-comments')?.checked || false,
-      social_sharing: document.getElementById('wizard-social-sharing')?.checked || false,
-      studylistlimit: document.getElementById('wizard-items-per-page')?.value || '20',
-      download_button_text: document.querySelector('input[name="wizard-download-text"]:checked')?.value || 'Listen',
-      gdpr_mode: document.getElementById('wizard-gdpr-mode')?.checked ? 1 : 0,
-      analytics_enabled: 1,
-      // Location details
-      location_address: document.getElementById('wizard-loc-address')?.value.trim() || '',
-      location_city: document.getElementById('wizard-loc-city')?.value.trim() || '',
-      location_state: document.getElementById('wizard-loc-state')?.value.trim() || '',
-      location_postcode: document.getElementById('wizard-loc-postcode')?.value.trim() || '',
-      location_phone: document.getElementById('wizard-loc-phone')?.value.trim() || '',
-    };
+        const data = {
+            ministry_style: style,
+            org_name: document.getElementById('wizard-org-name').value.trim(),
+            teacher_name: document.getElementById('wizard-teacher-name')?.value.trim() || '',
+            default_bible_version: document.getElementById('wizard-bible-version').value,
+            uploadpath: document.getElementById('wizard-upload-path').value.trim(),
+            provider_getbible: bibleProvider === 'getbible' ? 1 : 0,
+            provider_api_bible: bibleProvider === 'apibible' ? 1 : 0,
+            api_bible_api_key: document.getElementById('wizard-apibible-key')?.value.trim() || '',
+            metadesc: document.getElementById('wizard-metadesc')?.value.trim() || '',
+            primary_media: media,
+            create_sample_content: document.getElementById('wizard-sample-content').checked,
+            use_default_images: document.getElementById('wizard-default-images')?.checked || false,
+            enable_ai: document.getElementById('wizard-enable-ai').checked,
+            ai_voice: document.getElementById('wizard-ai-voice')?.value || 'third_person',
+            enable_podcast: document.getElementById('wizard-enable-podcast')?.checked || false,
+            enable_backup: document.getElementById('wizard-enable-backup')?.checked || false,
+            enable_comments: document.getElementById('wizard-enable-comments')?.checked || false,
+            social_sharing: document.getElementById('wizard-social-sharing')?.checked || false,
+            studylistlimit: document.getElementById('wizard-items-per-page')?.value || '20',
+            download_button_text: document.querySelector('input[name="wizard-download-text"]:checked')?.value || 'Listen',
+            gdpr_mode: document.getElementById('wizard-gdpr-mode')?.checked ? 1 : 0,
+            analytics_enabled: 1,
+            // Location details
+            location_address: document.getElementById('wizard-loc-address')?.value.trim() || '',
+            location_city: document.getElementById('wizard-loc-city')?.value.trim() || '',
+            location_state: document.getElementById('wizard-loc-state')?.value.trim() || '',
+            location_postcode: document.getElementById('wizard-loc-postcode')?.value.trim() || '',
+            location_phone: document.getElementById('wizard-loc-phone')?.value.trim() || '',
+        };
 
-    // Simple mode template choice
-    if (style === 'simple') {
-      data.simple_mode_template = document.querySelector('input[name="wizard-simple-template"]:checked')?.value || 'simple_mode1';
-      data.simplegridtextoverlay = document.getElementById('wizard-text-overlay')?.checked ? 1 : 0;
+        // Simple mode template choice
+        if (style === 'simple') {
+            data.simple_mode_template = document.querySelector('input[name="wizard-simple-template"]:checked')?.value || 'simple_mode1';
+            data.simplegridtextoverlay = document.getElementById('wizard-text-overlay')?.checked ? 1 : 0;
+        }
+
+        // YouTube config
+        if (media === 'youtube') {
+            data.youtube_api_key = document.getElementById('wizard-yt-api-key')?.value.trim() || '';
+            data.youtube_channel_id = document.getElementById('wizard-yt-channel')?.value.trim() || '';
+        }
+
+        // Vimeo config
+        if (media === 'vimeo') {
+            data.vimeo_access_token = document.getElementById('wizard-vimeo-token')?.value.trim() || '';
+        }
+
+        // Podcast details
+        if (data.enable_podcast) {
+            data.podcast_title = document.getElementById('wizard-podcast-title')?.value.trim() || '';
+            data.podcast_description = document.getElementById('wizard-podcast-description')?.value.trim() || '';
+            data.podcast_author = document.getElementById('wizard-podcast-author')?.value.trim() || '';
+            data.podcast_email = document.getElementById('wizard-podcast-email')?.value.trim() || '';
+        }
+
+        return data;
     }
 
-    // YouTube config
-    if (media === 'youtube') {
-      data.youtube_api_key = document.getElementById('wizard-yt-api-key')?.value.trim() || '';
-      data.youtube_channel_id = document.getElementById('wizard-yt-channel')?.value.trim() || '';
-    }
-
-    // Vimeo config
-    if (media === 'vimeo') {
-      data.vimeo_access_token = document.getElementById('wizard-vimeo-token')?.value.trim() || '';
-    }
-
-    // Podcast details
-    if (data.enable_podcast) {
-      data.podcast_title = document.getElementById('wizard-podcast-title')?.value.trim() || '';
-      data.podcast_description = document.getElementById('wizard-podcast-description')?.value.trim() || '';
-      data.podcast_author = document.getElementById('wizard-podcast-author')?.value.trim() || '';
-      data.podcast_email = document.getElementById('wizard-podcast-email')?.value.trim() || '';
-    }
-
-    return data;
-  }
-
-  /**
+    /**
    * Build the review summary (Step 5).
    */
-  function buildReview() {
-    const data = collectData();
-    const preset = presets[data.ministry_style] || {};
-    const styleLabel = preset.label ? Joomla.Text._(preset.label) || data.ministry_style : data.ministry_style;
+    function buildReview() {
+        const data = collectData();
+        const preset = presets[data.ministry_style] || {};
+        const styleLabel = preset.label ? Joomla.Text._(preset.label) || data.ministry_style : data.ministry_style;
 
-    const mediaLabels = {
-      local: 'Local Uploads',
-      youtube: 'YouTube',
-      vimeo: 'Vimeo',
-      direct: 'Direct Links',
-    };
+        const mediaLabels = {
+            local: 'Local Uploads',
+            youtube: 'YouTube',
+            vimeo: 'Vimeo',
+            direct: 'Direct Links',
+        };
 
-    let html = '<table class="table table-striped mb-0">';
-    html += `<tr><th style="width:40%">Ministry Style</th><td>${esc(styleLabel)}</td></tr>`;
-    html += `<tr><th>Organization</th><td>${data.org_name ? esc(data.org_name) : '<em>Not set</em>'}</td></tr>`;
-    if (data.teacher_name) {
-      html += `<tr><th>Default Teacher</th><td>${esc(data.teacher_name)}</td></tr>`;
+        let html = '<table class="table table-striped mb-0">';
+        html += `<tr><th style="width:40%">Ministry Style</th><td>${esc(styleLabel)}</td></tr>`;
+        html += `<tr><th>Organization</th><td>${data.org_name ? esc(data.org_name) : '<em>Not set</em>'}</td></tr>`;
+        if (data.teacher_name) {
+            html += `<tr><th>Default Teacher</th><td>${esc(data.teacher_name)}</td></tr>`;
+        }
+        html += `<tr><th>Bible Version</th><td>${esc(data.default_bible_version.toUpperCase())}</td></tr>`;
+        html += `<tr><th>Upload Path</th><td><code>${esc(data.uploadpath)}</code></td></tr>`;
+        html += `<tr><th>Primary Media</th><td>${esc(mediaLabels[data.primary_media] || data.primary_media)}</td></tr>`;
+
+        if (data.primary_media === 'youtube' && data.youtube_api_key) {
+            html += `<tr><th>YouTube API Key</th><td><code>${esc(data.youtube_api_key.substring(0, 8))}...</code></td></tr>`;
+        }
+        if (data.primary_media === 'vimeo' && data.vimeo_access_token) {
+            html += `<tr><th>Vimeo Token</th><td><code>${esc(data.vimeo_access_token.substring(0, 8))}...</code></td></tr>`;
+        }
+        html += `<tr><th>Download Button</th><td>${esc(data.download_button_text)}</td></tr>`;
+
+        if (data.enable_podcast) {
+            html += `<tr><th>Podcasting</th><td>Enabled</td></tr>`;
+            if (data.podcast_title) {
+                html += `<tr><th>Podcast Title</th><td>${esc(data.podcast_title)}</td></tr>`;
+            }
+        }
+
+        html += `<tr><th>Social Sharing</th><td>${data.social_sharing ? 'Enabled' : 'Disabled'}</td></tr>`;
+        html += `<tr><th>Comments</th><td>${data.enable_comments ? 'Enabled' : 'Disabled'}</td></tr>`;
+        html += `<tr><th>Items Per Page</th><td>${esc(data.studylistlimit)}</td></tr>`;
+        html += `<tr><th>Sample Content</th><td>${data.create_sample_content ? 'Yes' : 'No'}</td></tr>`;
+        html += `<tr><th>AI Assistant</th><td>${data.enable_ai ? 'Enabled' : 'Disabled'}</td></tr>`;
+
+        if (data.enable_ai) {
+            const voiceLabels = {
+                third_person: 'Third Person',
+                first_person: 'First Person',
+                conversational: 'Conversational',
+                summary: 'Summary',
+            };
+            html += `<tr><th>AI Writing Voice</th><td>${esc(voiceLabels[data.ai_voice] || data.ai_voice)}</td></tr>`;
+        }
+
+        if (data.gdpr_mode) {
+            html += `<tr><th>GDPR Privacy Mode</th><td>Enabled</td></tr>`;
+        }
+
+        html += '</table>';
+
+        reviewSummary.innerHTML = html;
     }
-    html += `<tr><th>Bible Version</th><td>${esc(data.default_bible_version.toUpperCase())}</td></tr>`;
-    html += `<tr><th>Upload Path</th><td><code>${esc(data.uploadpath)}</code></td></tr>`;
-    html += `<tr><th>Primary Media</th><td>${esc(mediaLabels[data.primary_media] || data.primary_media)}</td></tr>`;
 
-    if (data.primary_media === 'youtube' && data.youtube_api_key) {
-      html += `<tr><th>YouTube API Key</th><td><code>${esc(data.youtube_api_key.substring(0, 8))}...</code></td></tr>`;
-    }
-    if (data.primary_media === 'vimeo' && data.vimeo_access_token) {
-      html += `<tr><th>Vimeo Token</th><td><code>${esc(data.vimeo_access_token.substring(0, 8))}...</code></td></tr>`;
-    }
-    html += `<tr><th>Download Button</th><td>${esc(data.download_button_text)}</td></tr>`;
-
-    if (data.enable_podcast) {
-      html += `<tr><th>Podcasting</th><td>Enabled</td></tr>`;
-      if (data.podcast_title) {
-        html += `<tr><th>Podcast Title</th><td>${esc(data.podcast_title)}</td></tr>`;
-      }
-    }
-
-    html += `<tr><th>Social Sharing</th><td>${data.social_sharing ? 'Enabled' : 'Disabled'}</td></tr>`;
-    html += `<tr><th>Comments</th><td>${data.enable_comments ? 'Enabled' : 'Disabled'}</td></tr>`;
-    html += `<tr><th>Items Per Page</th><td>${esc(data.studylistlimit)}</td></tr>`;
-    html += `<tr><th>Sample Content</th><td>${data.create_sample_content ? 'Yes' : 'No'}</td></tr>`;
-    html += `<tr><th>AI Assistant</th><td>${data.enable_ai ? 'Enabled' : 'Disabled'}</td></tr>`;
-
-    if (data.enable_ai) {
-      const voiceLabels = {
-        third_person: 'Third Person',
-        first_person: 'First Person',
-        conversational: 'Conversational',
-        summary: 'Summary',
-      };
-      html += `<tr><th>AI Writing Voice</th><td>${esc(voiceLabels[data.ai_voice] || data.ai_voice)}</td></tr>`;
-    }
-
-    if (data.gdpr_mode) {
-      html += `<tr><th>GDPR Privacy Mode</th><td>Enabled</td></tr>`;
-    }
-
-    html += '</table>';
-
-    reviewSummary.innerHTML = html;
-  }
-
-  /**
+    /**
    * Send the wizard data to the server.
    */
-  async function applyWizard() {
-    const data = collectData();
-    applyBtn.disabled = true;
-    applyBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Applying...';
+    async function applyWizard() {
+        const data = collectData();
+        applyBtn.disabled = true;
+        applyBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Applying...';
 
-    const formData = new FormData();
-    formData.append(token, '1');
-    formData.append('wizard_data', JSON.stringify(data));
+        const formData = new FormData();
+        formData.append(token, '1');
+        formData.append('wizard_data', JSON.stringify(data));
 
-    try {
-      const response = await fetch(
-        `${baseUrl}?option=com_proclaim&task=cwmsetupwizard.apply&format=json`,
-        { method: 'POST', body: formData }
-      );
+        try {
+            const response = await fetch(
+                `${baseUrl}?option=com_proclaim&task=cwmsetupwizard.apply&format=json`,
+                { method: 'POST', body: formData }
+            );
 
-      const result = await response.json();
+            const result = await response.json();
 
-      if (result.success) {
-        Joomla.renderMessages({ message: [result.message || 'Setup complete!'] });
+            if (result.success) {
+                Joomla.renderMessages({ message: [result.message || 'Setup complete!'] });
 
-        if (result.data?.redirect) {
-          setTimeout(() => {
-            window.location.href = result.data.redirect;
-          }, 1500);
+                if (result.data?.redirect) {
+                    setTimeout(() => {
+                        window.location.href = result.data.redirect;
+                    }, 1500);
+                }
+            } else {
+                Joomla.renderMessages({ error: [result.message || 'An error occurred.'] });
+                applyBtn.disabled = false;
+                applyBtn.innerHTML = '<i class="fa-solid fa-check me-1"></i> Apply';
+            }
+        } catch (err) {
+            Joomla.renderMessages({ error: [err.message || 'Network error.'] });
+            applyBtn.disabled = false;
+            applyBtn.innerHTML = '<i class="fa-solid fa-check me-1"></i> Apply';
         }
-      } else {
-        Joomla.renderMessages({ error: [result.message || 'An error occurred.'] });
-        applyBtn.disabled = false;
-        applyBtn.innerHTML = '<i class="fa-solid fa-check me-1"></i> Apply';
-      }
-    } catch (err) {
-      Joomla.renderMessages({ error: [err.message || 'Network error.'] });
-      applyBtn.disabled = false;
-      applyBtn.innerHTML = '<i class="fa-solid fa-check me-1"></i> Apply';
     }
-  }
 
-  /**
+    /**
    * Dismiss the wizard without applying.
    */
-  async function dismissWizard() {
-    if (!confirm(Joomla.Text._('JBS_WIZARD_CONFIRM_DISMISS') || 'Skip the setup wizard?')) {
-      return;
+    async function dismissWizard() {
+        if (!confirm(Joomla.Text._('JBS_WIZARD_CONFIRM_DISMISS') || 'Skip the setup wizard?')) {
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append(token, '1');
+
+        try {
+            await fetch(
+                `${baseUrl}?option=com_proclaim&task=cwmsetupwizard.dismiss&format=json`,
+                { method: 'POST', body: formData }
+            );
+        } catch { /* ignore */ }
+
+        window.location.href = `${baseUrl}?option=com_proclaim&view=cwmcpanel`;
     }
 
-    const formData = new FormData();
-    formData.append(token, '1');
+    // --- Event Listeners ---
 
-    try {
-      await fetch(
-        `${baseUrl}?option=com_proclaim&task=cwmsetupwizard.dismiss&format=json`,
-        { method: 'POST', body: formData }
-      );
-    } catch { /* ignore */ }
+    // Style card selection (Step 1)
+    document.querySelectorAll('.style-card').forEach(card => {
+        card.addEventListener('click', () => {
+            document.querySelectorAll('.style-card').forEach(c => c.classList.remove('border-primary', 'shadow'));
+            card.classList.add('border-primary', 'shadow');
+            document.getElementById('wizard-ministry-style').value = card.dataset.style;
+            applyPresetDefaults(card.dataset.style);
+            updateNextButton();
+        });
 
-    window.location.href = `${baseUrl}?option=com_proclaim&view=cwmcpanel`;
-  }
-
-  // --- Event Listeners ---
-
-  // Style card selection (Step 1)
-  document.querySelectorAll('.style-card').forEach(card => {
-    card.addEventListener('click', () => {
-      document.querySelectorAll('.style-card').forEach(c => c.classList.remove('border-primary', 'shadow'));
-      card.classList.add('border-primary', 'shadow');
-      document.getElementById('wizard-ministry-style').value = card.dataset.style;
-      applyPresetDefaults(card.dataset.style);
-      updateNextButton();
+        card.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                card.click();
+            }
+        });
     });
 
-    card.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        card.click();
-      }
+    // Org name validation (Step 2)
+    document.getElementById('wizard-org-name')?.addEventListener('input', updateNextButton);
+
+    // Bible provider radio — show/hide API.Bible key field (Step 2)
+    document.querySelectorAll('input[name="wizard-bible-provider"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            const apiConfig = document.getElementById('wizard-apibible-config');
+            if (apiConfig) {
+                apiConfig.classList.toggle('d-none', radio.value !== 'apibible' || !radio.checked);
+            }
+        });
     });
-  });
 
-  // Org name validation (Step 2)
-  document.getElementById('wizard-org-name')?.addEventListener('input', updateNextButton);
-
-  // Bible provider radio — show/hide API.Bible key field (Step 2)
-  document.querySelectorAll('input[name="wizard-bible-provider"]').forEach(radio => {
-    radio.addEventListener('change', () => {
-      const apiConfig = document.getElementById('wizard-apibible-config');
-      if (apiConfig) {
-        apiConfig.classList.toggle('d-none', radio.value !== 'apibible' || !radio.checked);
-      }
+    // Media source radio — show/hide platform config panels (Step 4)
+    document.querySelectorAll('input[name="wizard-media"]').forEach(radio => {
+        radio.addEventListener('change', updateMediaConfig);
     });
-  });
 
-  // Media source radio — show/hide platform config panels (Step 4)
-  document.querySelectorAll('input[name="wizard-media"]').forEach(radio => {
-    radio.addEventListener('change', updateMediaConfig);
-  });
+    // Podcast toggle — show/hide podcast details (Step 4)
+    document.getElementById('wizard-enable-podcast')?.addEventListener('change', (e) => {
+        const podcastConfig = document.getElementById('wizard-podcast-config');
+        if (podcastConfig) podcastConfig.classList.toggle('d-none', !e.target.checked);
+    });
 
-  // Podcast toggle — show/hide podcast details (Step 4)
-  document.getElementById('wizard-enable-podcast')?.addEventListener('change', (e) => {
-    const podcastConfig = document.getElementById('wizard-podcast-config');
-    if (podcastConfig) podcastConfig.classList.toggle('d-none', !e.target.checked);
-  });
+    // AI toggle — show/hide voice selection (Step 4)
+    document.getElementById('wizard-enable-ai')?.addEventListener('change', (e) => {
+        const voiceSection = document.getElementById('wizard-ai-voice-section');
+        if (voiceSection) voiceSection.classList.toggle('d-none', !e.target.checked);
+    });
 
-  // AI toggle — show/hide voice selection (Step 4)
-  document.getElementById('wizard-enable-ai')?.addEventListener('change', (e) => {
-    const voiceSection = document.getElementById('wizard-ai-voice-section');
-    if (voiceSection) voiceSection.classList.toggle('d-none', !e.target.checked);
-  });
+    // Navigation
+    nextBtn.addEventListener('click', () => goToStep(currentStep + 1));
+    prevBtn.addEventListener('click', () => goToStep(currentStep - 1));
+    applyBtn.addEventListener('click', applyWizard);
+    dismissBtn.addEventListener('click', dismissWizard);
 
-  // Navigation
-  nextBtn.addEventListener('click', () => goToStep(currentStep + 1));
-  prevBtn.addEventListener('click', () => goToStep(currentStep - 1));
-  applyBtn.addEventListener('click', applyWizard);
-  dismissBtn.addEventListener('click', dismissWizard);
-
-  // Initialize
-  goToStep(1);
+    // Initialize
+    goToStep(1);
 })();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,15 @@ import baseConfig from './libraries/vendor/cwm/build-tools/templates/eslint.conf
 export default [
     ...baseConfig,
     {
+        // Skip minified files (lint sources, not build output) and vendored
+        // submodules (lib_cwmscripture is maintained in its own repo).
+        ignores: [
+            '**/*.min.js',
+            '**/lib_cwmscripture/**',
+            'plugins/content/scripturelinks/libraries/**',
+        ],
+    },
+    {
         files: ['**/*.js', '**/*.mjs', '**/*.es6.js'],
         languageOptions: {
             globals: {
@@ -10,6 +19,11 @@ export default [
                 Sortable: 'readonly',
                 intlTelInput: 'readonly',
                 Chart: 'readonly',
+                // Joomla 5+ editor API and legacy TinyMCE global
+                JoomlaEditor: 'readonly',
+                tinyMCE: 'readonly',
+                // AddToAny social-share configuration object
+                a2a_config: 'writable',
             },
         },
     },


### PR DESCRIPTION
First of three follow-up PRs from a JS coding-standards audit triggered by epic #1210. Mechanical cleanup — no behavior change.

## Background

`npm run lint:js` reported **1324 errors**, but 1300+ came from a single vendored minified file in the `lib_cwmscripture` submodule. After scoping to project source, **364 real errors across 8 files**; 345 were auto-fixable.

## Changes

### `eslint.config.mjs`
| | |
|---|---|
| New ignore: `**/*.min.js` | Lint sources, not build output |
| New ignore: `**/lib_cwmscripture/**` and `plugins/content/scripturelinks/libraries/**` | Vendored submodule, maintained in its own repo |
| New globals: `JoomlaEditor`, `tinyMCE`, `a2a_config` | Real code referenced these and triggered `no-undef` |

### Auto-fixed (`eslint --fix`)
Indentation drift in `cwm-landing-toggle.es6.js`, `setup-wizard.es6.js`, `message-wizard.es6.js`, others. Two `var` → `let`/`const` in `cwm-youtube-tracks.es6.js`.

### Manually fixed (not auto-fixable)
- `addon-youtube-browser.es6.js:256` — collapse useless `studyTitle` assignment
- `cwm-transcript.es6.js:84` — array destructuring on `tsParts.split()`
- `message-ai-assist.es6.js:567` — `pulseIndex++` → `pulseIndex += 1` (no-plusplus rule)
- `message-wizard.es6.js:135-147` — drop unused `getSelectedText` helper

## Verification
- [x] `npx eslint . --max-warnings=0` — exit 0
- [x] `npm test` — 229/229 Jest tests pass

## Out of scope (next PRs in the audit follow-up)
- PR 2: Migrate `Joomla.editors.instances` → `JoomlaEditor.get()` in 7 modal files
- PR 3: Fix `Joomla.Text._('K') || 'fallback'` truthy-key trap in 17 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)