### PR TITLE
chore(composer): exclude YouTube addon vendor from classmap scan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,10 @@
       "CWM\\Component\\Proclaim\\Api\\": "api/src/",
       "CWM\\Component\\Proclaim\\Site\\": "site/src/",
       "CWM\\Library\\Scripture\\": "libraries/lib_cwmscripture/src/"
-    }
+    },
+    "exclude-from-classmap": [
+      "/admin/src/Addons/Servers/Youtube/vendor/"
+    ]
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
## Problem

Every `composer install` / `composer update` / `composer dump-autoload` emitted several hundred lines of:

```
Class GuzzleHttp\Promise\PromiseInterface located in ./admin/src/Addons/Servers/Youtube/vendor/guzzlehttp/promises/src/PromiseInterface.php
does not comply with psr-4 autoloading standard (rule: CWM\Component\Proclaim\Administrator\ => ./admin/src). Skipping.
```

## Cause

The YouTube addon bundles its own Composer install (google/apiclient + Guzzle) at `admin/src/Addons/Servers/Youtube/vendor/`. That path lives *inside* the PSR-4 root `CWM\Component\Proclaim\Administrator\ => admin/src/`, so with `optimize-autoloader: true` Composer classmap-scans the entire tree and reports one warning per bundled class whose namespace doesn't match the rule.

## Fix

Add `exclude-from-classmap` for that directory.

## Why this is safe

Those classes were **already** being skipped — nothing from that tree was ever registered in the root classmap. The addon resolves them through its own autoloader, required at `admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php:15`. This is noise removal plus a faster autoload dump, with no runtime behavior change.

`composer.lock` is untouched — `autoload` is not part of the lock's content hash.

## Verification

- `composer dump-autoload` → no warnings, 4975 classes (was: ~hundreds of warnings)
- `composer validate --no-check-publish` → valid, no stale-lock warning
- `grep -c "Youtube/vendor" libraries/vendor/composer/autoload_classmap.php` → `0` (unchanged from before)
- Addon's `vendor/autoload.php` present and still required

🤖 Generated with [Claude Code](https://claude.com/claude-code)