### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 for GHSA-3jxr-9vmj-r5cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4275,16 +4275,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
Clears the last open Dependabot alert — the only high-severity one.

## The advisory

**GHSA-3jxr-9vmj-r5cp** — denial of service via exponential-time expansion of consecutive non-expanding `{}` groups. Affects `>= 3.0.0, < 5.0.7`; we were on 5.0.6.

## Real-world risk: low, despite the "high" label

`brace-expansion` is transitive-only, reached through `minimatch` under `@babel/cli`, `eslint`, and `jest` — all **devDependencies**:

```
├─┬ @babel/cli → glob → minimatch → brace-expansion
├─┬ eslint → minimatch → brace-expansion
└─┬ jest → (@jest/reporters|jest-config|jest-runtime) → glob → minimatch → brace-expansion
```

Our npm `dependencies` are only `@fancyapps/ui`, `chart.js`, and `core-js`, so the vulnerable code never reaches built assets in `media/` and never runs on a user's site. This was a build-time DoS on input we control — which is why it ranked below the Guzzle advisories in #1319 despite the higher severity score.

## Change

| Package | From | To |
|---|---|---|
| `brace-expansion` | 5.0.6 | 5.0.8 |

Applied via `npm audit fix`. Worth noting `npm update brace-expansion` does **not** move it — the pinned `minimatch` parents hold it back, so `audit fix` is the correct lever.

No `package.json` change; the lock is the only file touched (4 insertions, 4 deletions).

## Verification

- `npm audit` → **found 0 vulnerabilities** (was 1 high)
- `npm test` → 229 tests passing, 16/16 suites
- `npm run build` → exits 0, assets copy cleanly
- `git status` confirms `media/` stays gitignored — no build output leaked into the commit

Toolchain checks matter here since the bump sits underneath jest, eslint, and babel.

## Alert status after this

All 5 Dependabot alerts closed: 4 Composer (Guzzle) in #1319, 1 npm here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)