### PR TITLE
chore(deps): require cwm/build-tools ^1.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.8.1",
+    "cwm/build-tools": "^1.8.2",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be1f98e0880601e3314556783672b957",
+    "content-hash": "65b37c433f02f3d516b8221668bd4cff",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.8.1",
+            "version": "v1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "98c7706a5d6c8b852de3abfc9d02fe155c354370"
+                "reference": "02679af74e959772e36f3cb2d06d8ddf1c8df7ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/98c7706a5d6c8b852de3abfc9d02fe155c354370",
-                "reference": "98c7706a5d6c8b852de3abfc9d02fe155c354370",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/02679af74e959772e36f3cb2d06d8ddf1c8df7ae",
+                "reference": "02679af74e959772e36f3cb2d06d8ddf1c8df7ae",
                 "shasum": ""
             },
             "require": {
@@ -646,10 +646,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.2",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-27T00:04:04+00:00"
+            "time": "2026-07-27T00:23:54+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.8.2](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.8.2).

## Why

`cwm-release` was committing whatever happened to be in the working tree. Three of its four `git add -A` calls sat behind a `git diff --quiet` guard, and those disagree — the guard inspects only *tracked* files, the action stages everything.

Steps 6 and 8 both run *after* the release is pushed, and two consequences are specific to how this repo releases:

- **Step 6 force-moves the tag onto its commit**, so anything swept in landed in the published tag.
- **Step 8's `git stash` doesn't take untracked files**, so they followed the checkout onto `development` and were committed there.

Each step now stages only the file it writes — the configured `changelog.file`, and the resolved `versionsJson` (`build/versions.json` here).

## Verified

- Lockfile resolves `v1.8.2`
- Vendored `release.sh` carries the explicit staging at all three sites; the only remaining `git add -A` is step 4, where the pre-check makes it safe
- v1.8.0's notes rendering and v1.8.1's ARS lookup fix are both still intact in the vendored copy
- Upstream suite green on the tagged commit (247 tests, 681 assertions); scratch-repo test confirms strays are no longer committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq