### PR TITLE
fix(css): dark-mode contrast for already-selected Choices.js dropdown items

### DIFF
--- a/build/media_source/css/topics-field.css
+++ b/build/media_source/css/topics-field.css
@@ -31,3 +31,14 @@
 .subform-repeatable-group {
     overflow: visible !important;
 }
+
+/* Dark-mode contrast fix for already-selected items in the dropdown.
+   Atum's template only overrides .is-highlighted (the keyboard-focused
+   item) for dark mode, leaving .is-selected items with the bundled
+   choices.css `#f2f2f2` light background — which renders the inherited
+   light text invisible against light grey. Mirror atum's is-highlighted
+   pattern so the two states stay visually consistent. */
+[data-bs-theme="dark"] .choices .choices__list--dropdown .choices__item--selectable.is-selected,
+[data-bs-theme="dark"] .choices .choices__list[aria-expanded] .choices__item--selectable.is-selected {
+    background-color: var(--gray-800);
+}


### PR DESCRIPTION
## Bug

When the Joomla admin runs in **dark mode**, every \`joomla-field-fancy-select\` multi-select shows already-selected items (the ones with green checkmarks at the bottom of the dropdown) with a near-white background and near-white text — practically invisible. Hover correctly shows them dark grey because that's a different CSS state.

User-confirmed: "If mouse over it's correct" — hover triggers \`.is-highlighted\` which atum already styles correctly.

## Root cause

Joomla's atum admin template ships dark-mode overrides for \`.choices__item--selectable.is-highlighted\` (the keyboard-focused item) but NOT for \`.choices__item--selectable.is-selected\` (items already in the multi-select shown in the dropdown).

Bundled \`choices.css\` defaults both states to \`#f2f2f2\` light grey. Atum overrides only \`is-highlighted\` for dark mode → \`.is-selected\` keeps the bundled \`#f2f2f2\`, and on the dark dropdown's parent the inherited light text becomes invisible.

## Fix

One CSS rule in \`build/media_source/css/topics-field.css\` mirroring atum's existing \`is-highlighted\` dark-mode pattern:

\`\`\`css
[data-bs-theme="dark"] .choices .choices__list--dropdown .choices__item--selectable.is-selected,
[data-bs-theme="dark"] .choices .choices__list[aria-expanded] .choices__item--selectable.is-selected {
    background-color: var(--gray-800);
}
\`\`\`

\`var(--gray-800)\` matches what atum uses for \`.is-highlighted\` — hover and resting states stay visually consistent.

## Affects
Every admin multi-select using \`joomla-field-fancy-select\` in Proclaim (topics, teachers picker, etc.) when admin runs in dark mode.

## Discovered
On the message edit form during post-#1237 dark-mode visual review.

## Test plan
- [x] \`npm run build:css\` — clean, output at \`media/css/topics-field.{css,min.css}\`
- [x] Manual dark mode: open message edit, click topics field → confirm already-selected items in the dropdown have dark grey background with visible text (matching the hover state)
- [x] Light mode regression: confirm rendering unchanged

## Related
- Could potentially be filed upstream against atum (Joomla itself) — same gap will affect every Joomla extension using fancy-select. Out of scope for this PR but worth a separate issue at \`joomla/joomla-cms\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)