### PR TITLE
test(a11y): scan the quick-icons module, and cite the filed upstream issues

### DIFF
--- a/build/media_source/js/modal-iframe-a11y.es6.js
+++ b/build/media_source/js/modal-iframe-a11y.es6.js
@@ -17,10 +17,17 @@
  * axe reports the result as `frame-title` (WCAG 4.1.2): a screen reader
  * announcing the frame has nothing to call it.
  *
+ * The root cause is the sanitizer allowlist in
+ * build/media_source/vendor/bootstrap/js/modal.es6.js —
+ * `iframe: ['src', 'name', 'width', 'height']` — which strips the title the
+ * layout set. Reported upstream as joomla/joomla-cms#48152
+ * (https://github.com/joomla/joomla-cms/issues/48152); this runs until that
+ * lands and the oldest supported Joomla carries it.
+ *
  * Seen on every Proclaim modal-picker field (e.g. the server-type selector on
  * the server form). The name attribute survives the trip, so the repair is to
  * copy it back into title. No-ops on iframes that already carry one, so this
- * retires silently if Joomla fixes the injection.
+ * retires silently the day the fix ships upstream.
  */
 (() => {
     /**

--- a/modules/site/mod_proclaim_podcast/tmpl/default.php
+++ b/modules/site/mod_proclaim_podcast/tmpl/default.php
@@ -28,6 +28,9 @@ $wa->useStyle('com_proclaim.podcast');
 
 ?>
 
-<div class="mod_proclaim_podcast">
+<?php // com-proclaim: the shared wrapper every Proclaim view and module carries —
+      // it scopes component styling AND is the region the WCAG scans include,
+      // so an unwrapped module is invisible to the accessibility gate. ?>
+<div class="com-proclaim mod_proclaim_podcast">
     <?php echo $list; ?>
 </div>

--- a/tests/e2e/admin/a11y.spec.js
+++ b/tests/e2e/admin/a11y.spec.js
@@ -25,7 +25,8 @@ const PROCLAIM_CONTENT = 'section#content';
  *                  and editor iframes with no title
  *   .cm-editor     CodeMirror 6 (Joomla's code editor plugin) renders its
  *                  contenteditable with role="textbox" and no accessible
- *                  name; the template-code form uses editor="codemirror"
+ *                  name; the template-code form uses editor="codemirror".
+ *                  Reported upstream as joomla/joomla-cms#48153
  *   .choices       the remove-button is under the 24x24 minimum of SC 2.5.8
  *
  * All are reported upstream. Excluded by selector rather than by disabling
@@ -148,4 +149,26 @@ test.describe('Admin accessibility (WCAG 2.2 AA) @a11y', () => {
             });
         });
     }
+
+    // mod_proclaimicon renders on Joomla's Home Dashboard, outside any
+    // com_proclaim view, so none of the scans above ever reach it. Scan the
+    // dashboard confined to the module's own nav — the rest of the dashboard
+    // is Joomla's. The site modules need no counterpart here: they wrap in
+    // .com-proclaim, so the site scans pick them up wherever they are
+    // published.
+    test('quick-icons module meets WCAG AA', async ({ page }) => {
+        await page.goto('/administrator/index.php', { waitUntil: 'networkidle' });
+
+        const module = page.locator('nav.quick-icons[aria-label*="Proclaim"]');
+
+        // Not published on this dashboard — nothing to scan, and axe errors
+        // on an include selector that matches nothing.
+        if (!(await module.count())) {
+            test.skip(true, 'mod_proclaimicon is not published on this dashboard');
+        }
+
+        await expectNoViolations(page, expect, {
+            include: 'nav.quick-icons[aria-label*="Proclaim"]',
+        });
+    });
 });


### PR DESCRIPTION
Follow-ups to #1348 on the #1339 checklist:

- **Module coverage**: new admin scan for `mod_proclaimicon` on the Home Dashboard, confined to the module's own nav (skips when unpublished). The three site modules are covered by the existing site scans because they wrap in `.com-proclaim` — `mod_proclaim_podcast` gains that wrapper here, which it was missing (it was also unpublished on j6-dev; now published and scanning clean).
- **Upstream reports filed and cited in-code**:
  - [joomla-cms#48152](https://github.com/joomla/joomla-cms/issues/48152) — `modal.es6.js` sanitizer allowlist (`['src','name','width','height']`) strips the iframe `title` the PHP layout set; cited in the modal-iframe shim with the same retirement plan as the subform shim.
  - [joomla-cms#48153](https://github.com/joomla/joomla-cms/issues/48153) — Joomla's CodeMirror integration never wires the replaced textarea's label to the editing surface; cited on the `.cm-editor` exclusion.

Suite: **48 passed, 2 data-dependent skips, 0 failed** (2.0m).

Remaining on #1339 after this: SC 2.5.7 dragging alternatives, and the lib_cwmscripture / scripturelinks scan-ownership decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR