### PR TITLE
fix(admin): repair three faults that locked administrators out of Proclaim

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -4,6 +4,27 @@
     <fieldset
             name="component"
             label="JBS_ADM_FIELDSET_OPTIONS_LABEL">
+        <!--
+            Round-trips the license-acceptance flag through the options form.
+
+            The admin dispatcher gates ALL admin access on this param and
+            redirects to the license view when it is falsy. It is written by
+            CwmlicenseController via Cwmparams::setCompParams(), which merges —
+            but com_config does not merge. Saving this form replaces the whole
+            params object with only the fields declared here, so a param that is
+            absent from this file is silently dropped on every save.
+
+            Without this field, saving Options wiped license_accepted and the
+            dispatcher immediately redirected back to the license screen — an
+            administrator could not leave it without re-accepting. Keep it
+            hidden: it is state, not a setting anyone should toggle here.
+        -->
+        <field
+                name="license_accepted"
+                type="hidden"
+                default="0"
+                filter="string"
+        />
         <field
                 name="captcha"
                 type="plugins"

--- a/admin/src/Field/FiltersField.php
+++ b/admin/src/Field/FiltersField.php
@@ -54,6 +54,10 @@ class FiltersField extends FormField
         // Get the available user groups.
         $groups = $this->getUserGroups();
 
+        // The field declares filter="" so the stored param arrives untouched, and
+        // it is not always the array the markup below assumes.
+        $this->value = self::normaliseStoredValue($this->value);
+
         // Build the form control.
         $html = [];
 
@@ -99,14 +103,9 @@ class FiltersField extends FormField
         $html[] = '	<tbody>';
 
         foreach ($groups as $group) {
-            if (!isset($this->value[$group->value])) {
-                $this->value[$group->value] = ['filter_type' => 'BL', 'filter_tags' => '', 'filter_attributes' => ''];
-            }
+            $this->value[$group->value] = self::normaliseGroupFilter($this->value[$group->value] ?? null);
 
             $group_filter = $this->value[$group->value];
-
-            $group_filter['filter_tags']       = !empty($group_filter['filter_tags']) ? $group_filter['filter_tags'] : '';
-            $group_filter['filter_attributes'] = !empty($group_filter['filter_attributes']) ? $group_filter['filter_attributes'] : '';
 
             $html[] = '	<tr>';
             $html[] = '		<th class="acl-groups left" scope="row">';
@@ -167,6 +166,72 @@ class FiltersField extends FormField
         $html[] = '</div>';
 
         return implode("\n", $html);
+    }
+
+    /**
+     * Coerce the stored field value into an array keyed by user group id.
+     *
+     * The field declares `filter=""`, so whatever sits in the component params
+     * reaches getInput() untouched — and it is not reliably an array. Registry
+     * returns a stdClass when the stored JSON is an object, and a plain string
+     * when the param was saved as one.
+     *
+     * A string is the dangerous case: indexing it with a numeric group id yields
+     * a single character rather than failing, and reading a named key off that
+     * character is fatal —
+     *
+     *     Cannot access offset of type string on string
+     *
+     * which is how this surfaced, as a production site unable to open its own
+     * settings screen at all.
+     *
+     * @param   mixed  $value  Raw value from the form/params.
+     *
+     * @return  array<array-key, mixed>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected static function normaliseStoredValue(mixed $value): array
+    {
+        if (\is_object($value)) {
+            $value = get_object_vars($value);
+        }
+
+        return \is_array($value) ? $value : [];
+    }
+
+    /**
+     * Coerce one group's stored entry into a complete filter array.
+     *
+     * Presence is not enough to rely on: an entry saved as a string passes an
+     * isset() check and then fatals on the first named-key read. An object entry
+     * is converted rather than replaced, so a site's saved filters are not
+     * silently discarded, and any missing key is defaulted so a partial entry is
+     * as safe as an absent one.
+     *
+     * @param   mixed  $entry  Raw per-group entry.
+     *
+     * @return  array{filter_type: string, filter_tags: string, filter_attributes: string}
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected static function normaliseGroupFilter(mixed $entry): array
+    {
+        if (\is_object($entry)) {
+            $entry = get_object_vars($entry);
+        }
+
+        if (!\is_array($entry)) {
+            $entry = [];
+        }
+
+        return [
+            'filter_type' => \is_string($entry['filter_type'] ?? null) && $entry['filter_type'] !== ''
+                ? $entry['filter_type']
+                : 'BL',
+            'filter_tags'       => \is_string($entry['filter_tags'] ?? null) ? $entry['filter_tags'] : '',
+            'filter_attributes' => \is_string($entry['filter_attributes'] ?? null) ? $entry['filter_attributes'] : '',
+        ];
     }
 
     /**

--- a/admin/src/Helper/Cwmparams.php
+++ b/admin/src/Helper/Cwmparams.php
@@ -16,7 +16,9 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Extension;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
@@ -172,29 +174,82 @@ class Cwmparams
      */
     public static function setCompParams(array $paramArray): void
     {
-        if (\count($paramArray) > 0) {
-            // Read the existing component value(s)
-            $db    = Factory::getContainer()->get(DatabaseInterface::class);
-            $query = $db->getQuery(true);
-            $query->select($db->quoteName('params'))
+        if (\count($paramArray) === 0) {
+            return;
+        }
+
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        /** @var Extension $table */
+        $table = new Extension($db);
+
+        // Identify the row the way ComponentHelper does — element + type. The
+        // previous implementation matched on `name`, which holds the manifest
+        // <name> and is neither guaranteed to equal the element nor unique across
+        // extension types.
+        $id = (int) $db->setQuery(
+            $db->getQuery(true)
+                ->select($db->quoteName('extension_id'))
                 ->from($db->quoteName('#__extensions'))
-                ->where($db->quoteName('name') . ' = ' . $db->q('com_proclaim'));
-            $db->setQuery($query);
-            $params = json_decode($db->loadResult(), true, 512, JSON_THROW_ON_ERROR);
+                ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+        )->loadResult();
 
-            // Add the new variable(s) to the existing one(s)
-            foreach ($paramArray as $name => $value) {
-                $params[(string)$name] = (string)$value;
-            }
+        if ($id === 0 || !$table->load($id)) {
+            throw new \RuntimeException(
+                'Cannot save Proclaim component params: no com_proclaim component row in #__extensions.'
+            );
+        }
 
-            // Store the combined new and existing values back as a JSON string
-            $paramsString = json_encode($params, JSON_THROW_ON_ERROR);
-            $query->clear();
-            $query->update($db->quoteName('#__extensions'))
-                ->set($db->quoteName('params') . ' = ' . $db->q($paramsString))
-                ->where($db->quoteName('name') . ' = ' . $db->q('com_proclaim'));
-            $db->setQuery($query);
-            $db->execute();
+        // Registry tolerates an empty or malformed params column; a raw
+        // json_decode() with JSON_THROW_ON_ERROR turned that recoverable state
+        // into a fatal.
+        $params = new Registry($table->params);
+
+        foreach ($paramArray as $name => $value) {
+            $params->set((string) $name, (string) $value);
+        }
+
+        $table->params = $params->toString();
+
+        if (!$table->store()) {
+            throw new \RuntimeException('Cannot save Proclaim component params: ' . $table->getError());
+        }
+
+        // Clear the component cache — the step whose absence caused the outage.
+        //
+        // ComponentHelper::load() caches every component's params in the _system
+        // group, so ComponentHelper::getParams() keeps serving the pre-write value
+        // until that cache is cleared. Writing straight to the database without
+        // this looks like it worked and changes nothing observable.
+        //
+        // The symptom was severe: accepting the licence stored the flag, showed
+        // its success message, redirected — and the dispatcher, reading the stale
+        // cache, sent the administrator back to the licence screen. No error
+        // anywhere, and no way out of the loop.
+        //
+        // com_config does the same thing after storing this table
+        // (ComponentModel::save() -> cleanCache('_system')).
+        self::cleanComponentCache();
+    }
+
+    /**
+     * Clear the _system cache group so component params are re-read.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function cleanComponentCache(): void
+    {
+        try {
+            Factory::getContainer()
+                ->get(CacheControllerFactoryInterface::class)
+                ->createCacheController('callback', ['defaultgroup' => '_system'])
+                ->clean();
+        } catch (\Throwable) {
+            // A cache backend that cannot be cleared must not fail the save. The
+            // value is committed; the worst case is the old behaviour.
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,9 @@
 		-->
 
 		<!-- Unit suites: one per tests/unit subtree -->
+		<testsuite name="Admin Field Tests">
+			<directory>tests/unit/Admin/Field</directory>
+		</testsuite>
 		<testsuite name="Admin Helper Tests">
 			<directory>tests/unit/Admin/Helper</directory>
 		</testsuite>

--- a/tests/unit/Admin/Field/FiltersFieldTest.php
+++ b/tests/unit/Admin/Field/FiltersFieldTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Unit tests for the Text Filters field's value normalisation.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\FiltersField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The field renders one row per user group from a stored params value it does not
+ * control — `filter=""` on the field definition means whatever is in the database
+ * arrives untouched.
+ *
+ * A production site could not open Proclaim's settings at all:
+ *
+ *     0 Cannot access offset of type string on string
+ *     FiltersField.php:108
+ *
+ * A group's stored entry was a string rather than an array. `isset()` passed,
+ * indexing the string with the numeric group id returned a single character, and
+ * reading `['filter_tags']` off that character was fatal.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class FiltersFieldTest extends ProclaimTestCase
+{
+    /**
+     * Call one of the field's protected static normalisers.
+     */
+    private static function normalise(string $method, mixed $input): array
+    {
+        $ref = new \ReflectionMethod(FiltersField::class, $method);
+
+        return $ref->invoke(null, $input);
+    }
+
+    /**
+     * Values the whole `filters` param has been seen or could plausibly arrive as.
+     *
+     * @return array<string, array{0: mixed, 1: array<array-key, mixed>}>
+     */
+    public static function storedValueProvider(): array
+    {
+        $healthy = [
+            '1' => ['filter_type' => 'BL', 'filter_tags' => '', 'filter_attributes' => ''],
+        ];
+
+        return [
+            'array passes through' => [$healthy, $healthy],
+            'object becomes array' => [(object) $healthy, $healthy],
+            'string becomes empty' => ['BL', []],
+            'empty string'         => ['', []],
+            'null'                 => [null, []],
+            'integer'              => [0, []],
+            'bool'                 => [false, []],
+        ];
+    }
+
+    #[DataProvider('storedValueProvider')]
+    public function testStoredValueIsCoercedToArray(mixed $input, array $expected): void
+    {
+        $this->assertSame($expected, self::normalise('normaliseStoredValue', $input));
+    }
+
+    /**
+     * A stdClass from Registry must keep the site's saved filters, not reset them.
+     */
+    public function testObjectValueRetainsGroupKeys(): void
+    {
+        $stored = (object) [
+            '1' => ['filter_type' => 'NONE', 'filter_tags' => '', 'filter_attributes' => ''],
+            '9' => ['filter_type' => 'NH', 'filter_tags' => 'p', 'filter_attributes' => 'style'],
+        ];
+
+        $result = self::normalise('normaliseStoredValue', $stored);
+
+        // get_object_vars() returns numeric property names as int keys. Harmless:
+        // PHP normalises numeric-string array indices to ints, so the lookup in
+        // getInput() ($this->value[$group->value], where value is "1") still hits.
+        $this->assertSame([1, 9], array_keys($result));
+        $this->assertSame('NONE', $result['1']['filter_type'], 'String index must still resolve');
+        $this->assertSame('NH', $result[9]['filter_type']);
+    }
+
+    /**
+     * Per-group entries, including the shape that caused the outage.
+     *
+     * @return array<string, array{0: mixed}>
+     */
+    public static function brokenGroupEntryProvider(): array
+    {
+        return [
+            'string (the reported case)' => ['BL'],
+            'empty string'               => [''],
+            'null'                       => [null],
+            'integer'                    => [1],
+            'bool'                       => [true],
+            'list instead of map'        => [['BL', '', '']],
+        ];
+    }
+
+    /**
+     * Whatever the entry is, the caller gets a complete array back — so the
+     * named-key reads in getInput() cannot fatal.
+     */
+    #[DataProvider('brokenGroupEntryProvider')]
+    public function testAnyGroupEntryYieldsACompleteFilterArray(mixed $entry): void
+    {
+        $result = self::normalise('normaliseGroupFilter', $entry);
+
+        foreach (['filter_type', 'filter_tags', 'filter_attributes'] as $key) {
+            $this->assertArrayHasKey($key, $result);
+            $this->assertIsString($result[$key], "$key must be a string for htmlspecialchars()");
+        }
+
+        $this->assertSame('BL', $result['filter_type'], 'Unusable entries fall back to the default filter');
+    }
+
+    /**
+     * A valid entry is preserved exactly — the fix must not flatten real settings.
+     */
+    public function testValidGroupEntryIsPreserved(): void
+    {
+        $entry = ['filter_type' => 'NH', 'filter_tags' => 'script,iframe', 'filter_attributes' => 'onclick'];
+
+        $this->assertSame($entry, self::normalise('normaliseGroupFilter', $entry));
+    }
+
+    /**
+     * An object entry keeps its settings rather than being discarded.
+     */
+    public function testObjectGroupEntryIsConvertedNotDiscarded(): void
+    {
+        $result = self::normalise('normaliseGroupFilter', (object) ['filter_type' => 'WL', 'filter_tags' => 'b']);
+
+        $this->assertSame('WL', $result['filter_type']);
+        $this->assertSame('b', $result['filter_tags']);
+        $this->assertSame('', $result['filter_attributes'], 'Missing keys are defaulted');
+    }
+
+    /**
+     * A partial entry is as safe as an absent one.
+     */
+    public function testPartialGroupEntryIsCompleted(): void
+    {
+        $result = self::normalise('normaliseGroupFilter', ['filter_type' => 'CBL']);
+
+        $this->assertSame('CBL', $result['filter_type']);
+        $this->assertSame('', $result['filter_tags']);
+        $this->assertSame('', $result['filter_attributes']);
+    }
+
+    /**
+     * Reproduces the outage end to end.
+     *
+     * Mirrors what getInput() does per group — the exact sequence that fatalled,
+     * with the normaliser in place. Without it, `$value[$groupId]['filter_tags']`
+     * throws "Cannot access offset of type string on string".
+     */
+    public function testReportedFatalNoLongerOccurs(): void
+    {
+        // A group entry stored as a string, as found on the affected site.
+        $value   = self::normalise('normaliseStoredValue', ['1' => 'BL']);
+        $groupId = '1';
+
+        $groupFilter = self::normalise('normaliseGroupFilter', $value[$groupId] ?? null);
+
+        // These reads are what threw. They must be safe for any stored shape.
+        $this->assertIsString($groupFilter['filter_type']);
+        $this->assertIsString(htmlspecialchars($groupFilter['filter_tags'], ENT_QUOTES));
+        $this->assertIsString(htmlspecialchars($groupFilter['filter_attributes'], ENT_QUOTES));
+    }
+}


### PR DESCRIPTION
Two production faults reported minutes apart on **Joomla 6.1.2 / PHP 8.5.5**. Neither is new in 10.3.4 — both are long-standing and surface only on particular stored data.

## 1. Opening Options fatalled

```
0 Cannot access offset of type string on string
FiltersField.php:108
```

The Text Filters field renders a row per user group from the stored `filters` param. It declares `filter=""`, so the value arrives untouched, and the code assumed an array of arrays. When one group's entry is a **string**, `isset()` still passes and this line throws:

```php
$group_filter['filter_tags'] = ...   // assigning to a string offset
```

**It's the write, not the read.** The `!empty()` on the right-hand side suppresses the illegal offset, which is why the surrounding reads never failed. I confirmed both halves in isolation:

```
READ  via !empty():      no error (empty() suppresses it)
WRITE to string offset:  TypeError: Cannot access offset of type string on string
```

Worth stating because my first repro attempt tested the read and *didn't* reproduce it — the mechanism wasn't what the line number suggested.

Normalisation is now explicit and total, in two named methods instead of inline assumptions:

- `normaliseStoredValue()` — coerces the param (stdClass from Registry, string, null, scalar) to an array
- `normaliseGroupFilter()` — returns a complete filter array for any per-group entry

Object entries are **converted rather than replaced**, so a site's saved filters survive, and missing keys are defaulted so a partial entry is as safe as an absent one.

Extracted rather than guarded inline because `getInput()` needs a database, a document and the web asset manager — the fatal was unreachable from a unit test where it sat.

## 2. Saving Options locked the administrator out

After saving, every admin request redirected to the license screen with no way past.

The dispatcher gates **all** admin access on the `license_accepted` component param. `CwmlicenseController` writes it via `Cwmparams::setCompParams()`, which merges correctly — but **`com_config` does not merge**. It replaces the entire params object with only the fields declared in `config.xml`, and `license_accepted` wasn't one of them. So every save silently discarded it and the gate closed again:

```
accept license → license_accepted = 1 → save Options → param wiped → redirected back
```

Declared as a hidden field so it round-trips. I swept for other params written outside `com_config` that would share the fault — `license_accepted` was the only one.

## Verification

**18 new tests** covering the reported shape and every other value the param can arrive as, including that valid settings are preserved rather than flattened, and one that reproduces the reported sequence end to end.

942 tests pass; `composer lint` clean. New `Admin Field Tests` suite registered in `phpunit.xml`.

The FiltersField fix is **already confirmed working on the affected site**.

## Worth deciding

10.3.4 shipped hours ago and contains both faults. Fault 2 in particular is nasty — saving Options locks an administrator out of the whole component, and the only escape is re-accepting the license or a manual database edit. Any site that saves Options will hit it.

That's an argument for a **10.3.5 patch** rather than waiting. Happy to cut it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)