### PR TITLE
feat(api): explain why a write request will not route

### DIFF
--- a/plugins/webservices/proclaim/src/Extension/Proclaim.php
+++ b/plugins/webservices/proclaim/src/Extension/Proclaim.php
@@ -18,6 +18,7 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\ApiRouter;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -153,6 +154,87 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
             if ($writable) {
                 $this->createWriteRoutes($router, "v1/proclaim/$resource", $resource);
             }
+        }
+
+        $this->explainUnroutableRequest();
+    }
+
+    /**
+     * Say why the current request will not match a route, if it will not.
+     *
+     * A request the router cannot match gets a bare 404 with nothing indicating
+     * whether the endpoint was misspelled, deliberately absent, or read-only.
+     * That is the hardest kind of API problem to diagnose from the outside, and
+     * the answer is known right here.
+     *
+     * DEBUG level, so it costs nothing in production and appears as soon as an
+     * administrator turns debug on to find out why their client is failing. This
+     * deliberately does not care who is calling — it is diagnosing the API, not
+     * policing it, and it runs before authentication anyway.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function explainUnroutableRequest(): void
+    {
+        $method = strtoupper($this->getApplication()->getInput()->getMethod());
+
+        if (!\in_array($method, ['POST', 'PATCH', 'PUT', 'DELETE'], true)) {
+            return;
+        }
+
+        // Match the resource segment of a Proclaim API path, whatever the site's
+        // base URI or whether index.php is present.
+        if (preg_match('#/v1/proclaim/([a-z0-9_-]+)#i', $this->currentPath(), $m) !== 1) {
+            return;
+        }
+
+        $resource = strtolower($m[1]);
+
+        if (!\array_key_exists($resource, self::RESOURCES)) {
+            CwmlogHelper::debug(
+                \sprintf(
+                    '%s /v1/proclaim/%s will 404: no such Proclaim API resource. Available: %s.',
+                    $method,
+                    $resource,
+                    implode(', ', array_keys(self::RESOURCES))
+                ),
+                CwmlogHelper::CATEGORY_API
+            );
+
+            return;
+        }
+
+        if (self::RESOURCES[$resource] === false) {
+            CwmlogHelper::debug(
+                \sprintf(
+                    '%s /v1/proclaim/%s will 404: this resource is read-only by design, so no write'
+                    . ' route is registered. See the RESOURCES constant for why.',
+                    $method,
+                    $resource
+                ),
+                CwmlogHelper::CATEGORY_API
+            );
+        }
+    }
+
+    /**
+     * The requested path, or an empty string if it cannot be determined.
+     *
+     * Uri::getInstance() is what ApiRouter itself uses to resolve the route, so
+     * this sees the same value the router will.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function currentPath(): string
+    {
+        try {
+            return (string) urldecode(Uri::getInstance()->getPath());
+        } catch (\Throwable) {
+            return '';
         }
     }
 

--- a/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
+++ b/tests/unit/Admin/Api/Controller/WebservicesPluginTest.php
@@ -171,4 +171,82 @@ class WebservicesPluginTest extends ProclaimTestCase
             'createWriteRoutes() must remain guarded by the $writable flag'
         );
     }
+
+    /**
+     * Unroutable write requests are explained, at DEBUG.
+     *
+     * A request the router cannot match gets a bare 404 with nothing saying
+     * whether the endpoint was misspelled, absent, or read-only — the hardest
+     * kind of API problem to diagnose from outside, and the answer is known in
+     * the plugin. DEBUG keeps it free in production; CwmlogHelper::debug() is a
+     * no-op unless debug mode is on.
+     */
+    public function testUnroutableWritesAreExplainedAtDebugLevel(): void
+    {
+        $ref    = new \ReflectionMethod(Proclaim::class, 'explainUnroutableRequest');
+        $lines  = \array_slice(
+            file($ref->getFileName()),
+            $ref->getStartLine() - 1,
+            $ref->getEndLine() - $ref->getStartLine() + 1
+        );
+        $source = implode('', $lines);
+
+        // DEBUG only — never info/warning/error, which would record in production.
+        $this->assertStringContainsString('CwmlogHelper::debug(', $source);
+
+        foreach (['info', 'warning', 'error'] as $louder) {
+            $this->assertStringNotContainsString(
+                'CwmlogHelper::' . $louder . '(',
+                $source,
+                "Route diagnostics must stay at DEBUG, not {$louder}"
+            );
+        }
+
+        // Both failure modes are distinguished for the reader.
+        $this->assertStringContainsString('no such Proclaim API resource', $source);
+        $this->assertStringContainsString('read-only by design', $source);
+    }
+
+    /**
+     * Only write verbs are explained. A GET that 404s is a missing record, which
+     * the response already conveys.
+     */
+    public function testOnlyWriteVerbsAreExplained(): void
+    {
+        $ref    = new \ReflectionMethod(Proclaim::class, 'explainUnroutableRequest');
+        $lines  = \array_slice(
+            file($ref->getFileName()),
+            $ref->getStartLine() - 1,
+            $ref->getEndLine() - $ref->getStartLine() + 1
+        );
+        $source = implode('', $lines);
+
+        foreach (['POST', 'PATCH', 'PUT', 'DELETE'] as $verb) {
+            $this->assertStringContainsString("'$verb'", $source, "$verb should be explained");
+        }
+
+        $this->assertStringNotContainsString("'GET'", $source, 'GET should not be explained');
+    }
+
+    /**
+     * A writable resource must not be explained — its write route exists, so a
+     * failure there is authentication or validation, not routing. Guards against
+     * the diagnostic misattributing a 401 as a routing problem.
+     */
+    public function testWritableResourcesAreNotExplained(): void
+    {
+        $ref    = new \ReflectionMethod(Proclaim::class, 'explainUnroutableRequest');
+        $lines  = \array_slice(
+            file($ref->getFileName()),
+            $ref->getStartLine() - 1,
+            $ref->getEndLine() - $ref->getStartLine() + 1
+        );
+        $source = preg_replace('/\s+/', ' ', implode('', $lines));
+
+        $this->assertMatchesRegularExpression(
+            '/self::RESOURCES\[\$resource\] === false/',
+            $source,
+            'Only resources flagged read-only should be explained'
+        );
+    }
 }


### PR DESCRIPTION
Closes #1322.

A write aimed at a read-only resource — or at one that doesn't exist — returned a bare **404 with nothing indicating which**. From outside you can't tell a typo from a deliberate omission. The plugin knows the answer at the moment it decides not to register the route, so it now says so:

```
POST /v1/proclaim/servers will 404: this resource is read-only by design, so no
write route is registered. See the RESOURCES constant for why.

DELETE /v1/proclaim/templatecodes will 404: no such Proclaim API resource.
Available: sermons, teachers, series, podcasts, media, topics, locations,
messagetypes, playlists, comments, servers, templates.
```

**DEBUG level** — free in production, appears the moment an administrator turns debug on to find out why a client is failing.

## Why not the other two options in the issue

**Registering the write routes and refusing in the controller** would have let `AbstractReadOnlyController`'s existing refusal logging fire. But it means registering routes for resources that must never be writable — trading the clearest expression of the policy for a log line — and it changes what an unauthenticated caller sees from 404 to 401.

**Logging identity** was considered and dropped. Authentication happens *after* routing (`ApiApplication::route()` parses the route, then calls `login()` at line 291), so there's no identity at this point. More to the point, per your steer: this diagnoses the API rather than policing it. Whether a misconfigured client is authenticated isn't the question being asked.

## Scope

Only **write verbs** — a GET that 404s is a missing record and the response already says so.

Only resources flagged read-only, or absent from the registry. A writable resource has its write route, so a failure there is authentication or validation; attributing that to routing would actively mislead.

## Verified on a clean install

| request | result | explained? |
|---|---|---|
| `POST /servers` (read-only) | 404 | ✅ "read-only by design" |
| `DELETE /templatecodes` (absent) | 404 | ✅ lists available resources |
| `POST /topics` (writable) | 401 | ❌ correctly silent — auth failure, not routing |

That third row is the negative control, and the one worth having: it proves the diagnostic doesn't misattribute an auth problem as a routing problem.

With debug **off**, three read-only write attempts produced **no log file at all**.

924 tests pass; `composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)