### PR TITLE
chore(deps): bump cwm/build-tools to ^1.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.6.0",
+    "cwm/build-tools": "^1.6.1",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06cd7b1f0a6b0f85b16c2ff9552ab9e5",
+    "content-hash": "75047a4ae5eadb47c8ddd19d4c3c07ee",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "50f443630cd8e8020cd5c70afc22fc8afc2c3ae4"
+                "reference": "6ab28e446b7bf6574675569d82860b2b3317feb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/50f443630cd8e8020cd5c70afc22fc8afc2c3ae4",
-                "reference": "50f443630cd8e8020cd5c70afc22fc8afc2c3ae4",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/6ab28e446b7bf6574675569d82860b2b3317feb4",
+                "reference": "6ab28e446b7bf6574675569d82860b2b3317feb4",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.6.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.6.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-06-27T23:50:58+00:00"
+            "time": "2026-07-25T16:40:41+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.6.1](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.6.1), which fixes `cwm-link` symlinking `role=test` installs.

## Why this matters here

`link.php` selected every configured install via `PropertiesReader::installs()` instead of filtering to `role=dev`, so `composer symlink` linked **j6-test** back at this working repo — contradicting `InstallConfig`'s own contract that `role=dev` is the symlink target and `role=test` is a real install target for the built zip.

That turned our own test harness into a source deleter. `build/reset-testsite.php` deletes every path in `$siteDirs` to get a clean slate, and `is_dir()` returns **true for a symlink pointing at a directory** — so it walked *through* the links and would have emptied their targets. j6-test carried 12 such links, including:

```
components/com_proclaim -> Proclaim/site
media/com_proclaim      -> Proclaim/media
```

`composer test:install` would have wiped `admin/`, `site/`, `media/`, `modules/` and `plugins/` in the working tree. This was caught before running anything; no data was lost.

## Relationship to #1311

#1311 adds a guard inside `reset-testsite.php` (`rrmdir()` refuses to recurse through a symlink; stray links are stripped with a warning). That stays as defence in depth — a consumer-side helper should never be one config drift away from deleting source. **This PR removes the cause**; #1311 handles the symptom. They're independent and can merge in either order.

## Verification

After `composer update cwm/build-tools` (locked at `v1.6.1`), `composer symlink`:

| install | role | links |
|---|---|---|
| j5-dev | dev | 18 |
| j6-dev | dev | 18 |
| j62-dev | dev | 12 |
| j70-dev | dev | 12 |
| **j6-test** | **test** | **0** ✅ |

`composer symlink:check` → *"All symlinks are healthy."* 857 PHPUnit tests pass.

## Note

Anyone with an existing linked j6-test should confirm it's clean before running any reset harness:

```
find /path/to/j6-test -maxdepth 4 -type l -name "*proclaim*"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)