### PR TITLE
chore(deps): bump cwm/build-tools to ^1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.6.1",
+    "cwm/build-tools": "^1.6.2",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75047a4ae5eadb47c8ddd19d4c3c07ee",
+    "content-hash": "04ed1c6dfdff8c53d31dfda998eea871",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "6ab28e446b7bf6574675569d82860b2b3317feb4"
+                "reference": "2d86d2ac95724006b94a56a54bbf4b0ea7818d5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/6ab28e446b7bf6574675569d82860b2b3317feb4",
-                "reference": "6ab28e446b7bf6574675569d82860b2b3317feb4",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/2d86d2ac95724006b94a56a54bbf4b0ea7818d5c",
+                "reference": "2d86d2ac95724006b94a56a54bbf4b0ea7818d5c",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.6.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.6.2",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-25T16:40:41+00:00"
+            "time": "2026-07-25T22:30:35+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.6.2](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.6.2), which guards `build.dist.properties`.

## Why this repo cares

`build.dist.properties` is the template this project **commits**; per-machine values belong in the gitignored `build.properties`. The names differ by four characters and the wrong one gets edited — this repo had real credentials in the committed template:

```
builder.j5.db_user = root
builder.j5.db_pass = root
builder.j5.db_name = j5_dev
```

caught while staging an unrelated change. History was clean that time, but nothing would have said so — and `sync-configs` overwrites the file from the template, so the credentials would have vanished from the working tree while remaining in any commit that already captured them. The mistake erased its own evidence.

## What the guard does

Three checks before the write: refuse if the shared template itself carries credentials, warn if this repo's copy does (pointing at `git log -p -- build.dist.properties` so history gets checked rather than assumed), and report keys about to be deleted.

## Verified after updating

That third check earns its place here immediately:

```
build.dist.properties: NOTE — 11 key(s) present locally are not in
  the cwm-build-tools template and will be removed:
    builder.j6-test.role
    builder.j6-test.path
    builder.j6-test.url
    ...
```

**Those 11 keys would have been dropped silently** by any future `composer sync-configs` — the shared template only knew about `j5-test`, and this repo's release harness targets `j6-test`.

## One thing left deliberately undone

v1.6.2 adds a commented-out `j6-test` section to the shared template, so a second `role = test` install is now part of the schema. This repo's copy still declares that block actively, so running `sync-configs` would replace it with the commented template version.

I haven't run it — that changes a committed file and isn't part of a dependency bump. Worth doing as its own change if you want the two aligned; nothing operational depends on it, since the live config is the gitignored `build.properties`.

921 tests pass; `composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)