### PR TITLE
docs(a11y): reference the filed upstream issue in the subform shim

### DIFF
--- a/build/media_source/js/subform-tooltip-a11y.es6.js
+++ b/build/media_source/js/subform-tooltip-a11y.es6.js
@@ -23,7 +23,9 @@
  * unreachable either way.
  *
  * Confirmed present in Joomla 5.4.7, 6.1.2, 6.2.0 and 7.0.0, and only in the
- * repeatable-table layout. Reported upstream; this runs until that lands.
+ * repeatable-table layout. Reported upstream as joomla/joomla-cms#48151
+ * (https://github.com/joomla/joomla-cms/issues/48151); this runs until that
+ * lands and the oldest supported Joomla carries it. Tracked in #1341.
  *
  * Chosen over overriding the layout in admin/layouts/. The override would mean
  * carrying a 125-line copy of a core file across four Joomla versions, going


### PR DESCRIPTION
Adds the [joomla/joomla-cms#48151](https://github.com/joomla/joomla-cms/issues/48151) reference to the shim's header, per the #1341 checklist — so whoever eventually deletes it knows where to check first. Comment-only change (built output re-generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151X65uy1t64SDgxwq7mXmq