### PR TITLE
chore: bump active_development to 10.3.5 for next cycle

### DIFF
--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.3.4",
+        "version": "10.3.5",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {


### PR DESCRIPTION
Post-release housekeeping after v10.3.4.

`cwm-release` sets `versions.json` `current` but leaves `active_development` at the version just shipped. Left alone, the next cycle's SQL migration filenames and any explicit `@since` tags would target **10.3.4** — a version already released, where a migration file gets skipped entirely by the `prefix.version <= installed.version` rule. That's the silent-skip failure documented in the wiki's Database Schema notes.

New code should keep using `@since __DEPLOY_VERSION__` regardless; this is for the places that need a concrete next version.

Matches what the wiki already advertises after `composer release:wiki`:

```
| Development | 10.3.5 | - | 5.1+ / 6.0 | 8.3.0+ |
```

Single-line change:

```diff
     "active_development": {
-        "version": "10.3.4",
+        "version": "10.3.5",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)