### PR TITLE
refactor: resolve cluster-C TODOs (dead code + stale-comment cleanup)

### DIFF
--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -249,32 +249,6 @@ class CwmadminModel extends AdminModel
         }
     }
 
-    /**
-     * Get Media Files
-     *
-     * @return mixed
-     *
-     * @since 7.0
-     *
-     * @todo  not sure if this should be here.
-     */
-    public function getMediaFiles(): mixed
-    {
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->getQuery(true);
-        $query->select('*');
-        $query->from($db->quoteName('#__bsms_mediafiles'));
-        $db->setQuery($query);
-        $mediafiles = $db->loadObjectList();
-
-        foreach ($mediafiles as $i => $mediafile) {
-            $reg = new Registry();
-            $reg->loadString($mediafile->params);
-            $mediafiles[$i]->params = $reg;
-        }
-
-        return $mediafiles;
-    }
 
     /**
      * Fixes database problems

--- a/admin/src/Service/HTML/CWMHtml5Inline.php
+++ b/admin/src/Service/HTML/CWMHtml5Inline.php
@@ -37,7 +37,6 @@ class CWMHtml5Inline
      * @return  string
      *
      * @since      10.0.0
-     * @todo Need to clean up and verify all sanserif.
      */
     public static function render(
         object $media,

--- a/site/src/Helper/Cwmimages.php
+++ b/site/src/Helper/Cwmimages.php
@@ -352,8 +352,6 @@ class Cwmimages
      *           }
      *
      * @since    7.0
-     *
-     * @todo This looks like it needs a rework.
      */
     public static function getTeacherImage(?string $image1 = null, ?string $image2 = null): object
     {

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -190,7 +190,6 @@ class HtmlView extends BaseHtmlView
      * @return  void
      *
      * @throws \Exception
-     * @todo  Need to clean up the display function as there is stuff needed to change up.
      *
      * @since 7.0
      */
@@ -352,9 +351,6 @@ class HtmlView extends BaseHtmlView
         $this->item->scripture1    = $CWMListing->getScripture($scriptureParams, $item, 0, 1);
         $this->item->scripture2    = $CWMListing->getScripture($scriptureParams, $item, 0, 2);
         $this->item->allScriptures = $CWMListing->getAllScriptures($scriptureParams, $item);
-
-        // @todo check to see if this works
-        $this->item->topics = $this->item->topic_text;
 
         if ($item->params->get('showrelated') > 0) {
             $relatedstudies = new Cwmrelatedstudies();
@@ -557,7 +553,7 @@ class HtmlView extends BaseHtmlView
         $pathway = $app->getPathway();
 
         $this->item->metadesc = mb_substr(trim(strip_tags($this->item->studyintro ?? '')), 0, 160);
-        $this->item->metakey  = $this->item->topics;
+        $this->item->metakey  = $this->item->topic_text;
 
         // Because the application sets a default page title,
         // we need to get it from the menu item itself


### PR DESCRIPTION
Cluster C of the in-code TODO sweep — the "cleanup/verify" notes. Each was investigated before acting; two turned out to be real dead/redundant code, three were non-actionable comments.

## Verified findings

**C2 — dead method removed**
`CwmadminModel::getMediaFiles(): mixed` had **no caller**. The only no-arg `getMediaFiles()` call site (Cwmmessage view) resolves to `CwmmessageModel`'s own `getMediaFiles(): array`. Removed (resolves "not sure if this should be here"). No imports orphaned.

**C5 — verified, then fixed (this one was a trap)**
`Cwmsermon` view had `$this->item->topics = $this->item->topic_text` tagged *"check to see if this works"*. It **does** — `topics` was a redundant alias consumed 200 lines later by `$this->item->metakey = $this->item->topics`. Rather than keep the topic_text→topics→metakey hop, **metakey now reads `topic_text` directly** (matching the sibling line that already does `setMetaData('keywords', $this->item->topic_text . …)`). Behavior preserved; redundant alias gone.
> ⚠️ Naively deleting the alias would have silently emptied the sermon meta-keywords — caught by re-grepping for readers after the edit.

**C1 / C3 / C4 — non-actionable comments removed**
- `CWMHtml5Inline::render` "verify all sanserif" — the token `sanserif` appears **nowhere** in the file; orphaned note.
- `Cwmimages::getTeacherImage` "needs a rework" and `Cwmsermon::display` "clean up the display function" — aspirational, no discrete defect.

## Verification
- `php -l` clean on all 4 files; `composer lint` clean
- `composer test:unit` → **693/693**; `composer test:integration` → **112/112**

In-code TODO count after this: **1 remaining** (cluster D — `CwmtopicTable::bind()` "consider deprecating this override").

🤖 Generated with [Claude Code](https://claude.com/claude-code)