### PR TITLE
fix(e2e): retry logins, authenticate only the sites in play, reuse sessions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Api Tests,Integration Admin Table Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",
-    "test:a11y": "npx playwright test --grep @a11y",
+    "test:a11y": "npx playwright test --grep @a11y --project=admin-j6 --project=site-j6",
     "test:all": ["@test", "@test:js"],
     "test:reset-testsite": "@php build/reset-testsite.php",
     "test:migrations": "@php build/verify-migrations.php",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,84 @@
+# Proclaim E2E suite
+
+Browser tests (Playwright) covering the admin and site halves of the
+component, including the WCAG 2.2 AA accessibility gate. They run against
+**real local Joomla installs**, not fixtures — which is why they are not in
+CI (nothing there to point them at) and instead gate releases via
+`composer test:release`.
+
+## Prerequisites
+
+1. **Two dev sites**, a Joomla 5 and a Joomla 6 install with Proclaim
+   deployed (symlinked via `composer symlink` is the usual arrangement).
+2. **`build.properties`** in the repo root (gitignored; copy
+   `build.dist.properties` and fill in):
+
+   ```properties
+   builder.j5dev.url      = https://j5-dev.local:8890
+   builder.j5dev.username = admin
+   builder.j5dev.password = …
+   builder.j6dev.url      = https://j6-dev.local:8890
+   builder.j6dev.username = admin
+   builder.j6dev.password = …
+   # or a shared fallback for both:
+   builder.joomla_username = admin
+   builder.joomla_password = …
+   ```
+
+3. **Playwright's Chromium** — one-time:
+
+   ```bash
+   npx playwright install chromium
+   ```
+
+   The suite runs real Chromium in new headless mode (`channel: 'chromium'`),
+   not `chrome-headless-shell`: the accessibility rules `color-contrast` and
+   `target-size` measure rendered output, and a pass from a renderer users
+   don't run is a weak basis for a conformance claim.
+
+## Running
+
+```bash
+composer test:e2e     # everything, all four projects (admin/site × J5/J6)
+composer test:a11y    # WCAG 2.2 AA scans only — J6 projects only
+npx playwright test --project=admin-j6        # one project
+npx playwright test --ui                      # interactive debugging
+npm run test:e2e:report                       # open the last HTML report
+```
+
+The a11y specs are J6-only by design (Proclaim renders identical markup on
+both platforms; J5 exists to catch Joomla-version behaviour differences,
+which the functional specs cover). `composer test:a11y` passes
+`--project=admin-j6 --project=site-j6` so a J5 hiccup can never block an
+accessibility run.
+
+## Authentication
+
+`global-setup.js` logs into the admin of each site **the selected projects
+actually use** and saves the session under `tests/e2e/.auth/` — only the
+`admin-*` projects consume a session; the `site-*` projects browse
+anonymously. A still-valid saved session is reused, and a login that does
+run is retried with backoff before it may fail the run (#1342).
+
+## Failure modes worth knowing
+
+- **"Page is an error page"** — the guard against scanning a Joomla error
+  page and calling it compliant. Usually a wrong view name in a spec or a
+  broken install.
+- **"PHP error output leaked into the page"** — a dev site with
+  `display_errors` printed a Deprecated/Warning/Fatal into the markup. That
+  is a real PHP bug in whatever rendered the page; fix it rather than the
+  test. (Twice these have surfaced as bogus "contrast violations" on
+  Xdebug's stack-trace tables.)
+- **Data-dependent skips** — detail views reached by clicking the first row
+  of a listing skip, not fail, on an empty database.
+
+## Where things live
+
+| Path | What |
+|---|---|
+| `admin/`, `site/` | The specs; `a11y.spec.js` in each is the WCAG gate |
+| `helpers/axe.js` | Shared axe-core wrapper: WCAG 2.2 AA tags, readable failure reports, error-page + PHP-leak guards |
+| `global-setup.js` | Site-aware admin authentication (see above) |
+| `.auth/` | Saved session state (gitignored) |
+| `../../playwright.config.js` | Projects, base URLs from build.properties, real-Chromium channel |

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,8 +1,21 @@
 /**
- * Playwright global setup — authenticates against j5-dev and j6-dev admin
- * and saves session storage state for reuse across all admin specs.
+ * Playwright global setup — authenticates against the dev-site admins and
+ * saves session storage state for reuse across all admin specs.
  *
- * Runs once before the entire test suite.
+ * Runs once before the entire test suite. Three behaviours matter here, all
+ * from #1342 — a transient login failure used to cost the whole run:
+ *
+ *   - Only the sites the selected projects actually use are authenticated.
+ *     Which sites those are is read from the resolved config: a project that
+ *     declares a storageState needs its site's admin session, one that
+ *     doesn't (the site-* projects) needs nothing. `--project=admin-j6`
+ *     therefore never touches j5-dev.
+ *   - A still-valid saved session is reused instead of re-authenticating.
+ *     Joomla admin sessions outlive a test run by default, so back-to-back
+ *     runs skip the login dance (and its flake surface) entirely.
+ *   - A login that does run is retried with backoff before it fails the run.
+ *     The observed failure mode is a rejection that succeeds moments later
+ *     with identical credentials — a flake, not a misconfiguration.
  *
  * Configuration follows a two-layer approach:
  *   1. build.dist.properties — defaults (committed)
@@ -42,75 +55,185 @@ function loadProps(root) {
     return { ...dist, ...local };
 }
 
-async function loginAdmin(browser, baseUrl, username, password, storageStatePath) {
-    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
-    const page = await ctx.newPage();
+/**
+ * Project names passed on the command line, e.g. --project=admin-j6.
+ *
+ * Playwright hands globalSetup the full resolved config with every project
+ * in it, regardless of any --project filter (upstream: playwright#14212),
+ * so the filter has to be recovered from argv. Empty array = no filter.
+ */
+function selectedProjectNames() {
+    const names = [];
+    const argv = process.argv;
 
-    // Load the login page
-    await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'networkidle' });
-
-    // Confirm the login form is present
-    const loginVisible = await page.locator('#form-login').isVisible({ timeout: 10000 }).catch(() => false);
-    if (!loginVisible) {
-        console.log(`  Already authenticated at ${baseUrl}, saving state.`);
-        await ctx.storageState({ path: storageStatePath });
-        await ctx.close();
-        return;
+    for (let i = 0; i < argv.length; i += 1) {
+        if (argv[i] === '--project' && argv[i + 1]) {
+            names.push(argv[i + 1]);
+        } else if (argv[i].startsWith('--project=')) {
+            names.push(argv[i].slice('--project='.length));
+        }
     }
 
-    // Fill credentials
-    await page.fill('#mod-login-username', username);
-    await page.fill('#mod-login-password', password);
-
-    // Submit the form via JS to bypass Joomla's form-validate JS which
-    // can prevent submission in headless mode. form.submit() bypasses the
-    // onsubmit handler but correctly includes all hidden fields (CSRF token).
-    await page.evaluate(() => document.getElementById('form-login').submit());
-
-    // Wait for the resulting page to be fully loaded
-    await page.waitForLoadState('networkidle', { timeout: 25000 });
-
-    // Verify we're no longer on the login page
-    const stillOnLogin = await page.locator('#form-login').isVisible({ timeout: 2000 }).catch(() => false);
-    if (stillOnLogin) {
-        const url = page.url();
-        await ctx.close();
-        throw new Error(
-            `Login failed for ${baseUrl} — credentials rejected or form not submitted.\n` +
-            `Check builder.j5dev.username / builder.j5dev.password (or j6dev) in build.properties.\n` +
-            `Current URL: ${url}`
-        );
-    }
-
-    await ctx.storageState({ path: storageStatePath });
-    console.log(`  Saved auth state → ${path.basename(storageStatePath)}`);
-    await ctx.close();
+    return names;
 }
 
-module.exports = async function globalSetup() {
+/**
+ * Whether a saved storage state still holds an authenticated admin session.
+ *
+ * One page load either way: reusing costs the same navigation the login
+ * would start with, and skips the credential dance that follows.
+ */
+async function stateStillValid(browser, baseUrl, storageStatePath) {
+    if (!fs.existsSync(storageStatePath)) {
+        return false;
+    }
+
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: storageStatePath });
+
+    try {
+        const page = await ctx.newPage();
+        await page.goto(`${baseUrl}/administrator/index.php`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 15000,
+        });
+
+        // The login form appearing means the session expired; treat any
+        // navigation failure the same way and fall through to a fresh login.
+        const loginVisible = await page.locator('#form-login')
+            .isVisible({ timeout: 3000 })
+            .catch(() => true);
+
+        return !loginVisible;
+    } catch {
+        return false;
+    } finally {
+        await ctx.close();
+    }
+}
+
+async function loginAdmin(browser, baseUrl, username, password, storageStatePath) {
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+
+    try {
+        const page = await ctx.newPage();
+
+        // Load the login page
+        await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'networkidle' });
+
+        // Confirm the login form is present
+        const loginVisible = await page.locator('#form-login').isVisible({ timeout: 10000 }).catch(() => false);
+        if (!loginVisible) {
+            console.log(`  Already authenticated at ${baseUrl}, saving state.`);
+            await ctx.storageState({ path: storageStatePath });
+            return;
+        }
+
+        // Fill credentials
+        await page.fill('#mod-login-username', username);
+        await page.fill('#mod-login-password', password);
+
+        // Submit the form via JS to bypass Joomla's form-validate JS which
+        // can prevent submission in headless mode. form.submit() bypasses the
+        // onsubmit handler but correctly includes all hidden fields (CSRF token).
+        await page.evaluate(() => document.getElementById('form-login').submit());
+
+        // Wait for the resulting page to be fully loaded
+        await page.waitForLoadState('networkidle', { timeout: 25000 });
+
+        // Verify we're no longer on the login page
+        const stillOnLogin = await page.locator('#form-login').isVisible({ timeout: 2000 }).catch(() => false);
+        if (stillOnLogin) {
+            throw new Error(
+                `Login failed for ${baseUrl} — credentials rejected or form not submitted.\n` +
+                `Check builder.j5dev.username / builder.j5dev.password (or j6dev) in build.properties.\n` +
+                `Current URL: ${page.url()}`
+            );
+        }
+
+        await ctx.storageState({ path: storageStatePath });
+        console.log(`  Saved auth state → ${path.basename(storageStatePath)}`);
+    } finally {
+        await ctx.close();
+    }
+}
+
+/**
+ * loginAdmin with retries. The whole suite hangs off this succeeding, so a
+ * transient rejection gets a second and third chance before it is allowed
+ * to be fatal.
+ */
+async function loginAdminWithRetry(browser, baseUrl, username, password, storageStatePath) {
+    const attempts = 3;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            await loginAdmin(browser, baseUrl, username, password, storageStatePath);
+            return;
+        } catch (err) {
+            if (attempt === attempts) {
+                throw err;
+            }
+            const delayMs = attempt * 2500;
+            console.warn(
+                `  Login attempt ${attempt}/${attempts} failed (${String(err.message || err).split('\n')[0]}); `
+                + `retrying in ${delayMs / 1000}s…`
+            );
+            await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+        }
+    }
+}
+
+module.exports = async function globalSetup(config) {
     const root = path.join(__dirname, '../..');
     const props = loadProps(root);
-
-    const j5Url = props['builder.j5dev.url'] || 'https://j5-dev.local:8890';
-    const j6Url = props['builder.j6dev.url'] || 'https://j6-dev.local:8890';
-
-    // Per-site credentials with shared fallback
-    const j5User = props['builder.j5dev.username'] || props['builder.joomla_username'];
-    const j5Pass = props['builder.j5dev.password'] || props['builder.joomla_password'];
-    const j6User = props['builder.j6dev.username'] || props['builder.joomla_username'];
-    const j6Pass = props['builder.j6dev.password'] || props['builder.joomla_password'];
-
-    if (!j5User || !j5Pass || !j6User || !j6Pass) {
-        throw new Error(
-            'Missing admin credentials.\n' +
-            'Set builder.j5dev.username / builder.j5dev.password (and j6dev) in build.properties.\n' +
-            'Or set builder.joomla_username / builder.joomla_password as a shared fallback.'
-        );
-    }
 
     const authDir = path.join(__dirname, '.auth');
     if (!fs.existsSync(authDir)) {
         fs.mkdirSync(authDir, { recursive: true });
+    }
+
+    // The sites this repo can authenticate against, keyed by the storage
+    // state file the Playwright projects reference.
+    const sites = [
+        {
+            label: 'j5-dev',
+            url: props['builder.j5dev.url'] || 'https://j5-dev.local:8890',
+            username: props['builder.j5dev.username'] || props['builder.joomla_username'],
+            password: props['builder.j5dev.password'] || props['builder.joomla_password'],
+            stateFile: 'admin-j5.json',
+        },
+        {
+            label: 'j6-dev',
+            url: props['builder.j6dev.url'] || 'https://j6-dev.local:8890',
+            username: props['builder.j6dev.username'] || props['builder.joomla_username'],
+            password: props['builder.j6dev.password'] || props['builder.joomla_password'],
+            stateFile: 'admin-j6.json',
+        },
+    ];
+
+    // Authenticate only the sites the selected projects consume. A project
+    // needs a site's admin session exactly when it declares that site's
+    // storageState; the site-* projects declare none and need none.
+    const selected = selectedProjectNames();
+    const projects = (config.projects || [])
+        .filter((p) => !selected.length || selected.includes(p.name));
+
+    const needed = sites.filter((site) => projects.some(
+        (p) => p.use && typeof p.use.storageState === 'string' && p.use.storageState.endsWith(site.stateFile)
+    ));
+
+    if (!needed.length) {
+        console.log('\nGlobal setup: no selected project needs an admin session; nothing to authenticate.\n');
+        return;
+    }
+
+    const missing = needed.filter((site) => !site.username || !site.password);
+    if (missing.length) {
+        throw new Error(
+            `Missing admin credentials for ${missing.map((s) => s.label).join(', ')}.\n` +
+            'Set builder.j5dev.username / builder.j5dev.password (and j6dev) in build.properties.\n' +
+            'Or set builder.joomla_username / builder.joomla_password as a shared fallback.'
+        );
     }
 
     // globalSetup runs outside the project fixtures, so the `use.channel`
@@ -125,11 +248,17 @@ module.exports = async function globalSetup() {
     const browser = await chromium.launch({ channel: 'chromium' });
 
     try {
-        console.log(`\nAuthenticating against j5-dev (${j5Url})…`);
-        await loginAdmin(browser, j5Url, j5User, j5Pass, path.join(authDir, 'admin-j5.json'));
+        for (const site of needed) {
+            const statePath = path.join(authDir, site.stateFile);
 
-        console.log(`Authenticating against j6-dev (${j6Url})…`);
-        await loginAdmin(browser, j6Url, j6User, j6Pass, path.join(authDir, 'admin-j6.json'));
+            if (await stateStillValid(browser, site.url, statePath)) {
+                console.log(`Reusing valid admin session for ${site.label} (${path.basename(statePath)}).`);
+                continue;
+            }
+
+            console.log(`\nAuthenticating against ${site.label} (${site.url})…`);
+            await loginAdminWithRetry(browser, site.url, site.username, site.password, statePath);
+        }
     } finally {
         await browser.close();
     }


### PR DESCRIPTION
Closes the robustness half of #1342.

## What changed

**`global-setup.js`**
- **Site-aware auth**: only the sites the selected projects consume get authenticated. Derived from the resolved config — a project needs a site's admin session exactly when it declares that site's `storageState`; the `site-*` projects declare none. (`--project` is recovered from argv because Playwright hands globalSetup the unfiltered project list — upstream playwright#14212.)
- **Session reuse**: a still-valid saved session is reused instead of re-authenticating, so back-to-back runs skip the login dance and its flake surface entirely.
- **Retry with backoff**: 3 attempts (2.5s/5s waits) before a login failure is allowed to be fatal — the observed flake was a rejection that succeeded moments later with identical credentials.

**`composer test:a11y`** now passes `--project=admin-j6 --project=site-j6` explicitly (the a11y specs are J6-only by design), so an accessibility run no longer depends on j5-dev existing, being reachable, or accepting a login.

**`tests/e2e/README.md`** documents the local prerequisites (dev sites, `build.properties` keys, `npx playwright install chromium`) and the suite's failure modes (error-page guard, PHP-leak guard, data-dependent skips) — the third checkbox of the issue's part 2.

## Verified

| Scenario | Result |
|---|---|
| `--project=site-j6` | "no selected project needs an admin session; nothing to authenticate" |
| `composer test:a11y` | authenticates j6 only — 48 passed, j5 never touched |
| immediate rerun | "Reusing valid admin session for j6-dev" |
| unfiltered run | both sites authenticated/reused |

## Not in this PR

The structural half of #1342 — the suite only runs on one configured laptop. The disposable-install machinery it needs is the same as #1330's; leaving the issue open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR