### PR TITLE
chore: bump active_development to 10.3.7

### DIFF
--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.3.6",
+        "version": "10.3.7",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {


### PR DESCRIPTION
Post-release housekeeping after v10.3.6.

`cwm-release` sets `current` but leaves `active_development` at the version just shipped. The release harness derives the version it builds and asserts from `active_development`, so it needs to lead `current` before the next gate run.

Recurring manual step — tracked as a gap in the release tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)