### PR TITLE
feat(debug): instrument Wistia and Resi HTTP calls via apiRequest

### DIFF
--- a/admin/src/Addons/Servers/Resi/CWMAddonResi.php
+++ b/admin/src/Addons/Servers/Resi/CWMAddonResi.php
@@ -21,7 +21,6 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Http\HttpFactory;
 use Joomla\Registry\Registry;
 
 /**
@@ -399,8 +398,6 @@ class CWMAddonResi extends CWMAddon
         }
 
         try {
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Content-Type' => 'application/json',
                 'Accept'       => 'application/json',
@@ -411,7 +408,7 @@ class CWMAddonResi extends CWMAddon
                 'grant_type'    => 'client_credentials',
             ], JSON_THROW_ON_ERROR);
 
-            $response = $http->post('https://api.resi.io/v1/oauth/token', $body, $headers);
+            $response = $this->apiRequest('POST', 'https://api.resi.io/v1/oauth/token', $headers, $body, 'resi.oauth');
 
             if ($response->getStatusCode() === 200) {
                 $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
@@ -475,14 +472,12 @@ class CWMAddonResi extends CWMAddon
 
         try {
             $token    = $this->getOAuthToken($serverId);
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Authorization' => 'Bearer ' . $token,
                 'Accept'        => 'application/json',
             ];
 
-            $response = $http->get('https://api.resi.io/v1/ondemand/videos/' . rawurlencode($videoId), $headers);
+            $response = $this->apiRequest('GET', 'https://api.resi.io/v1/ondemand/videos/' . rawurlencode($videoId), $headers, null, 'resi.video');
 
             if ($response->getStatusCode() !== 200) {
                 $errorData = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
@@ -539,8 +534,6 @@ class CWMAddonResi extends CWMAddon
             throw new \RuntimeException(Text::_('JBS_ADDON_RESI_NO_CLIENT_ID'));
         }
 
-        $factory  = new HttpFactory();
-        $http     = $factory->getHttp();
         $headers  = [
             'Content-Type' => 'application/json',
             'Accept'       => 'application/json',
@@ -551,7 +544,7 @@ class CWMAddonResi extends CWMAddon
             'grant_type'    => 'client_credentials',
         ], JSON_THROW_ON_ERROR);
 
-        $response = $http->post('https://api.resi.io/v1/oauth/token', $body, $headers);
+        $response = $this->apiRequest('POST', 'https://api.resi.io/v1/oauth/token', $headers, $body, 'resi.oauth');
 
         if ($response->getStatusCode() !== 200) {
             $errorData = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
@@ -704,14 +697,12 @@ class CWMAddonResi extends CWMAddon
 
         try {
             $token    = $this->getOAuthToken((int) $server->id);
-            $factory  = new HttpFactory();
-            $http     = $factory->getHttp();
             $headers  = [
                 'Authorization' => 'Bearer ' . $token,
                 'Accept'        => 'application/json',
             ];
 
-            $response = $http->get('https://api.resi.io/v1/ondemand/videos/' . rawurlencode($videoId), $headers);
+            $response = $this->apiRequest('GET', 'https://api.resi.io/v1/ondemand/videos/' . rawurlencode($videoId), $headers, null, 'resi.video');
 
             if ($response->getStatusCode() !== 200) {
                 return;

--- a/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
+++ b/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
@@ -22,7 +22,6 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Http\HttpFactory;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
@@ -328,14 +327,12 @@ class CWMAddonWistia extends CWMAddon
     {
         $videoUrl = 'https://home.wistia.com/medias/' . $mediaHash;
         $url      = 'https://fast.wistia.com/oembed?url=' . urlencode($videoUrl);
-        $factory  = new HttpFactory();
-        $http     = $factory->getHttp();
         $headers  = [
             'Accept' => 'application/json',
         ];
 
         try {
-            $response = $http->get($url, $headers);
+            $response = $this->apiRequest('GET', $url, $headers, null, 'wistia.oembed');
 
             if ($response->getStatusCode() !== 200) {
                 throw new \RuntimeException('Wistia oEmbed error: HTTP ' . $response->getStatusCode());
@@ -423,17 +420,18 @@ class CWMAddonWistia extends CWMAddon
         }
 
         try {
-            $http     = (new \Joomla\Http\HttpFactory())->getHttp();
             $headers  = [
                 'Authorization' => 'Bearer ' . $apiToken,
                 'Content-Type'  => 'application/x-www-form-urlencoded',
             ];
 
             $body     = http_build_query(['description' => $description]);
-            $response = $http->put(
+            $response = $this->apiRequest(
+                'PUT',
                 'https://api.wistia.com/v1/medias/' . rawurlencode($hashedId) . '.json',
+                $headers,
                 $body,
-                $headers
+                'wistia.syncDescription'
             );
 
             if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
@@ -495,17 +493,18 @@ class CWMAddonWistia extends CWMAddon
 
         $synced  = 0;
         $errors  = [];
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
         $headers = [
             'Authorization' => 'Bearer ' . $apiToken,
         ];
 
         foreach ($videoMap as $hash => $mediaIds) {
             try {
-                $response = $http->get(
+                $response = $this->apiRequest(
+                    'GET',
                     'https://api.wistia.com/v1/medias/' . rawurlencode($hash) . '/stats.json',
-                    $headers
+                    $headers,
+                    null,
+                    'wistia.stats'
                 );
 
                 if ($response->getStatusCode() !== 200) {
@@ -633,13 +632,11 @@ class CWMAddonWistia extends CWMAddon
             }
 
             // Test API connection by getting account info
-            $factory = new HttpFactory();
-            $http    = $factory->getHttp();
             $headers = [
                 'Authorization' => 'Bearer ' . $apiToken,
             ];
 
-            $response = $http->get('https://api.wistia.com/v1/account.json', $headers);
+            $response = $this->apiRequest('GET', 'https://api.wistia.com/v1/account.json', $headers, null, 'wistia.testConnection');
 
             if ($response->getStatusCode() !== 200) {
                 return [
@@ -780,16 +777,17 @@ class CWMAddonWistia extends CWMAddon
             $params['project_id'] = $projectId;
         }
 
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
         $headers = [
             'Authorization' => 'Bearer ' . $apiToken,
         ];
 
         try {
-            $response = $http->get(
+            $response = $this->apiRequest(
+                'GET',
                 'https://api.wistia.com/v1/medias.json?' . http_build_query($params),
-                $headers
+                $headers,
+                null,
+                'wistia.search'
             );
 
             if ($response->getStatusCode() !== 200) {
@@ -871,16 +869,17 @@ class CWMAddonWistia extends CWMAddon
             return ['success' => false, 'error' => 'no api_token'];
         }
 
-        $factory = new HttpFactory();
-        $http    = $factory->getHttp();
         $headers = [
             'Authorization' => 'Bearer ' . $apiToken,
         ];
 
         try {
-            $response = $http->get(
+            $response = $this->apiRequest(
+                'GET',
                 'https://api.wistia.com/v1/projects.json?per_page=100&sort_by=name&sort_direction=asc',
-                $headers
+                $headers,
+                null,
+                'wistia.projects'
             );
 
             if ($response->getStatusCode() !== 200) {


### PR DESCRIPTION
## What

Completes **server-addon API logging**, reusing the `CWMAddon::apiRequest()` helper added in #1256.

## Changes

- **`CWMAddonWistia`** — routed all **6** call sites through `apiRequest`: oembed (GET), `syncDescription` (PUT + body), stats (GET, in loop), testConnection (GET), search (GET), projects (GET). Dropped the `HttpFactory` import.
- **`CWMAddonResi`** — routed all **4** call sites through `apiRequest`: OAuth token (POST ×2), video metadata (GET ×2). Dropped the `HttpFactory` import.

## Behaviour

No functional change — same response objects, same status-code checks and exception flow. With debug on, e.g.:

```
[api] wistia.syncDescription: PUT https://api.wistia.com/v1/medias/abc.json -> 200 (210ms)
[api] resi.oauth: POST https://api.resi.io/v1/oauth/token -> 200 (160ms)
```

`792` tests green.

## Debug Mode Expansion — status after this PR

All component HTTP call sites are now instrumented: queries, AI providers, podcast, and the three server addons (Vimeo/Wistia/Resi). Remaining: memory tracking + template-render diagnostics in `CwmDebug`. (Scripture providers live in `lib_cwmscripture` — separate repo, out of scope for component `CwmDebug`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)