### PR TITLE
feat(api): expose 7 more resources, read-only where writes are unsafe

### DIFF
--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -288,6 +288,16 @@ class CwmlocationsModel extends ListModel
             $query->where($db->quoteName('location.access') . ' = ' . (int) $access);
         }
 
+        // Restrict non-admin users to their authorised view levels. Required for
+        // security, not just tidiness: this model backs the REST API, where an
+        // unauthenticated caller would otherwise receive locations whose view
+        // level they cannot see.
+        $user = $this->getCurrentUser();
+
+        if (!$user->authorise('core.admin')) {
+            $query->whereIn($db->quoteName('location.access'), $user->getAuthorisedViewLevels());
+        }
+
         // Apply location-based visibility filter (multi-campus support).
         // Super admins get [] from getUserLocations() — no filter added (see all).
         $visibleLocations = CwmlocationHelper::getUserLocations();

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -251,7 +251,7 @@ class CwmmessagetypesModel extends ListModel
 
         // Add the list ordering clause.
         $orderCol  = $this->state->get('list.ordering', 'messagetype.message_type');
-        $orderDirn = $this->state->get('list.direction', 'acs');
+        $orderDirn = $this->state->get('list.direction', 'ASC');
         $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
         return $query;

--- a/admin/src/Model/CwmplaylistsModel.php
+++ b/admin/src/Model/CwmplaylistsModel.php
@@ -180,6 +180,16 @@ class CwmplaylistsModel extends ListModel
             $query->where($db->quoteName('playlist.access') . ' = ' . (int) $access);
         }
 
+        // Restrict non-admin users to their authorised view levels. Required for
+        // security, not just tidiness: this model backs the REST API, where an
+        // unauthenticated caller would otherwise receive playlists whose view
+        // level they cannot see.
+        $user = $this->getCurrentUser();
+
+        if (!$user->authorise('core.admin')) {
+            $query->whereIn($db->quoteName('playlist.access'), $user->getAuthorisedViewLevels());
+        }
+
         // Filter by server.
         if ($serverId = $this->getState('filter.server_id')) {
             $query->where($db->quoteName('playlist.server_id') . ' = ' . (int) $serverId);

--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -121,6 +121,17 @@ class CwmtemplatecodesModel extends ListModel
         $query->select($db->quoteName('uc.name', 'editor'))
             ->join('LEFT', $db->quoteName('#__users', 'uc') . ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('templatecode.checked_out'));
 
+        // NOTE: this entity has no view-level filter, and cannot have one —
+        // #__bsms_templatecode has no `access` column, so it cannot carry a view
+        // level the way every other Proclaim entity does. The campus filter
+        // further down (location_id, NULL-tolerant) is the only segmentation this
+        // table can express.
+        //
+        // That is why templatecodes is deliberately NOT exposed over the REST API
+        // while every sibling entity is: the field worth serving holds PHP source,
+        // and no ACL here could scope who reads it. Adding an `access` column is
+        // the prerequisite for exposing this entity.
+
         // Filter by search in filename or study title
         $search = $this->getState('filter.search');
 

--- a/admin/src/Model/CwmtemplatesModel.php
+++ b/admin/src/Model/CwmtemplatesModel.php
@@ -223,7 +223,7 @@ class CwmtemplatesModel extends ListModel
 
         // Add the list ordering clause
         $orderCol  = $this->state->get('list.ordering', 'template.id');
-        $orderDirn = $this->state->get('list.direction', 'ACS');
+        $orderDirn = $this->state->get('list.direction', 'ASC');
         $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
         return $query;

--- a/api/src/Controller/AbstractReadOnlyController.php
+++ b/api/src/Controller/AbstractReadOnlyController.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
+
+/**
+ * Base controller for resources the API exposes read-only.
+ *
+ * Some Proclaim entities are safe to publish but must never be writable over
+ * HTTP — either because they carry secrets (server credentials), because they
+ * are site markup rather than content (templates, template code), or because a
+ * write would trigger real side effects or bypass moderation (playlists sync,
+ * comments).
+ *
+ * The webservices plugin already declines to register write routes for these,
+ * so this class is defence in depth: it means a resource cannot become writable
+ * by accident if a route is ever added elsewhere, or if this controller is
+ * dispatched directly. `RouteNotFoundException` is what ApiApplication turns
+ * into a 404, which is the honest answer — for these resources the write route
+ * genuinely does not exist.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+abstract class AbstractReadOnlyController extends ApiController
+{
+    /**
+     * Creating is not supported for this resource.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function add()
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('created'));
+    }
+
+    /**
+     * Updating is not supported for this resource.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function edit()
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('updated'));
+    }
+
+    /**
+     * Deleting is not supported for this resource.
+     *
+     * @param   integer|null  $id  Ignored.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function delete($id = null)
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('deleted'));
+    }
+
+    /**
+     * Build the refusal message for a blocked write verb.
+     *
+     * @param   string  $verb  Past-tense verb, e.g. 'created'.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function readOnlyMessage(string $verb): string
+    {
+        return \sprintf(
+            'The %s resource is read-only and cannot be %s through the API.',
+            $this->contentType,
+            $verb
+        );
+    }
+}

--- a/api/src/Controller/CommentsController.php
+++ b/api/src/Controller/CommentsController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for study comments — READ ONLY.
+ *
+ * GET /api/index.php/v1/proclaim/comments       — list (published only)
+ * GET /api/index.php/v1/proclaim/comments/:id   — detail
+ *
+ * Filters: ?filter[search]=&filter[study_id]=
+ *
+ * Comments are queryable but never writable. An HTTP create endpoint would be a
+ * spam vector that bypasses the front-end submission path and its moderation
+ * gate, so no write route is registered. The view also withholds `user_email`
+ * and `user_id`: the address is personal data that must not be published, and
+ * the account id would let a caller correlate commenters with site users.
+ *
+ * Unlike other resources this lists published comments only — an archived or
+ * unpublished comment is one a moderator has deliberately withheld.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CommentsController extends AbstractReadOnlyController
+{
+    protected $contentType = 'comments';
+
+    protected $default_view = 'comments';
+
+    /**
+     * List comments — published only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', 1);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('study_id', $apiFilter)) {
+            $this->modelState->set('filter.study_id', (int) $apiFilter['study_id']);
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'comments' => 'Cwmcomments',
+            'comment'  => 'Cwmcomment',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/src/Controller/LocationsController.php
+++ b/api/src/Controller/LocationsController.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for locations (campuses).
+ *
+ * GET    /api/index.php/v1/proclaim/locations       — list (published + archived)
+ * GET    /api/index.php/v1/proclaim/locations/:id   — detail
+ * POST   /api/index.php/v1/proclaim/locations       — create
+ * PATCH  /api/index.php/v1/proclaim/locations/:id   — update
+ * DELETE /api/index.php/v1/proclaim/locations/:id   — delete
+ *
+ * Filters: ?filter[search]=&filter[language]=
+ *
+ * Note that the list model also applies Proclaim's multi-campus visibility
+ * filter, so a caller only ever sees locations they are entitled to.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LocationsController extends ApiController
+{
+    protected $contentType = 'locations';
+
+    protected $default_view = 'locations';
+
+    /**
+     * List locations — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('language', $apiFilter)) {
+            $this->modelState->set('filter.language', $clean->clean($apiFilter['language'], 'CMD'));
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'locations' => 'Cwmlocations',
+            'location'  => 'Cwmlocation',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Normalize API JSON input for the location model.
+     *
+     * @param   array  $data  The incoming data
+     *
+     * @return  array  The processed data
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function preprocessSaveData(array $data): array
+    {
+        $user = $this->app->getIdentity();
+
+        // Strip internal system fields to prevent mass assignment, plus three
+        // that must never be settable over the API: email_to is a notification
+        // target (an open door to redirecting site mail), and user_id /
+        // contact_id bind a location to a Joomla account.
+        unset(
+            $data['asset_id'],
+            $data['checked_out'],
+            $data['checked_out_time'],
+            $data['modified_by'],
+            $data['email_to'],
+            $data['user_id'],
+            $data['contact_id']
+        );
+
+        if (isset($data['created_by']) && !$user->authorise('core.admin', 'com_proclaim')) {
+            unset($data['created_by']);
+        }
+
+        if (!$user->authorise('core.edit.state', 'com_proclaim')) {
+            $data['published'] = 0;
+        }
+
+        return $data;
+    }
+}

--- a/api/src/Controller/MessagetypesController.php
+++ b/api/src/Controller/MessagetypesController.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for message types (study types).
+ *
+ * GET    /api/index.php/v1/proclaim/messagetypes       — list (published + archived)
+ * GET    /api/index.php/v1/proclaim/messagetypes/:id   — detail
+ * POST   /api/index.php/v1/proclaim/messagetypes       — create
+ * PATCH  /api/index.php/v1/proclaim/messagetypes/:id   — update
+ * DELETE /api/index.php/v1/proclaim/messagetypes/:id   — delete
+ *
+ * Filters: ?filter[search]=
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MessagetypesController extends ApiController
+{
+    protected $contentType = 'messagetypes';
+
+    protected $default_view = 'messagetypes';
+
+    /**
+     * List message types — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'messagetypes' => 'Cwmmessagetypes',
+            'messagetype'  => 'Cwmmessagetype',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Normalize API JSON input for the message type model.
+     *
+     * @param   array  $data  The incoming data
+     *
+     * @return  array  The processed data
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function preprocessSaveData(array $data): array
+    {
+        $user = $this->app->getIdentity();
+
+        // Strip internal system fields — prevent mass assignment
+        unset($data['asset_id'], $data['checked_out'], $data['checked_out_time'], $data['modified_by']);
+
+        if (isset($data['created_by']) && !$user->authorise('core.admin', 'com_proclaim')) {
+            unset($data['created_by']);
+        }
+
+        if (!$user->authorise('core.edit.state', 'com_proclaim')) {
+            $data['published'] = 0;
+        }
+
+        return $data;
+    }
+}

--- a/api/src/Controller/PlaylistsController.php
+++ b/api/src/Controller/PlaylistsController.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for playlists — READ ONLY.
+ *
+ * GET /api/index.php/v1/proclaim/playlists       — list (published + archived)
+ * GET /api/index.php/v1/proclaim/playlists/:id   — detail
+ *
+ * Filters: ?filter[search]=&filter[server_id]=&filter[series_id]=
+ *
+ * Playlists are queryable but never writable. `sync_enabled` and
+ * `writeback_enabled` govern whether Proclaim pushes changes to the remote
+ * platform, so a PATCH here would not just edit a local row — it could arm real
+ * mutations against a church's live YouTube account. Playlist state is changed
+ * deliberately in the admin UI, never as a side effect of an HTTP call.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlaylistsController extends AbstractReadOnlyController
+{
+    protected $contentType = 'playlists';
+
+    protected $default_view = 'playlists';
+
+    /**
+     * List playlists — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('server_id', $apiFilter)) {
+            $this->modelState->set('filter.server_id', (int) $apiFilter['server_id']);
+        }
+
+        if (\array_key_exists('series_id', $apiFilter)) {
+            $this->modelState->set('filter.series_id', (int) $apiFilter['series_id']);
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'playlists' => 'Cwmplaylists',
+            'playlist'  => 'Cwmplaylist',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/src/Controller/ServersController.php
+++ b/api/src/Controller/ServersController.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for media servers — READ ONLY.
+ *
+ * GET /api/index.php/v1/proclaim/servers       — list (published + archived)
+ * GET /api/index.php/v1/proclaim/servers/:id   — detail
+ *
+ * Filters: ?filter[search]=&filter[type]=
+ *
+ * Servers are queryable but never writable, and the `params` column is withheld
+ * entirely by the view: it is the registry that holds each addon's credentials
+ * (api_key, client_secret, access_token). Writing servers over HTTP would let a
+ * caller overwrite or exfiltrate those, so no write route is registered and
+ * AbstractReadOnlyController refuses the verbs outright.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ServersController extends AbstractReadOnlyController
+{
+    protected $contentType = 'servers';
+
+    protected $default_view = 'servers';
+
+    /**
+     * List servers — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('type', $apiFilter)) {
+            $this->modelState->set('filter.type', $clean->clean($apiFilter['type'], 'CMD'));
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'servers' => 'Cwmservers',
+            'server'  => 'Cwmserver',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/src/Controller/TemplatesController.php
+++ b/api/src/Controller/TemplatesController.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for display templates — READ ONLY.
+ *
+ * GET /api/index.php/v1/proclaim/templates       — list (published + archived)
+ * GET /api/index.php/v1/proclaim/templates/:id   — detail
+ *
+ * Filters: ?filter[search]=&filter[type]=
+ *
+ * Templates are queryable but never writable. They are site markup rather than
+ * content, so an HTTP write is a defacement vector — it would let a caller
+ * change what every visitor sees on the front end. The `params` column is
+ * withheld by the view as it carries template configuration, not content.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TemplatesController extends AbstractReadOnlyController
+{
+    protected $contentType = 'templates';
+
+    protected $default_view = 'templates';
+
+    /**
+     * List templates — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('type', $apiFilter)) {
+            $this->modelState->set('filter.type', $clean->clean($apiFilter['type'], 'CMD'));
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'templates' => 'Cwmtemplates',
+            'template'  => 'Cwmtemplate',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/src/Controller/TopicsController.php
+++ b/api/src/Controller/TopicsController.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for topics.
+ *
+ * GET    /api/index.php/v1/proclaim/topics       — list (published + archived)
+ * GET    /api/index.php/v1/proclaim/topics/:id   — detail
+ * POST   /api/index.php/v1/proclaim/topics       — create
+ * PATCH  /api/index.php/v1/proclaim/topics/:id   — update
+ * DELETE /api/index.php/v1/proclaim/topics/:id   — delete
+ *
+ * Filters: ?filter[search]=&filter[language]=
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TopicsController extends ApiController
+{
+    protected $contentType = 'topics';
+
+    protected $default_view = 'topics';
+
+    /**
+     * List topics — published and archived only.
+     *
+     * @return  static
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $this->modelState->set('filter.published', [1, 2]);
+
+        $apiFilter = $this->input->get('filter', [], 'array');
+        $clean     = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilter)) {
+            $this->modelState->set('filter.search', $clean->clean($apiFilter['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('language', $apiFilter)) {
+            $this->modelState->set('filter.language', $clean->clean($apiFilter['language'], 'CMD'));
+        }
+
+        return parent::displayList();
+    }
+
+    /**
+     * Get the model, mapping API names to Cwm-prefixed Proclaim classes.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'topics' => 'Cwmtopics',
+            'topic'  => 'Cwmtopic',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Normalize API JSON input for the topic model.
+     *
+     * @param   array  $data  The incoming data
+     *
+     * @return  array  The processed data
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function preprocessSaveData(array $data): array
+    {
+        $user = $this->app->getIdentity();
+
+        // Strip internal system fields — prevent mass assignment
+        unset($data['asset_id'], $data['checked_out'], $data['checked_out_time'], $data['modified_by']);
+
+        if (isset($data['created_by']) && !$user->authorise('core.admin', 'com_proclaim')) {
+            unset($data['created_by']);
+        }
+
+        if (!$user->authorise('core.edit.state', 'com_proclaim')) {
+            $data['published'] = 0;
+        }
+
+        return $data;
+    }
+}

--- a/api/src/View/Comments/JsonapiView.php
+++ b/api/src/View/Comments/JsonapiView.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Comments;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for study comments.
+ *
+ * SECURITY: `user_email` and `user_id` must never appear in either list below.
+ * The comments list query does select user_email, so these field lists are the
+ * only thing withholding a commenter's address from an HTTP response — leaking
+ * it would be a personal-data breach, and user_id would let a caller correlate
+ * commenters with site accounts. Do not add them.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'study_id',
+        'full_name',
+        'comment_date',
+        'comment_text',
+        'published',
+        'access',
+        'language',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * Note that study_id is absent: the comments list query does not select it.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'full_name',
+        'comment_date',
+        'comment_text',
+        'published',
+        'access',
+        'language',
+    ];
+}

--- a/api/src/View/Locations/JsonapiView.php
+++ b/api/src/View/Locations/JsonapiView.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Locations;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for locations (campuses).
+ *
+ * A location's postal address, phone and web page are public-facing contact
+ * details, so they are rendered. Deliberately withheld: `email_to` (the site's
+ * notification target), `user_id` and `contact_id` (bindings to Joomla
+ * accounts), and `fax` / `mobile` / `misc` / `sortname1-3`, which are internal
+ * or personal rather than published contact info.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'location_text',
+        'address',
+        'suburb',
+        'state',
+        'country',
+        'postcode',
+        'telephone',
+        'webpage',
+        'image',
+        'published',
+        'access',
+        'language',
+        'ordering',
+        'landing_show',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * Limited to what the locations list query selects.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'location_text',
+        'published',
+        'access',
+    ];
+}

--- a/api/src/View/Messagetypes/JsonapiView.php
+++ b/api/src/View/Messagetypes/JsonapiView.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Messagetypes;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for message types (study types).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'message_type',
+        'alias',
+        'published',
+        'access',
+        'ordering',
+        'landing_show',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'message_type',
+        'alias',
+        'published',
+        'access',
+        'ordering',
+    ];
+}

--- a/api/src/View/Playlists/JsonapiView.php
+++ b/api/src/View/Playlists/JsonapiView.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Playlists;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for playlists.
+ *
+ * `params` and `default_settings` are withheld: both carry sync configuration
+ * rather than content. `remote_playlist_id` is rendered because it is the public
+ * platform identifier that already appears in a playlist's own share URL.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'title',
+        'alias',
+        'description',
+        'remote_playlist_id',
+        'server_id',
+        'series_id',
+        'sync_enabled',
+        'writeback_enabled',
+        'last_sync',
+        'published',
+        'access',
+        'language',
+        'ordering',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * Limited to what the playlists list query selects — it does not include
+     * alias, description, writeback_enabled or language.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'title',
+        'remote_playlist_id',
+        'server_id',
+        'series_id',
+        'sync_enabled',
+        'last_sync',
+        'published',
+        'access',
+        'ordering',
+    ];
+}

--- a/api/src/View/Servers/JsonapiView.php
+++ b/api/src/View/Servers/JsonapiView.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Servers;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for media servers.
+ *
+ * SECURITY: `params` must never appear in either list below. It is the registry
+ * holding each server addon's credentials — api_key, client_secret,
+ * access_token — and the item model loads the full row, so omitting it here is
+ * the only thing keeping those out of an HTTP response. The list query does not
+ * select it, but the item query does. Do not add it.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'server_name',
+        'type',
+        'location_id',
+        'media',
+        'stats_synced_at',
+        'published',
+        'access',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'server_name',
+        'type',
+        'location_id',
+        'published',
+    ];
+}

--- a/api/src/View/Templates/JsonapiView.php
+++ b/api/src/View/Templates/JsonapiView.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Templates;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for display templates.
+ *
+ * `tmpl` (the markup itself) is rendered on the item only, never in lists — it
+ * is the substance of the resource, but large and pointless to repeat per row.
+ * `params` is withheld as it carries template configuration.
+ *
+ * Sites that would rather not publish their markup at all should set the
+ * `api_access` option to "API Key Required" rather than public reads.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'title',
+        'type',
+        'tmpl',
+        'location_id',
+        'published',
+        'access',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * Limited to what the templates list query selects.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'title',
+        'published',
+    ];
+}

--- a/api/src/View/Topics/JsonapiView.php
+++ b/api/src/View/Topics/JsonapiView.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Topics;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for topics.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'topic_text',
+        'published',
+        'access',
+        'language',
+        'params',
+    ];
+
+    /**
+     * The fields to render in the list response.
+     *
+     * Limited to what the topics list query selects — it does not include
+     * access or language.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderList = [
+        'id',
+        'topic_text',
+        'published',
+    ];
+}

--- a/plugins/webservices/proclaim/src/Extension/Proclaim.php
+++ b/plugins/webservices/proclaim/src/Extension/Proclaim.php
@@ -30,19 +30,63 @@ use Joomla\Router\Route;
  *   1 = Public reads (GET open, writes require API key)
  *   2 = API Key Required (all operations require Bearer token)
  *
- * Read endpoints (GET):
- *   /api/index.php/v1/proclaim/{sermons|teachers|series|podcasts|media}
+ * Read endpoints (GET) — every resource in self::RESOURCES:
+ *   /api/index.php/v1/proclaim/{resource}
  *   /api/index.php/v1/proclaim/{resource}/:id
  *
- * Write endpoints (always require API key):
+ * Write endpoints (always require an API key) — only resources flagged writable
+ * in self::RESOURCES; see that constant for why the rest are read-only:
  *   POST   /api/index.php/v1/proclaim/{resource}      — Create
  *   PATCH  /api/index.php/v1/proclaim/{resource}/:id  — Update
  *   DELETE /api/index.php/v1/proclaim/{resource}/:id  — Delete
+ *
+ * Regardless of routing, every list query is filtered to the caller's authorised
+ * view levels by the underlying model, so a public read never returns rows a
+ * user could not see in the site itself.
  *
  * @since  10.3.0
  */
 class Proclaim extends CMSPlugin implements SubscriberInterface
 {
+    /**
+     * Exposed resources, mapped to whether write routes are registered.
+     *
+     * Read-only entries are not merely unimplemented — each has a concrete
+     * write-side hazard, and the matching controller extends
+     * AbstractReadOnlyController so the verbs are refused even if a route were
+     * added elsewhere:
+     *
+     *   servers        credentials live in params (api_key, client_secret,
+     *                  access_token); a write would overwrite or exfiltrate them
+     *   templates      site markup — an HTTP write is a defacement vector
+     *   comments       a write would bypass the front-end moderation gate
+     *   playlists      sync_enabled / writeback_enabled arm real mutations
+     *                  against a church's live YouTube account
+     *
+     * Deliberately absent: templatecodes. #__bsms_templatecode has no `access`
+     * column, so unlike every other entity here it cannot honour view levels —
+     * and the field worth serving holds PHP source. Exposing it would mean
+     * publishing code that no ACL could scope. Adding an `access` column to that
+     * table is the prerequisite for reconsidering it.
+     *
+     * @var    array<string, bool>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const RESOURCES = [
+        'sermons'      => true,
+        'teachers'     => true,
+        'series'       => true,
+        'podcasts'     => true,
+        'media'        => true,
+        'topics'       => true,
+        'locations'    => true,
+        'messagetypes' => true,
+        'playlists'    => false,
+        'comments'     => false,
+        'servers'      => false,
+        'templates'    => false,
+    ];
+
     /**
      * @since   10.3.0
      */
@@ -75,11 +119,12 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
         $isPublic = ($apiAccess === 1);
         $router   = $event->getRouter();
 
-        $resources = ['sermons', 'teachers', 'series', 'podcasts', 'media'];
-
-        foreach ($resources as $resource) {
+        foreach (self::RESOURCES as $resource => $writable) {
             $this->createReadOnlyRoutes($router, "v1/proclaim/$resource", $resource, $isPublic);
-            $this->createWriteRoutes($router, "v1/proclaim/$resource", $resource);
+
+            if ($writable) {
+                $this->createWriteRoutes($router, "v1/proclaim/$resource", $resource);
+            }
         }
     }
 

--- a/tests/unit/Admin/Api/Controller/ReadOnlyResourceTest.php
+++ b/tests/unit/Admin/Api/Controller/ReadOnlyResourceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * Unit tests for the read-only API resources and their withheld fields.
+ *
+ * These assert security properties, not conveniences. Each assertion here stands
+ * between an HTTP caller and either a credential, someone's personal data, or a
+ * write that would have real side effects.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Api\Controller;
+
+use CWM\Component\Proclaim\Api\Controller\AbstractReadOnlyController;
+use CWM\Component\Proclaim\Api\Controller\ServersController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+class ReadOnlyResourceTest extends ProclaimTestCase
+{
+    /**
+     * Controllers that must never accept writes.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function readOnlyControllerProvider(): array
+    {
+        return [
+            'servers'   => ['ServersController'],
+            'templates' => ['TemplatesController'],
+            'comments'  => ['CommentsController'],
+            'playlists' => ['PlaylistsController'],
+        ];
+    }
+
+    /**
+     * Each read-only resource extends the base that refuses writes.
+     *
+     */
+    #[DataProvider('readOnlyControllerProvider')]
+    public function testReadOnlyControllerExtendsReadOnlyBase(string $class): void
+    {
+        $fqcn = 'CWM\\Component\\Proclaim\\Api\\Controller\\' . $class;
+
+        $this->assertTrue(class_exists($fqcn), "$class should exist");
+        $this->assertTrue(
+            is_subclass_of($fqcn, AbstractReadOnlyController::class),
+            "$class must extend AbstractReadOnlyController so writes are refused"
+        );
+    }
+
+    /**
+     * The writable controllers must NOT extend the read-only base, or their
+     * legitimate write endpoints would 404.
+     */
+    public function testWritableControllersAreNotReadOnly(): void
+    {
+        foreach (['TopicsController', 'LocationsController', 'MessagetypesController'] as $class) {
+            $fqcn = 'CWM\\Component\\Proclaim\\Api\\Controller\\' . $class;
+
+            $this->assertTrue(class_exists($fqcn), "$class should exist");
+            $this->assertFalse(
+                is_subclass_of($fqcn, AbstractReadOnlyController::class),
+                "$class is meant to be writable and must not extend AbstractReadOnlyController"
+            );
+        }
+    }
+
+    /**
+     * Write verbs on the read-only base throw rather than falling through to the
+     * parent implementation.
+     *
+     */
+    #[DataProvider('writeVerbProvider')]
+    public function testWriteVerbsThrow(string $method): void
+    {
+        $controller = $this->newReadOnlyController();
+
+        $this->expectException(RouteNotFoundException::class);
+
+        $controller->$method();
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function writeVerbProvider(): array
+    {
+        return [
+            'add'    => ['add'],
+            'edit'   => ['edit'],
+            'delete' => ['delete'],
+        ];
+    }
+
+    /**
+     * The servers view must never render `params` — it holds api_key,
+     * client_secret and access_token for every server addon, and the item query
+     * loads the full row.
+     */
+    public function testServersViewWithholdsCredentialParams(): void
+    {
+        foreach (['fieldsToRenderItem', 'fieldsToRenderList'] as $property) {
+            $fields = $this->viewFields('Servers', $property);
+
+            $this->assertNotContains(
+                'params',
+                $fields,
+                "Servers $property must not expose params — it contains server credentials"
+            );
+        }
+    }
+
+    /**
+     * The comments view must never render `user_email` or `user_id`. The comments
+     * list query does select user_email, so these lists are the only thing
+     * keeping a commenter's address out of the response.
+     */
+    public function testCommentsViewWithholdsPersonalData(): void
+    {
+        foreach (['fieldsToRenderItem', 'fieldsToRenderList'] as $property) {
+            $fields = $this->viewFields('Comments', $property);
+
+            foreach (['user_email', 'user_id'] as $forbidden) {
+                $this->assertNotContains(
+                    $forbidden,
+                    $fields,
+                    "Comments $property must not expose $forbidden"
+                );
+            }
+        }
+    }
+
+    /**
+     * Sanity check that the views expose something — a typo'd property name would
+     * otherwise make the assertions above pass against an empty array.
+     */
+    public function testWithholdingTestsAreMeaningful(): void
+    {
+        foreach (['Servers', 'Comments'] as $view) {
+            foreach (['fieldsToRenderItem', 'fieldsToRenderList'] as $property) {
+                $this->assertNotEmpty(
+                    $this->viewFields($view, $property),
+                    "$view::$property should not be empty"
+                );
+            }
+        }
+    }
+
+    /**
+     * Read a JSON:API view's field list without booting the view.
+     *
+     * @return array<int, string>
+     */
+    private function viewFields(string $view, string $property): array
+    {
+        $fqcn = 'CWM\\Component\\Proclaim\\Api\\View\\' . $view . '\\JsonapiView';
+
+        $this->assertTrue(class_exists($fqcn), "$view JsonapiView should exist");
+
+        $defaults = (new \ReflectionClass($fqcn))->getDefaultProperties();
+
+        return $defaults[$property] ?? [];
+    }
+
+    /**
+     * A real read-only controller, constructed without running the parent
+     * constructor so no application or MVC factory is required. ServersController
+     * stands in for the family — it already declares its own contentType, which
+     * feeds the refusal message.
+     */
+    private function newReadOnlyController(): AbstractReadOnlyController
+    {
+        return (new \ReflectionClass(ServersController::class))
+            ->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
+++ b/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
@@ -12,6 +12,7 @@ namespace CWM\Component\Proclaim\Tests\Admin\Api\Controller;
 
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
 use CWM\Plugin\WebServices\Proclaim\Extension\Proclaim;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test class for Proclaim webservices plugin
@@ -64,9 +65,92 @@ class WebservicesPluginTest extends ProclaimTestCase
     }
 
     /**
-     * Verify all 5 resources are registered in onBeforeApiRoute.
+     * Resources the API exposes, and whether each accepts writes.
+     *
+     * @return array<string, array{0: string, 1: bool}>
      */
-    public function testAllResourcesRegistered(): void
+    public static function resourceProvider(): array
+    {
+        return [
+            'sermons'      => ['sermons', true],
+            'teachers'     => ['teachers', true],
+            'series'       => ['series', true],
+            'podcasts'     => ['podcasts', true],
+            'media'        => ['media', true],
+            'topics'       => ['topics', true],
+            'locations'    => ['locations', true],
+            'messagetypes' => ['messagetypes', true],
+            'playlists'    => ['playlists', false],
+            'comments'     => ['comments', false],
+            'servers'      => ['servers', false],
+            'templates'    => ['templates', false],
+        ];
+    }
+
+    /**
+     * Every expected resource is registered, with the expected write posture.
+     *
+     */
+    #[DataProvider('resourceProvider')]
+    public function testResourceRegisteredWithExpectedWritePosture(string $resource, bool $writable): void
+    {
+        $resources = (new \ReflectionClass(Proclaim::class))->getConstant('RESOURCES');
+
+        $this->assertArrayHasKey($resource, $resources, "Resource '$resource' should be registered");
+        $this->assertSame(
+            $writable,
+            $resources[$resource],
+            "Resource '$resource' should " . ($writable ? '' : 'NOT ') . 'accept writes'
+        );
+    }
+
+    /**
+     * The registry must not grow silently — a new resource has to be a deliberate
+     * change here, so nothing gets exposed without a matching decision on writes.
+     */
+    public function testNoUnexpectedResourcesRegistered(): void
+    {
+        $resources = (new \ReflectionClass(Proclaim::class))->getConstant('RESOURCES');
+
+        $this->assertSame(
+            array_keys(self::resourceProvider()),
+            array_keys($resources),
+            'Registered resources drifted from the expected set'
+        );
+    }
+
+    /**
+     * templatecodes must stay unexposed.
+     *
+     * #__bsms_templatecode has no `access` column, so unlike every other entity
+     * in the registry it cannot honour view levels — and the field worth serving
+     * holds PHP source. Exposing it would publish code that no ACL could scope.
+     * If an `access` column is ever added, this test is the place to revisit.
+     */
+    public function testTemplatecodesIsNotExposed(): void
+    {
+        $resources = (new \ReflectionClass(Proclaim::class))->getConstant('RESOURCES');
+
+        $this->assertArrayNotHasKey(
+            'templatecodes',
+            $resources,
+            'templatecodes cannot be ACL-segmented (no access column) and serves PHP source'
+        );
+
+        $this->assertFalse(
+            class_exists('CWM\\Component\\Proclaim\\Api\\Controller\\TemplatecodesController'),
+            'No API controller should exist for templatecodes'
+        );
+    }
+
+    /**
+     * Write routes are only created for writable resources.
+     *
+     * Guards the loop in onBeforeApiRoute: the createWriteRoutes() call must stay
+     * behind the writable flag, otherwise every read-only resource silently gains
+     * POST/PATCH/DELETE.
+     */
+    public function testWriteRoutesGatedOnWritableFlag(): void
     {
         $ref   = new \ReflectionMethod(Proclaim::class, 'onBeforeApiRoute');
         $lines = \array_slice(
@@ -74,10 +158,12 @@ class WebservicesPluginTest extends ProclaimTestCase
             $ref->getStartLine() - 1,
             $ref->getEndLine() - $ref->getStartLine() + 1
         );
-        $source = implode('', $lines);
+        $source = preg_replace('/\s+/', ' ', implode('', $lines));
 
-        foreach (['sermons', 'teachers', 'series', 'podcasts', 'media'] as $resource) {
-            $this->assertStringContainsString($resource, $source, "Resource '$resource' should be registered");
-        }
+        $this->assertMatchesRegularExpression(
+            '/if \(\$writable\) \{ \$this->createWriteRoutes\(/',
+            $source,
+            'createWriteRoutes() must remain guarded by the $writable flag'
+        );
     }
 }

--- a/tests/unit/Admin/Model/ListDirectionDefaultTest.php
+++ b/tests/unit/Admin/Model/ListDirectionDefaultTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Guards the default sort direction in every admin list model.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Model;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Every `list.direction` fallback must be a valid SQL sort direction.
+ *
+ * Two models shipped with 'acs' / 'ACS' — a transposition of 'asc'. It was
+ * invisible in the admin UI, where the request always supplies a direction, so
+ * the default never applied. The REST API supplies none, so the fallback reached
+ * the query as `ORDER BY col ACS`, which is a syntax error: the query returned
+ * false and the endpoint 500'd.
+ *
+ * This scans source rather than executing the models because the bug lives in a
+ * default argument that only a request-less caller ever reaches.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ListDirectionDefaultTest extends ProclaimTestCase
+{
+    /**
+     * Directions MySQL will accept, plus the empty string some models use to mean
+     * "unordered" and let the query builder decide.
+     *
+     * @var string[]
+     */
+    private const VALID = ['asc', 'desc', ''];
+
+    public function testEveryListDirectionDefaultIsValidSql(): void
+    {
+        $offenders = [];
+
+        foreach ($this->modelFiles() as $file) {
+            $source = (string) file_get_contents($file);
+
+            // Match the default in get('list.direction', '<default>').
+            preg_match_all(
+                '/[\'"]list\.direction[\'"]\s*,\s*[\'"]([^\'"]*)[\'"]/',
+                $source,
+                $matches
+            );
+
+            foreach ($matches[1] as $default) {
+                if (!\in_array(strtolower($default), self::VALID, true)) {
+                    $offenders[] = basename($file) . " => '" . $default . "'";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "Invalid default sort direction(s) — these produce an SQL syntax error when no\n"
+            . "direction is supplied, as happens on every API request:\n  "
+            . implode("\n  ", $offenders)
+        );
+    }
+
+    /**
+     * The scan must actually find directions, or the test above passes vacuously.
+     */
+    public function testScanFindsListDirectionDefaults(): void
+    {
+        $found = 0;
+
+        foreach ($this->modelFiles() as $file) {
+            $found += preg_match_all(
+                '/[\'"]list\.direction[\'"]\s*,\s*[\'"][^\'"]*[\'"]/',
+                (string) file_get_contents($file)
+            );
+        }
+
+        $this->assertGreaterThan(5, $found, 'Expected several list.direction defaults across the models');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function modelFiles(): array
+    {
+        $dir   = \dirname(__DIR__, 4) . '/admin/src/Model';
+        $files = glob($dir . '/*.php') ?: [];
+
+        $this->assertNotEmpty($files, "No admin models found at {$dir}");
+
+        return $files;
+    }
+}


### PR DESCRIPTION
Phase 2 of the REST API work, on top of #1311. Takes the API from **5 resources to 12**: adds topics, locations, messagetypes, playlists, comments, servers and templates.

## Not everything is safe to write

The webservices plugin now maps each resource to whether write routes are registered at all:

| resource | writes | why |
|---|---|---|
| topics, locations, messagetypes | ✅ | plain taxonomy, same shape as the existing five |
| **servers** | ❌ | credentials live in `params` — `api_key`, `client_secret`, `access_token` |
| **templates** | ❌ | site markup — an HTTP write is a defacement vector |
| **comments** | ❌ | a write bypasses the front-end moderation gate |
| **playlists** | ❌ | `sync_enabled` / `writeback_enabled` arm **real mutations against a live YouTube account** |

Read-only resources extend a new `AbstractReadOnlyController` whose write verbs throw `RouteNotFoundException`. The routes already aren't registered, so this is defence in depth — a resource can't become writable by accident if a route is added elsewhere.

## Withheld fields

Field lists are the *only* thing standing between a caller and this data, because the underlying queries do fetch it:

- **`servers.params`** — the list query doesn't select it, but the **item query loads the full row**. Omitting it from the view is what keeps every server addon's credentials out of the response.
- **`comments.user_email` / `user_id`** — the comments list query **does** select `user_email`, so the view is the only thing withholding a commenter's address.
- **locations** — `email_to`, `user_id` and `contact_id` are also stripped on write; `email_to` is a notification target, an open door to redirecting site mail.

## templatecodes is deliberately not exposed

It was in the original scope and has been dropped. `#__bsms_templatecode` has **no `access` column**, so unlike every sibling entity it cannot honour view levels — and the field worth serving holds **PHP source**:

```
templatecode: "<?php\n\n/**\n * Helper for Template Code ..."
```

Exposing it would publish code that no ACL could scope. Adding an `access` column is the prerequisite for reconsidering; `testTemplatecodesIsNotExposed` records the decision so it isn't quietly reversed.

## Three fixes that fell out of exercising these paths

**Two models had no view-level filter at all.** `CwmlocationsModel` and `CwmplaylistsModel` never filtered by authorised view levels. Harmless while admin-only; not harmless once they back a public API, where an unauthenticated caller would have received rows whose view level they cannot see.

**Two models had a sort-direction typo.** `CwmmessagetypesModel` and `CwmtemplatesModel` defaulted `list.direction` to `'acs'` / `'ACS'`. Latent in admin — the request always supplies a direction, so the default never applied. The API supplies none, so it reached the query as `ORDER BY col ACS`: a syntax error that made `getItems()` return `false` and the endpoint 500. `ListDirectionDefaultTest` now guards **every** model against the whole class of typo (verified by reintroducing the bug and watching it fail).

## Verification — clean install on j6-test

All 12 resources `200`; `templatecodes` `404`.

| | POST | PATCH | DELETE |
|---|---|---|---|
| read-only (servers, templates, comments, playlists) | 404 | 404 | 404 |
| writable (topics, locations, messagetypes) | 401 | 401 | 401 |

Read-only writes 404 because they're unrouted; writable writes 401 because they're routed but always require a key.

**ACL segmentation, per resource** — each row set to a view level the caller lacks, then restored:

| resource | baseline | denied level | restored |
|---|---|---|---|
| topics | 20 | **0** | 20 |
| locations | 1 | **0** | 1 |
| messagetypes | 1 | **0** | 1 |
| comments | 1 | **0** | 1 |
| servers | 3 | **0** | 3 |
| templates | 1 | **0** | 1 |
| playlists | 1 | **0** | 1 |

The denied level is **derived at runtime, never hardcoded** — level ids are site-specific, and which ones a guest holds is Joomla core configuration (`guest_usergroup` + `#__viewlevels`), not something Proclaim defines. A probe confirmed the API guest resolves to `uid=0, core.admin=false, levels=[1,5]` under `ApiApplication`, so the filter is genuinely entered rather than short-circuited.

**Leak checks** — canary secrets planted in `servers.params` and `playlists.params`/`default_settings`, and a real address in `comments.user_email`, were all absent from list *and* item responses.

884 tests pass; `composer lint` clean; `composer test:install` passes end to end.

## Note

`composer test:release` still reinstalls cleanly, so this stacks safely on #1311/#1312/#1313. Worth filing a follow-up for the `access` column on `#__bsms_templatecode` if that resource is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)