### PR TITLE
feat(playlist): platform-neutral contract + Vimeo, remote_* columns (#1273 phase 5)

### DIFF
--- a/admin/forms/playlist.xml
+++ b/admin/forms/playlist.xml
@@ -25,7 +25,7 @@
         <option value="">JBS_CMN_SELECT_SERVER</option>
     </field>
 
-    <field name="youtube_playlist_id" type="PlaylistPicker"
+    <field name="remote_playlist_id" type="PlaylistPicker"
            label="JBS_PLAYLIST_YOUTUBE_ID" description="JBS_PLAYLIST_YOUTUBE_ID_DESC"
            size="50" filter="trim"
            hint="PLxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"/>

--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -402,6 +402,7 @@ JBS_PLAYLIST_DEFAULT_TEACHER_DESC = "The teacher assigned to studies created dur
 JBS_PLAYLIST_DEFAULT_DESCRIPTION = "Default Description"
 JBS_PLAYLIST_DEFAULT_DESCRIPTION_DESC = "Default description text applied to studies created during a sync."
 JBS_PLAYLIST_BROWSE = "Browse Playlists"
+JBS_PLAYLIST_NOT_SUPPORTED = "This server type does not support playlists."
 JBS_PLAYLIST_PICK_TITLE = "Choose a YouTube Playlist"
 JBS_PLAYLIST_PICK_NO_SERVER = "Select a server first, then browse its playlists."
 JBS_PLAYLIST_PICK_EMPTY = "No playlists found on this server's channel."

--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
     `title`               VARCHAR(250)              DEFAULT NULL,
     `alias`               VARCHAR(400)     NOT NULL DEFAULT '',
     `description`         MEDIUMTEXT,
-    `youtube_playlist_id` VARCHAR(64)      NOT NULL DEFAULT '' COMMENT 'Remote playlist ID (e.g. YouTube playlist ID)',
+    `remote_playlist_id` VARCHAR(64)      NOT NULL DEFAULT '' COMMENT 'Remote playlist ID (e.g. YouTube playlist ID)',
     `server_id`           INT(10) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'FK to #__bsms_servers',
     `series_id`           INT(10) UNSIGNED          DEFAULT NULL COMMENT 'Optional FK to #__bsms_series',
     `default_settings`    TEXT COMMENT 'JSON of default settings applied to synced videos',
@@ -181,15 +181,15 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlist_items`
     `id`               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
     `playlist_id`      INT(10) UNSIGNED NOT NULL,
     `mediafile_id`     INT(10) UNSIGNED          DEFAULT NULL COMMENT 'FK to #__bsms_mediafiles; NULL when no local media yet',
-    `youtube_video_id` VARCHAR(32)      NOT NULL DEFAULT '' COMMENT 'Reconciliation key matched against params.filename',
+    `remote_video_id` VARCHAR(32)      NOT NULL DEFAULT '' COMMENT 'Reconciliation key matched against params.filename',
     `title`            VARCHAR(400)     NOT NULL DEFAULT '',
     `position`         INT(11)          NOT NULL DEFAULT '0',
     `created`          DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `idx_playlist_video` (`playlist_id`, `youtube_video_id`),
+    UNIQUE KEY `idx_playlist_video` (`playlist_id`, `remote_video_id`),
     KEY `idx_playlist` (`playlist_id`),
     KEY `idx_mediafile` (`mediafile_id`),
-    KEY `idx_video` (`youtube_video_id`)
+    KEY `idx_video` (`remote_video_id`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/admin/sql/updates/mysql/10.3.3-20260513.sql
+++ b/admin/sql/updates/mysql/10.3.3-20260513.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
     `title`               VARCHAR(250)              DEFAULT NULL,
     `alias`               VARCHAR(400)     NOT NULL DEFAULT '',
     `description`         MEDIUMTEXT,
-    `youtube_playlist_id` VARCHAR(64)      NOT NULL DEFAULT '',
+    `remote_playlist_id` VARCHAR(64)      NOT NULL DEFAULT '',
     `server_id`           INT(10) UNSIGNED NOT NULL DEFAULT '0',
     `series_id`           INT(10) UNSIGNED          DEFAULT NULL,
     `default_settings`    TEXT,
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
   DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 -- Playlist items junction (#1273 phase 2): maps a playlist to the Proclaim
--- media files it contains. youtube_video_id is the reconciliation key — bulk
+-- media files it contains. remote_video_id is the reconciliation key — bulk
 -- import matches it against existing #__bsms_mediafiles (params.filename) so we
 -- link rather than duplicate. mediafile_id is nullable: a playlist video with no
 -- local media yet is still recorded so the membership/order is preserved.
@@ -60,15 +60,15 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlist_items`
     `id`               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
     `playlist_id`      INT(10) UNSIGNED NOT NULL,
     `mediafile_id`     INT(10) UNSIGNED          DEFAULT NULL,
-    `youtube_video_id` VARCHAR(32)      NOT NULL DEFAULT '',
+    `remote_video_id` VARCHAR(32)      NOT NULL DEFAULT '',
     `title`            VARCHAR(400)     NOT NULL DEFAULT '',
     `position`         INT(11)          NOT NULL DEFAULT '0',
     `created`          DATETIME                  DEFAULT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `idx_playlist_video` (`playlist_id`, `youtube_video_id`),
+    UNIQUE KEY `idx_playlist_video` (`playlist_id`, `remote_video_id`),
     KEY `idx_playlist` (`playlist_id`),
     KEY `idx_mediafile` (`mediafile_id`),
-    KEY `idx_video` (`youtube_video_id`)
+    KEY `idx_video` (`remote_video_id`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -26,6 +26,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
 use Joomla\Http\HttpFactory;
 use Joomla\Http\Response;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -680,6 +681,62 @@ abstract class CWMAddon
                 return false;
             }
         }));
+    }
+
+    /**
+     * List a server's remote playlists/collections.
+     *
+     * The platform-neutral contract the playlist engine and the picker call.
+     * Override in a playlist-capable addon. Must return:
+     *   ['success' => bool, 'error' => ?string,
+     *    'playlists' => [ ['playlistId' => string, 'title' => string, 'description' => string, 'thumbnail' => string], ... ]]
+     *
+     * @param   Input  $input  Request input (expects server_id).
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylists(Input $input): array
+    {
+        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED'), 'playlists' => []];
+    }
+
+    /**
+     * List the items (videos) inside one remote playlist, paginated.
+     *
+     * Override in a playlist-capable addon. Must return:
+     *   ['success' => bool, 'error' => ?string,
+     *    'videos' => [ ['videoId' => string, 'title' => string], ... ],
+     *    'nextPageToken' => ?string]
+     *
+     * @param   Input  $input  Request input (expects server_id, playlist_id, page_token, max_results).
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylistItems(Input $input): array
+    {
+        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED'), 'videos' => [], 'nextPageToken' => null];
+    }
+
+    /**
+     * Extract this platform's stable media ID from a stored URL/value.
+     *
+     * Instance-level so the playlist engine never names a platform. Defaults to
+     * the addon's static extractMediaId() — which YouTube/Vimeo/Wistia already
+     * implement — so playlist reconciliation generalizes for free.
+     *
+     * @param   string  $text  A media URL or bare ID.
+     *
+     * @return  string|null  The platform media ID, or null.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function extractRemoteMediaId(string $text): ?string
+    {
+        return static::extractMediaId($text);
     }
 
     /**

--- a/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
+++ b/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
@@ -581,7 +581,172 @@ class CWMAddonVimeo extends CWMAddon
             'getMetadata',
             'fetchVideos',
             'fetchFolders',
+            'fetchRemotePlaylists',
+            'fetchRemotePlaylistItems',
         ];
+    }
+
+    /**
+     * Vimeo supports the playlist system via showcases (albums).
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function supportsPlaylists(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Platform-neutral contract: list the account's showcases (albums) as playlists.
+     *
+     * @param   Input  $input  Request input (expects server_id).
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylists(Input $input): array
+    {
+        $serverId = $input->getInt('server_id', 0);
+
+        if (!$serverId) {
+            return ['success' => false, 'error' => 'No server ID provided', 'playlists' => []];
+        }
+
+        try {
+            $accessToken = $this->getServerAccessToken($serverId);
+        } catch (\JsonException $e) {
+            return ['success' => false, 'error' => 'no access_token' . $e->getMessage(), 'playlists' => []];
+        }
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
+        ];
+
+        try {
+            $response = $this->apiRequest(
+                'GET',
+                'https://api.vimeo.com/me/albums?per_page=100&fields=uri,name,description',
+                $headers,
+                null,
+                'vimeo.albums'
+            );
+
+            if ($response->getStatusCode() !== 200) {
+                return ['success' => false, 'error' => 'Vimeo API error (HTTP ' . $response->getStatusCode() . ')', 'playlists' => []];
+            }
+
+            $data      = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            $playlists = [];
+
+            foreach ($data['data'] ?? [] as $album) {
+                $albumId = '';
+
+                if (preg_match('/\/albums\/(\d+)/', $album['uri'] ?? '', $m)) {
+                    $albumId = $m[1];
+                }
+
+                if ($albumId === '') {
+                    continue;
+                }
+
+                $playlists[] = [
+                    'playlistId'  => $albumId,
+                    'title'       => $album['name'] ?? '',
+                    'description' => $album['description'] ?? '',
+                    'thumbnail'   => '',
+                ];
+            }
+
+            return ['success' => true, 'playlists' => $playlists];
+        } catch (\Exception $e) {
+            return ['success' => false, 'error' => $e->getMessage(), 'playlists' => []];
+        }
+    }
+
+    /**
+     * Platform-neutral contract: list a showcase's videos, paginated.
+     *
+     * Vimeo paginates by page number; we map the engine's opaque page_token to a
+     * page number and return the next page number (or null) as nextPageToken.
+     *
+     * @param   Input  $input  Request input (server_id, playlist_id, page_token, max_results).
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylistItems(Input $input): array
+    {
+        $serverId = $input->getInt('server_id', 0);
+        $albumId  = $input->getString('playlist_id', '');
+        $page     = max(1, (int) ($input->getString('page_token', '') ?: '1'));
+        $perPage  = max(1, min(100, $input->getInt('max_results', 50)));
+
+        if (!$serverId) {
+            return ['success' => false, 'error' => 'No server ID provided', 'videos' => [], 'nextPageToken' => null];
+        }
+
+        if ($albumId === '') {
+            return ['success' => false, 'error' => 'No playlist ID provided', 'videos' => [], 'nextPageToken' => null];
+        }
+
+        try {
+            $accessToken = $this->getServerAccessToken($serverId);
+        } catch (\JsonException $e) {
+            return ['success' => false, 'error' => 'no access_token' . $e->getMessage(), 'videos' => [], 'nextPageToken' => null];
+        }
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Accept'        => 'application/vnd.vimeo.*+json;version=3.4',
+        ];
+
+        $params = [
+            'per_page' => $perPage,
+            'page'     => $page,
+            'fields'   => 'uri,name',
+        ];
+
+        try {
+            $response = $this->apiRequest(
+                'GET',
+                'https://api.vimeo.com/me/albums/' . rawurlencode($albumId) . '/videos?' . http_build_query($params),
+                $headers,
+                null,
+                'vimeo.albumVideos'
+            );
+
+            if ($response->getStatusCode() !== 200) {
+                return ['success' => false, 'error' => 'Vimeo API error (HTTP ' . $response->getStatusCode() . ')', 'videos' => [], 'nextPageToken' => null];
+            }
+
+            $data   = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            $videos = [];
+
+            foreach ($data['data'] ?? [] as $video) {
+                $videoId = '';
+
+                if (preg_match('/\/videos\/(\d+)/', $video['uri'] ?? '', $m)) {
+                    $videoId = $m[1];
+                }
+
+                if ($videoId === '') {
+                    continue;
+                }
+
+                $videos[] = ['videoId' => $videoId, 'title' => $video['name'] ?? ''];
+            }
+
+            $hasNext = !empty($data['paging']['next']);
+
+            return ['success' => true, 'videos' => $videos, 'nextPageToken' => $hasNext ? (string) ($page + 1) : null];
+        } catch (\Exception $e) {
+            return ['success' => false, 'error' => $e->getMessage(), 'videos' => [], 'nextPageToken' => null];
+        }
     }
 
     /**

--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -475,6 +475,36 @@ class CWMAddonYoutube extends CWMAddon
     }
 
     /**
+     * Platform-neutral contract: list the channel's playlists.
+     *
+     * @param   Input  $input  Request input.
+     *
+     * @return  array
+     *
+     * @throws  \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylists(Input $input): array
+    {
+        return $this->fetchChannelPlaylists($input);
+    }
+
+    /**
+     * Platform-neutral contract: list a playlist's videos.
+     *
+     * @param   Input  $input  Request input.
+     *
+     * @return  array
+     *
+     * @throws  \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    public function fetchRemotePlaylistItems(Input $input): array
+    {
+        return $this->fetchPlaylistVideos($input);
+    }
+
+    /**
      * Fetch video statistics from YouTube Data API for media linked to this server.
      * Batches up to 50 video IDs per API call. When $batchLimit > 0, only the
      * least-recently-synced videos are processed (never-synced first).
@@ -668,6 +698,8 @@ class CWMAddonYoutube extends CWMAddon
             'searchChannelVideos',
             'fetchChannelPlaylists',
             'fetchPlaylistVideos',
+            'fetchRemotePlaylists',
+            'fetchRemotePlaylistItems',
             'fetchLiveVideos',
             'getVideoStatus',
             'disconnectOAuth',

--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -17,7 +17,6 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
-use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
 use CWM\Component\Proclaim\Administrator\Table\CwmplaylistTable;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
@@ -151,7 +150,7 @@ final class CwmplaylistSyncHelper
     /**
      * Fetch a channel's playlists and upsert each as a Proclaim Playlist.
      *
-     * Existing playlists are matched on (youtube_playlist_id, server_id).
+     * Existing playlists are matched on (remote_playlist_id, server_id).
      *
      * Conflict gate: the YouTube title is only re-applied to an existing playlist
      * when it actually changed AND the local row was NOT edited by a human since
@@ -175,7 +174,7 @@ final class CwmplaylistSyncHelper
     {
         $out = ['created' => 0, 'updated' => 0, 'skipped' => 0, 'playlistIds' => [], 'conflicts' => [], 'error' => null];
 
-        $response = $addon->fetchChannelPlaylists(new Input(['server_id' => $serverId]));
+        $response = $addon->fetchRemotePlaylists(new Input(['server_id' => $serverId]));
 
         if (empty($response['success'])) {
             $out['error'] = $response['error'] ?? 'Unknown error fetching playlists.';
@@ -209,10 +208,10 @@ final class CwmplaylistSyncHelper
 
             if ($isNew) {
                 $data = [
-                    'title'               => $newTitle,
-                    'youtube_playlist_id' => $remoteId,
-                    'server_id'           => $serverId,
-                    'last_sync'           => $now,
+                    'title'              => $newTitle,
+                    'remote_playlist_id' => $remoteId,
+                    'server_id'          => $serverId,
+                    'last_sync'          => $now,
                     // Sensible defaults for a freshly imported playlist; all
                     // user-editable afterwards.
                     'published'    => 1,
@@ -233,9 +232,9 @@ final class CwmplaylistSyncHelper
                 }
 
                 $data = [
-                    'youtube_playlist_id' => $remoteId,
-                    'server_id'           => $serverId,
-                    'last_sync'           => $now,
+                    'remote_playlist_id' => $remoteId,
+                    'server_id'          => $serverId,
+                    'last_sync'          => $now,
                 ];
 
                 // Conflict gate + "only write if changed".
@@ -296,10 +295,10 @@ final class CwmplaylistSyncHelper
      * video ID against the supplied local map, and upserts a junction row per
      * video. Junction rows for videos no longer in the playlist are removed.
      *
-     * @param   DatabaseInterface  $db          Database driver.
-     * @param   CWMAddon           $addon       YouTube addon instance.
-     * @param   integer            $playlistId  Local playlist row ID.
-     * @param   array<string,int>  $videoMap    videoId => mediafileId map (built once per run).
+     * @param   DatabaseInterface              $db          Database driver.
+     * @param   CWMAddon                       $addon       Playlist-capable addon instance.
+     * @param   integer                        $playlistId  Local playlist row ID.
+     * @param   array<string,array<string,int>>  $videoMap  type => (videoId => mediafileId), built once per run.
      *
      * @return  array{items:int, matched:int, unmatched:int, error:?string}
      *
@@ -312,20 +311,22 @@ final class CwmplaylistSyncHelper
 
         $playlist = $db->setQuery(
             $db->getQuery(true)
-                ->select($db->quoteName(['youtube_playlist_id', 'server_id']))
-                ->from($db->quoteName('#__bsms_playlists'))
-                ->where($db->quoteName('id') . ' = :id')
+                ->select($db->quoteName(['p.remote_playlist_id', 'p.server_id', 's.type']))
+                ->from($db->quoteName('#__bsms_playlists', 'p'))
+                ->join('INNER', $db->quoteName('#__bsms_servers', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('p.server_id'))
+                ->where($db->quoteName('p.id') . ' = :id')
                 ->bind(':id', $playlistId, \Joomla\Database\ParameterType::INTEGER)
         )->loadObject();
 
-        if (!$playlist || $playlist->youtube_playlist_id === '') {
-            $out['error'] = 'Playlist has no remote YouTube playlist ID.';
+        if (!$playlist || $playlist->remote_playlist_id === '') {
+            $out['error'] = 'Playlist has no remote playlist ID.';
 
             return $out;
         }
 
-        $remoteId = (string) $playlist->youtube_playlist_id;
+        $remoteId = (string) $playlist->remote_playlist_id;
         $serverId = (int) $playlist->server_id;
+        $typeMap  = $videoMap[(string) $playlist->type] ?? [];
         $now      = Factory::getDate()->toSql();
 
         $position   = 0;
@@ -333,7 +334,7 @@ final class CwmplaylistSyncHelper
         $pageToken  = '';
 
         do {
-            $response = $addon->fetchPlaylistVideos(new Input([
+            $response = $addon->fetchRemotePlaylistItems(new Input([
                 'server_id'   => $serverId,
                 'playlist_id' => $remoteId,
                 'page_token'  => $pageToken,
@@ -353,7 +354,7 @@ final class CwmplaylistSyncHelper
                     continue;
                 }
 
-                $mediafileId = $videoMap[$videoId] ?? null;
+                $mediafileId = $typeMap[$videoId] ?? null;
                 $mediafileId === null ? $out['unmatched']++ : $out['matched']++;
 
                 self::upsertItem($db, $playlistId, $videoId, (string) ($video['title'] ?? ''), $mediafileId, $position, $now);
@@ -402,7 +403,10 @@ final class CwmplaylistSyncHelper
             return 0;
         }
 
-        $videoId = CWMAddonYoutube::extractMediaId((string) $decoded['filename']);
+        // Identify the video using any playlist-capable platform's extractor — a
+        // media file's URL is the source of truth, regardless of which server
+        // type it is filed under.
+        $videoId = self::extractAnyRemoteId((string) $decoded['filename']);
 
         if ($videoId === null) {
             return 0;
@@ -417,7 +421,7 @@ final class CwmplaylistSyncHelper
                     ->update($db->quoteName('#__bsms_playlist_items'))
                     ->set($db->quoteName('mediafile_id') . ' = NULL')
                     ->where($db->quoteName('mediafile_id') . ' = :mid')
-                    ->where($db->quoteName('youtube_video_id') . ' != :vid')
+                    ->where($db->quoteName('remote_video_id') . ' != :vid')
                     ->bind(':mid', $mediafileId, \Joomla\Database\ParameterType::INTEGER)
                     ->bind(':vid', $videoId, \Joomla\Database\ParameterType::STRING)
             )->execute();
@@ -427,7 +431,7 @@ final class CwmplaylistSyncHelper
                 $db->getQuery(true)
                     ->update($db->quoteName('#__bsms_playlist_items'))
                     ->set($db->quoteName('mediafile_id') . ' = :mid')
-                    ->where($db->quoteName('youtube_video_id') . ' = :vid')
+                    ->where($db->quoteName('remote_video_id') . ' = :vid')
                     ->where($db->quoteName('mediafile_id') . ' IS NULL')
                     ->bind(':mid', $mediafileId, \Joomla\Database\ParameterType::INTEGER)
                     ->bind(':vid', $videoId, \Joomla\Database\ParameterType::STRING)
@@ -473,28 +477,50 @@ final class CwmplaylistSyncHelper
     }
 
     /**
-     * Build a YouTube-video-ID => mediafile-ID map from the existing media library.
+     * Build a per-platform video-ID => mediafile-ID map from the media library.
      *
-     * Reads every media file's stored URL (params.filename) and extracts the
-     * YouTube video ID from it. This is the reconciliation index that lets bulk
-     * import link to media we already have rather than duplicate it.
+     * One sub-map per playlist-capable server type, each built with that
+     * platform's own ID extractor — so a YouTube ID and a Vimeo ID never
+     * collide. This is the reconciliation index that lets import/sync link to
+     * media we already have rather than duplicate it.
      *
      * @param   DatabaseInterface  $db  Database driver.
      *
-     * @return  array<string,int>  videoId => mediafileId (first match wins).
+     * @return  array<string,array<string,int>>  type => (videoId => mediafileId).
      *
      * @since   __DEPLOY_VERSION__
      */
     public static function buildLocalVideoMap(DatabaseInterface $db): array
     {
+        $types = array_values(array_unique(array_map(
+            static fn ($srv) => (string) $srv['type'],
+            CWMAddon::getPlaylistCapableServers()
+        )));
+
+        if ($types === []) {
+            return [];
+        }
+
+        // Scan all media with a URL once, then build one sub-map per platform by
+        // running that platform's own extractor. A YouTube URL filed under any
+        // server type still matches the YouTube map (the extractor recognises the
+        // URL, not the server record); a platform's extractor returns null for
+        // other platforms' URLs, so the maps stay disjoint.
         $rows = $db->setQuery(
             $db->getQuery(true)
                 ->select($db->quoteName(['id', 'params']))
                 ->from($db->quoteName('#__bsms_mediafiles'))
-                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%youtu%'))
-        )->loadAssocList();
+                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%http%'))
+        )->loadAssocList() ?: [];
 
-        return self::extractVideoMapFromRows($rows ?: []);
+        $map = [];
+
+        foreach ($types as $type) {
+            $addon       = CWMAddon::getInstance($type);
+            $map[$type]  = self::extractVideoMapFromRows($rows, [$addon, 'extractRemoteMediaId']);
+        }
+
+        return $map;
     }
 
     /**
@@ -502,15 +528,17 @@ final class CwmplaylistSyncHelper
      *
      * Extracted as a static, dependency-free method so the matching core can be
      * unit-tested without a database. Each row must have 'id' and 'params'
-     * (a JSON string whose 'filename' holds the media URL).
+     * (a JSON string whose 'filename' holds the media URL). The platform's ID
+     * extractor is injected so this stays platform-neutral and testable.
      *
-     * @param   array<int,array{id:mixed,params:mixed}>  $rows  Media-file rows.
+     * @param   array<int,array{id:mixed,params:mixed}>  $rows       Media-file rows.
+     * @param   callable                                 $extractor  fn(string $url): ?string.
      *
      * @return  array<string,int>  videoId => mediafileId (first match wins).
      *
      * @since   __DEPLOY_VERSION__
      */
-    public static function extractVideoMapFromRows(array $rows): array
+    public static function extractVideoMapFromRows(array $rows, callable $extractor): array
     {
         $map = [];
 
@@ -527,7 +555,7 @@ final class CwmplaylistSyncHelper
                 continue;
             }
 
-            $videoId = CWMAddonYoutube::extractMediaId((string) $decoded['filename']);
+            $videoId = $extractor((string) $decoded['filename']);
 
             if ($videoId === null || isset($map[$videoId])) {
                 continue;
@@ -537,6 +565,42 @@ final class CwmplaylistSyncHelper
         }
 
         return $map;
+    }
+
+    /**
+     * Extract a remote media ID from a URL using any playlist-capable platform.
+     *
+     * Tries each capable platform's extractor and returns the first match. Used
+     * by on-save linking, where we only have the media URL — not which platform
+     * it belongs to. Platform extractors recognise only their own URLs, so the
+     * first non-null result is unambiguous.
+     *
+     * @param   string  $url  The media URL.
+     *
+     * @return  string|null  The remote media ID, or null if no platform matched.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function extractAnyRemoteId(string $url): ?string
+    {
+        $types = array_unique(array_map(
+            static fn ($srv) => (string) $srv['type'],
+            CWMAddon::getPlaylistCapableServers()
+        ));
+
+        foreach ($types as $type) {
+            try {
+                $videoId = CWMAddon::getInstance($type)->extractRemoteMediaId($url);
+            } catch (\RuntimeException) {
+                continue;
+            }
+
+            if ($videoId !== null) {
+                return $videoId;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -561,17 +625,17 @@ final class CwmplaylistSyncHelper
                 ->select($db->quoteName('id'))
                 ->from($db->quoteName('#__bsms_playlist_items'))
                 ->where($db->quoteName('playlist_id') . ' = :pid')
-                ->where($db->quoteName('youtube_video_id') . ' = :vid')
+                ->where($db->quoteName('remote_video_id') . ' = :vid')
                 ->bind(':pid', $playlistId, \Joomla\Database\ParameterType::INTEGER)
                 ->bind(':vid', $videoId, \Joomla\Database\ParameterType::STRING)
         )->loadResult() ?? 0);
 
         $item = (object) [
-            'playlist_id'      => $playlistId,
-            'mediafile_id'     => $mediafileId,
-            'youtube_video_id' => $videoId,
-            'title'            => $title,
-            'position'         => $position,
+            'playlist_id'     => $playlistId,
+            'mediafile_id'    => $mediafileId,
+            'remote_video_id' => $videoId,
+            'title'           => $title,
+            'position'        => $position,
         ];
 
         if ($existingId > 0) {
@@ -605,7 +669,7 @@ final class CwmplaylistSyncHelper
 
         if ($keepVideos !== []) {
             $quoted = array_map([$db, 'quote'], array_unique($keepVideos));
-            $query->where($db->quoteName('youtube_video_id') . ' NOT IN (' . implode(',', $quoted) . ')');
+            $query->where($db->quoteName('remote_video_id') . ' NOT IN (' . implode(',', $quoted) . ')');
         }
 
         $db->setQuery($query)->execute();
@@ -628,7 +692,7 @@ final class CwmplaylistSyncHelper
             $db->getQuery(true)
                 ->select($db->quoteName('id'))
                 ->from($db->quoteName('#__bsms_playlists'))
-                ->where($db->quoteName('youtube_playlist_id') . ' = :rid')
+                ->where($db->quoteName('remote_playlist_id') . ' = :rid')
                 ->where($db->quoteName('server_id') . ' = :sid')
                 ->bind(':rid', $remoteId, \Joomla\Database\ParameterType::STRING)
                 ->bind(':sid', $serverId, \Joomla\Database\ParameterType::INTEGER)

--- a/admin/src/Model/CwmplaylistsModel.php
+++ b/admin/src/Model/CwmplaylistsModel.php
@@ -141,7 +141,7 @@ class CwmplaylistsModel extends ListModel
                     'playlist.title',
                     'playlist.published',
                     'playlist.access',
-                    'playlist.youtube_playlist_id',
+                    'playlist.remote_playlist_id',
                     'playlist.server_id',
                     'playlist.series_id',
                     'playlist.sync_enabled',

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -299,8 +299,8 @@ class CwmmediafileTable extends Table
             Cwmassets::stripEmptyAssetRow($this);
 
             // Immediately attach this media file to any playlist that already
-            // lists its YouTube video (local-only; safe no-op for non-YouTube
-            // media and on sites without the playlist tables).
+            // lists its remote video (local-only; safe no-op for non-playlist
+            // platforms and on sites without the playlist tables).
             CwmplaylistSyncHelper::linkMediafileToPlaylists((int) $this->id, (string) $this->params);
         }
 

--- a/admin/src/Table/CwmplaylistTable.php
+++ b/admin/src/Table/CwmplaylistTable.php
@@ -81,7 +81,7 @@ class CwmplaylistTable extends Table
      * @var string|null
      * @since 10.3.3
      */
-    public ?string $youtube_playlist_id = null;
+    public ?string $remote_playlist_id = null;
 
     /**
      * Server ID (FK to #__bsms_servers) that hosts the playlist

--- a/admin/tmpl/cwmplaylist/edit.php
+++ b/admin/tmpl/cwmplaylist/edit.php
@@ -48,7 +48,7 @@ echo Route::_('index.php?option=com_proclaim&layout=' . $currentLayout . '&id=' 
                 <?php echo $this->form->renderField('alias'); ?>
                 <?php echo $this->form->renderField('description'); ?>
                 <?php echo $this->form->renderField('server_id'); ?>
-                <?php echo $this->form->renderField('youtube_playlist_id'); ?>
+                <?php echo $this->form->renderField('remote_playlist_id'); ?>
                 <?php echo $this->form->renderField('series_id'); ?>
                 <?php echo $this->form->renderField('sync_enabled'); ?>
                 <?php echo $this->form->renderField('last_sync'); ?>

--- a/admin/tmpl/cwmplaylists/default.php
+++ b/admin/tmpl/cwmplaylists/default.php
@@ -137,8 +137,8 @@ echo Route::_('index.php?option=com_proclaim&view=cwmplaylists'); ?>" method="po
                             <?php else : ?>
                                 <span><?php echo $this->escape($item->title); ?></span>
                             <?php endif; ?>
-                            <?php if (!empty($item->youtube_playlist_id)) : ?>
-                                <div class="small text-muted"><?php echo $this->escape($item->youtube_playlist_id); ?></div>
+                            <?php if (!empty($item->remote_playlist_id)) : ?>
+                                <div class="small text-muted"><?php echo $this->escape($item->remote_playlist_id); ?></div>
                             <?php endif; ?>
                         </td>
                         <td class="small d-none d-md-table-cell">

--- a/build/media_source/js/playlist-picker.es6.js
+++ b/build/media_source/js/playlist-picker.es6.js
@@ -2,7 +2,7 @@
  * Playlist picker (#1273 phase 4)
  *
  * Opens a modal listing the selected server's live channel playlists and, on
- * pick, writes the remote playlist ID into the read-only youtube_playlist_id
+ * pick, writes the remote playlist ID into the read-only remote_playlist_id
  * field and auto-fills the Title when it is still empty (e.g. on a new playlist).
  *
  * Reuses the existing fetchChannelPlaylists XHR endpoint. No build-time deps
@@ -107,7 +107,21 @@
     load(serverId) {
       this.setBody(`<div class="text-center p-4"><span class="icon-spinner icon-spin" aria-hidden="true"></span> ${Joomla.Text._('JGLOBAL_LOADING')}</div>`);
 
-      let url = 'index.php?option=com_proclaim&task=cwmmediafile.xhr&type=youtube&handler=fetchChannelPlaylists';
+      // Resolve the platform type from the server select's data-server-types map
+      // so the picker works for any playlist-capable platform, not just YouTube.
+      const serverField = document.querySelector('[name="jform[server_id]"]');
+      let serverType = 'youtube';
+
+      if (serverField) {
+        try {
+          const map = JSON.parse(serverField.getAttribute('data-server-types') || '{}');
+          serverType = map[serverId] || serverType;
+        } catch (e) {
+          // keep the default
+        }
+      }
+
+      let url = `index.php?option=com_proclaim&task=cwmmediafile.xhr&type=${encodeURIComponent(serverType)}&handler=fetchRemotePlaylists`;
       url += `&server_id=${encodeURIComponent(serverId)}`;
       url += `&${Joomla.getOptions('csrf.token')}=1`;
 
@@ -166,7 +180,7 @@
      * Apply the chosen playlist to the form and close.
      */
     pick(playlistId, title) {
-      const idField = document.querySelector('[name="jform[youtube_playlist_id]"]');
+      const idField = document.querySelector('[name="jform[remote_playlist_id]"]');
 
       if (idField) {
         idField.value = playlistId;

--- a/tests/unit/Admin/Helper/CwmplaylistSyncHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmplaylistSyncHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Tests\Admin\Helper;
 
+use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
 use CWM\Component\Proclaim\Administrator\Helper\CwmplaylistSyncHelper;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -45,7 +46,7 @@ class CwmplaylistSyncHelperTest extends ProclaimTestCase
             ['id' => 14, 'params' => json_encode(['filename' => 'JustABareId'])],
         ];
 
-        $map = CwmplaylistSyncHelper::extractVideoMapFromRows($rows);
+        $map = CwmplaylistSyncHelper::extractVideoMapFromRows($rows, [CWMAddonYoutube::class, 'extractMediaId']);
 
         $this->assertSame(10, $map['cXhKlo2nxPs']);
         $this->assertSame(11, $map['dQw4w9WgXcQ']);
@@ -73,7 +74,7 @@ class CwmplaylistSyncHelperTest extends ProclaimTestCase
             ['id' => 6, 'params' => json_encode(['filename' => 'https://youtu.be/cXhKlo2nxPs'])], // dup -> ignored
         ];
 
-        $map = CwmplaylistSyncHelper::extractVideoMapFromRows($rows);
+        $map = CwmplaylistSyncHelper::extractVideoMapFromRows($rows, [CWMAddonYoutube::class, 'extractMediaId']);
 
         $this->assertCount(1, $map);
         $this->assertSame(5, $map['cXhKlo2nxPs']);
@@ -89,6 +90,6 @@ class CwmplaylistSyncHelperTest extends ProclaimTestCase
      */
     public function testExtractVideoMapEmpty(): void
     {
-        $this->assertSame([], CwmplaylistSyncHelper::extractVideoMapFromRows([]));
+        $this->assertSame([], CwmplaylistSyncHelper::extractVideoMapFromRows([], [CWMAddonYoutube::class, 'extractMediaId']));
     }
 }


### PR DESCRIPTION
## Phase 5 — Generalize beyond YouTube + add Vimeo (#1273)

Targets `epic/1273-youtube-playlist-sync` (stacked on phase 4).

Makes the playlist system platform-neutral so a new platform opts in cleanly, and
adds **Vimeo** as a second implementer to prove the abstraction. Driven by this
session's cross-platform research (Vimeo/Wistia were the cheap wins).

### Capability contract (on `CWMAddon`)
- `fetchRemotePlaylists()` / `fetchRemotePlaylistItems()` — platform-neutral
  list-groupings / list-items, replacing the YouTube-named calls in the engine.
- `extractRemoteMediaId()` — instance extractor; defaults to the addon's static
  `extractMediaId()` (which YouTube/Vimeo/Wistia already implement) so
  reconciliation generalizes for free.
- **YouTube** implements the two fetch methods as thin delegators. **Vimeo**
  implements them via showcases (`/me/albums`). Both whitelisted for XHR.

### Engine no longer names a platform
- Selects servers + instantiates the addon **per type** via the capability registry.
- `buildLocalVideoMap()` builds one sub-map per capable platform by running that
  platform's extractor over all media URLs — so a YouTube video filed under **any**
  server type still reconciles (extractors recognise the URL, not the server
  record; platforms' ID formats don't collide). This fixed a real miss: ~25
  YouTube videos filed under a `legacy`-typed server.
- On-save linking matches via any capable platform's extractor.

### Schema neutralised (cheap pre-release — nothing shipped yet)
- `youtube_playlist_id` → `remote_playlist_id`, `youtube_video_id` → `remote_video_id`
  across install/migration, Table, Model, forms, templates, engine, picker JS.

### Picker
Resolves the server's platform type from the `ServerList` `data-server-types` map
and calls the neutral `fetchRemotePlaylists` handler.

### Verified (live, j6-dev)
- Import: 22 updated / **334 matched** / 189 unmatched (the legacy-hosted YouTube
  videos now reconcile).
- Conflict gate preserved+reported; one-sided remote change applied; on-save
  re-links; delete unlinks.
- `composer test:unit`: **696 tests green** (matcher now injects the extractor).
- Vimeo path implemented but **not live-verified** — no Vimeo credentials on j6-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)