### PR TITLE
fix(js): replace Joomla.Text._() truthy-key trap with safe helper

### DIFF
--- a/build/media_source/js/addon-vimeo-browser.es6.js
+++ b/build/media_source/js/addon-vimeo-browser.es6.js
@@ -6,6 +6,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     window.Proclaim = window.Proclaim || {};
 
     window.Proclaim.VimeoBrowser = {
@@ -335,7 +344,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');
@@ -394,7 +403,7 @@
             fetch(url, { signal: AbortSignal.timeout(30000) })
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');
@@ -533,7 +542,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');

--- a/build/media_source/js/addon-wistia-browser.es6.js
+++ b/build/media_source/js/addon-wistia-browser.es6.js
@@ -6,6 +6,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     window.Proclaim = window.Proclaim || {};
 
     window.Proclaim.WistiaBrowser = {
@@ -331,7 +340,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');
@@ -389,7 +398,7 @@
             fetch(url, { signal: AbortSignal.timeout(30000) })
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');
@@ -525,7 +534,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');

--- a/build/media_source/js/addon-youtube-browser.es6.js
+++ b/build/media_source/js/addon-youtube-browser.es6.js
@@ -6,6 +6,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     window.Proclaim = window.Proclaim || {};
 
     window.Proclaim.YoutubeBrowser = {
@@ -289,7 +298,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');
@@ -373,7 +382,7 @@
             fetch(url)
                 .then((response) => {
                     if (response.status === 403 || response.status === 401) {
-                        const expiredMsg = Joomla.Text._('JLIB_ENVIRONMENT_SESSION_EXPIRED') || 'Your session has expired. Please log in again.';
+                        const expiredMsg = t('JLIB_ENVIRONMENT_SESSION_EXPIRED', 'Your session has expired. Please log in again.');
                         Joomla.renderMessages({ error: [expiredMsg] });
                         setTimeout(() => { window.location.reload(); }, 3000);
                         throw new Error('Session expired');

--- a/build/media_source/js/admin-imagetools.es6.js
+++ b/build/media_source/js/admin-imagetools.es6.js
@@ -14,6 +14,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const { token } = config.dataset;
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
     // All XHR requests must bypass browser cache — counts and batch responses
     // change on every call as images are migrated/recovered/converted.
     const noCache = { cache: 'no-store' };
@@ -603,7 +611,7 @@ document.addEventListener('DOMContentLoaded', () => {
         cwmFetch(`index.php?option=com_proclaim&task=cwmadmin.getThumbRegenCountXHR&${token}=1`)
             .then((data) => {
                 const grandTotal = data.total;
-                const types = ['studies', 'teachers', 'series'].filter((t) => data[t] > 0);
+                const types = ['studies', 'teachers', 'series'].filter((type) => data[type] > 0);
                 processNextType(types, 0, grandTotal);
             });
 
@@ -1164,7 +1172,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const pipelineKeys = {
             running: 'JBS_ADM_PIPELINE_RUNNING', done: 'JBS_ADM_PIPELINE_DONE', skipped: 'JBS_ADM_PIPELINE_SKIPPED', error: 'JBS_ADM_PIPELINE_ERROR',
         };
-        badge.textContent = Joomla.Text._(pipelineKeys[state] || '') || state;
+        badge.textContent = t(pipelineKeys[state] || '', state);
     }
 
     function setPipelineStatus(text) {
@@ -1303,7 +1311,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const cleanupKeys = {
             running: 'JBS_ADM_CLEANUP_PIPELINE_RUNNING', done: 'JBS_ADM_CLEANUP_PIPELINE_DONE', skipped: 'JBS_ADM_CLEANUP_PIPELINE_SKIPPED', error: 'JBS_ADM_CLEANUP_PIPELINE_ERROR',
         };
-        badge.textContent = Joomla.Text._(cleanupKeys[state] || '') || state;
+        badge.textContent = t(cleanupKeys[state] || '', state);
     }
 
     function setCleanupStatus(text) {

--- a/build/media_source/js/admin-youtube-log.es6.js
+++ b/build/media_source/js/admin-youtube-log.es6.js
@@ -11,6 +11,15 @@
 document.addEventListener('DOMContentLoaded', () => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     // --- Level filter ---
     const levelFilter = document.getElementById('yt-log-level-filter');
 
@@ -57,8 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Reset quota counter buttons ---
     document.querySelectorAll('.btn-reset-yt-quota').forEach((btn) => {
         btn.addEventListener('click', () => {
-            const msg = Joomla.Text._('JBS_ADM_YOUTUBE_QUOTA_RESET_CONFIRM')
-                || 'Reset the quota counter for this server?';
+            const msg = t('JBS_ADM_YOUTUBE_QUOTA_RESET_CONFIRM', 'Reset the quota counter for this server?');
 
             if (!window.confirm(msg)) {
                 return;
@@ -102,7 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
 
                         Joomla.renderMessages({message: [
-                            Joomla.Text._('JBS_ADM_YOUTUBE_QUOTA_RESET_SUCCESS') || 'Quota counter has been reset.'
+                            t('JBS_ADM_YOUTUBE_QUOTA_RESET_SUCCESS', 'Quota counter has been reset.')
                         ]});
                     } else {
                         Joomla.renderMessages({error: [data.error || 'Reset failed']});
@@ -122,8 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (clearBtn) {
         clearBtn.addEventListener('click', () => {
-            const msg = Joomla.Text._('JBS_ADM_YOUTUBE_LOG_CLEAR_CONFIRM')
-                || 'Are you sure you want to clear all YouTube log entries?';
+            const msg = t('JBS_ADM_YOUTUBE_LOG_CLEAR_CONFIRM', 'Are you sure you want to clear all YouTube log entries?');
 
             if (!window.confirm(msg)) {
                 return;

--- a/build/media_source/js/cwm-fetch.es6.js
+++ b/build/media_source/js/cwm-fetch.es6.js
@@ -13,6 +13,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     /** Timeout presets (milliseconds) */
     const ADMIN_TIMEOUT = 30000;
     const FRONTEND_TIMEOUT = 15000;
@@ -103,7 +112,7 @@
     function notifySessionExpired() {
         if (typeof Joomla !== 'undefined' && Joomla.renderMessages) {
             const msg = (typeof Joomla.Text !== 'undefined' && Joomla.Text._)
-                ? Joomla.Text._('JBS_CMN_SESSION_EXPIRED') || 'Your session has expired. Please reload and log in again.'
+                ? t('JBS_CMN_SESSION_EXPIRED', 'Your session has expired. Please reload and log in again.')
                 : 'Your session has expired. Please reload and log in again.';
 
             Joomla.renderMessages({ error: [msg] });

--- a/build/media_source/js/cwm-transcript.es6.js
+++ b/build/media_source/js/cwm-transcript.es6.js
@@ -11,6 +11,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     /**
      * Parse a VTT timestamp (HH:MM:SS.mmm or MM:SS.mmm) into seconds.
      *
@@ -148,7 +157,7 @@
         const searchInput = document.createElement('input');
         searchInput.type = 'search';
         searchInput.className = 'form-control form-control-sm';
-        searchInput.placeholder = Joomla.Text._('JBS_MED_TRANSCRIPT_SEARCH') || 'Search transcript...';
+        searchInput.placeholder = t('JBS_MED_TRANSCRIPT_SEARCH', 'Search transcript...');
         searchInput.setAttribute('aria-label', searchInput.placeholder);
         searchWrap.appendChild(searchInput);
         panel.appendChild(searchWrap);
@@ -185,11 +194,11 @@
             let lastActive = -1;
 
             media.addEventListener('timeupdate', () => {
-                const t = media.currentTime;
+                const time = media.currentTime;
                 let activeIdx = -1;
 
                 for (let i = cues.length - 1; i >= 0; i -= 1) {
-                    if (t >= cues[i].start && t < cues[i].end) {
+                    if (time >= cues[i].start && time < cues[i].end) {
                         activeIdx = i;
                         break;
                     }

--- a/build/media_source/js/cwmadmin.es6.js
+++ b/build/media_source/js/cwmadmin.es6.js
@@ -12,6 +12,15 @@
 ((Joomla) => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     /**
    * CWM Admin Page Manager
    */
@@ -242,7 +251,7 @@
 
                 if (result.success && result.data) {
                     container.innerHTML = result.data.html;
-                    this.announceToScreenReader(Joomla.Text._('JBS_ADM_STATS_LOADED') || 'Statistics loaded');
+                    this.announceToScreenReader(t('JBS_ADM_STATS_LOADED', 'Statistics loaded'));
                 } else {
                     container.innerHTML = `<span class="text-danger">${result.message || 'Error loading stats'}</span>`;
                 }
@@ -339,7 +348,7 @@
 
             // Reset modal state
             if (spinner) spinner.style.display = 'block';
-            if (statusText) statusText.textContent = Joomla.Text._('JBS_ADM_ALIAS_UPDATING') || 'Updating aliases...';
+            if (statusText) statusText.textContent = t('JBS_ADM_ALIAS_UPDATING', 'Updating aliases...');
             if (resultText) resultText.textContent = '';
             if (footer) footer.style.display = 'none';
 
@@ -359,14 +368,14 @@
                     // Show success state
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-checkmark text-success me-2"></i>${
-                            Joomla.Text._('JBS_ADM_ALIAS_COMPLETE') || 'Alias update complete!'}`;
+                            t('JBS_ADM_ALIAS_COMPLETE', 'Alias update complete!')}`;
                     }
                     if (resultText) {
                         const count = result.count || 0;
                         if (count > 0) {
                             resultText.textContent = result.message || `${count} aliases updated`;
                         } else {
-                            resultText.textContent = Joomla.Text._('JBS_ADM_ALIAS_NONE') || 'No aliases needed to be updated.';
+                            resultText.textContent = t('JBS_ADM_ALIAS_NONE', 'No aliases needed to be updated.');
                         }
                     }
 
@@ -380,7 +389,7 @@
                     // Show error state
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                            Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                            t('JBS_ADM_ERROR', 'Error')}`;
                     }
                     if (resultText) {
                         resultText.textContent = result.message || 'An error occurred';
@@ -394,7 +403,7 @@
                 if (spinner) spinner.style.display = 'none';
                 if (statusText) {
                     statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                        Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                        t('JBS_ADM_ERROR', 'Error')}`;
                 }
                 if (resultText) {
                     resultText.textContent = error.message || 'An error occurred';
@@ -420,7 +429,7 @@
             if (choose) choose.style.display = 'none';
             if (progress) progress.style.display = 'block';
             if (spinner) spinner.style.display = 'block';
-            if (statusText) statusText.textContent = Joomla.Text._('JBS_ADM_SCHEMA_SYNCING') || 'Syncing schema data...';
+            if (statusText) statusText.textContent = t('JBS_ADM_SCHEMA_SYNCING', 'Syncing schema data...');
             if (resultText) resultText.textContent = '';
             if (footer) footer.style.display = 'none';
 
@@ -433,7 +442,7 @@
                 if (result.success) {
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-checkmark text-success me-2"></i>${
-                            Joomla.Text._('JBS_ADM_SCHEMA_SYNC_COMPLETE') || 'Schema sync complete!'}`;
+                            t('JBS_ADM_SCHEMA_SYNC_COMPLETE', 'Schema sync complete!')}`;
                     }
                     if (resultText) {
                         resultText.textContent = result.message || `${result.count} items synced`;
@@ -447,7 +456,7 @@
                 } else {
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                            Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                            t('JBS_ADM_ERROR', 'Error')}`;
                     }
                     if (resultText) {
                         resultText.textContent = result.message || 'An error occurred';
@@ -460,7 +469,7 @@
                 if (spinner) spinner.style.display = 'none';
                 if (statusText) {
                     statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                        Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                        t('JBS_ADM_ERROR', 'Error')}`;
                 }
                 if (resultText) {
                     resultText.textContent = error.message || 'An error occurred';
@@ -484,7 +493,7 @@
                 plays: 'JBS_ADM_RESET_STATS_CONFIRM_PLAYS',
             };
             if (statusEl) statusEl.style.display = 'none';
-            if (textEl) textEl.textContent = Joomla.Text._(keys[field]) || `Reset all ${field} to zero?`;
+            if (textEl) textEl.textContent = t(keys[field], `Reset all ${field} to zero?`);
             if (confirmEl) confirmEl.style.display = '';
         }
 
@@ -519,7 +528,7 @@
                 const result = await this.fetchJson(url);
                 if (statusEl) {
                     statusEl.style.display = 'block';
-                    const doneKey = Joomla.Text._('JBS_ADM_RESET_STATS_DONE') || '%s record(s) reset to zero.';
+                    const doneKey = t('JBS_ADM_RESET_STATS_DONE', '%s record(s) reset to zero.');
                     if (result.success) {
                         statusEl.innerHTML = `<div class="alert alert-success mb-0"><i class="icon-checkmark me-1" aria-hidden="true"></i>${doneKey.replace('%s', result.updated)}</div>`;
                     } else {
@@ -560,7 +569,7 @@
             // Validate selections
             if (!fromValue || fromValue === 'x' || !toValue || toValue === 'x') {
                 Joomla.renderMessages({
-                    error: [Joomla.Text._('JBS_ADM_SELECT_FROM_TO') || 'Please select both From and To values.'],
+                    error: [t('JBS_ADM_SELECT_FROM_TO', 'Please select both From and To values.')],
                 });
                 return;
             }
@@ -575,7 +584,7 @@
             // Reset modal state
             if (modalTitle) modalTitle.textContent = title;
             if (spinner) spinner.style.display = 'block';
-            if (statusText) statusText.textContent = Joomla.Text._('JBS_ADM_PLAYER_TOOLS_PROCESSING') || 'Processing changes...';
+            if (statusText) statusText.textContent = t('JBS_ADM_PLAYER_TOOLS_PROCESSING', 'Processing changes...');
             if (resultText) resultText.textContent = '';
             if (footer) footer.style.display = 'none';
 
@@ -610,7 +619,7 @@
                     // Show success state
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-checkmark text-success me-2"></i>${
-                            Joomla.Text._('JBS_ADM_PLAYER_TOOLS_COMPLETE') || 'Operation complete!'}`;
+                            t('JBS_ADM_PLAYER_TOOLS_COMPLETE', 'Operation complete!')}`;
                     }
                     if (resultText) {
                         resultText.textContent = result.message || `${result.count} records updated`;
@@ -630,7 +639,7 @@
                     // Show error state
                     if (statusText) {
                         statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                            Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                            t('JBS_ADM_ERROR', 'Error')}`;
                     }
                     if (resultText) {
                         resultText.textContent = result.message || 'An error occurred';
@@ -644,7 +653,7 @@
                 if (spinner) spinner.style.display = 'none';
                 if (statusText) {
                     statusText.innerHTML = `<i class="icon-warning text-danger me-2"></i>${
-                        Joomla.Text._('JBS_ADM_ERROR') || 'Error'}`;
+                        t('JBS_ADM_ERROR', 'Error')}`;
                 }
                 if (resultText) {
                     resultText.textContent = error.message || 'An error occurred';
@@ -686,8 +695,7 @@
             }
 
             // Confirm thumbnail resize
-            const confirmMsg = Joomla.Text._('JBS_ADM_THUMBNAIL_RESIZE_CONFIRM')
-        || `You modified the default thumbnail size(s). Thumbnails will be recreated for: ${thumbnailChanges.join(', ')}. Click OK to continue.`;
+            const confirmMsg = t('JBS_ADM_THUMBNAIL_RESIZE_CONFIRM', `You modified the default thumbnail size(s). Thumbnails will be recreated for: ${thumbnailChanges.join(', ')}. Click OK to continue.`);
 
             if (!confirm(confirmMsg)) {
                 return;
@@ -728,7 +736,7 @@
                 // Get total counts (filtered to changed types only) for progress display
                 const countsUrl = `index.php?option=com_proclaim&task=cwmadmin.getThumbRegenCountXHR&${this.token}=1`;
                 const counts = await this.fetchJson(countsUrl);
-                const grandTotal = imageTypes.reduce((sum, t) => sum + (counts[t] || 0), 0);
+                const grandTotal = imageTypes.reduce((sum, type) => sum + (counts[type] || 0), 0);
 
                 if (grandTotal === 0) {
                     if (this.thumbnailModal) this.thumbnailModal.hide();
@@ -751,7 +759,7 @@
                     }
                 };
 
-                const regenLabel = Joomla.Text._('JBS_ADM_REGENERATING') || 'Regenerating';
+                const regenLabel = t('JBS_ADM_REGENERATING', 'Regenerating');
 
                 for (const type of imageTypes) {
                     const newSize = typeSizes[type] || 300;

--- a/build/media_source/js/delete-confirm.es6.js
+++ b/build/media_source/js/delete-confirm.es6.js
@@ -17,6 +17,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     /* ── helpers ─────────────────────────────────────────────────── */
 
     /**
@@ -161,7 +170,7 @@
         // ── footer
         const footer = el('div', 'modal-footer');
 
-        const btnCancel = el('button', 'btn btn-secondary', Joomla.Text._('JCANCEL') || 'Cancel');
+        const btnCancel = el('button', 'btn btn-secondary', t('JCANCEL', 'Cancel'));
         btnCancel.type = 'button';
         btnCancel.setAttribute('data-bs-dismiss', 'modal');
 

--- a/build/media_source/js/message-ai-assist.es6.js
+++ b/build/media_source/js/message-ai-assist.es6.js
@@ -14,6 +14,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     const config = document.getElementById('message-ai-config');
 
     if (!config) {
@@ -286,7 +295,7 @@
                 if (data.success) {
                     showAppliedFeedback(
                         btn,
-                        (Joomla.Text._('JBS_CMN_AI_CHAPTERS_APPLIED') || '{count} chapters saved')
+                        (t('JBS_CMN_AI_CHAPTERS_APPLIED', '{count} chapters saved'))
                             .replace('{count}', data.count),
                     );
                 } else {
@@ -596,7 +605,7 @@
 
             // Validate at least one checked
             if (!wantTopics && !wantIntro && !wantText && !wantChapters) {
-                alert(Joomla.Text._('JBS_CMN_AI_SELECT_ONE') || 'Select at least one field to generate.');
+                alert(t('JBS_CMN_AI_SELECT_ONE', 'Select at least one field to generate.'));
 
                 return;
             }
@@ -802,7 +811,7 @@
                     navigator.clipboard.writeText(textarea.value).then(() => {
                         showAppliedFeedback(
                             btnCopyChapters,
-                            Joomla.Text._('JBS_CMN_AI_CHAPTERS_COPIED') || 'Copied',
+                            t('JBS_CMN_AI_CHAPTERS_COPIED', 'Copied'),
                         );
                     });
                 }
@@ -845,7 +854,7 @@
 
                     if (data.quota_error) {
                         ytErr.innerHTML += '<br><small class="mt-1 d-block">'
-                            + (Joomla.Text._('JBS_CMN_YT_QUOTA_HELP') || 'You can increase your quota in the YouTube server settings, or request a higher quota from Google.')
+                            + (t('JBS_CMN_YT_QUOTA_HELP', 'You can increase your quota in the YouTube server settings, or request a higher quota from Google.'))
                             + ' <a href="https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas" '
                             + 'target="_blank" rel="noopener">Google API Console</a></small>';
                     }
@@ -998,7 +1007,7 @@
                     navigator.clipboard.writeText(textarea.value).then(() => {
                         showAppliedFeedback(
                             btnYtCopyChapters,
-                            Joomla.Text._('JBS_CMN_YT_SYNC_CHAPTERS_COPIED') || 'Copied',
+                            t('JBS_CMN_YT_SYNC_CHAPTERS_COPIED', 'Copied'),
                         );
                     });
                 }

--- a/build/media_source/js/message-wizard.es6.js
+++ b/build/media_source/js/message-wizard.es6.js
@@ -7,6 +7,15 @@
 document.addEventListener('DOMContentLoaded', () => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     const TOTAL_STEPS = 6;
     let currentStep = 1;
 
@@ -186,26 +195,26 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         let html = '<dl class="row mb-0">';
-        html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_TITLE') || 'Title') + '</dt>';
+        html += '<dt class="col-sm-3">' + (t('JBS_CMN_TITLE', 'Title')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(getValue('jform_studytitle') || '—') + '</dd>';
 
-        html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_STUDY_DATE') || 'Date') + '</dt>';
+        html += '<dt class="col-sm-3">' + (t('JBS_CMN_STUDY_DATE', 'Date')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(getValue('jform_studydate') || '—') + '</dd>';
 
-        html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_TEACHERS') || 'Teachers') + '</dt>';
+        html += '<dt class="col-sm-3">' + (t('JBS_CMN_TEACHERS', 'Teachers')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(teacherNames.join(', ') || '—') + '</dd>';
 
         // Series — get text from the modal field display
         const seriesDisplay = document.getElementById('jform_series_id_name');
         const seriesText = seriesDisplay ? seriesDisplay.value.trim() : '';
-        html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_SERIES') || 'Series') + '</dt>';
+        html += '<dt class="col-sm-3">' + (t('JBS_CMN_SERIES', 'Series')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(seriesText || '—') + '</dd>';
 
-        html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_SCRIPTURE') || 'Scripture') + '</dt>';
+        html += '<dt class="col-sm-3">' + (t('JBS_CMN_SCRIPTURE', 'Scripture')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(scriptureRefs.join('; ') || '—') + '</dd>';
 
         if (introPreview) {
-            html += '<dt class="col-sm-3">' + (Joomla.Text._('JBS_CMN_STUDYINTRO') || 'Description') + '</dt>';
+            html += '<dt class="col-sm-3">' + (t('JBS_CMN_STUDYINTRO', 'Description')) + '</dt>';
             html += '<dd class="col-sm-9">' + escHtml(introPreview) + (introPreview.length >= 200 ? '...' : '') + '</dd>';
         }
 

--- a/build/media_source/js/podcast-audio.es6.js
+++ b/build/media_source/js/podcast-audio.es6.js
@@ -4,6 +4,15 @@
  * @package  Proclaim.Site
  * @since    10.1.0
  */
+
+// Local helper: Joomla.Text._() returns the raw key string when a key
+// is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+// fires the fallback. Compare against the key itself to detect misses.
+const t = (key, fallback) => {
+    const v = Joomla.Text._(key);
+    return v === key ? fallback : v;
+};
+
 window.loadVideo = function loadVideo(path) {
     const audio = document.querySelector('audio');
     const loading = document.getElementById('audio-loading');
@@ -12,7 +21,7 @@ window.loadVideo = function loadVideo(path) {
     if (audio) {
         if (loading) {
             loading.style.display = 'block';
-            loading.innerHTML = `${Joomla.Text._('JBS_CMN_LOADING') || 'Loading'}...`;
+            loading.innerHTML = `${t('JBS_CMN_LOADING', 'Loading')}...`;
             loading.className = 'alert alert-info';
         }
 
@@ -20,7 +29,7 @@ window.loadVideo = function loadVideo(path) {
 
         timeoutId = setTimeout(() => {
             if (loading) {
-                loading.innerHTML = Joomla.Text._('JBS_CMN_LOADING_TIMEOUT') || 'Loading is taking longer than expected...';
+                loading.innerHTML = t('JBS_CMN_LOADING_TIMEOUT', 'Loading is taking longer than expected...');
                 loading.className = 'alert alert-warning';
             }
         }, 10000);
@@ -36,7 +45,7 @@ window.loadVideo = function loadVideo(path) {
         audio.onerror = function () {
             clearTimeout(timeoutId);
             if (loading) {
-                loading.innerHTML = Joomla.Text._('JBS_CMN_LOADING_ERROR') || 'Error loading audio file.';
+                loading.innerHTML = t('JBS_CMN_LOADING_ERROR', 'Error loading audio file.');
                 loading.className = 'alert alert-danger';
             }
         };

--- a/build/media_source/js/schema-indicators.es6.js
+++ b/build/media_source/js/schema-indicators.es6.js
@@ -17,6 +17,15 @@
 (() => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     function init() {
         const customFields = Joomla.getOptions('com_proclaim.schemaCustomFields') || [];
 
@@ -68,9 +77,8 @@
                     badge.className = 'badge bg-info ms-2';
                     badge.style.fontSize = '0.7em';
                     badge.style.verticalAlign = 'middle';
-                    badge.textContent = Joomla.Text._('PLG_SCHEMAORG_PROCLAIM_BADGE_CUSTOM') || 'Custom';
-                    badge.title = Joomla.Text._('PLG_SCHEMAORG_PROCLAIM_BADGE_CUSTOM_DESC')
-                        || 'This field was manually customized and won\'t auto-update. Clear the field to restore auto-sync.';
+                    badge.textContent = t('PLG_SCHEMAORG_PROCLAIM_BADGE_CUSTOM', 'Custom');
+                    badge.title = t('PLG_SCHEMAORG_PROCLAIM_BADGE_CUSTOM_DESC', 'This field was manually customized and won\'t auto-update. Clear the field to restore auto-sync.');
                     label.appendChild(badge);
                 }
 

--- a/build/media_source/js/scripture-autocomplete.es6.js
+++ b/build/media_source/js/scripture-autocomplete.es6.js
@@ -14,6 +14,15 @@
 ((Joomla) => {
     'use strict';
 
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
+
     if (!Joomla) {
         return;
     }
@@ -452,7 +461,7 @@
         const searchInput = document.createElement('input');
         searchInput.type = 'text';
         searchInput.className = 'form-control form-control-sm';
-        searchInput.placeholder = Joomla.Text._('JBS_STY_SEARCH_VERSIONS') || 'Search versions...';
+        searchInput.placeholder = t('JBS_STY_SEARCH_VERSIONS', 'Search versions...');
         searchInput.style.cssText = 'margin-bottom:4px;font-size:12px;';
         wrapper.insertBefore(searchInput, select);
 

--- a/build/media_source/js/setup-wizard.es6.js
+++ b/build/media_source/js/setup-wizard.es6.js
@@ -12,6 +12,14 @@
 'use strict';
 
 (function () {
+    // Local helper: Joomla.Text._() returns the raw key string when a key
+    // is unregistered (truthy), so `Joomla.Text._('K') || 'fallback'` never
+    // fires the fallback. Compare against the key itself to detect misses.
+    const t = (key, fallback) => {
+        const v = Joomla.Text._(key);
+        return v === key ? fallback : v;
+    };
+
     const config = window.ProcSetupWizard || {};
     const token = config.token || '';
     const baseUrl = config.baseUrl || '';
@@ -324,7 +332,7 @@
    * Dismiss the wizard without applying.
    */
     async function dismissWizard() {
-        if (!confirm(Joomla.Text._('JBS_WIZARD_CONFIRM_DISMISS') || 'Skip the setup wizard?')) {
+        if (!confirm(t('JBS_WIZARD_CONFIRM_DISMISS', 'Skip the setup wizard?'))) {
             return;
         }
 


### PR DESCRIPTION
Third (largest) of three follow-up PRs from the JS coding-standards audit. **Live bug fix.**

## The bug

`Joomla.Text._('SOME_KEY')` returns the **raw key string** when the key was never registered server-side via `Text::script()`. The return value is truthy, so the common idiom

```js
const msg = Joomla.Text._('SOME_KEY') || 'Default';
```

**never fires the fallback** when the key is missing. Users see literal `"SOME_KEY"` instead of either the translation or the intended default. Documented as the `Joomla.Text._() Returns Raw Key When Unregistered` gotcha in the joomla skill.

## The fix

Per-file helper, then mechanical rewrite of every call site:

```js
const t = (key, fallback) => {
    const v = Joomla.Text._(key);
    return v === key ? fallback : v;
};

// Before
const msg = Joomla.Text._('SOME_KEY') || 'Default';

// After
const msg = t('SOME_KEY', 'Default');
```

**51 call sites across 15 files.** Bulk transformation via a Python script + 3 targeted manual edits for cases the regex didn't cover (template-literal fallback, computed-key cases).

| File | fixes |
|---|---|
| `cwmadmin.es6.js` | 19 (incl. 1 template-literal fallback) |
| `message-wizard.es6.js` | 6 |
| `message-ai-assist.es6.js` | 5 |
| `addon-vimeo-browser.es6.js` | 3 |
| `addon-wistia-browser.es6.js` | 3 |
| `admin-youtube-log.es6.js` | 3 |
| `podcast-audio.es6.js` | 3 |
| `admin-imagetools.es6.js` | 2 (computed-key cases) |
| `addon-youtube-browser.es6.js` | 2 |
| `schema-indicators.es6.js` | 2 |
| `setup-wizard.es6.js`, `scripture-autocomplete.es6.js`, `delete-confirm.es6.js`, `cwm-transcript.es6.js`, `cwm-fetch.es6.js` | 1 each |

## Out of scope (intentional)

- **`cwm-vtt-upload.es6.js`** — already neutralized at the field level on `epic/1210-captions` (PR #1233 registers the two consumed keys via `addScriptOptions`). Touching it here would create a merge conflict with the captions integration PR #1232. After that PR merges, an optional cleanup pass can apply the helper pattern here too for consistency.
- **`admin-imagetools.es6.js` error-template lines** like `${err.message || err}` — the `||` is on the JS Error object, not the translation. Not the antipattern.
- **`media-analytics-modal.es6.js:18` `Joomla.Text._(key) || key`** — returning the raw key as the intentional fallback. Correct pattern; leave alone.
- **`backup-restore.es6.js:400` `${result.data.filename || ''}`** — same as above; `||` not on the translation.

## Verification
- [x] `npm test` — 229/229 Jest tests pass
- [x] `grep -rEn "Joomla\.Text\._\([^)]*\)[[:space:]]*\|\|[[:space:]]*['\"\`]" build/media_source/js/` — only `cwm-vtt-upload.es6.js` remains (out-of-scope, neutralized at field level)
- [ ] Manual: open an admin page that triggers a deliberately-misregistered key path → confirm fallback renders, not raw key

## PR ordering
Independent of #1234 (ESLint cleanup) and #1235 (editor API migration). All three audit-followup PRs can merge in any order — they touch disjoint code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)