### PR TITLE
docs(api): record that templatecode writes would be code execution

### DIFF
--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -128,9 +128,11 @@ class CwmtemplatecodesModel extends ListModel
         // table can express.
         //
         // That is why templatecodes is deliberately NOT exposed over the REST API
-        // while every sibling entity is: the field worth serving holds PHP source,
-        // and no ACL here could scope who reads it. Adding an `access` column is
-        // the prerequisite for exposing this entity.
+        // while every sibling entity is. Two separate reasons: the column holds
+        // PHP source that no ACL here could scope for reading, and
+        // CwmtemplatecodeTable::store() writes it to an executable PHP file in the
+        // web root, so a write endpoint would be remote code execution. Adding an
+        // `access` column would address only the first.
 
         // Filter by search in filename or study title
         $search = $this->getState('filter.search');

--- a/plugins/webservices/proclaim/src/Extension/Proclaim.php
+++ b/plugins/webservices/proclaim/src/Extension/Proclaim.php
@@ -64,11 +64,21 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
      *   playlists      sync_enabled / writeback_enabled arm real mutations
      *                  against a church's live YouTube account
      *
-     * Deliberately absent: templatecodes. #__bsms_templatecode has no `access`
-     * column, so unlike every other entity here it cannot honour view levels —
-     * and the field worth serving holds PHP source. Exposing it would mean
-     * publishing code that no ACL could scope. Adding an `access` column to that
-     * table is the prerequisite for reconsidering it.
+     * Deliberately absent, and not merely pending: templatecodes.
+     *
+     * CwmtemplatecodeTable::store() writes the `templatecode` column to a real
+     * PHP file under components/com_proclaim/tmpl/ via File::write(), which the
+     * front end then executes as a template. A write endpoint would therefore let
+     * a caller put arbitrary PHP in the web root — remote code execution, not a
+     * content problem, and no ACL makes that acceptable.
+     *
+     * Reads are separately unsafe: the column holds PHP source, and
+     * #__bsms_templatecode has no `access` column, so unlike every other entity
+     * here it cannot honour view levels at all.
+     *
+     * Adding an `access` column would address the read side ONLY. It would not
+     * make writes safe. Do not treat that column as the single prerequisite for
+     * exposing this resource.
      *
      * @var    array<string, bool>
      * @since  __DEPLOY_VERSION__

--- a/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
+++ b/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
@@ -122,10 +122,15 @@ class WebservicesPluginTest extends ProclaimTestCase
     /**
      * templatecodes must stay unexposed.
      *
-     * #__bsms_templatecode has no `access` column, so unlike every other entity
-     * in the registry it cannot honour view levels — and the field worth serving
-     * holds PHP source. Exposing it would publish code that no ACL could scope.
-     * If an `access` column is ever added, this test is the place to revisit.
+     * CwmtemplatecodeTable::store() writes the `templatecode` column to a real
+     * PHP file under components/com_proclaim/tmpl/, which the front end executes.
+     * A write endpoint would let a caller put arbitrary PHP in the web root, so
+     * this is a code-execution boundary rather than a content decision.
+     *
+     * Reads are separately unsafe: the column holds PHP source and the table has
+     * no `access` column, so it cannot honour view levels. Adding that column
+     * would fix the read side only — it would NOT make writes safe. Do not treat
+     * this test as waiting on a schema change.
      */
     public function testTemplatecodesIsNotExposed(): void
     {


### PR DESCRIPTION
**No behaviour change.** Comments and one test docblock only.

## The problem was in the documentation, not the code

Keeping `templatecodes` out of the API was recorded as *"no `access` column, and the field holds PHP source"*, with the note that **adding an `access` column is the prerequisite for reconsidering**.

That understates the risk and points the next person the wrong way.

`CwmtemplatecodeTable::store()` writes the `templatecode` column to a real PHP file:

```php
$filename = 'default_' . $this->filename . '.php';
$file     = JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmsermons/' . $filename;
...
if (!File::write($file, $templateCodeContent)) {
```

The front end then executes that file as a template. **A write endpoint would let a caller put arbitrary PHP in the web root** — remote code execution, and no ACL makes that acceptable.

## Nothing is vulnerable

The resource is not exposed. There is no controller, view, or route for it, and `testTemplatecodesIsNotExposed` keeps it that way (#1314).

The risk is that someone acting on *"adding an access column is the prerequisite"* adds the column, exposes the resource, and reasonably believes they've addressed the objection — while opening a write path that writes executable PHP. That's a footgun I left in the comments.

## Corrected in the three places the reasoning lives

- `Proclaim::RESOURCES` docblock (webservices plugin)
- `testTemplatecodesIsNotExposed` docblock
- The note in `CwmtemplatecodesModel`

All three now separate the two problems — reads leak PHP source and can't honour view levels; writes are code execution — and state explicitly that an `access` column would address **the read side only**.

## How it surfaced

Syncing the wiki. `Database-Schema.md` already documented it:

> *"On save, the code is written to a physical PHP file in the appropriate view folder."*

I verified it against `CwmtemplatecodeTable` rather than taking the wiki's word, then followed it back to my own comments.

921 tests pass; `composer lint` clean.