### PR TITLE
fix(build): don't fail the release gate on migration-free versions

### DIFF
--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -14,13 +14,24 @@
  *
  * Data-driven: EXPECTATIONS is keyed by version. When a release adds migrations,
  * add an entry describing the tables/columns/indexes it introduces and the
- * #__schemas version it should advance to. Old entries stay as regression cover.
+ * #__schemas version it should advance to.
+ *
+ * Version resolution — a release that ships no migrations must not fail the gate,
+ * but a release that ships migrations nobody described must:
+ *   - exact x.y.z entry exists      => verify it
+ *   - no entry, but update SQL for  => FAIL; the expectations were forgotten
+ *     this version exists
+ *   - no entry and no update SQL    => re-verify the newest earlier entry as
+ *     regression cover. A fresh install of a no-migration release still has to
+ *     carry everything its predecessors introduced, so this is what catches
+ *     install.sql drifting behind the update SQL.
  *
  * Usage:   php build/verify-migrations.php [version]
  *   version  Optional override; defaults to active_development in versions.json.
  *
- * Exit code: 0 = every assertion passed on every test install; 1 = one or more
- * failed (or no test install / no expectations for the version).
+ * Exit code: 0 = every assertion passed on every test install (or there is
+ * genuinely nothing to verify); 1 = one or more failed, no role=test install, or
+ * a version shipped migrations with no expectations describing them.
  *
  * @package  Proclaim.Build
  * @since    __DEPLOY_VERSION__
@@ -81,17 +92,53 @@ if ($version === null) {
 }
 
 // Match a dotted x.y.z prefix so tags like 10.3.3-dev / 10.3.3-beta1 resolve.
-$key = null;
+if (preg_match('/^(\d+\.\d+\.\d+)/', $version, $m) !== 1) {
+    fwrite(STDERR, "Could not parse an x.y.z version from '{$version}'.\n");
 
-if (preg_match('/^(\d+\.\d+\.\d+)/', $version, $m) === 1 && isset($EXPECTATIONS[$m[1]])) {
-    $key = $m[1];
+    exit(1);
+}
+
+$base = $m[1];
+
+/*
+ * Resolve which expectation set to verify.
+ *
+ * An exact match is used when present. Otherwise the version either ships
+ * migrations nobody described — a real gap, so fail — or ships none at all, in
+ * which case the newest earlier set is re-verified rather than skipping the
+ * check. That matters: a fresh install of a no-migration release must still
+ * carry every table/column/index its predecessors introduced, which is what
+ * catches install.sql drifting behind the update SQL.
+ */
+$mode = 'exact';
+
+if (isset($EXPECTATIONS[$base])) {
+    $key = $base;
+} elseif (($shipped = migrationFilesFor($root, $base)) !== []) {
+    fwrite(STDERR, "Version {$base} ships migration SQL but has no \$EXPECTATIONS entry:\n");
+
+    foreach ($shipped as $file) {
+        fwrite(STDERR, '  ' . basename($file) . "\n");
+    }
+
+    fwrite(STDERR, "Describe the tables/columns/indexes they add in " . __FILE__ . ".\n");
+
+    exit(1);
+} else {
+    $earlier = array_filter(
+        array_keys($EXPECTATIONS),
+        static fn (string $k): bool => version_compare($k, $base, '<=')
+    );
+    usort($earlier, 'version_compare');
+
+    $key  = $earlier === [] ? null : end($earlier);
+    $mode = 'regression';
 }
 
 if ($key === null) {
-    fwrite(STDERR, "No migration expectations defined for version '{$version}'.\n");
-    fwrite(STDERR, "Add an entry to \$EXPECTATIONS in " . __FILE__ . " when this release ships migrations.\n");
+    echo "Version {$base} ships no migrations and no earlier expectations exist — nothing to verify.\n";
 
-    exit(1);
+    exit(0);
 }
 
 $expected = $EXPECTATIONS[$key];
@@ -111,6 +158,11 @@ $red     = "\033[31m";
 $yellow  = "\033[33m";
 $reset   = "\033[0m";
 $overall = true;
+
+if ($mode === 'regression') {
+    echo "Version {$base} ships no migrations — re-verifying the {$key} schema as regression cover\n";
+    echo "(a fresh {$base} install must still carry everything {$key} introduced).\n";
+}
 
 echo "Verifying {$key} migrations across " . \count($installs) . " test install(s)\n";
 
@@ -225,6 +277,30 @@ exit(1);
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Update SQL files belonging to a given x.y.z version.
+ *
+ * Joomla schema files here are named `<version>[-suffix].sql` (e.g.
+ * `10.3.3-20260711.sql`), so match the version segment exactly rather than as a
+ * loose prefix — otherwise 10.3.4 would also claim 10.3.40's files.
+ *
+ * @return list<string>
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function migrationFilesFor(string $root, string $version): array
+{
+    $files = glob($root . '/admin/sql/updates/mysql/' . $version . '*.sql') ?: [];
+
+    return array_values(
+        array_filter($files, static function (string $file) use ($version): bool {
+            $name = basename($file, '.sql');
+
+            return $name === $version || str_starts_with($name, $version . '-');
+        })
+    );
+}
 
 /**
  * @since __DEPLOY_VERSION__


### PR DESCRIPTION
`composer test:release` could not pass for 10.3.4. Step 5 calls `build/verify-migrations.php`, which hard-failed with:

```
No migration expectations defined for version '10.3.4'.
```

…whenever `$EXPECTATIONS` had no entry for the active-development version. 10.3.4 ships no migrations (newest update SQL is `10.3.3-20260711.sql`), so there was nothing to describe and no way to say so. The gate was unpassable by construction, which blocked cutting the release.

## Why not just add an empty entry

That fixes the symptom and quietly discards the gate's whole point. A release that *does* ship migrations nobody described must still fail — an empty-stub convention makes "no migrations" and "expectations forgotten" indistinguishable, and the forgotten case is the one worth catching.

So the two cases are resolved apart by looking at what's actually on disk:

| condition | behaviour |
|---|---|
| exact `x.y.z` entry exists | verify it (unchanged) |
| no entry, but update SQL exists for the version | **FAIL**, listing the files — expectations were forgotten |
| no entry and no update SQL | re-verify the newest earlier entry as regression cover |

## The third case closes a real gap

This file's docblock claimed *"Old entries stay as regression cover"* — but the resolver only ever matched a single key, so earlier entries were **never checked by anything**. The documented behaviour didn't exist.

Re-verifying them on a migration-free release isn't busywork. A fresh install of 10.3.4 must still carry every table, column and index 10.3.3 introduced, so this is what catches `install.sql` drifting behind the update SQL — a silent class of bug where upgraders get a column that fresh installs never receive. It found nothing today, which is the point: it now proves `install.sql` is current instead of assuming it.

## Verification

Every branch of the resolver, exit codes measured without pipes:

| version | condition | exit | behaviour |
|---|---|---|---|
| `10.3.4` | no SQL, earlier entry exists | 0 | regression-verifies 10.3.3, 11 assertions pass |
| `10.3.3` | exact entry | 0 | verified directly |
| `10.3.0` | ships SQL, no entry | 1 | fails, lists both `.sql` files |
| `10.0.0` | ships SQL, no entry | 1 | fails |
| `1.0.0` | no SQL, no earlier entry | 0 | "nothing to verify" |
| `not-a-version` | unparseable | 1 | clear parse error |

Full gate, both halves, against j6-test:

```
CLEAN-INSTALL TEST PASSED for 10.3.4.
UPGRADE TEST PASSED 10.3.3 -> 10.3.4.
```

`composer lint` clean (0 of 461).

## Incidental confirmation of #1311

Those runs reinstall the merged package, so they double as a second end-to-end check of the API packaging fix — including on the **upgrade** path, which is what real 10.3.3 users hit rather than a fresh install:

```
plugin | proclaim | webservices | enabled=1
api/components/com_proclaim/src/Controller/ -> 5 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)