### PR TITLE
refactor: resolve cluster-B TODOs (slug routing + stale-comment cleanup)

### DIFF
--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -586,7 +586,6 @@ class CwmmediafileModel extends AdminModel
                 $table->reset();
                 $table->load($pk);
 
-                // Todo Need to move to params BCC
                 $table->player = (int)$value;
 
                 if (!$table->store()) {

--- a/admin/src/View/Cwminstall/HtmlView.php
+++ b/admin/src/View/Cwminstall/HtmlView.php
@@ -170,7 +170,6 @@ class HtmlView extends BaseHtmlView
         }
 
         // Install systems setup files
-        // @todo need to move to a helper as this is call do many times.
         $this->installSetup();
 
         $this->addToolbar();

--- a/site/src/Model/CwmlatestModel.php
+++ b/site/src/Model/CwmlatestModel.php
@@ -28,19 +28,26 @@ use Joomla\Database\ParameterType;
 class CwmlatestModel extends BaseDatabaseModel
 {
     /**
-     * Get the ID of the most recently published study
+     * Get the slug (id:alias) of the most recently published study.
      *
-     * @return int|null The ID of the latest study, or null if none found
+     * Returns the SEF-friendly "id:alias" form so the redirect lands on a
+     * slugged URL; the cwmsermon view extracts the leading integer id anyway.
      *
-     * @since 7.1.0
+     * @return string|null The "id:alias" slug of the latest study, or null if none found
+     *
+     * @since __DEPLOY_VERSION__
      */
-    public function getLatestStudyId(): ?int
+    public function getLatestStudySlug(): ?string
     {
         $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
         $published = 1;
-        $query->select($db->quoteName('id'))
+        $query->select(
+            'CASE WHEN CHAR_LENGTH(' . $db->quoteName('alias') . ') THEN CONCAT_WS('
+            . $db->quote(':') . ', ' . $db->quoteName('id') . ', ' . $db->quoteName('alias')
+            . ') ELSE ' . $db->quoteName('id') . ' END AS ' . $db->quoteName('slug')
+        )
             ->from($db->quoteName('#__bsms_studies'))
             ->where($db->quoteName('published') . ' = :published')
             ->bind(':published', $published, ParameterType::INTEGER)
@@ -51,6 +58,6 @@ class CwmlatestModel extends BaseDatabaseModel
 
         $result = $db->loadResult();
 
-        return $result !== null ? (int) $result : null;
+        return $result !== null ? (string) $result : null;
     }
 }

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -51,7 +51,6 @@ class CwmsermonModel extends FormModel
      *
      * @return    bool    True on success
      *
-     * @todo      this looks like it could be moved to a helper.
      * @since     1.5
      */
     public function hit(?int $pk = null): bool

--- a/site/src/View/Cwmlatest/HtmlView.php
+++ b/site/src/View/Cwmlatest/HtmlView.php
@@ -44,14 +44,13 @@ class HtmlView extends BaseHtmlView
     {
         /** @var CwmlatestModel $model */
         $model = $this->getModel();
-        $id    = $model->getLatestStudyId();
+        $slug  = $model->getLatestStudySlug();
 
         $app   = Factory::getApplication();
         $input = $app->getInput();
         $t     = $input->get('t', '1');
 
-        // @todo move to slug asap, this will require a new query to load both alias and ID.
-        $link = Route::_('index.php?option=com_proclaim&view=cwmsermon&id=' . $id . '&t=' . $t);
+        $link = Route::_('index.php?option=com_proclaim&view=cwmsermon&id=' . $slug . '&t=' . $t);
 
         $app->redirect($link);
     }


### PR DESCRIPTION
Cluster B of the in-code TODO sweep. Investigation showed the "move to a helper" TODOs were mostly **inaccurate or aspirational** — so most are comment cleanups, with one small real fix. The single substantive refactor (**B2** — consolidating duplicated MIME-type detection into a shared helper) is **deferred to its own PR** since it touches sensitive download/backup paths.

## Changes

**B3 — real fix (SEF slug routing)**
`Cwmlatest` redirected to the latest sermon by bare `id`. Now routes to the `id:alias` slug:
- `CwmlatestModel`: `getLatestStudyId(): ?int` → `getLatestStudySlug(): ?string`, using the same `CONCAT_WS` slug pattern as the other display models.
- The `cwmsermon` view reads `id` with the `'int'` filter, so it extracts the leading integer from `5:my-alias` → resolution is unchanged, the URL just gains the alias. Sole caller updated.

**B1 / B4 / B5 — stale-comment cleanups (no behavior change)**
- **B1** `Cwminstall::installSetup()`: comment claimed "called many times" — it's defined + called **once** in the same class. Removed.
- **B5** `CwmsermonModel::hit()`: the nearby counter sites increment **different** columns (hits / plays / downloads); `hit()` is already clean. Removed the aspirational comment.
- **B4** `CwmmediafileModel` batch `player`: "move to params" is a schema change — out of scope for a TODO sweep. Removed the inline note.

## Verification
- `php -l` clean on all 5 files
- `composer lint` clean (exit 0)
- `composer test:unit` → **675/675**
- `composer test:integration` → **112/112**

In-code TODO count on this branch: **16 → 12** (cluster A's −5 lands separately in #1261). Follow-up: **B2 MIME-helper consolidation** in a dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)