### PR TITLE
refactor: consolidate duplicated MIME detection into Cwmmime helper (B2)

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -717,25 +718,7 @@ abstract class CWMAddon
      */
     protected function getMimeTypeFromExtension(string $filename): ?string
     {
-        $path      = parse_url($filename, PHP_URL_PATH);
-        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-
-        $mimeTypes = [
-            'mp3'  => 'audio/mpeg',
-            'mp4'  => 'video/mp4',
-            'm4a'  => 'audio/mp4',
-            'm4v'  => 'video/mp4',
-            'ogg'  => 'audio/ogg',
-            'oga'  => 'audio/ogg',
-            'ogv'  => 'video/ogg',
-            'wav'  => 'audio/wav',
-            'webm' => 'video/webm',
-            'flac' => 'audio/flac',
-            'aac'  => 'audio/aac',
-            'pdf'  => 'application/pdf',
-        ];
-
-        return $mimeTypes[$extension] ?? null;
+        return Cwmmime::fromExtension($filename);
     }
 
     /**

--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Local;
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmuploadscript;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
@@ -321,28 +322,7 @@ class CWMAddonLocal extends CWMAddon
 
         // MIME type: try real detection first, fall back to extension
         if ($needsMime) {
-            $mimeType = null;
-
-            if (\function_exists('mime_content_type')) {
-                $mimeType = mime_content_type($localPath);
-
-                if ($mimeType === 'application/octet-stream') {
-                    $mimeType = null;
-                }
-            }
-
-            if (!$mimeType && class_exists('finfo')) {
-                $finfo    = new \finfo(FILEINFO_MIME_TYPE);
-                $mimeType = $finfo->file($localPath);
-
-                if ($mimeType === 'application/octet-stream') {
-                    $mimeType = null;
-                }
-            }
-
-            if (!$mimeType) {
-                $mimeType = $this->getMimeTypeFromExtension($localPath);
-            }
+            $mimeType = Cwmmime::detect($localPath);
 
             if ($mimeType) {
                 $params->set('mime_type', $mimeType);

--- a/admin/src/Helper/Cwmmime.php
+++ b/admin/src/Helper/Cwmmime.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Shared MIME-type detection helper.
+ *
+ * Consolidates the extension→MIME maps and the mime_content_type → finfo →
+ * extension detection chain that were previously duplicated across the backup
+ * library, the addon base/local classes, and the podcast helper.
+ *
+ * @package  Proclaim.Admin
+ * @since    __DEPLOY_VERSION__
+ */
+final class Cwmmime
+{
+    /**
+     * Canonical single-extension → MIME-type map.
+     *
+     * Note: this is for detecting a single file's type. The broader pipe-keyed
+     * "allowed types" catalog used by the media upload field lives in
+     * Cwmmedia::getMimetypes() and is a separate concern.
+     *
+     * @var array<string, string>
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private const MAP = [
+        // Audio
+        'mp3'  => 'audio/mpeg',
+        'm4a'  => 'audio/mp4',
+        'm4b'  => 'audio/mp4',
+        'oga'  => 'audio/ogg',
+        'ogg'  => 'audio/ogg',
+        'wav'  => 'audio/wav',
+        'flac' => 'audio/flac',
+        'aac'  => 'audio/aac',
+        'wma'  => 'audio/x-ms-wma',
+        // Video
+        'mp4'  => 'video/mp4',
+        'm4v'  => 'video/mp4',
+        'ogv'  => 'video/ogg',
+        'webm' => 'video/webm',
+        'mov'  => 'video/quicktime',
+        'avi'  => 'video/x-msvideo',
+        'mkv'  => 'video/x-matroska',
+        'wmv'  => 'video/x-ms-wmv',
+        // Documents
+        'pdf'  => 'application/pdf',
+        'txt'  => 'text/plain',
+        'htm'  => 'text/html',
+        'html' => 'text/html',
+        'doc'  => 'application/msword',
+        'xls'  => 'application/vnd.ms-excel',
+        'ppt'  => 'application/vnd.ms-powerpoint',
+        'sql'  => 'text/x-sql',
+        'php'  => 'text/plain',
+        // Images
+        'gif'  => 'image/gif',
+        'png'  => 'image/png',
+        'jpg'  => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        // Archives / binaries
+        'zip' => 'application/zip',
+        'exe' => 'application/octet-stream',
+    ];
+
+    /**
+     * Resolve a MIME type from a filename or URL by its extension.
+     *
+     * @param   string  $pathOrFilename  A file path, filename, or URL.
+     *
+     * @return  string|null  The mapped MIME type, or null when the extension is unknown.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function fromExtension(string $pathOrFilename): ?string
+    {
+        $path      = parse_url($pathOrFilename, PHP_URL_PATH) ?: $pathOrFilename;
+        $extension = strtolower(pathinfo((string) $path, PATHINFO_EXTENSION));
+
+        return self::MAP[$extension] ?? null;
+    }
+
+    /**
+     * Detect a file's MIME type: real detection (mime_content_type, then finfo),
+     * falling back to the extension map.
+     *
+     * @param   string  $filepath  Path to a local, readable file.
+     *
+     * @return  string|null  The detected MIME type, or null when undetermined.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function detect(string $filepath): ?string
+    {
+        if (\function_exists('mime_content_type')) {
+            $mimeType = mime_content_type($filepath);
+
+            if ($mimeType && $mimeType !== 'application/octet-stream') {
+                return $mimeType;
+            }
+        }
+
+        if (class_exists('finfo')) {
+            $finfo    = new \finfo(FILEINFO_MIME_TYPE);
+            $mimeType = $finfo->file($filepath);
+
+            if ($mimeType && $mimeType !== 'application/octet-stream') {
+                return $mimeType;
+            }
+        }
+
+        return self::fromExtension($filepath);
+    }
+
+    /**
+     * Resolve a MIME type for a download response. Honours an explicit type,
+     * otherwise derives one from the extension, falling back to a forced download.
+     *
+     * @param   string  $mimeType  An explicit MIME type, or '' to derive one.
+     * @param   string  $file      The file path/name used to derive the type.
+     *
+     * @return  string  A non-empty MIME type suitable for a Content-Type header.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function forDownload(string $mimeType, string $file): string
+    {
+        if ($mimeType !== '') {
+            return $mimeType;
+        }
+
+        return self::fromExtension($file) ?? 'application/force-download';
+    }
+}

--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\Version;
 use Joomla\CMS\Factory;
@@ -748,7 +749,7 @@ class Cwmbackup
         @ob_end_clean();
 
         // Verify MimeType or Extract the MimeType
-        $mime_type = $this->verifyMimeType($mime_type, $file);
+        $mime_type = Cwmmime::forDownload($mime_type, $file);
 
         // Reset the execution time limit for file output
         if (\function_exists('set_time_limit')) {
@@ -791,51 +792,6 @@ class Cwmbackup
             flush();
         }
         return true;
-    }
-
-    /**
-     * Verify MimeType
-     *
-     * @param   string  $mime_type  MimeType (optional)
-     * @param   string  $file       File with a full path
-     *
-     * @return string Return correct MimeType (ex. application/zip)
-     *
-     * @since 10.0.0
-     * @todo may need to move this out into a helper file.
-     */
-    private function verifyMimeType(string $mime_type = '', string $file = ''): string
-    {
-        /* Figure out the MIME type (if not specified) */
-        $known_mime_types = [
-            "pdf"  => "application/pdf",
-            "txt"  => "text/plain",
-            "html" => "text/html",
-            "htm"  => "text/html",
-            "exe"  => "application/octet-stream",
-            "zip"  => "application/zip",
-            "doc"  => "application/msword",
-            "xls"  => "application/vnd.ms-excel",
-            "ppt"  => "application/vnd.ms-powerpoint",
-            "gif"  => "image/gif",
-            "png"  => "image/png",
-            "jpeg" => "image/jpg",
-            "jpg"  => "image/jpg",
-            "php"  => "text/plain",
-            "sql"  => "text/x-sql",
-        ];
-
-        if ($mime_type === '') {
-            $file_extension = strtolower(substr(strrchr($file, "."), 1));
-
-            if (\array_key_exists($file_extension, $known_mime_types)) {
-                return $known_mime_types[$file_extension];
-            }
-
-            return "application/force-download";
-        }
-
-        return $mime_type;
     }
 
     /**

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
@@ -2584,46 +2585,7 @@ class Cwmpodcast
      */
     protected function detectMimeType(string $filepath): ?string
     {
-        // Try mime_content_type first
-        if (\function_exists('mime_content_type')) {
-            $mimeType = mime_content_type($filepath);
-            if ($mimeType && $mimeType !== 'application/octet-stream') {
-                return $mimeType;
-            }
-        }
-
-        // Try finfo
-        if (class_exists('finfo')) {
-            $finfo    = new \finfo(FILEINFO_MIME_TYPE);
-            $mimeType = $finfo->file($filepath);
-            if ($mimeType && $mimeType !== 'application/octet-stream') {
-                return $mimeType;
-            }
-        }
-
-        // Fall back to extension-based detection
-        $extension = strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
-        $mimeTypes = [
-            'mp3'  => 'audio/mpeg',
-            'mp4'  => 'video/mp4',
-            'm4a'  => 'audio/mp4',
-            'm4v'  => 'video/mp4',
-            'ogg'  => 'audio/ogg',
-            'oga'  => 'audio/ogg',
-            'ogv'  => 'video/ogg',
-            'wav'  => 'audio/wav',
-            'webm' => 'video/webm',
-            'flac' => 'audio/flac',
-            'aac'  => 'audio/aac',
-            'wma'  => 'audio/x-ms-wma',
-            'wmv'  => 'video/x-ms-wmv',
-            'avi'  => 'video/x-msvideo',
-            'mov'  => 'video/quicktime',
-            'mkv'  => 'video/x-matroska',
-            'pdf'  => 'application/pdf',
-        ];
-
-        return $mimeTypes[$extension] ?? null;
+        return Cwmmime::detect($filepath);
     }
 
     /**

--- a/tests/unit/Admin/Helper/CwmmimeTest.php
+++ b/tests/unit/Admin/Helper/CwmmimeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Unit tests for Cwmmime helper
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test class for the shared Cwmmime helper.
+ *
+ * Pure-logic tests covering the extension map and download-header resolution
+ * that were previously duplicated across Cwmbackup, CWMAddon and Cwmpodcast.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmmime::class)]
+class CwmmimeTest extends ProclaimTestCase
+{
+    public static function extensionProvider(): array
+    {
+        return [
+            // Media (preserves the previous addon/podcast map values)
+            'mp3 -> audio/mpeg'  => ['sermon.mp3', 'audio/mpeg'],
+            'm4a -> audio/mp4'   => ['talk.m4a', 'audio/mp4'],
+            'ogg -> audio/ogg'   => ['clip.ogg', 'audio/ogg'],
+            'mp4 -> video/mp4'   => ['video.mp4', 'video/mp4'],
+            'webm -> video/webm' => ['v.webm', 'video/webm'],
+            'mov -> quicktime'   => ['v.mov', 'video/quicktime'],
+            // Documents / archives (preserves the previous backup map intent)
+            'pdf -> pdf'    => ['notes.pdf', 'application/pdf'],
+            'zip -> zip'    => ['backup.zip', 'application/zip'],
+            'sql -> x-sql'  => ['dump.sql', 'text/x-sql'],
+            'doc -> msword' => ['file.doc', 'application/msword'],
+            // Case-insensitive + URL + nested path handling
+            'uppercase MP3'  => ['SERMON.MP3', 'audio/mpeg'],
+            'url with query' => ['https://cdn.example.com/a/b.mp3?token=xyz', 'audio/mpeg'],
+            'nested path'    => ['/var/www/media/file.pdf', 'application/pdf'],
+            // Unknown / none
+            'unknown extension' => ['file.xyz', null],
+            'no extension'      => ['README', null],
+        ];
+    }
+
+    #[DataProvider('extensionProvider')]
+    public function testFromExtension(string $input, ?string $expected): void
+    {
+        $this->assertSame($expected, Cwmmime::fromExtension($input));
+    }
+
+    public function testForDownloadHonoursExplicitMimeType(): void
+    {
+        $this->assertSame('application/zip', Cwmmime::forDownload('application/zip', 'whatever.bin'));
+    }
+
+    public function testForDownloadDerivesFromExtensionWhenBlank(): void
+    {
+        $this->assertSame('application/zip', Cwmmime::forDownload('', 'backup.zip'));
+        $this->assertSame('text/x-sql', Cwmmime::forDownload('', 'dump.sql'));
+    }
+
+    public function testForDownloadFallsBackToForceDownloadForUnknownExtension(): void
+    {
+        $this->assertSame('application/force-download', Cwmmime::forDownload('', 'mystery.xyz'));
+    }
+}


### PR DESCRIPTION
The deferred substantive item from the cluster-B TODO sweep. Resolves the `@todo may need to move this out into a helper file` on `Cwmbackup::verifyMimeType` — **and** the broader duplication it pointed at: the same extension→MIME maps and `mime_content_type → finfo → extension` detection chain were copy-pasted across four places.

## New helper — `admin/src/Helper/Cwmmime.php`
- `fromExtension($pathOrFilename): ?string` — canonical extension→MIME map (union of the prior maps; handles URLs + nested paths + case)
- `detect($filepath): ?string` — the `mime_content_type → finfo → extension` fallback chain
- `forDownload($mimeType, $file): string` — explicit-type passthrough, else extension, else `application/force-download`

## Migrated call sites (behavior preserved)
| Before | After |
|---|---|
| `Cwmbackup::verifyMimeType()` (private, 1 caller) | `Cwmmime::forDownload()` — method removed |
| `CWMAddon::getMimeTypeFromExtension()` | delegates to `Cwmmime::fromExtension()` |
| `Cwmpodcast::detectMimeType()` | delegates to `Cwmmime::detect()` |
| `CWMAddonLocal` inline detect chain | `Cwmmime::detect()` |

The two addon/podcast fallback maps were **identical** to the new canonical map for every key they defined, so those paths are byte-for-byte unchanged.

## Deliberately out of scope
`Cwmmedia::getMimetypes()` is **left untouched** — it's a different concern (the pipe-keyed `'htm|html' => …` *allowed-types catalog* feeding the upload form field + admin model, not single-file detection).

## One intentional normalization
`jpg`: `image/jpg` → `image/jpeg` (the former is non-standard). This value was only reachable on the backup **download** path, which serves `.zip`/`.sql` files — so no real-world output changes.

## Verification
- `php -l` clean on all files; `composer lint` clean
- New `CwmmimeTest` — **18 cases** locking in the map + download-resolution behavior
- `composer test:unit` → **693/693**; `composer test:integration` → **112/112**

Completes the cluster-B TODO work (follows #1262). In-code TODO count: **−1** here. Remaining sweep: clusters **C** (5) and **D** (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)