### PR TITLE
chore: bump active_development to 10.3.6

### DIFF
--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.3.5",
+        "version": "10.3.6",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {


### PR DESCRIPTION
Post-release housekeeping after v10.3.5, needed before cutting 10.3.6.

`cwm-release` sets `current` but leaves `active_development` at the version just shipped — both read 10.3.5. The release harness derives the version it builds and asserts from `active_development`, so it has to lead `current` before `composer test:release` runs, or the gate verifies a build labelled with the previous release.

Single line:

```diff
     "active_development": {
-        "version": "10.3.5",
+        "version": "10.3.6",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)