### PR TITLE
docs(release): user-facing 10.3.6 notes, wired into the release pipeline

### DIFF
--- a/build/release-bullets-10.3.6.txt
+++ b/build/release-bullets-10.3.6.txt
@@ -1,0 +1,9 @@
+The REST API now works. On every earlier 10.3.x release it returned "not found" on every address, on every site — so if you tried it and gave up, that was not your configuration.
+Turning it on is one step: enable the "Web Services - Proclaim" plugin under System, Plugins. There is no separate Proclaim setting to hunt for.
+Reads require an API token by default. If you want an open read-only feed, switch on "Allow public reads" in that same plugin. Creating, updating and deleting always require a token either way.
+Twelve kinds of content are available: sermons, teachers, series, podcasts, media files, topics, locations and study types can be read and written; playlists, comments, servers and templates are read-only on purpose.
+Nothing is exposed that a visitor could not already see. Every response is limited to the access levels of whoever is asking, so restricted content stays restricted. Media-server credentials and commenter email addresses are never returned to anyone.
+Changes made through the API are recorded in Joomla's Action Logs alongside changes made in the admin, each marked with where it came from, so an audit shows both together.
+Fixed: Proclaim's Options screen could fail to open with a "Cannot access offset" error, depending on how a site's text-filter settings were stored.
+Fixed: saving Options could lock you out of Proclaim entirely, sending you back to the licence screen no matter how many times you accepted it. Sites already stuck can clear the Joomla cache and accept once more.
+Upgrading from 10.3.4 or 10.3.5 is recommended for every site — both faults above affect the admin, and the API is unusable before this release.

--- a/build/release-notes-10.3.6.md
+++ b/build/release-notes-10.3.6.md
@@ -1,0 +1,33 @@
+Proclaim's REST API works in this release. On every earlier 10.3.x release it
+returned "not found" at every address, on every site — so if you tried it and
+gave up, that was not your configuration.
+
+**Upgrading is recommended for every site.** Two admin faults below could stop
+you reaching Proclaim's settings at all.
+
+## The REST API
+
+* **Turning it on is one step** — enable the *Web Services - Proclaim* plugin
+  under **System → Plugins**. There is no separate Proclaim setting to hunt for.
+* **Reads need an API token by default.** If you want an open, read-only feed,
+  switch on *Allow public reads* in that same plugin. Creating, updating and
+  deleting always require a token either way.
+* **Twelve kinds of content are available.** Sermons, teachers, series,
+  podcasts, media files, topics, locations and study types can be read and
+  written. Playlists, comments, servers and templates are read-only on purpose.
+* **Nothing is exposed that the caller could not already see.** Every response
+  is limited to the access levels of whoever is asking, so restricted content
+  stays restricted. Media-server credentials and commenter email addresses are
+  never returned to anyone.
+* **Changes are recorded.** Edits made through the API appear in Joomla's Action
+  Logs alongside edits made in the admin, each marked with where it came from,
+  so an audit shows both together.
+
+## Fixed
+
+* Proclaim's **Options** screen could fail to open with a *"Cannot access offset
+  of type string on string"* error, depending on how a site's text-filter
+  settings were stored.
+* Saving **Options** could lock you out of Proclaim entirely, returning you to
+  the licence screen no matter how many times you accepted it. A site already
+  stuck can clear the Joomla cache and accept once more.

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -170,6 +170,9 @@
         "bulletsDir": "build",
         "command": "cwm-article"
     },
+    "release": {
+        "notesFile": "build/release-notes-{version}.md"
+    },
     "dev": {
         "deriveLinks": true
     },


### PR DESCRIPTION
Follows the report that the changelog link lands on a page showing only PR titles as unrendered Markdown.

## What was wrong

The 10.3.6 download page — where Joomla's update link sends site administrators — showed its entire changelog as:

> \#\# What's Changed \* fix(api): make the API switchable — drop api_access for the plugin's own state by @bcordis in https://... \*\*Full Changelog\*\*: https://...

Two separate problems: ARS renders `notes` as HTML so the Markdown stayed literal and collapsed onto one line (fixed in [cwm-build-tools#35](https://github.com/Joomla-Bible-Study/cwm-build-tools/pull/35)), and the content was GitHub's auto-generated PR titles, which are written for us rather than for the person deciding whether to update.

## This PR

- **`build/release-notes-10.3.6.md`** — notes written for the reader: the API works now, the plugin is the switch, reads need a token unless public reads are on, twelve resources, nothing exposed beyond the caller's access levels, and the two admin faults that make upgrading worth doing.
- **`release.notesFile`** in `cwm-build.config.json`, pointing at `build/release-notes-{version}.md`. `cwm-release` now picks the notes up automatically for both the GitHub release and the ARS page, with the generated PR list kept beneath them. Older cwm-build-tools ignore the key.
- **`build/release-bullets-10.3.6.txt`** — the announcement source, same convention as 10.3.1.

## Already applied

The live 10.3.6 ARS notes have been republished from this file; the download page now serves proper headings and lists, with no literal Markdown left on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq