### PR TITLE
refactor: remove stale 'deprecate this override' TODO on CwmtopicTable::bind() (cluster D)

### DIFF
--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -188,7 +188,6 @@ class CwmtopicTable extends Table
      *
      * @return  bool  True on success.
      *
-     * @todo    Consider deprecating this override
      * @link    http://docs.joomla.org/Table/bind
      * @since   11.1
      */


### PR DESCRIPTION
The final item in the in-code TODO sweep.

## Finding
`CwmtopicTable::bind()` carried `@todo Consider deprecating this override`. Investigation shows the override is **load-bearing**, not deprecatable — it:
1. converts the `params` array to a JSON string,
2. binds ACL `rules` via `setRules()`, and
3. **casts the typed `?int` properties** (`id`, `published`, `asset_id`, …) so a form posting string values doesn't throw a PHP 8.3 `TypeError`.

Crucially, **all 13 Proclaim Table classes** use this exact `bind()` + int-cast pattern — it's the established type-safety convention. Singling out this one override for deprecation was incorrect, so the comment is removed and the override stays.

> Noted for the future (not in scope here): the 13 near-identical `bind()` overrides could one day be DRYed into a shared base `Table` class with a per-class int-field list. That's a 13-class refactor, well beyond resolving a stale comment.

## Verification
- `php -l` clean; `composer lint` clean
- `composer test:integration` → **112/112** (docblock-only change)

## Sweep complete
In-code TODO count: **16 → 0**. Series: #1261 (A), #1262 (B-light), #1263 (B2), #1264 (C), this (D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)