### PR TITLE
fix(images): surface low-res warning on all uploads; preserve ratio in migration

### DIFF
--- a/admin/src/Helper/CwmImageMigration.php
+++ b/admin/src/Helper/CwmImageMigration.php
@@ -2077,9 +2077,23 @@ class CwmImageMigration
                 $thumbRelPath = $relDir . '/thumb_' . $baseName . '.jpg';
                 $imageRelPath = $relDir . '/' . basename($imagePath);
 
-                // Generate thumbnail
-                $image     = new Image($imagePath);
-                $thumbnail = $image->resize($size, (int) round($size * 0.5625), true, Image::SCALE_INSIDE);
+                // Generate thumbnail preserving the original aspect ratio.
+                // $size is the max dimension; the other side scales proportionally
+                // (matches Cwmthumbnail::create so portrait/square images aren't
+                // squashed into a 16:9 box and re-blurred during migration).
+                $image        = new Image($imagePath);
+                $sourceWidth  = $image->getWidth();
+                $sourceHeight = $image->getHeight();
+
+                if ($sourceWidth >= $sourceHeight) {
+                    $thumbWidth  = $size;
+                    $thumbHeight = (int) round($size * ($sourceHeight / $sourceWidth));
+                } else {
+                    $thumbHeight = $size;
+                    $thumbWidth  = (int) round($size * ($sourceWidth / $sourceHeight));
+                }
+
+                $thumbnail = $image->resize($thumbWidth, $thumbHeight, true, Image::SCALE_INSIDE);
                 $thumbnail->toFile($thumbPath, IMAGETYPE_JPEG);
 
                 // Always regenerate WebP variants

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -447,6 +447,10 @@ class CwmmessageModel extends AdminModel
             return true;
         }
 
+        if (!empty($validation['warning']) && $app->isClient('administrator')) {
+            $app->enqueueMessage($validation['warning'], 'warning');
+        }
+
         // For new records, save first to get the ID
         if ($isNew) {
             $data['image']      = '';

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -250,6 +250,10 @@ class CwmserieModel extends AdminModel
             return parent::save($data);
         }
 
+        if (!empty($validation['warning']) && $app->isClient('administrator')) {
+            $app->enqueueMessage($validation['warning'], 'warning');
+        }
+
         // For new records, save first to get the ID
         if ($isNew) {
             $data['image']            = '';


### PR DESCRIPTION
## What

Two small consistency fixes in the teacher/series/message image pipeline, closing out the remaining code items on the teacher-image-quality task.

## Changes

1. **Low-res warning surfaced everywhere.** `Cwmthumbnail::validate()` already returns a `warning` when an uploaded image is below 400px on both sides, but only `CwmteacherModel` enqueued it. `CwmserieModel` and `CwmmessageModel` validated the image and silently discarded the warning. Both now enqueue it (admin client only), matching the teacher model — so admins get nudged to upload higher-resolution originals for series and message images too.

2. **Migration preserves aspect ratio.** `CwmImageMigration` thumbnail regeneration still forced a 16:9 box (`$size * 0.5625`) — the exact behavior `Cwmthumbnail::create()` was fixed to avoid. On a migration this would re-blur portrait/square photos (e.g. teacher headshots). It now preserves the source aspect ratio, mirroring `create()`.

## Verification

`229` thumbnail + migration tests pass. No new production behavior beyond the two fixes above; tests-side unchanged.

## Context

Most of the teacher-image-quality task was already done in prior work (aspect-ratio in `create()`, `thumbnail_teacher_size` default 100→400, landing prefers `teacher_image`). This PR is the last of the code items. The only remaining item is non-code: re-uploading a few genuinely low-res teacher originals, which the warning now flags at upload time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)