### PR TITLE
style(css): drop redundant % unit from zero-width progress bars

### DIFF
--- a/admin/tmpl/cwmadmin/edit.php
+++ b/admin/tmpl/cwmadmin/edit.php
@@ -60,7 +60,7 @@ $this->useCoreUI = true;
             </div>
             <div class="modal-body">
                 <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="<?php echo Text::_('JBS_ADM_THUMBNAIL_PROGRESS'); ?>">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%">0%</div>
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0">0%</div>
                 </div>
                 <p class="status-text text-center mt-2 mb-0" aria-live="polite"></p>
             </div>
@@ -566,7 +566,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
             </ol>
             <div id="pipeline-progress-wrap" style="display:none;" class="mb-3">
                 <div class="progress" role="progressbar" aria-label="<?php echo Text::_('JBS_ADM_PIPELINE_PROGRESS'); ?>" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                    <div id="pipeline-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
+                    <div id="pipeline-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0;"></div>
                 </div>
             </div>
             <p id="pipeline-status-text" class="mb-3 text-body-secondary" aria-live="polite"></p>
@@ -592,7 +592,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
                     </div>
                     <div id="thumb-regen-progress" class="mb-3" style="display:none;">
                         <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                            <div class="progress-bar bg-info" style="width: 0%"></div>
+                            <div class="progress-bar bg-info" style="width: 0"></div>
                         </div>
                         <div class="mt-2" id="thumb-regen-status"></div>
                     </div>
@@ -634,7 +634,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
                                     </div>
                                     <div id="webp-progress" class="mb-3" style="display:none;">
                                         <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                                            <div class="progress-bar bg-success" style="width: 0%"></div>
+                                            <div class="progress-bar bg-success" style="width: 0"></div>
                                         </div>
                                         <div class="mt-2" id="webp-status"></div>
                                     </div>
@@ -654,7 +654,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
                                     </div>
                                     <div id="recovery-progress" class="mb-3" style="display:none;">
                                         <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                                            <div class="progress-bar bg-warning" style="width: 0%"></div>
+                                            <div class="progress-bar bg-warning" style="width: 0"></div>
                                         </div>
                                         <div class="mt-2" id="recovery-status"></div>
                                     </div>
@@ -674,7 +674,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
                                     </div>
                                     <div id="relink-progress" class="mb-3" style="display:none;">
                                         <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                                            <div class="progress-bar bg-primary" style="width: 0%"></div>
+                                            <div class="progress-bar bg-primary" style="width: 0"></div>
                                         </div>
                                         <div class="mt-2" id="relink-status"></div>
                                     </div>
@@ -725,7 +725,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
                             </ol>
                             <div id="cleanup-pipeline-progress-wrap" style="display:none;" class="mb-3">
                                 <div class="progress" role="progressbar" aria-label="<?php echo Text::_('JBS_ADM_CLEANUP_PIPELINE_PROGRESS'); ?>" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                                    <div id="cleanup-pipeline-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%;"></div>
+                                    <div id="cleanup-pipeline-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0;"></div>
                                 </div>
                             </div>
                             <div id="cleanup-pipeline-confirm" class="alert alert-warning mb-3" style="display:none;">
@@ -815,7 +815,7 @@ $piInstalled = strpos($this->pi, 'href=') !== false;
         <div id="imagetools-migration-driver" style="display:none;" aria-hidden="true">
             <div id="migration-counts"></div>
             <div id="migration-progress">
-                <div class="progress"><div class="progress-bar" style="width: 0%"></div></div>
+                <div class="progress"><div class="progress-bar" style="width: 0"></div></div>
                 <div id="migration-status"></div>
             </div>
             <div id="migration-error-report"></div>

--- a/admin/tmpl/cwmadmin/edit_csvimport.php
+++ b/admin/tmpl/cwmadmin/edit_csvimport.php
@@ -120,7 +120,7 @@ use Joomla\CMS\Session\Session;
             <h3 class="tab-description"><?php echo Text::_('JBS_CSV_PROGRESS_TITLE'); ?></h3>
             <div class="progress mb-2" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                 <div class="progress-bar progress-bar-striped progress-bar-animated" id="csv-progress-bar"
-                     style="width: 0%">0%</div>
+                     style="width: 0">0%</div>
             </div>
             <p id="csv-progress-text" class="text-center mb-0" aria-live="polite"></p>
         </div>

--- a/admin/tmpl/cwmadmin/edit_servermigration.php
+++ b/admin/tmpl/cwmadmin/edit_servermigration.php
@@ -76,7 +76,7 @@ use Joomla\CMS\Session\Session;
             <h3 class="tab-description"><?php echo Text::_('JBS_SMG_PROGRESS_TITLE'); ?></h3>
             <div class="progress mb-2" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                 <div class="progress-bar progress-bar-striped progress-bar-animated" id="smg-progress-bar"
-                     style="width: 0%">0%</div>
+                     style="width: 0">0%</div>
             </div>
             <p id="smg-progress-text" class="text-center mb-0" aria-live="polite"></p>
         </div>

--- a/admin/tmpl/cwmadmin/edit_upgrade.php
+++ b/admin/tmpl/cwmadmin/edit_upgrade.php
@@ -148,7 +148,7 @@ use Joomla\CMS\Session\Session;
             <div class="mb-3">
                 <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
                      id="upgrade-progress" aria-label="<?php echo Text::_('JBS_UPG_PROGRESS'); ?>">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%">0%</div>
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0">0%</div>
                 </div>
             </div>
 

--- a/admin/tmpl/cwmarchive/edit.php
+++ b/admin/tmpl/cwmarchive/edit.php
@@ -53,7 +53,7 @@ $this->getDocument()->addScriptOptions('com_proclaim.archive', [
                 </div>
                 <p class="status-text text-center fw-bold mb-2" aria-live="polite"><?php echo Text::_('JBS_ADM_PROCESSING'); ?></p>
                 <div class="progress mb-3" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%">0%</div>
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0">0%</div>
                 </div>
                 <p class="detail-text text-muted small text-center mb-0" aria-live="polite"></p>
             </div>

--- a/admin/tmpl/cwmassets/edit.php
+++ b/admin/tmpl/cwmassets/edit.php
@@ -188,7 +188,7 @@ Text::script('JCLOSE');
                     <span id="fix-status-text"><?php echo Text::_('JBS_CMN_PROCESSING'); ?></span>
                 </div>
                 <div class="progress mb-3" style="height: 25px;">
-                    <div id="fix-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div id="fix-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <span id="fix-progress-text">0%</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Clears 13 IDE CSS inspection warnings ("Unit of measure '%' is redundant" / "Redundant measure unit") flagged in the admin templates.

All occurrences are Bootstrap progress bars initialized at `style="width: 0%"`. Since `0` needs no unit, the inspection flags the `%` as redundant. Changed the inline style attribute to `width: 0` in each case.

## Files

- `admin/tmpl/cwmadmin/edit.php` (8)
- `admin/tmpl/cwmadmin/edit_csvimport.php` (1)
- `admin/tmpl/cwmadmin/edit_servermigration.php` (1)
- `admin/tmpl/cwmadmin/edit_upgrade.php` (1)
- `admin/tmpl/cwmarchive/edit.php` (1)
- `admin/tmpl/cwmassets/edit.php` (1)

## Safety

- **Functionally identical** — `width: 0` and `width: 0%` both render a zero-width bar; JS still animates the bars to percentage widths at runtime.
- The **visible `0%` label text** (`>0%</div>`) is unchanged — only the `style` attribute was edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)