### PR TITLE
feat(cpanel): surface content awaiting editorial review on the dashboard

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -1246,6 +1246,10 @@ JBS_CPL_PIM_ERROR_BUTTON = "Error : CWM-Proclaim Documentation"
 JBS_CPL_SCHEMA_OUT_OF_SYNC = "Database Schema Out of Sync"
 JBS_CPL_SCHEMA_OUT_OF_SYNC_DESC = "Your database schema (version %s) is behind the current code (version %s). Some features may not work correctly until the database is updated."
 JBS_CPL_SCHEMA_FIX_BUTTON = "Fix Database"
+JBS_CPL_PENDING_REVIEW_TITLE = "Content Awaiting Review"
+JBS_CPL_PENDING_REVIEW_DESC_N_1 = "%d study is unpublished and awaiting editorial review. Content submitted through the API by users without publishing rights is saved unpublished until approved."
+JBS_CPL_PENDING_REVIEW_DESC_N_MORE = "%d studies are unpublished and awaiting editorial review. Content submitted through the API by users without publishing rights is saved unpublished until approved."
+JBS_CPL_PENDING_REVIEW_BUTTON = "Review Unpublished Studies"
 
 ;; IBM Install, Backup, Migrate
 JBS_SUCCESS = "records changed"

--- a/admin/src/View/Cwmcpanel/HtmlView.php
+++ b/admin/src/View/Cwmcpanel/HtmlView.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Administrator\View\Cwmcpanel;
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
 use CWM\Component\Proclaim\Administrator\Model\CwmcpanelModel;
 use Joomla\CMS\Component\ComponentHelper;
@@ -45,6 +46,18 @@ class HtmlView extends BaseHtmlView
      * @since    7.0.0
      */
     public string $total_messages;
+
+    /**
+     * Count of studies awaiting editorial review (unpublished).
+     *
+     * Surfaced as a dashboard notice for users who can publish, so content
+     * submitted via the API by non-editors (forced to published=0) does not
+     * sit unnoticed. 0 when the current user lacks core.edit.state.
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    public int $pendingReview = 0;
 
     /**
      * The model state
@@ -98,6 +111,15 @@ class HtmlView extends BaseHtmlView
 
         $this->hasPostInstallationMessages = $model->hasPostInstallMessages();
         $this->extension_id                = ComponentHelper::getComponent('com_proclaim')->id;
+
+        // Editorial review notice: count unpublished studies, but only for users
+        // who can actually publish them. Location-filtered so multi-campus
+        // editors only see pending content they can act on.
+        $user = Factory::getApplication()->getIdentity();
+
+        if ($user && $user->authorise('core.edit.state', 'com_proclaim')) {
+            $this->pendingReview = CwmcountHelper::getCountByState('#__bsms_studies', 0, 'location');
+        }
 
         // Display the template
         parent::display($tpl);

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -248,6 +248,24 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
             </div>
         <?php endif; ?>
         <?php
+            // Content awaiting editorial review (unpublished studies) — shown to publishers only
+            if ($this->pendingReview > 0) :
+        ?>
+            <div class="col-12">
+                <div class="alert alert-info">
+                    <span class="icon-pencil-2" aria-hidden="true"></span>
+                    <strong><?php echo Text::_('JBS_CPL_PENDING_REVIEW_TITLE'); ?></strong>
+                    <p class="mb-1">
+                        <?php echo Text::plural('JBS_CPL_PENDING_REVIEW_DESC_N', $this->pendingReview); ?>
+                    </p>
+                    <a href="<?php echo Route::_('index.php?option=com_proclaim&view=cwmmessages&filter[published]=0'); ?>"
+                       class="btn btn-info btn-sm">
+                        <?php echo Text::_('JBS_CPL_PENDING_REVIEW_BUTTON'); ?>
+                    </a>
+                </div>
+            </div>
+        <?php endif; ?>
+        <?php
             // Database schema out-of-sync warning
             $schemaGap = CwmupgradeHelper::isSchemaOutOfDate();
             if ($schemaGap) :

--- a/tests/integration/Admin/Helper/CwmcountHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmcountHelperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Integration tests for CwmcountHelper count queries.
+ *
+ * Focuses on the unpublished (state 0) count path used by the CPanel
+ * "Content Awaiting Review" notice, plus the state-count vs. total invariant.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Test class for CwmcountHelper.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmcountHelperTest extends IntegrationTestCase
+{
+    /**
+     * Skip the whole class when no live database is available.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Live database not available for count integration test.');
+        }
+    }
+
+    #[TestDox('getCountByState(state 0) returns a non-negative unpublished count')]
+    public function testUnpublishedCountIsNonNegative(): void
+    {
+        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
+
+        $this->assertIsInt($unpublished);
+        $this->assertGreaterThanOrEqual(0, $unpublished, 'Unpublished study count must not be negative');
+    }
+
+    #[TestDox('Unpublished count never exceeds the non-trashed total')]
+    public function testUnpublishedCountWithinTotal(): void
+    {
+        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
+        $total       = CwmcountHelper::getTotalCount('#__bsms_studies');
+
+        $this->assertLessThanOrEqual(
+            $total,
+            $unpublished,
+            'Unpublished count should be a subset of the non-trashed total'
+        );
+    }
+
+    #[TestDox('Published, unpublished and archived are counted independently')]
+    public function testStateCountsAreIndependent(): void
+    {
+        // Each state is a distinct, separately-cached query; their sum cannot
+        // exceed the non-trashed total (which excludes only state -2).
+        $published   = CwmcountHelper::getCountByState('#__bsms_studies', 1);
+        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
+        $archived    = CwmcountHelper::getCountByState('#__bsms_studies', 2);
+        $total       = CwmcountHelper::getTotalCount('#__bsms_studies');
+
+        $this->assertLessThanOrEqual(
+            $total,
+            $published + $unpublished + $archived,
+            'Sum of published/unpublished/archived must not exceed the non-trashed total'
+        );
+    }
+}


### PR DESCRIPTION
## What

Closes a gap in the editorial approval workflow. The REST API forces `published=0` for users without `core.edit.state` (an approval gate), but **nothing told publishers content was waiting** — only comments had a pending badge; studies/series sat unnoticed.

This adds a dashboard notice card on the Proclaim CPanel showing the count of unpublished studies, with a button linking straight to the messages list pre-filtered to unpublished.

## Details

- **Notice card** in `admin/tmpl/cwmcpanel/default.php`, styled like the existing schema-out-of-sync card (`alert alert-info`).
- **Gated on `core.edit.state`** — only people who can actually publish see it (computed in `Cwmcpanel/HtmlView.php`).
- **Location-filtered** via `CwmcountHelper::getCountByState('#__bsms_studies', 0, 'location')`, so multi-campus editors only see pending content they can act on.
- **No new query logic** — reuses the existing, cached `getCountByState` (state `0` = unpublished).
- **Deep link** uses `view=cwmmessages&filter[published]=0` (same `filter[...]` convention already used by `cwmserie/edit.php` and `cwmteacher/messages.php`).
- New `Text::plural` strings (`JBS_CPL_PENDING_REVIEW_*`) in en-GB.

## Tests

Adds the **first integration coverage for `CwmcountHelper`** (3 tests): non-negative unpublished count, count ≤ non-trashed total, and the state-counts-vs-total invariant. `787` tests green (+3).

## Notes

- New strings are en-GB only; other languages fall back to en-GB until `composer sync-languages` runs.
- Remaining (future) items on this task: optional email/notification-bell/task-plugin reminders for `core.edit.state` users. This PR covers the dashboard surface — the highest-value, most self-contained piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)