### PR TITLE
refactor: remove dead code flagged by stale TODOs (cluster A)

### DIFF
--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -72,30 +72,6 @@ class CwmserverModel extends AdminModel
     private object $data;
 
     /**
-     * @var bool
-     * @since 9.0.0
-     * @todo  need to look into this and see if we need it still.
-     */
-    private mixed $event_after_upload;
-
-    /**
-     * Constructor
-     *
-     * @param   array  $config  An array of configuration options (name, state, dbo, table_path, ignore_request).
-     *
-     * @throws  \Exception
-     * @since   12.2
-     */
-    public function __construct($config = [])
-    {
-        parent::__construct($config);
-
-        if (isset($config['event_after_upload'])) {
-            $this->event_after_upload = $config['event_after_upload'];
-        }
-    }
-
-    /**
      * Reverse look up of id to server_type
      *
      * @param   int   $pk   ID to get

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -280,53 +280,6 @@ class CwmtopicTable extends Table
     }
 
     /**
-     * check and (re-)construct the alias before storing the topic
-     *
-     * @param   array  $data      Data of record
-     * @param   int    $recordId  id
-     *
-     * @return  bool|array ?
-     *
-     * @since 9.0.0
-     *
-     * @todo  this look like it is not used. (Neither Tom nor Brent wrote this one)
-     */
-    public function checkAlias($data = [], $recordId = null): array|bool
-    {
-        $topic = $data['topic_text'];
-
-        // Topic_text not given? -> use the first language item with some text
-        if ($topic == null || \strlen($topic) == 0) {
-            if (isset($data['params']) && \is_array($data['params'])) {
-                foreach ($data['params'] as $language) {
-                    if (\strlen($language) > 0) {
-                        $topic = $language;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // If still empty: use id
-        // todo: For new items, this is always '0'. Next primary key would be nice...
-        if ($topic == null || \strlen($topic) == 0) {
-            $topic = $recordId;
-        }
-
-        // Add prefix if needed
-        if (strncmp($topic, 'JBS_TOP_', 8) != 0) {
-            $topic = 'JBS_TOP_' . $topic;
-        }
-
-        // And form well
-        // replace all non a-Z 0-9 by '_'
-        $topic              = strtoupper(preg_replace('/[^a-z0-9]/i', '_', $topic));
-        $data['topic_text'] = $topic;
-
-        return $data;
-    }
-
-    /**
      * Method to compute the default name of the asset.
      * The default name is in the form `table_name.id`
      * where id is the value of the primary key of the table.

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -51,7 +51,6 @@ class CwmseriesdisplayModel extends ItemModel
      * @throws \Exception
      *
      * @since 7.1.0
-     * @todo  look are removing this may not used. bcc
      */
     public function getItem($pk = null): mixed
     {

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -60,7 +60,6 @@ class CwmseriespodcastdisplayModel extends ItemModel
      * @throws \Exception
      *
      * @since 7.1.0
-     * @todo  look at removing this, as it may not be used. bcc
      */
     public function getItem($pk = null): mixed
     {


### PR DESCRIPTION
Works through the first cluster of in-code `@todo` comments — the four "may not be used" ones — by **verifying usage** before acting.

## Genuinely dead → removed
- **`CwmtopicTable::checkAlias()`** — zero callers anywhere in the repo (the comment itself noted "neither Tom nor Brent wrote this one"). Removed the method; this also eliminates the nested `// todo: ... next primary key` comment.
- **`CwmserverModel::$event_after_upload`** — write-only property: assigned in the constructor from `$config`, but never read, and never passed in config anywhere. Removed the property and the now-redundant passthrough constructor. The passthrough also silently dropped the `MVCFactory` argument; removing it aligns `CwmserverModel` with its peer edit models (CwmteacherModel, CwmmessageModel, … none define a constructor) and lets the factory flow through to `AdminModel`.

## False alarms → comment removed only
- **`CwmseriespodcastdisplayModel::getItem()`** and **`CwmseriesdisplayModel::getItem()`** are **used** — their views call `$this->get('Item')`, which Joomla maps to `getItem()`. Removed the inaccurate "may not be used" comments; code untouched.

## Verification
- `php -l` clean on all 4 files
- `composer lint` clean (exit 0)
- `composer test:unit` → **675/675**
- `composer test:integration` → **112/112** (includes Admin Table Tests)

In-code TODO count: **16 → 11**. Part of an ongoing TODO-cleanup sweep (cluster A of A–D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)