### PR TITLE
chore(deps): bump intl-tel-input 29.0.5 -> 29.1.1 (closes #1268)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "csso": "^5.0.5",
         "eslint": "^10.0.1",
         "globals": "^17.4.0",
-        "intl-tel-input": "^29.0.5",
+        "intl-tel-input": "^29.1.1",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "rollup": "^4.58.0",
@@ -5460,9 +5460,9 @@
       "license": "ISC"
     },
     "node_modules/intl-tel-input": {
-      "version": "29.0.5",
-      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-29.0.5.tgz",
-      "integrity": "sha512-6tp+w5oteAeOnOkzLSZtnEm2Mljd9uPGd43krPat8mm8F0ROA6GyK3pqovMBJ1uVDNxJI+iMQgfpf0a3+0bpVQ==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-29.1.1.tgz",
+      "integrity": "sha512-Joaswth+mOoaGm4htL/xvgcQufjcNrdHIdVkTOLJxbfjwLw5mrhL8GBDrUfPePvvuc2IJmoiWXyJ1TJn1udoNw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "csso": "^5.0.5",
     "eslint": "^10.0.1",
     "globals": "^17.4.0",
-    "intl-tel-input": "^29.0.5",
+    "intl-tel-input": "^29.1.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "rollup": "^4.58.0",


### PR DESCRIPTION
## Summary

Bumps the bundled `intl-tel-input` vendor library 29.0.5 → **29.1.1**, the last outstanding item from the weekly vendor-check report (#1268).

The other items that report flagged were already resolved earlier this session:
- `friendsofphp/php-cs-fixer` → 3.95.11 (#1275)
- `phpunit/phpunit` → 12.5.30 (#1275)
- `roave/security-advisories` → already at `36ba91e8`, newer than the flagged ref (#1275)

## Validation
- `npm run build:assets` → copies intl-tel-input 29.1.1 cleanly
- `npm test` → 229 JS tests pass
- `npm run lint:js` → clean

Closes #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)