### PR TITLE
fix(youtube): decode API-encoded titles to stop double-escaping

### DIFF
--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -993,8 +993,8 @@ class CWMAddonYoutube extends CWMAddon
             foreach ($response->items as $item) {
                 $videos[] = [
                     'videoId'     => $item->snippet->resourceId->videoId,
-                    'title'       => $item->snippet->title,
-                    'description' => $item->snippet->description,
+                    'title'       => $this->decodeApiText($item->snippet->title),
+                    'description' => $this->decodeApiText($item->snippet->description),
                     'thumbnail'   => $item->snippet->thumbnails?->medium?->url ?? $item->snippet->thumbnails?->default?->url ?? '',
                     'publishedAt' => $item->snippet->publishedAt,
                 ];
@@ -1100,8 +1100,8 @@ class CWMAddonYoutube extends CWMAddon
             foreach ($response->items as $item) {
                 $videos[] = [
                     'videoId'     => $item->id->videoId,
-                    'title'       => $item->snippet->title,
-                    'description' => $item->snippet->description,
+                    'title'       => $this->decodeApiText($item->snippet->title),
+                    'description' => $this->decodeApiText($item->snippet->description),
                     'thumbnail'   => $item->snippet->thumbnails?->medium?->url ?? $item->snippet->thumbnails?->default?->url ?? '',
                     'publishedAt' => $item->snippet->publishedAt,
                 ];
@@ -1189,8 +1189,8 @@ class CWMAddonYoutube extends CWMAddon
             foreach ($response->items as $item) {
                 $playlists[] = [
                     'playlistId'  => $item->id,
-                    'title'       => $item->snippet->title,
-                    'description' => $item->snippet->description ?? '',
+                    'title'       => $this->decodeApiText($item->snippet->title),
+                    'description' => $this->decodeApiText($item->snippet->description),
                     'thumbnail'   => $item->snippet->thumbnails?->medium?->url ?? $item->snippet->thumbnails?->default?->url ?? '',
                 ];
             }
@@ -1282,8 +1282,8 @@ class CWMAddonYoutube extends CWMAddon
             foreach ($response->items as $item) {
                 $videos[] = [
                     'videoId'     => $item->snippet->resourceId->videoId,
-                    'title'       => $item->snippet->title,
-                    'description' => $item->snippet->description,
+                    'title'       => $this->decodeApiText($item->snippet->title),
+                    'description' => $this->decodeApiText($item->snippet->description),
                     'thumbnail'   => $item->snippet->thumbnails?->medium?->url ?? $item->snippet->thumbnails?->default?->url ?? '',
                     'publishedAt' => $item->snippet->publishedAt,
                 ];
@@ -1381,8 +1381,8 @@ class CWMAddonYoutube extends CWMAddon
             foreach ($response->items as $item) {
                 $videos[] = [
                     'videoId'     => $item->id->videoId,
-                    'title'       => $item->snippet->title,
-                    'description' => $item->snippet->description,
+                    'title'       => $this->decodeApiText($item->snippet->title),
+                    'description' => $this->decodeApiText($item->snippet->description),
                     'thumbnail'   => $item->snippet->thumbnails?->medium?->url ?? $item->snippet->thumbnails?->default?->url ?? '',
                     'publishedAt' => $item->snippet->publishedAt,
                     'liveBadge'   => $eventType === 'live' ? 'LIVE' : ($eventType === 'upcoming' ? 'UPCOMING' : ''),
@@ -1463,8 +1463,8 @@ class CWMAddonYoutube extends CWMAddon
                 'success' => true,
                 'message' => Text::_('JBS_ADDON_YOUTUBE_API_SUCCESS'),
                 'channel' => [
-                    'title'           => $channel->snippet->title,
-                    'description'     => substr($channel->snippet->description ?? '', 0, 100),
+                    'title'           => $this->decodeApiText($channel->snippet->title),
+                    'description'     => substr($this->decodeApiText($channel->snippet->description), 0, 100),
                     'subscriberCount' => $channel->statistics->subscriberCount ?? null,
                     'videoCount'      => $channel->statistics->videoCount ?? null,
                 ],
@@ -1735,7 +1735,7 @@ class CWMAddonYoutube extends CWMAddon
 
                 // Set Title if empty
                 if (empty($params->get('title'))) {
-                    $params->set('title', $item->snippet->title);
+                    $params->set('title', $this->decodeApiText($item->snippet->title));
                 }
 
                 // Set Duration
@@ -1755,7 +1755,7 @@ class CWMAddonYoutube extends CWMAddon
                 $existingChapters = $params->get('chapters', []);
 
                 if (empty($existingChapters)) {
-                    $description = $item->snippet->description ?? '';
+                    $description = $this->decodeApiText($item->snippet->description);
                     $chapters    = \CWM\Component\Proclaim\Administrator\Helper\CwmaiHelper::parseYouTubeChapters($description);
 
                     if (!empty($chapters)) {
@@ -1784,6 +1784,26 @@ class CWMAddonYoutube extends CWMAddon
                 );
             }
         }
+    }
+
+    /**
+     * Decode HTML entities in text returned by the YouTube Data API.
+     *
+     * The API returns snippet titles/descriptions already HTML-encoded (e.g. an
+     * apostrophe as `&#39;`, a double-quote as `&quot;`). Downstream consumers
+     * escape again when rendering, so the raw value must be decoded to plain text
+     * here at the API boundary to avoid double-escaping in the picker UI and to
+     * store clean titles when a video is imported into a message.
+     *
+     * @param   string|null  $text  Raw API text.
+     *
+     * @return  string  Decoded plain text.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function decodeApiText(?string $text): string
+    {
+        return html_entity_decode($text ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
## Problem

YouTube video titles were rendering with literal HTML entities in the picker cards — e.g. `The Investigative Judgment&#39;s Assurance` and `Present Truth Series - &quot;The Investigative Judgement...&quot;` — instead of the intended `'` and `"`.

This is **double HTML-escaping**, not a translation issue. The YouTube Data API returns snippet titles/descriptions already HTML-encoded (apostrophe → `&#39;`, double-quote → `&quot;`). The picker JS then escapes again via `escapeHtml()`, turning `&#39;` into `&amp;#39;`, which the browser renders as the literal text `&#39;`.

## Fix

Decode the entities **once at the API boundary** (PHP side) via a new private `decodeApiText()` helper (`html_entity_decode(..., ENT_QUOTES | ENT_HTML5, 'UTF-8')`) in `CWMAddonYoutube.php`.

This is the correct layer to fix at:
- The JS `escapeHtml()` is the XSS guard for untrusted API strings and **stays intact** — it now escapes exactly once, producing correct output.
- The import-to-message path was previously storing the encoded title (`&#39;`) directly into the message **title column in the DB** — this fix means imported titles land as clean text.

### Covered mappings
All six snippet → JSON mappings the picker consumes:
- channel videos, channel search, channel playlists, playlist videos, live videos, channel info

Plus:
- the import-to-message title (`detectMetadata`, was writing `&#39;` to the DB)
- the description used for chapter auto-extraction

## Out of scope
- The dead `buildPlaylistList()` method (never called; broken legacy example code) is left untouched.
- Vimeo/Wistia browsers use the same `escapeHtml` JS pattern, but their APIs return **plain-text** titles (not pre-encoded), so they are already correct — decoding them would be wrong.

## Testing
- `php -l` clean
- `php-cs-fixer` clean (0 fixes)
- No JS rebuild needed — the fix is entirely PHP-side; `media/js` assets are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)