### PR TITLE
feat(debug): instrument podcast HTTP calls with CwmDebug::logApi

### DIFF
--- a/admin/src/Helper/CwmpodcastIndexHelper.php
+++ b/admin/src/Helper/CwmpodcastIndexHelper.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\Http\HttpFactory;
+use Joomla\Http\Response;
 
 /**
  * Podcast Index API Helper — submit and search podcast feeds.
@@ -92,6 +93,40 @@ class CwmpodcastIndexHelper
     }
 
     /**
+     * Issue an authenticated GET to the Podcast Index API with debug logging.
+     *
+     * Times the request and records it via CwmDebug::logApi when JBSMDEBUG is on
+     * (transport failures go through CwmDebug::error, which always writes).
+     * Zero overhead when debug is off.
+     *
+     * @param   string  $label  Caller label for debug output (submitFeed/searchByFeedUrl)
+     * @param   string  $url    The fully built request URL
+     *
+     * @return  Response  The HTTP response (status left for the caller to check)
+     *
+     * @throws  \Exception  If the request itself fails (connection, TLS, …)
+     * @since   __DEPLOY_VERSION__
+     */
+    private function apiGet(string $label, string $url): Response
+    {
+        $http    = HttpFactory::getHttp();
+        $startNs = CwmDebug::isEnabled() ? hrtime(true) : null;
+
+        try {
+            $response = $http->get($url, $this->getAuthHeaders());
+        } catch (\Exception $e) {
+            CwmDebug::error('Podcast Index ' . $label . ' request failed', $e, 'api');
+
+            throw $e;
+        }
+
+        $elapsed = $startNs !== null ? (hrtime(true) - $startNs) / 1_000_000 : 0.0;
+        CwmDebug::logApi('podcast.index.' . $label, 'GET', $url, $response->getStatusCode(), $elapsed);
+
+        return $response;
+    }
+
+    /**
      * Submit a feed URL to Podcast Index for indexing.
      *
      * GET /add/byfeedurl?url={feedUrl}
@@ -107,8 +142,7 @@ class CwmpodcastIndexHelper
     public function submitFeed(string $feedUrl): object
     {
         $url      = $this->baseUrl . '/add/byfeedurl?url=' . urlencode($feedUrl);
-        $http     = HttpFactory::getHttp();
-        $response = $http->get($url, $this->getAuthHeaders());
+        $response = $this->apiGet('submitFeed', $url);
 
         $status = $response->getStatusCode();
         $body   = (string) $response->getBody();
@@ -144,8 +178,7 @@ class CwmpodcastIndexHelper
     public function searchByFeedUrl(string $feedUrl): ?object
     {
         $url      = $this->baseUrl . '/podcasts/byfeedurl?url=' . urlencode($feedUrl);
-        $http     = HttpFactory::getHttp();
-        $response = $http->get($url, $this->getAuthHeaders());
+        $response = $this->apiGet('searchByFeedUrl', $url);
 
         $status = $response->getStatusCode();
         $body   = (string) $response->getBody();

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
@@ -2531,6 +2532,8 @@ class Cwmpodcast
      */
     protected function getRemoteFileHeaders(string $url): ?array
     {
+        $startNs = CwmDebug::isEnabled() ? hrtime(true) : null;
+
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_NOBODY, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -2543,9 +2546,17 @@ class Cwmpodcast
 
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlErr  = curl_error($ch);
         curl_close($ch);
 
+        $elapsed = $startNs !== null ? (hrtime(true) - $startNs) / 1_000_000 : 0.0;
+        CwmDebug::logApi('podcast.remoteHeaders', 'HEAD', $url, (int) $httpCode, $elapsed);
+
         if ($httpCode < 200 || $httpCode >= 400 || $response === false) {
+            if ($response === false && $curlErr !== '') {
+                CwmDebug::error('Remote header check failed for ' . $url . ': ' . $curlErr, null, 'api');
+            }
+
             return null;
         }
 


### PR DESCRIPTION
## What

Continues the Debug Mode API-logging pass (after the AI provider calls in #1254) into the **podcast subsystem**.

## Changes

- **`CwmpodcastIndexHelper`** — extracted a shared `apiGet()` helper used by `submitFeed()` and `searchByFeedUrl()`. Times the request, logs it via `logApi` (GET, URL, status, elapsed), and `error()`s transport failures. DRYs the two near-identical `HttpFactory` blocks.
- **`Cwmpodcast::getRemoteFileHeaders`** (site) — the remote-media HEAD check now logs via `logApi` (with the captured HTTP code + elapsed) and `error()`s a hard curl failure that previously returned `null` with **no trace** (a broken enclosure URL was invisible).

## Behaviour

Zero overhead when `JBSMDEBUG` is off. With debug on, e.g.:

```
[api] podcast.index.searchByFeedUrl: GET https://api.podcastindex.org/.../byfeedurl?url=... -> 200 (210.4ms)
[api] podcast.remoteHeaders: HEAD https://cdn.example.com/ep1.mp3 -> 200 (88.1ms)
```

No functional change — callers still check status / handle 404 exactly as before.

## Tests

`792` tests green (logApi already covered in `CwmDebugTest`; these are wiring-only).

## Remaining on Debug Mode Expansion

- Server-addon API calls (Vimeo/Wistia/Resi) — many scattered HTTP calls across three large files; a focused follow-up.
- Memory tracking + template-render diagnostics in `CwmDebug`.
- Scripture providers live in `lib_cwmscripture` (separate repo) — not eligible for the component's `CwmDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)