### PR TITLE
chore: gitignore local .claude/settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ build.properties
 # Claude Code personal/local settings (not shared)
 .claude/settings.local.json
 .claude/settings.local.json.bak
+/.claude/settings.json


### PR DESCRIPTION
Adds `/.claude/settings.json` to `.gitignore`, alongside the already-ignored `settings.local.json`, under the existing *"Claude Code personal/local settings (not shared)"* group.

The file was never tracked — this just formalizes keeping the local Claude Code settings out of version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)