### PR TITLE
fix(layout-editor): align fields in landing section settings modal

### DIFF
--- a/build/media_source/css/layout-editor.css
+++ b/build/media_source/css/layout-editor.css
@@ -928,12 +928,14 @@
     color: var(--layout-text-primary);
 }
 
-.view-settings-modal .controls {
+.view-settings-modal .controls,
+.section-settings-modal .controls {
     margin-bottom: .25rem;
 }
 
 /* Description text below form fields */
-.view-settings-modal .controls > br + * {
+.view-settings-modal .controls > br + *,
+.section-settings-modal .controls > br + * {
     font-size: 0.875rem;
     color: var(--layout-text-muted);
     line-height: 1.4;
@@ -944,35 +946,45 @@
    (240px label + flex controls) doesn't leave enough width for editors
    inside the modal context */
 .view-settings-modal .control-group:has(textarea),
-.view-settings-modal .control-group:has(.js-editor-tinymce) {
+.view-settings-modal .control-group:has(.js-editor-tinymce),
+.section-settings-modal .control-group:has(textarea),
+.section-settings-modal .control-group:has(.js-editor-tinymce) {
     flex-direction: column;
 }
 
 .view-settings-modal .control-group:has(textarea) .control-label,
-.view-settings-modal .control-group:has(.js-editor-tinymce) .control-label {
+.view-settings-modal .control-group:has(.js-editor-tinymce) .control-label,
+.section-settings-modal .control-group:has(textarea) .control-label,
+.section-settings-modal .control-group:has(.js-editor-tinymce) .control-label {
     inline-size: 100%;
     padding-bottom: 0;
 }
 
 /* Prevent TinyMCE editor from overflowing the modal */
-.view-settings-modal .tox-tinymce {
+.view-settings-modal .tox-tinymce,
+.section-settings-modal .tox-tinymce {
     max-width: 100%;
 }
 
-.view-settings-modal .control-group:has(.js-editor-tinymce) .controls {
+.view-settings-modal .control-group:has(.js-editor-tinymce) .controls,
+.section-settings-modal .control-group:has(.js-editor-tinymce) .controls {
     max-inline-size: 100%;
     overflow: hidden;
 }
 
-/* Two-column layout for form fields on larger screens */
+/* Two-column layout for form fields on larger screens. The view-settings
+   modal lays fields out per accordion body; the section-settings modal uses a
+   single flat .options-form container — both need the same grid. */
 @media (min-width: 768px) {
-    .view-settings-modal .accordion-body {
+    .view-settings-modal .accordion-body,
+    .section-settings-modal .options-form {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem 2rem;
     }
 
-    .view-settings-modal .control-group {
+    .view-settings-modal .control-group,
+    .section-settings-modal .control-group {
         margin-bottom: 0;
     }
 
@@ -980,7 +992,11 @@
     .view-settings-modal .control-group:has(textarea),
     .view-settings-modal .control-group:has(.editor),
     .view-settings-modal .control-group:has(.js-editor-tinymce),
-    .view-settings-modal .control-group:has([type="editor"]) {
+    .view-settings-modal .control-group:has([type="editor"]),
+    .section-settings-modal .control-group:has(textarea),
+    .section-settings-modal .control-group:has(.editor),
+    .section-settings-modal .control-group:has(.js-editor-tinymce),
+    .section-settings-modal .control-group:has([type="editor"]) {
         grid-column: 1 / -1;
     }
 }


### PR DESCRIPTION
## What

The **section settings modal** (gear icon on a landing-page section card in the Layout Editor — Teachers, Series, Locations, etc.) rendered form fields with misaligned labels/inputs, while the **view settings modal** looked correct.

## Root cause

A block of modal field-layout rules in `build/media_source/css/layout-editor.css` was scoped to `.view-settings-modal` **only**, even though the section comment said "view/**section** settings modals":

- `.controls` spacing
- field description text
- editor (textarea / TinyMCE) **vertical-stacking** ← the main visual mess
- TinyMCE overflow containment
- the **two-column grid** layout

The section modal got the shared `.control-group` / `.control-label` margin rules but none of the above, so its fields fell back to Atum's default side-by-side layout that doesn't fit the modal.

## Fix

Extend those rules to `.section-settings-modal`. The two modals use different containers:
- view settings → per-fieldset `.accordion-body`
- section settings → a single flat `#sectionSettingsContent.options-form`

…so the grid is applied to `.section-settings-modal .options-form`. The `.view-settings-modal` selectors are **untouched**, so the already-correct view modal cannot regress.

## Notes

- Source-only change (`build/media_source/css`); `media/css` is regenerated by `npm run build:css` (verified — minifies cleanly).
- Patch-appropriate (CSS alignment, no behavior change).
- **Not yet pixel-verified in-browser** — the change mirrors the proven view-settings rules onto the section modal. Happy to do a dev-site visual pass on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)