### PR TITLE
feat(debug): instrument AI provider HTTP calls; add CwmDebug::logApi

### DIFF
--- a/admin/src/Helper/CwmDebug.php
+++ b/admin/src/Helper/CwmDebug.php
@@ -187,6 +187,43 @@ class CwmDebug
     }
 
     /**
+     * Log an outbound HTTP/API call for diagnostic purposes.
+     *
+     * @param   string    $label       Caller label (e.g. 'ai.claude', 'podcast.index')
+     * @param   string    $method      HTTP method (GET, POST, HEAD, …)
+     * @param   string    $url         Request URL
+     * @param   int|null  $statusCode  Response status code, if known
+     * @param   float     $elapsedMs   Elapsed milliseconds, if measured
+     *
+     * @return  void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function logApi(
+        string $label,
+        string $method,
+        string $url,
+        ?int $statusCode = null,
+        float $elapsedMs = 0.0
+    ): void {
+        if (!self::isEnabled()) {
+            return;
+        }
+
+        $msg = $method . ' ' . $url;
+
+        if ($statusCode !== null) {
+            $msg .= ' -> ' . $statusCode;
+        }
+
+        if ($elapsedMs > 0) {
+            $msg .= ' (' . round($elapsedMs, 1) . 'ms)';
+        }
+
+        self::log($label . ': ' . $msg, 'api');
+    }
+
+    /**
      * Get the buffered debug messages (e.g. for appending to AJAX responses).
      *
      * @return  string[]

--- a/admin/src/Helper/CwmaiHelper.php
+++ b/admin/src/Helper/CwmaiHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Http\HttpFactory;
+use Joomla\Http\Response;
 use Joomla\Registry\Registry;
 
 /**
@@ -581,6 +582,44 @@ class CwmaiHelper
     }
 
     /**
+     * POST a JSON payload to an AI provider endpoint with debug instrumentation.
+     *
+     * Centralises the HTTP client creation for the provider calls and records
+     * the request (method, URL, status, elapsed) via CwmDebug when JBSMDEBUG is
+     * on. Transport-level failures are logged via CwmDebug::error (which always
+     * writes) before being re-thrown. Zero overhead when debug is off.
+     *
+     * @param   string  $provider  Provider label for debug output (claude/gemini/openai)
+     * @param   string  $url       Endpoint URL
+     * @param   string  $payload   JSON request body
+     * @param   array   $headers   Request headers
+     *
+     * @return  Response  The HTTP response (status is left for the caller to check)
+     *
+     * @throws  \Exception  If the request itself fails (connection, TLS, …)
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function postJson(string $provider, string $url, string $payload, array $headers): Response
+    {
+        $http    = (new HttpFactory())->getHttp();
+        $label   = 'ai.' . $provider;
+        $startNs = CwmDebug::isEnabled() ? hrtime(true) : null;
+
+        try {
+            $response = $http->post($url, $payload, $headers);
+        } catch (\Exception $e) {
+            CwmDebug::error($provider . ' API request failed', $e, 'ai');
+
+            throw $e;
+        }
+
+        $elapsed = $startNs !== null ? (hrtime(true) - $startNs) / 1_000_000 : 0.0;
+        CwmDebug::logApi($label, 'POST', $url, $response->getStatusCode(), $elapsed);
+
+        return $response;
+    }
+
+    /**
      * Call the Anthropic Claude API
      *
      * @param   string  $apiKey        API key
@@ -595,9 +634,6 @@ class CwmaiHelper
      */
     private static function callClaude(string $apiKey, string $model, string $systemPrompt, string $userMessage): array
     {
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
-
         $payload = json_encode([
             'model'      => $model,
             'max_tokens' => 8192,
@@ -613,7 +649,7 @@ class CwmaiHelper
             'anthropic-version' => '2023-06-01',
         ];
 
-        $response = $http->post('https://api.anthropic.com/v1/messages', $payload, $headers);
+        $response = self::postJson('claude', 'https://api.anthropic.com/v1/messages', $payload, $headers);
 
         if ($response->getStatusCode() !== 200) {
             try {
@@ -657,9 +693,6 @@ class CwmaiHelper
      */
     private static function callGemini(string $apiKey, string $model, string $systemPrompt, string $userMessage): array
     {
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
-
         // Ensure no double models/ prefix
         $model   = str_replace('models/', '', $model);
         $url     = 'https://generativelanguage.googleapis.com/v1beta/models/' . $model . ':generateContent?key=' . $apiKey;
@@ -684,7 +717,7 @@ class CwmaiHelper
             'Content-Type' => 'application/json',
         ];
 
-        $response = $http->post($url, $payload, $headers);
+        $response = self::postJson('gemini', $url, $payload, $headers);
 
         if ($response->getStatusCode() !== 200) {
             try {
@@ -728,9 +761,6 @@ class CwmaiHelper
      */
     private static function callOpenAI(string $apiKey, string $model, string $systemPrompt, string $userMessage): array
     {
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
-
         $payload = json_encode([
             'model'       => $model,
             'max_tokens'  => 8192,
@@ -747,7 +777,7 @@ class CwmaiHelper
             'Authorization' => 'Bearer ' . $apiKey,
         ];
 
-        $response = $http->post('https://api.openai.com/v1/chat/completions', $payload, $headers);
+        $response = self::postJson('openai', 'https://api.openai.com/v1/chat/completions', $payload, $headers);
 
         if ($response->getStatusCode() !== 200) {
             try {

--- a/tests/unit/Admin/Helper/CwmDebugTest.php
+++ b/tests/unit/Admin/Helper/CwmDebugTest.php
@@ -76,6 +76,14 @@ class CwmDebugTest extends ProclaimTestCase
         $this->assertSame([], CwmDebug::getBuffer());
     }
 
+    #[TestDox('logApi is a no-op when JBSMDEBUG is off')]
+    public function testLogApiNoopWhenDisabled(): void
+    {
+        CwmDebug::logApi('ai.claude', 'POST', 'https://api.example.com/v1/messages', 200, 12.3);
+
+        $this->assertSame([], CwmDebug::getBuffer(), 'Disabled logApi must not buffer anything');
+    }
+
     #[TestDox('log and error also no-op the buffer when disabled')]
     public function testLogAndTimerNoopWhenDisabled(): void
     {


### PR DESCRIPTION
## What

The next piece of **Debug Mode Expansion** — outbound API-call logging, starting with the highest-value path: the AI content-generation calls.

## Changes

- **`CwmDebug::logApi(label, method, url, status, ms)`** — a new zero-overhead-when-off logger for outbound HTTP calls (category `api`), matching the existing `logQuery` style.
- **`CwmaiHelper`** — extracted a shared `postJson()` helper now used by `callClaude` / `callGemini` / `callOpenAI`. It:
  - times each request (only when debug is on),
  - logs it via `logApi` (method, URL, status, elapsed),
  - captures transport-level failures via `CwmDebug::error` (which always writes) before re-throwing,
  - and **DRYs** the three near-identical `new HttpFactory()` blocks.

## Why

AI calls previously left **no trace** — a failed key, quota error, or slow response was invisible. With debug on you now get:

```
[api] ai.claude: POST https://api.anthropic.com/v1/messages -> 200 (842.7ms)
[api] ai.openai: POST https://api.openai.com/v1/chat/completions -> 401 (96.2ms)
```

Non-200 responses are logged too (the caller still throws on them as before — behaviour unchanged).

## Tests

Adds `logApi` no-op coverage to `CwmDebugTest`. Verified the enabled format via probe. `792` tests green.

## Remaining on Debug Mode Expansion

Still open for a follow-up: the podcast URL HEAD check (`Cwmpodcast` curl), `CwmpodcastIndexHelper` directory pings, server-addon API calls (Vimeo/Wistia/Resi), and memory/template-render instrumentation. The scripture providers live in `lib_cwmscripture` (separate repo) and can't use the component's `CwmDebug` — that's a separate library task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)