### PR TITLE
chore(deps): bump cwm/build-tools to ^1.7.0 and sync build.dist.properties

### DIFF
--- a/build.dist.properties
+++ b/build.dist.properties
@@ -23,16 +23,39 @@
 # version is set).
 joomla.version = 5.4.2
 
-# Comma-separated list of install ids. Each id must have a matching block
-# of `builder.<id>.*` keys below.
-builder.installs = j5, j6, j5-test, j6-test
+# Comma-separated list of install ids. Each id must have a matching block of
+# `builder.<id>.*` keys below.
+#
+# Two examples ship here — one of each role. **Add as many as you need**: one
+# per Joomla version you support, or several of the same version. To add one,
+# copy a block, change the id, and add that id to this list. Ids are arbitrary
+# labels (`j6`, `j7-test`, `client-staging`) — nothing keys off the name.
+builder.installs = j5, j5-test
 
-# ----- Joomla 5 development install ----------------------------------------
-# role values:
-#   dev  — symlink-style working install. `cwm-link` deploys here.
-#   test — artifact-style install. `cwm-install-zip` deploys the dist zip
-#          here and `cwm-verify --target test` queries it.
+# ----- ROLES ----------------------------------------------------------------
+# Every install declares a role, and the role decides how it is treated. This is
+# the most important line in each block:
+#
+#   role = dev    SYMLINKED. `cwm-link` points the install's extension
+#                 directories at your working repo, so edits appear on the site
+#                 immediately with no build step. Never wiped by any command.
+#
+#   role = test   NOT SYMLINKED — a real, file-backed install. `cwm-install-zip`
+#                 deploys the built dist zip here, and the release harness
+#                 (`composer test:install` / `test:upgrade`) WIPES AND
+#                 REINSTALLS it to verify the artifact from a clean slate.
+#
 # (Default role is `dev` when omitted.)
+#
+# Never point a `role = test` install at a symlinked directory. Those commands
+# delete extension directories, and is_dir() is true for a symlink to a
+# directory — so a linked test install means the delete walks through the link
+# and empties your working repo. `cwm-link` skips `role = test` installs for
+# this reason (v1.6.1), and the reset harness strips any stray link it finds
+# before deleting anything (v1.6.2). Both are backstops, not permission to
+# link one.
+
+# ----- Development install (symlinked) --------------------------------------
 builder.j5.role        = dev
 builder.j5.path        = /path/to/joomla5
 builder.j5.url         = https://j5-dev.local
@@ -45,24 +68,11 @@ builder.j5.admin_user  = admin
 builder.j5.admin_pass  = admin
 builder.j5.admin_email = admin@example.com
 
-# ----- Joomla 6 development install ----------------------------------------
-builder.j6.role        = dev
-builder.j6.path        = /path/to/joomla6
-builder.j6.url         = https://j6-dev.local
-builder.j6.version     = 6.0.0
-builder.j6.db_host     = localhost
-builder.j6.db_user     =
-builder.j6.db_pass     =
-builder.j6.db_name     =
-builder.j6.admin_user  = admin
-builder.j6.admin_pass  = admin
-builder.j6.admin_email = admin@example.com
-
-# ----- Joomla 5 test install (artifact verification) ----------------------
-# `cwm-install-zip` deploys the built dist zip into this install so you can
-# exercise the install scriptfile, manifest declarations, and schema
-# migrations end-to-end before release. Remove if you don't run a separate
-# test install — or delete j5-test from `builder.installs` above.
+# ----- Test install (real files, wiped by the release harness) --------------
+# Exercises the install scriptfile, manifest declarations and schema migrations
+# end-to-end before release. Remove this block and drop `j5-test` from
+# `builder.installs` if you don't run one — the harness reports having no
+# target rather than failing.
 builder.j5-test.role        = test
 builder.j5-test.path        = /path/to/joomla5-test
 builder.j5-test.url         = https://j5-test.local
@@ -74,25 +84,6 @@ builder.j5-test.db_name     =
 builder.j5-test.admin_user  = admin
 builder.j5-test.admin_pass  = admin
 builder.j5-test.admin_email = admin@example.com
-
-# ----- Joomla 6 test install (artifact verification) ----------------------
-# Target for the release-validation harness: `composer test:install`,
-# `composer test:upgrade`, and `composer test:release` reset this install,
-# install the built (and previous-release) package here, and assert the
-# schema migrations landed (build/verify-migrations.php). Must be a real,
-# non-symlinked Joomla install, separate from the dev sites above. At least
-# one role = test install is required for the harness to have a target.
-builder.j6-test.role        = test
-builder.j6-test.path        = /path/to/joomla6-test
-builder.j6-test.url         = https://j6-test.local
-builder.j6-test.version     = 6.0.0
-builder.j6-test.db_host     = localhost
-builder.j6-test.db_user     =
-builder.j6-test.db_pass     =
-builder.j6-test.db_name     =
-builder.j6-test.admin_user  = admin
-builder.j6-test.admin_pass  = admin
-builder.j6-test.admin_email = admin@example.com
 
 # ----- CWM sibling paths --------------------------------------------------
 # Per-developer absolute paths to CWM siblings declared in

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.6.2",
+    "cwm/build-tools": "^1.7.0",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04ed1c6dfdff8c53d31dfda998eea871",
+    "content-hash": "be754bb7261e87a9eb3b7e1f035a7997",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.6.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "2d86d2ac95724006b94a56a54bbf4b0ea7818d5c"
+                "reference": "7ed575f83469bf7a2017aa80a1e05b4746270f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/2d86d2ac95724006b94a56a54bbf4b0ea7818d5c",
-                "reference": "2d86d2ac95724006b94a56a54bbf4b0ea7818d5c",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/7ed575f83469bf7a2017aa80a1e05b4746270f81",
+                "reference": "7ed575f83469bf7a2017aa80a1e05b4746270f81",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.6.2",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.7.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-25T22:30:35+00:00"
+            "time": "2026-07-26T20:58:33+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Closes #1323.

Picks up [cwm-build-tools v1.7.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.7.0), which reshapes the shared template per the direction on #1323:

> *"We should only have two examples and state that you can always add more, and maybe do something to state if we have a non-symlink version."*

## What v1.7.0 changed upstream

- **Two install examples**, one per role, with an explicit note to add as many as needed. Ids are arbitrary labels; nothing keys off the name.
- **A `ROLES` section** promoting the symlinked-vs-not distinction from a three-line aside — `role = dev` is symlinked at the working repo, `role = test` is a real file-backed install the release harness wipes and reinstalls.

## What syncing does here

Removes the `j6` and `j6-test` example blocks from this repo's committed template. Reported rather than silent, thanks to the v1.6.2 guard:

```
build.dist.properties: NOTE — 22 key(s) present locally are not in
  the cwm-build-tools template and will be removed:
    builder.j6.role ... builder.j6-test.admin_email
```

That's the intended outcome. Four hand-maintained examples read as a set to reproduce; the template now shows the pattern and says to copy it.

## Nothing operational changes

`build.dist.properties` is only the starting point a fresh clone copies to `build.properties`. The live config is gitignored and untouched — **verified after syncing** that the harness still resolves its target:

```
role=test installs: 1 -> j6-test
```

So `composer test:install` / `test:upgrade` continue to work against j6-test exactly as before. A fresh clone now starts from `j5` + `j5-test` and adds its own — which is what everyone here already does. This repo's real environment has **five** installs (j5-dev, j6-dev, j6-test, j62-dev, j70-dev), none of which matched the old four examples, which is rather the point.

## Left out deliberately

`sync-configs` also wants to add `/media/joomla.asset.json` to `.gitignore`'s managed block — but **line 46 already ignores it**, outside the markers. That's a duplicate rather than drift, so I reverted it here. Better fixed by removing the hand-written line so the managed block owns the path; not folding an unrelated `.gitignore` edit into a dependency bump.

921 tests pass; `composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)