### PR TITLE
chore(deps): require cwm/build-tools ^1.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.8.2",
+    "cwm/build-tools": "^1.9.0",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65b37c433f02f3d516b8221668bd4cff",
+    "content-hash": "b628b29fadc077996c3cdf01bf2fa294",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.8.2",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "02679af74e959772e36f3cb2d06d8ddf1c8df7ae"
+                "reference": "368bcfed99427dfc39f1d4472b1feb069e84d4b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/02679af74e959772e36f3cb2d06d8ddf1c8df7ae",
-                "reference": "02679af74e959772e36f3cb2d06d8ddf1c8df7ae",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/368bcfed99427dfc39f1d4472b1feb069e84d4b9",
+                "reference": "368bcfed99427dfc39f1d4472b1feb069e84d4b9",
                 "shasum": ""
             },
             "require": {
@@ -625,7 +625,14 @@
             },
             "scripts": {
                 "test": [
+                    "@test:php",
+                    "@test:python"
+                ],
+                "test:php": [
                     "phpunit"
+                ],
+                "test:python": [
+                    "python3 -m unittest discover -s tests/python -v"
                 ]
             },
             "license": [
@@ -646,10 +653,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.8.2",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.9.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-27T00:23:54+00:00"
+            "time": "2026-07-27T11:11:44+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.9.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.9.0).

## Directly relevant here

**`composer vendor:check` now works.** It printed "✓ OK" for this repo while 11 dev dependencies were outdated (`npm outdated`'s exit-1-on-findings was treated as failure). It now also audits for advisories (GHSA ids, `--locked`), discovers and checks the three nested Composer projects — the YouTube addon, lib_cwmscripture, scripturelinks — and **fails closed** (exit 2, "treat as unknown, not clean") when an audit cannot run.

**`cwm-release` selects the artifact by version** rather than first glob match — the defect that shipped `pkg_proclaim-10.3.2.zip` as the 10.3.3 release. Clearing `build/dist` before releasing is no longer load-bearing.

## Verified

- Lockfile resolves v1.9.0; `scripts/lib/artifacts.sh` and the new vendor-check present in the vendored copy
- Ran the **vendored** vendor-check end to end against this repo: the 11 previously-hidden outdated dev deps are reported
- Upstream: 306 PHP + 25 Python + 11 shell tests green at the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq