### PR TITLE
chore(deps): require cwm/build-tools ^1.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.8.0",
+    "cwm/build-tools": "^1.8.1",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0f5e2d7413fd7a30efe1b412b7310ee",
+    "content-hash": "be1f98e0880601e3314556783672b957",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "71fdf2eaa10195225da1700709c07fb3b333a7a0"
+                "reference": "98c7706a5d6c8b852de3abfc9d02fe155c354370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/71fdf2eaa10195225da1700709c07fb3b333a7a0",
-                "reference": "71fdf2eaa10195225da1700709c07fb3b333a7a0",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/98c7706a5d6c8b852de3abfc9d02fe155c354370",
+                "reference": "98c7706a5d6c8b852de3abfc9d02fe155c354370",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-26T23:38:31+00:00"
+            "time": "2026-07-27T00:04:04+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.8.1](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.8.1).

## Why

`cwm-ars-publish`'s create-vs-update lookups sent JSON:API `filter[...]` syntax, which ARS ignores — it reads bare input keys (`category_id`, `search`, `release_id`). Combined with the 20-row default page cap, both lookups were matching against an arbitrary window of every release and item on the site. A miss takes the create branch → duplicate ARS release or duplicate download item, reported as success.

| Lookup | Before | After |
|---|---|---|
| release | 20 rows, all categories | **1 row** |
| item | 20 rows spanning 19 release_ids | **1 row** |

Not theoretical for us: Proclaim's category holds **31 releases** and the site **45 items**, both well past the cap. This was live exposure on the next release.

## Verified

- Lockfile resolves `v1.8.1`
- Vendored `ars-publish.sh` uses the bare-parameter queries; no `filter[...]` remains in either ARS script
- v1.8.0's notes rendering is still intact in the vendored copy (`render-notes.php`, `release.notesFile`)
- Upstream suite green on the tagged commit (247 tests, 681 assertions), and a full re-publish of 10.3.6 updated the existing release and item rather than creating duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq