### PR TITLE
chore(js): migrate Joomla.editors.instances → JoomlaEditor.get

### DIFF
--- a/build/media_source/js/cwmadmin-locations-modal.es6.js
+++ b/build/media_source/js/cwmadmin-locations-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/cwmadmin-messages-modal.es6.js
+++ b/build/media_source/js/cwmadmin-messages-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/cwmadmin-series-modal.es6.js
+++ b/build/media_source/js/cwmadmin-series-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/cwmadmin-servers-modal.es6.js
+++ b/build/media_source/js/cwmadmin-servers-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/cwmadmin-teachers-modal.es6.js
+++ b/build/media_source/js/cwmadmin-teachers-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/cwmadmin-types-modal.es6.js
+++ b/build/media_source/js/cwmadmin-types-modal.es6.js
@@ -32,7 +32,7 @@
         }
 
         const tag = `<a ${hreflang} href="${link}">${title}</a>`;
-        window.parent.Joomla.editors.instances[editor].replaceSelection(tag);
+        window.parent.JoomlaEditor.get(editor).replaceSelection(tag);
 
         if (window.parent.Joomla.Modal) {
             window.parent.Joomla.Modal.getCurrent().close();

--- a/build/media_source/js/templatecode-snippets.es6.js
+++ b/build/media_source/js/templatecode-snippets.es6.js
@@ -20,7 +20,7 @@
    * @param {string} text      The snippet text to insert
    */
     const insertSnippet = (editorId, text) => {
-        const editor = Joomla.editors.instances[editorId];
+        const editor = JoomlaEditor.get(editorId);
 
         if (!editor) {
             return;


### PR DESCRIPTION
Second of three follow-up PRs from the JS coding-standards audit. Surface-level API rename — no behavior change.

## Background

The `Joomla.editors.instances[id]` proxy is documented as the **legacy** editor API in Joomla 5+. The modern equivalent is `JoomlaEditor.get(id)` which returns the same underlying wrapper but is the supported entry point going forward.

Per the skill's editor-api reference:
> The `JoomlaEditor` JS API (`get`, `getActive`, `getValue`, `setValue`, `getSelection`, `replaceSelection`, `disable`, `getRawInstance`, `getType`) — modern entry point. The legacy `Joomla.editors.instances` proxy remains for back-compat.

## Changes

Touches 7 files, 1 line each:

| File | Old → New |
|---|---|
| `cwmadmin-types-modal.es6.js` | `window.parent.Joomla.editors.instances[editor].replaceSelection(tag)` → `window.parent.JoomlaEditor.get(editor).replaceSelection(tag)` |
| `cwmadmin-servers-modal.es6.js` | same |
| `cwmadmin-messages-modal.es6.js` | same |
| `cwmadmin-teachers-modal.es6.js` | same |
| `cwmadmin-series-modal.es6.js` | same |
| `cwmadmin-locations-modal.es6.js` | same |
| `templatecode-snippets.es6.js` | `Joomla.editors.instances[editorId]` → `JoomlaEditor.get(editorId)` |

## Verification
- [x] `grep -rn "Joomla\.editors\.instances\[" build/media_source/js/` — 0 references remain
- [x] Lint clean on touched files (1 known `JoomlaEditor not defined` error in `templatecode-snippets.es6.js:23` resolves once #1234 merges — that PR adds `JoomlaEditor` to the eslint globals list)
- [ ] Manual: open the messages list → click an XTD button (insert link, etc.) → confirm tag inserts into the editor

## Out of scope (next in audit follow-up)
- PR 3: `Joomla.Text._('K') || 'fallback'` truthy-key trap fixes across 17 files

## PR ordering
This PR is independent of #1234 (ESLint cleanup) but the lint check will pass cleaner once #1234 merges first because it adds `JoomlaEditor` to the eslint globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)