### PR TITLE
chore: gitignore media/captions/ runtime upload directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ test-results/
 /build/.translation_cache.json
 /build/.source_cache.json
 media/backup/*.sql
+media/captions/
 media/youtube_cache/
 
 # OSX


### PR DESCRIPTION
## Summary
Adds `media/captions/` to `.gitignore` so caption files uploaded through the VTT field don't get accidentally staged.

Caught while manually testing PR #1232 — two test uploads (`caption_*_sample.srt`, `caption_*_sample.vtt`) ended up staged in the working copy. The directory is purely a runtime upload destination, no source lives there.

## Test plan
- [ ] Upload a caption file via Media File edit form
- [ ] Run `git status` — uploaded file does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)