### PR TITLE
chore(deps): require cwm/build-tools ^1.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.7.0",
+    "cwm/build-tools": "^1.8.0",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be754bb7261e87a9eb3b7e1f035a7997",
+    "content-hash": "d0f5e2d7413fd7a30efe1b412b7310ee",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "7ed575f83469bf7a2017aa80a1e05b4746270f81"
+                "reference": "71fdf2eaa10195225da1700709c07fb3b333a7a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/7ed575f83469bf7a2017aa80a1e05b4746270f81",
-                "reference": "7ed575f83469bf7a2017aa80a1e05b4746270f81",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/71fdf2eaa10195225da1700709c07fb3b333a7a0",
+                "reference": "71fdf2eaa10195225da1700709c07fb3b333a7a0",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.7.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-26T20:58:33+00:00"
+            "time": "2026-07-26T23:38:31+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.8.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.8.0).

## Why this matters now

`release.notesFile` landed in `cwm-build.config.json` with #1334, but **v1.7.0 does not read it** — the key was inert. Without this bump, 10.3.7 would have published GitHub's list of PR titles as raw Markdown into ARS's HTML field, which is exactly the problem that started this.

## What v1.8.0 brings

- Release notes are converted to HTML before being sent to ARS, by `Release\ReleaseNotesFormatter`. Source is escaped before markup is added, so a GitHub release body cannot inject HTML into the site.
- `release.notesFile` is honoured by `cwm-release` for both the GitHub release and the ARS page, with the generated PR list kept beneath the hand-written notes.
- `cwm-ars-publish -n <file>` / `ARS_NOTES_FILE` — the flag used to correct the notes on the already-published 10.1.x–10.3.x releases.

## Verified

- Lockfile resolves `v1.8.0`; the vendored copy carries `render-notes.php` and `ReleaseNotesFormatter.php`
- Ran the **vendored** renderer against `build/release-notes-10.3.6.md` — it resolves its autoloader correctly from Proclaim's non-standard `libraries/vendor` path and emits the expected HTML
- Confirmed the `{version}` pattern resolves to the real 10.3.6 notes file
- Upstream suite: 247 tests, 681 assertions, green on the tagged commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq