### PR TITLE
fix(sql): CREATE TABLE ( on table-name line so Database-fix parses playlist tables

### DIFF
--- a/admin/sql/updates/mysql/10.3.3-20260513.sql
+++ b/admin/sql/updates/mysql/10.3.3-20260513.sql
@@ -14,8 +14,7 @@ ALTER TABLE `#__bsms_studies`
 -- distinct from a Series. May optionally back a Series via series_id, but also
 -- exists for cross-cutting groupings (e.g. "All Church Services").
 
-CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
-(
+CREATE TABLE IF NOT EXISTS `#__bsms_playlists` (
     `id`                  INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
     `title`               VARCHAR(250)              DEFAULT NULL,
     `alias`               VARCHAR(400)     NOT NULL DEFAULT '',
@@ -55,8 +54,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
 -- link rather than duplicate. mediafile_id is nullable: a playlist video with no
 -- local media yet is still recorded so the membership/order is preserved.
 
-CREATE TABLE IF NOT EXISTS `#__bsms_playlist_items`
-(
+CREATE TABLE IF NOT EXISTS `#__bsms_playlist_items` (
     `id`               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
     `playlist_id`      INT(10) UNSIGNED NOT NULL,
     `mediafile_id`     INT(10) UNSIGNED          DEFAULT NULL,


### PR DESCRIPTION
## Problem

**Extensions → Manage → Database** perpetually reports:

> - Table `<prefix>_bsms_playlists(` does not exist. (From file 10.3.3-20260513.sql.)
> - Table `<prefix>_bsms_playlist_items(` does not exist. (From file 10.3.3-20260513.sql.)

Note the **trailing `(`** in the table name — and clicking **Fix** never clears it.

## Root cause

Joomla's schema checker `MysqlChangeItem::buildCheckQuery()`
(`libraries/src/Schema/ChangeItem/MysqlChangeItem.php`) does:

```php
$this->updateQuery = str_replace("\n", '', $this->updateQuery); // strips newlines, NO space
```

`10.3.3-20260513.sql` wrote the opening `(` on the line **after** the table name:

```sql
CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
(
```

After newline-stripping, the name and paren glue together — `` `#__bsms_playlists`( `` — so the
parser takes that as the table name and builds `SHOW TABLES LIKE 'prefix_bsms_playlists('`, which
can never match. The result is a permanent false-positive that **Database → Fix cannot resolve**,
regardless of whether the tables actually exist or what `#__schemas` records.

Every other Proclaim/Joomla update file keeps the `(` on the table-name line, which is why only
these two tables are affected.

## Fix

Move the `(` onto the `CREATE TABLE` line for both playlist tables. The schema checker then builds
the correct `SHOW TABLES LIKE 'prefix_bsms_playlists'` and matches. Verified by replicating the
parser's exact steps against the edited file.

Pure formatting change — the DDL executes identically; only the schema-diff parser was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)