### PR TITLE
fix(release): repair pkg assembly + clean-install install-script bugs

### DIFF
--- a/build/build-package.sh
+++ b/build/build-package.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Build the full installable pkg_proclaim-<version>.zip end to end:
+#   1. build the sibling sub-packages (lib_cwmscripture, scripturelinks) fresh
+#   2. build com_proclaim's assets + component zip  (cwm-build)
+#   3. assemble the package wrapper                 (cwm-package)
+#
+# This is the single command the release-test harness and the release runbook
+# use to produce the artifact users install. Non-interactive.
+#
+# Usage: build/build-package.sh <version>
+#
+# @since __DEPLOY_VERSION__
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BIN="libraries/vendor/bin"
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: version required — usage: build/build-package.sh <version>" >&2
+    exit 1
+fi
+
+echo "-- [pkg 1/3] build sibling sub-packages"
+bash build/build-subpackages.sh
+
+echo "-- [pkg 2/3] build com_proclaim assets + component (${VERSION})"
+CWM_NONINTERACTIVE=1 "$BIN/cwm-build" --version "$VERSION"
+
+echo "-- [pkg 3/3] assemble pkg_proclaim-${VERSION}.zip"
+CWM_NONINTERACTIVE=1 "$BIN/cwm-package" --version "$VERSION"
+
+ZIP="build/dist/pkg_proclaim-${VERSION}.zip"
+
+if [ ! -f "$ZIP" ]; then
+    echo "ERROR: expected package not produced: $ZIP" >&2
+    exit 1
+fi
+
+echo "Package ready: ${ZIP}"

--- a/build/build-subpackages.sh
+++ b/build/build-subpackages.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Build the sibling extension packages that pkg_proclaim bundles, fresh from the
+# current submodule checkouts, into each submodule's build/dist. Proclaim's
+# cwm-build.config.json consumes the results via `prebuilt` includes.
+#
+# The two siblings are independent repos with different build shapes:
+#   - lib_cwmscripture      → cwm-build   (component-shaped cwm-build.config.json)
+#   - content/scripturelinks → cwm-package (package-shaped cwm-build.config.json)
+#
+# Both are driven with Proclaim's own build-tools binary (it reads the CWD's
+# config), non-interactively, at each submodule's own manifest version. Their
+# build/dist output is gitignored, so this leaves the submodules git-clean.
+#
+# @since __DEPLOY_VERSION__
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${ROOT}/libraries/vendor/bin"
+
+export PATH="${BIN}:${PATH}"
+export CWM_NONINTERACTIVE=1
+
+LIB_DIR="${ROOT}/libraries/lib_cwmscripture"
+PLG_DIR="${ROOT}/plugins/content/scripturelinks"
+
+if [ ! -f "${LIB_DIR}/cwm-build.config.json" ] || [ ! -f "${PLG_DIR}/cwm-build.config.json" ]; then
+    echo "ERROR: submodules not populated — run 'git submodule update --init --recursive' first." >&2
+    exit 1
+fi
+
+echo "-- building lib_cwmscripture (cwm-build)"
+( cd "${LIB_DIR}" && "${BIN}/cwm-build" )
+
+echo "-- building content/scripturelinks (cwm-package)"
+( cd "${PLG_DIR}" && "${BIN}/cwm-package" )
+
+echo "Sub-packages built."

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -100,21 +100,17 @@
             { "from": "build/language/en-GB/en-GB.pkg_proclaim.sys.ini",
               "to":   "language/en-GB/en-GB.pkg_proclaim.sys.ini" }
         ],
+        "_includes_comment": "The two sibling extensions are independent repos (git submodules) with their own build toolchains — lib_cwmscripture builds via cwm-build, scripturelinks via cwm-package. They are built fresh into their own build/dist by build/build-subpackages.sh (run before cwm-package), and consumed here as `prebuilt` artifacts. The former `subBuild` entries referenced a build/build-package.php that no longer exists in either submodule.",
         "includes": [
             {
-                "type":        "subBuild",
-                "path":        "libraries/lib_cwmscripture",
-                "buildScript": "build/build-package.php",
-                "distGlob":    "build/dist/lib_cwmscripture-*.zip",
-                "outputName":  "lib_cwmscripture.zip"
+                "type":       "prebuilt",
+                "distGlob":   "libraries/lib_cwmscripture/build/dist/lib_cwmscripture-*.zip",
+                "outputName": "lib_cwmscripture.zip"
             },
             {
-                "type":        "subBuild",
-                "path":        "plugins/content/scripturelinks",
-                "buildScript": "build/build-package.php",
-                "args":        ["--plugin-only"],
-                "distGlob":    "build/dist/plg_content_scripturelinks*.zip",
-                "outputName":  "plg_content_scripturelinks.zip"
+                "type":       "prebuilt",
+                "distGlob":   "plugins/content/scripturelinks/build/dist/plg_content_scripturelinks*.zip",
+                "outputName": "plg_content_scripturelinks.zip"
             },
             {
                 "type":       "self",

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -376,10 +376,18 @@ class com_proclaimInstallerScript extends InstallerScript
         // our preflight (and the install routines that follow) can
         // resolve the classes.
         if ($type !== 'uninstall') {
-            $libBase = JPATH_LIBRARIES . '/lib_cwmscripture/src';
+            // The library manifest declares <libraryname>cwmscripture</libraryname>,
+            // so Joomla installs it to libraries/cwmscripture — not libraries/
+            // lib_cwmscripture. Check the real install path first, keeping the old
+            // name as a fallback for any environment that still uses it.
+            foreach (['/cwmscripture/src', '/lib_cwmscripture/src'] as $libSuffix) {
+                $libBase = JPATH_LIBRARIES . $libSuffix;
 
-            if (is_dir($libBase) && !class_exists('CWM\\Library\\Scripture\\Helper\\ScriptureHelper', false)) {
-                \JLoader::registerNamespace('CWM\\Library\\Scripture', $libBase, false, false, 'psr4');
+                if (is_dir($libBase) && !class_exists('CWM\\Library\\Scripture\\Helper\\ScriptureHelper', false)) {
+                    \JLoader::registerNamespace('CWM\\Library\\Scripture', $libBase, false, false, 'psr4');
+
+                    break;
+                }
             }
 
             if (!class_exists('CWM\\Library\\Scripture\\Helper\\ScriptureHelper')) {
@@ -1093,17 +1101,32 @@ class com_proclaimInstallerScript extends InstallerScript
             } catch (\Exception $e) {
                 Factory::getApplication()->enqueueMessage('Failed to register guided tour: ' . $e->getMessage(), 'error');
             }
+        }
 
+        // Legacy data migrations run on UPGRADES only. A fresh install's SQL
+        // already creates the current schema, so there is nothing to migrate —
+        // running these against freshly seeded default rows only produces
+        // spurious warnings (e.g. the podcast-link "could not be matched" notice)
+        // and, historically, fatals when a moved helper no longer exists.
+        if ($type === 'update') {
             // Migrate legacy scripture columns to junction table
             try {
                 $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
 
                 if (file_exists($migrationPath)) {
                     require_once $migrationPath;
-                    // Also require the helper dependencies
+                    // These helpers moved to lib_cwmscripture in 10.3.0 and the
+                    // migration autoloads the library class via the namespace
+                    // registered in preflight(). Only require a legacy in-component
+                    // copy if one is still present — a bare require_once of the
+                    // (now missing) file is a fatal that the catch below can't trap.
                     $helperDir = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/';
-                    require_once $helperDir . 'ScriptureReference.php';
-                    require_once $helperDir . 'CwmscriptureHelper.php';
+
+                    foreach (['ScriptureReference.php', 'CwmscriptureHelper.php'] as $legacyHelper) {
+                        if (is_file($helperDir . $legacyHelper)) {
+                            require_once $helperDir . $legacyHelper;
+                        }
+                    }
 
                     $migrated = CwmscriptureMigration::migrate();
 
@@ -1162,7 +1185,9 @@ class com_proclaimInstallerScript extends InstallerScript
 
             // Migrate scripture settings from component params to plugin params
             $this->migrateScriptureParamsToPlugin();
+        }
 
+        if ($type === 'install' || $type === 'update') {
             // Ensure all Proclaim tables have primary keys.
             // Sites upgraded from v7/v8/v9 may lack PKs because the original
             // CREATE TABLE IF NOT EXISTS skipped existing tables.  We check


### PR DESCRIPTION
## Context

While building a release-validation harness (separate PR), building and clean-installing `pkg_proclaim` end-to-end via the **Extensions web installer** surfaced four pre-existing, **release-blocking** defects. Clean-install e2e had never actually been exercised (see the `pkg_proclaim Issues` note), so these went unnoticed.

Each was verified fixed by a clean install on a pristine Joomla 6.1 site.

## Packaging — `pkg_proclaim` could not be assembled at all

- `cwm-build.config.json`'s `package.includes` still referenced a `build/build-package.php` sub-build script that **no longer exists** in either sibling submodule (they migrated to their own `cwm-build` / `cwm-package`). `cwm-package` aborted before assembling. Switched both entries from `subBuild` → `prebuilt`, globbing each submodule's own `build/dist` output.
- Added **`build/build-subpackages.sh`** (builds `lib_cwmscripture` via `cwm-build` and `content/scripturelinks` via `cwm-package`, fresh) and **`build/build-package.sh`** (sub-packages → `cwm-build` → `cwm-package`) so the `prebuilt` artifacts exist.

## Clean install (`proclaim.script.php`)

1. **preflight** checked `libraries/lib_cwmscripture/src`, but the library manifest declares `<libraryname>cwmscripture</libraryname>` → it installs to `libraries/cwmscripture/src`. The namespace never registered and every fresh install aborted with *"requires lib_cwmscripture to be installed first."* Now checks the real path (old name kept as fallback).
2. **postflight** `require_once`'d `ScriptureReference.php`, which **moved to lib_cwmscripture in 10.3.0**. A bare `require_once` of the missing file is a fatal the surrounding `catch` can't trap. Guarded with `is_file`.
3. The block of **legacy data migrations** (`migrate*` / `dropLegacy*` / `fix*Legacy*`) ran under `install || update`. On a fresh install there is nothing to migrate; running them against freshly-seeded defaults produced a spurious *"1 podcast link(s) could not be matched to a menu item"* warning (and, before fix #2, a fatal). Gated the whole block to `$type === 'update'`; guided tours, `helpURL`, and `ensurePrimaryKeys` stay on both.

## Verification

Clean install via **Extensions → Install → Install from Folder** on a pristine J6.1 site: **"Installation of the package was successful"** with no spurious warnings; all 27 `#__bsms_*` tables created; every 10.3.3 migration column/table/index present; `#__schemas` at `10.3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)