### PR TITLE
feat(debug): shared addon apiRequest() + instrument Vimeo HTTP calls

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -16,12 +16,15 @@ namespace CWM\Component\Proclaim\Administrator\Addons;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
+use Joomla\Http\HttpFactory;
+use Joomla\Http\Response;
 use Joomla\Registry\Registry;
 
 /**
@@ -648,6 +651,59 @@ abstract class CWMAddon
     public function detectMetadata(Registry $params, object $server, string $set_path, Registry $path, Cwmpodcast $jbspodcast): void
     {
         // Default implementation does nothing
+    }
+
+    /**
+     * Perform an outbound HTTP request to a server-addon API with debug logging.
+     *
+     * Centralises HTTP client creation for the server addons (Vimeo, Wistia,
+     * Resi, …). Times the request and records it via CwmDebug::logApi when
+     * JBSMDEBUG is on; transport failures go through CwmDebug::error (which
+     * always writes) before being re-thrown. Zero overhead when debug is off.
+     * Callers keep their own status-code / response handling.
+     *
+     * @param   string       $method   HTTP verb: GET, POST, PUT, PATCH, DELETE
+     * @param   string       $url      Request URL
+     * @param   array        $headers  Request headers
+     * @param   string|null  $body     Request body for POST/PUT/PATCH (null otherwise)
+     * @param   string       $label    Caller label for debug output (defaults to addon type)
+     *
+     * @return  Response  The HTTP response (status left for the caller to check)
+     *
+     * @throws  \Exception  If the request itself fails (connection, TLS, …)
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function apiRequest(
+        string $method,
+        string $url,
+        array $headers = [],
+        ?string $body = null,
+        string $label = ''
+    ): Response {
+        $http    = (new HttpFactory())->getHttp();
+        $verb    = strtoupper($method);
+        $label   = $label !== '' ? $label : $this->getType();
+        $startNs = CwmDebug::isEnabled() ? hrtime(true) : null;
+
+        try {
+            $response = match ($verb) {
+                'GET'    => $http->get($url, $headers),
+                'DELETE' => $http->delete($url, $headers),
+                'POST'   => $http->post($url, (string) $body, $headers),
+                'PUT'    => $http->put($url, (string) $body, $headers),
+                'PATCH'  => $http->patch($url, (string) $body, $headers),
+                default  => throw new \InvalidArgumentException('Unsupported HTTP method: ' . $verb),
+            };
+        } catch (\Exception $e) {
+            CwmDebug::error($label . ' ' . $verb . ' request failed', $e, 'api');
+
+            throw $e;
+        }
+
+        $elapsed = $startNs !== null ? (hrtime(true) - $startNs) / 1_000_000 : 0.0;
+        CwmDebug::logApi($label, $verb, $url, $response->getStatusCode(), $elapsed);
+
+        return $response;
     }
 
     /**

--- a/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
+++ b/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
@@ -22,7 +22,6 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Http\HttpFactory;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
@@ -330,14 +329,12 @@ class CWMAddonVimeo extends CWMAddon
     {
         try {
             $url      = 'https://vimeo.com/api/oembed.json?url=https://vimeo.com/' . $videoId;
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Accept' => 'application/json',
             ];
 
             try {
-                $response = $http->get($url, $headers);
+                $response = $this->apiRequest('GET', $url, $headers, null, 'vimeo.oembed');
 
                 if ($response->getStatusCode() !== 200) {
                     throw new \RuntimeException('Vimeo oEmbed error: HTTP ' . $response->getStatusCode());
@@ -421,8 +418,6 @@ class CWMAddonVimeo extends CWMAddon
         }
 
         try {
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Authorization' => 'Bearer ' . $accessToken,
                 'Content-Type'  => 'application/json',
@@ -430,7 +425,7 @@ class CWMAddonVimeo extends CWMAddon
             ];
 
             $body     = json_encode(['description' => $description], JSON_THROW_ON_ERROR);
-            $response = $http->patch('https://api.vimeo.com/videos/' . $videoId, $body, $headers);
+            $response = $this->apiRequest('PATCH', 'https://api.vimeo.com/videos/' . $videoId, $headers, $body, 'vimeo.syncDescription');
 
             if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
                 return ['success' => true];
@@ -504,8 +499,6 @@ class CWMAddonVimeo extends CWMAddon
 
         $synced  = 0;
         $errors  = [];
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
         $headers = [
             'Authorization' => 'Bearer ' . $accessToken,
             'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
@@ -523,7 +516,7 @@ class CWMAddonVimeo extends CWMAddon
                     'fields' => 'uri,stats',
                 ]);
 
-                $response = $http->get('https://api.vimeo.com/videos?' . $params, $headers);
+                $response = $this->apiRequest('GET', 'https://api.vimeo.com/videos?' . $params, $headers, null, 'vimeo.stats');
 
                 if ($response->getStatusCode() !== 200) {
                     $errors[] = 'Vimeo API error: HTTP ' . $response->getStatusCode();
@@ -658,14 +651,12 @@ class CWMAddonVimeo extends CWMAddon
             }
 
             // Test API connection by getting user info
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Authorization' => 'Bearer ' . $accessToken,
                 'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
             ];
 
-            $response = $http->get('https://api.vimeo.com/me', $headers);
+            $response = $this->apiRequest('GET', 'https://api.vimeo.com/me', $headers, null, 'vimeo.testConnection');
 
             if ($response->getStatusCode() !== 200) {
                 return [
@@ -790,8 +781,6 @@ class CWMAddonVimeo extends CWMAddon
         $query    = $input->getString('query', '');
         $folderId = $input->getString('folder_id', '');
 
-        $factory  = new HttpFactory();
-        $http     = $factory->getHttp();
         $headers  = [
             'Authorization' => 'Bearer ' . $accessToken,
             'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
@@ -814,7 +803,7 @@ class CWMAddonVimeo extends CWMAddon
             : 'https://api.vimeo.com/me/projects/' . rawurlencode($folderId) . '/videos';
 
         try {
-            $response = $http->get($endpoint . '?' . http_build_query($params), $headers);
+            $response = $this->apiRequest('GET', $endpoint . '?' . http_build_query($params), $headers, null, 'vimeo.search');
 
             if ($response->getStatusCode() !== 200) {
                 return ['success' => false, 'error' => 'Vimeo API error (HTTP ' . $response->getStatusCode() . ')'];
@@ -905,17 +894,18 @@ class CWMAddonVimeo extends CWMAddon
             return ['success' => false, 'error' => 'no access_token'. $e->getMessage()];
         }
 
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
         $headers = [
             'Authorization' => 'Bearer ' . $accessToken,
             'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
         ];
 
         try {
-            $response = $http->get(
+            $response = $this->apiRequest(
+                'GET',
                 'https://api.vimeo.com/me/projects?per_page=100&fields=uri,name',
-                $headers
+                $headers,
+                null,
+                'vimeo.folders'
             );
 
             if ($response->getStatusCode() !== 200) {


### PR DESCRIPTION
## What

Continues the Debug Mode API-logging pass into the **server addons**, starting with shared infrastructure on the base class + the Vimeo addon.

## Changes

- **`CWMAddon` (base class)** — new `protected apiRequest(method, url, headers, body, label): Response` helper. Centralises `HttpFactory` client creation for **all** server addons, supports GET/POST/PUT/PATCH/DELETE, times the request, logs it via `CwmDebug::logApi`, and `error()`s transport failures before re-throwing. Zero overhead when `JBSMDEBUG` is off; callers keep their own status-code handling.
- **`CWMAddonVimeo`** — routed all **6** HTTP call sites through `apiRequest` (oembed, `syncDescription` PATCH, stats, testConnection, search, folders) and dropped the now-unused `HttpFactory` import.

## Behaviour

No functional change — same response objects, same status/exception handling. With debug on, e.g.:

```
[api] vimeo.search: GET https://api.vimeo.com/me/videos?... -> 200 (180.4ms)
[api] vimeo.syncDescription: PATCH https://api.vimeo.com/videos/123 -> 200 (220.1ms)
```

`792` tests green.

## Why base + Vimeo only

The `apiRequest` helper is the reusable part — once it's on the base class, **Wistia (~6 sites) and Resi (~4, incl. OAuth POSTs) become mechanical**. Those are untested integration paths where a subtle GET-vs-POST or body/header mix-up wouldn't be caught by lint, so they get their own focused PR rather than being bundled here.

## Remaining on Debug Mode Expansion

- Wistia + Resi addons (reuse `apiRequest`)
- Memory tracking + template-render diagnostics in `CwmDebug`
- Scripture providers — separate `lib_cwmscripture` repo, can't use component `CwmDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)