### PR TITLE
fix(images): sanitize & length-cap generated message image filenames (closes #1272)

### DIFF
--- a/admin/src/Helper/Cwmthumbnail.php
+++ b/admin/src/Helper/Cwmthumbnail.php
@@ -43,6 +43,16 @@ class Cwmthumbnail
     ];
 
     /**
+     * Maximum length of the generated base filename (before the version hash and
+     * extension are appended). Keeps the final name — including the "thumb_"
+     * prefix and ".webp" variants — comfortably within the 255-byte filesystem
+     * limit and avoids unwieldy names built from long sermon titles.
+     *
+     * @since 10.3.3
+     */
+    private const int MAX_BASENAME_LENGTH = 80;
+
+    /**
      * Validate an image file before processing
      *
      * @param   string  $filePath       Absolute path to the file
@@ -176,6 +186,41 @@ class Cwmthumbnail
      *
      * @since 9.0.0
      */
+    /**
+     * Build a filesystem- and URL-safe base filename from a title (or fall back
+     * to the original filename), slugified and length-capped.
+     *
+     * Both inputs are run through ApplicationHelper::stringURLSafe so that spaces,
+     * smart quotes, commas and other characters that break filesystem paths and
+     * URLs are stripped — the previous behaviour passed the raw original filename
+     * through unchanged, producing names such as
+     * "Anticipating the Return of Christ … 1105 am by.jpg" (#1272). The result is
+     * truncated to MAX_BASENAME_LENGTH characters and falls back to "image" when
+     * slugification yields an empty string.
+     *
+     * @param   string|null  $title         Preferred source for the name (e.g. sermon title)
+     * @param   string       $originalPath  Path used for the fallback basename
+     *
+     * @return  string  A safe, non-empty base filename (no extension, no version hash)
+     *
+     * @since 10.3.3
+     */
+    public static function buildSafeBaseFilename(?string $title, string $originalPath): string
+    {
+        $source = ($title !== null && trim($title) !== '')
+            ? $title
+            : pathinfo($originalPath, PATHINFO_FILENAME);
+
+        $base = ApplicationHelper::stringURLSafe((string) $source);
+
+        if (mb_strlen($base) > self::MAX_BASENAME_LENGTH) {
+            // Trim to the limit, then drop any dash left dangling by the cut.
+            $base = rtrim(mb_substr($base, 0, self::MAX_BASENAME_LENGTH), '-');
+        }
+
+        return $base !== '' ? $base : 'image';
+    }
+
     public static function create(
         string $file,
         string $path,
@@ -194,12 +239,9 @@ class Cwmthumbnail
         // Get file extension
         $extension = strtolower(pathinfo($originalPath, PATHINFO_EXTENSION));
 
-        // Generate filename from title or use original basename
-        if ($title !== null && trim($title) !== '') {
-            $baseFilename = ApplicationHelper::stringURLSafe($title);
-        } else {
-            $baseFilename = pathinfo($originalPath, PATHINFO_FILENAME);
-        }
+        // Generate a filesystem- and URL-safe filename from the title (falling
+        // back to the original basename), slugified and length-capped. See #1272.
+        $baseFilename = self::buildSafeBaseFilename($title, $originalPath);
 
         // Add a short version hash based on file content to bust browser cache
         // when the image is replaced with a new file at the same logical path.

--- a/tests/integration/Admin/Helper/CwmthumbnailBuildSafeBaseFilenameTest.php
+++ b/tests/integration/Admin/Helper/CwmthumbnailBuildSafeBaseFilenameTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Integration tests for Cwmthumbnail::buildSafeBaseFilename()
+ *
+ * Covers issue #1272: message image filenames built from long sermon titles or
+ * raw upload names (with spaces, smart quotes and commas) must be slugified and
+ * length-capped so they are safe on the filesystem and in URLs.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmthumbnail;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Cwmthumbnail::class)]
+class CwmthumbnailBuildSafeBaseFilenameTest extends IntegrationTestCase
+{
+    public function testSlugifiesTitle(): void
+    {
+        $result = Cwmthumbnail::buildSafeBaseFilename('Romans Study Part 1', '/tmp/original.jpg');
+
+        $this->assertSame('romans-study-part-1', $result);
+    }
+
+    public function testEmptyTitleFallsBackToBasename(): void
+    {
+        $result = Cwmthumbnail::buildSafeBaseFilename('   ', '/tmp/photo.jpg');
+
+        $this->assertSame('photo', $result);
+    }
+
+    /**
+     * The fallback basename branch must be sanitised too — previously it passed
+     * the raw filename through unchanged, which is the core of issue #1272.
+     */
+    public function testSanitisesFallbackBasename(): void
+    {
+        $result = Cwmthumbnail::buildSafeBaseFilename(null, '/tmp/My Photo, Final.jpg');
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9-]+$/', $result);
+        $this->assertNotSame('', $result);
+    }
+
+    /**
+     * The real-world #1272 filename: long, smart quotes, commas — must become a
+     * safe, length-capped slug with no trailing dash.
+     */
+    public function testCapsLongMessyTitle(): void
+    {
+        $title = '“Anticipating the Return of Christ A Future Hope” by Elder Uche Sampson '
+            . 'Communion Sabbath Sabbath, June 27th at 1105 am by';
+
+        $result = Cwmthumbnail::buildSafeBaseFilename($title, '/tmp/original.jpg');
+
+        $this->assertLessThanOrEqual(80, mb_strlen($result));
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9-]+$/', $result);
+        $this->assertStringEndsNotWith('-', $result);
+    }
+
+    public function testFallsBackToImageWhenSlugIsEmpty(): void
+    {
+        // A filename of only dashes slugifies to an empty string.
+        $result = Cwmthumbnail::buildSafeBaseFilename('', '/tmp/---.jpg');
+
+        $this->assertSame('image', $result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **#1272 — Message Image Problem**. `Cwmthumbnail::create()` generated the stored image/thumbnail filename in two ways, both flawed:

- **With a title:** slugified via `stringURLSafe`, but **never length-capped**.
- **Without a title:** used the **raw upload basename with no sanitization at all**.

That let filenames like this reach the filesystem verbatim:

> `"Anticipating the Return of Christ A Future Hope" by Elder Uche Sampson Communion Sabbath Sabbath, June 27th at 1105 am by.jpg`

The spaces, smart quotes (`"…"`) and commas break the URLs to the stored image, and long sermon titles push the derived name — plus the `thumb_` prefix, `-{hash}` and `.webp` variants — toward the 255-byte filesystem limit. This is the "filesystem conversion of the filename not being recognized" behaviour reported.

## Fix

Extracted the naming logic into a new, testable `Cwmthumbnail::buildSafeBaseFilename()`:

- **Both** the title and the fallback basename now go through `ApplicationHelper::stringURLSafe` (the fallback was previously raw).
- Result is **capped at 80 chars** (`MAX_BASENAME_LENGTH`), with any trailing dash from the cut trimmed.
- An empty slug (e.g. a name of only punctuation) **falls back to `image`** so the file always gets a valid, content-hashed name.

Net: every derived name (full image, `thumb_`, `.webp`) stays URL-safe and well within the byte limit.

## Tests

5 new integration tests in `CwmthumbnailBuildSafeBaseFilenameTest` (integration suite because `stringURLSafe` reads Joomla config from the DB), including the exact real-world #1272 filename. Full PHP suite: **815 tests pass**, php-cs-fixer clean.

Closes #1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)