### PR TITLE
test(api): REST API acceptance on a clean package install

### DIFF
--- a/build/test-install.sh
+++ b/build/test-install.sh
@@ -44,10 +44,13 @@ fi
 echo "-- [3/5] install ${ZIP} (fresh)"
 "$BIN/cwm-install-zip" --zip "$ZIP"
 
-echo "-- [4/5] verify extension registration"
+echo "-- [4/6] verify extension registration"
 "$BIN/cwm-verify" --target test
 
-echo "-- [5/5] verify migrations landed"
+echo "-- [5/6] verify migrations landed"
 php build/verify-migrations.php "$VERSION"
+
+echo "-- [6/6] verify the REST API landed (#1309/#1310/#1331 guards)"
+php build/verify-api-install.php
 
 echo "CLEAN-INSTALL TEST PASSED for ${VERSION}."

--- a/build/verify-api-install.php
+++ b/build/verify-api-install.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Verify the REST API landed on every role=test install — the assertions
+ * #1309, #1310 and #1331 needed and never had (#1330).
+ *
+ * Three bugs shipped together and left the API unreachable on every install
+ * that wasn't hand-prepared, each invisible to a different layer of testing:
+ *
+ *   #1309  plg_webservices_proclaim never installed — asserted here as an
+ *          enabled #__extensions row.
+ *   #1310  API controllers never deployed to the api application — asserted
+ *          here as the controller file existing on disk under api/.
+ *   #1331  the plugin's parameters must be seeded at install so the API is
+ *          reachable (authenticated) out of the box — asserted here as
+ *          public_reads present in the row's params.
+ *
+ * Runs as part of `composer test:install` against the site the installer
+ * just built — not a dev site assembled by reset-testsite file copying,
+ * which is precisely what hid #1309 and #1310. The admin-facing and
+ * over-the-wire halves of the acceptance test live in
+ * tests/e2e/api/api-acceptance.spec.js.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+declare(strict_types=1);
+
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$root = \dirname(__DIR__);
+
+require $root . '/libraries/vendor/autoload.php';
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to verify.\n");
+
+    exit(0);
+}
+
+$failures = 0;
+
+foreach ($installs as $install) {
+    echo "=== verify API install on {$install->id} ({$install->path}) ===\n";
+
+    // --- #1310: the api application actually received the controllers -------
+    $controller = $install->path . '/api/components/com_proclaim/src/Controller/SermonsController.php';
+
+    if (is_file($controller)) {
+        echo "  OK   api/ controllers deployed (SermonsController.php present)\n";
+    } else {
+        fwrite(STDERR, "  FAIL api/components/com_proclaim/src/Controller/SermonsController.php missing —\n");
+        fwrite(STDERR, "       the manifest's <api> section did not deploy (the #1310 signature).\n");
+        $failures++;
+    }
+
+    // --- #1309 + #1331: plugin row, enabled, with seeded params -------------
+    $configFile = $install->path . '/configuration.php';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "  FAIL configuration.php not found — is this a Joomla install?\n");
+        $failures++;
+
+        continue;
+    }
+
+    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
+        require $file;
+        $c = new \JConfig();
+
+        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
+    })($configFile);
+
+    $port = 3306;
+
+    if (str_contains($host, ':')) {
+        [$host, $port] = explode(':', $host, 2);
+        $port          = (int) $port;
+    }
+
+    $db = mysqli_connect($host, $user, $pass, $name, $port);
+
+    if ($db === false) {
+        fwrite(STDERR, "  FAIL could not connect to database {$name}.\n");
+        $failures++;
+
+        continue;
+    }
+
+    $row = mysqli_fetch_assoc(mysqli_query(
+        $db,
+        "SELECT enabled, params FROM {$prefix}extensions
+         WHERE type = 'plugin' AND folder = 'webservices' AND element = 'proclaim'"
+    ) ?: null);
+
+    if ($row === null || $row === false) {
+        fwrite(STDERR, "  FAIL plg_webservices_proclaim has no #__extensions row —\n");
+        fwrite(STDERR, "       the package never installed it (the #1309 signature).\n");
+        $failures++;
+    } elseif ((int) $row['enabled'] !== 1) {
+        fwrite(STDERR, "  FAIL plg_webservices_proclaim is installed but disabled —\n");
+        fwrite(STDERR, "       a clean install must come up with the API reachable (#1331).\n");
+        $failures++;
+    } else {
+        echo "  OK   plg_webservices_proclaim installed and enabled\n";
+
+        $params = json_decode((string) $row['params'], true);
+
+        if (!\is_array($params) || !\array_key_exists('public_reads', $params)) {
+            fwrite(STDERR, "  FAIL plugin params not seeded at install (no public_reads) —\n");
+            fwrite(STDERR, "       defaults must be stored, not implied (#1331). params: {$row['params']}\n");
+            $failures++;
+        } else {
+            echo "  OK   plugin params seeded (public_reads={$params['public_reads']})\n";
+        }
+    }
+
+    mysqli_close($db);
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\nAPI INSTALL VERIFICATION FAILED ({$failures} assertion(s)).\n");
+
+    exit(1);
+}
+
+echo "API install verification passed.\n";

--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,7 @@
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",
     "test:a11y": "npx playwright test --grep @a11y --project=admin-j6 --project=site-j6",
+    "test:api": ["@test:install", "npx playwright test --project=api-test"],
     "test:all": ["@test", "@test:js"],
     "test:reset-testsite": "@php build/reset-testsite.php",
     "test:migrations": "@php build/verify-migrations.php",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,47 +9,18 @@
  * per-site credentials (builder.j5dev.username, etc.) and site URLs.
  */
 
-const fs = require('fs');
-const path = require('path');
 const { defineConfig, devices } = require('@playwright/test');
+const { loadProps, installForRole } = require('./tests/e2e/helpers/properties');
 
-/** Parse a Java-style .properties file into a plain object. */
-function parseProperties(filePath) {
-    const props = {};
-    if (!fs.existsSync(filePath)) {
-        return props;
-    }
-    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
-    for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith('#')) {
-            continue;
-        }
-        const eq = trimmed.indexOf('=');
-        if (eq === -1) {
-            continue;
-        }
-        const key = trimmed.slice(0, eq).trim();
-        const value = trimmed.slice(eq + 1).trim();
-        props[key] = value;
-    }
-    return props;
-}
-
-/**
- * Load properties with dist-file defaults overridden by local build.properties.
- * Keys present in build.properties always take precedence.
- */
-function loadProps() {
-    const dist = parseProperties(path.join(__dirname, 'build.dist.properties'));
-    const local = parseProperties(path.join(__dirname, 'build.properties'));
-    return { ...dist, ...local };
-}
-
-const props = loadProps();
+const props = loadProps(__dirname);
 
 const j5Url = props['builder.j5dev.url'] || 'https://j5-dev.local:8890';
 const j6Url = props['builder.j6dev.url'] || 'https://j6-dev.local:8890';
+
+// The role=test install — the site `composer test:install` provisions from
+// the built package. Discovered by role, not by name: install naming is
+// local to each build.properties. No role=test install, no API project.
+const testInstall = installForRole(props, 'test');
 
 module.exports = defineConfig({
     testDir: './tests/e2e',
@@ -139,5 +110,19 @@ module.exports = defineConfig({
                 baseURL: j6Url,
             },
         },
+
+        // The API acceptance spec (#1330) runs against the role=test install
+        // and nowhere else: its whole point is asserting the state the
+        // installer produces, which the symlinked dev sites cannot represent.
+        // Omitted entirely when build.properties declares no role=test site.
+        ...(testInstall ? [{
+            name: 'api-test',
+            testMatch: '**/api/**/*.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: testInstall.url,
+                storageState: 'tests/e2e/.auth/admin-test.json',
+            },
+        }] : []),
     ],
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -39,8 +39,9 @@ CI (nothing there to point them at) and instead gate releases via
 ## Running
 
 ```bash
-composer test:e2e     # everything, all four projects (admin/site × J5/J6)
+composer test:e2e     # everything (admin/site × J5/J6, plus api-test if configured)
 composer test:a11y    # WCAG 2.2 AA scans only — J6 projects only
+composer test:api     # clean package install + REST API acceptance (#1330)
 npx playwright test --project=admin-j6        # one project
 npx playwright test --ui                      # interactive debugging
 npm run test:e2e:report                       # open the last HTML report
@@ -51,6 +52,18 @@ both platforms; J5 exists to catch Joomla-version behaviour differences,
 which the functional specs cover). `composer test:a11y` passes
 `--project=admin-j6 --project=site-j6` so a J5 hiccup can never block an
 accessibility run.
+
+## The API acceptance project
+
+`tests/e2e/api/` runs against the **role=test** install — whichever entry in
+`build.properties` carries `builder.<id>.role = test`, discovered by role
+rather than by name. That is the site `composer test:install` provisions
+from the built package, which is the whole point: #1309/#1310/#1328 all
+shipped because every other layer tested a site assembled by something
+other than the installer. `composer test:api` chains the clean install and
+the spec; with no role=test install configured, the project simply doesn't
+exist. The DB-row and on-disk halves of the assertion live in
+`build/verify-api-install.php`, inside `composer test:install` itself.
 
 ## Authentication
 

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -1,0 +1,143 @@
+/**
+ * E2E — REST API acceptance on a package-installed site (#1330)
+ *
+ * Runs against the role=test install (`api-j6test` project), the site
+ * `composer test:install` provisions from the built package — not a dev site
+ * assembled by symlinks or file copying, which is exactly what hid #1309 and
+ * #1310 for three releases. The DB-row and on-disk assertions live in
+ * build/verify-api-install.php inside the install harness; this spec covers
+ * everything an administrator or API consumer actually touches:
+ *
+ *   - the plugin is visible and manageable in the Plugins screen
+ *   - an unauthenticated request gets 401, NOT 404 — 404 is the signature
+ *     all three shipped bugs produce (routes never registered)
+ *   - a Joomla API token obtained the way an admin obtains one (their
+ *     profile) reaches the API and gets a JSON:API document
+ *   - the one remaining setting, public_reads, works when set the way an
+ *     admin sets it — through the plugin's own edit form. #1328's lesson:
+ *     writing the value straight to the database would pass while the UI
+ *     path is broken, so the UI path is the one exercised.
+ *
+ * Serial: the token test feeds the authenticated request, and the
+ * public_reads test must restore the shipped default for the 401 assertion
+ * to stay meaningful on re-runs.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const API_SERMONS = '/api/index.php/v1/proclaim/sermons';
+
+test.describe.serial('REST API acceptance (package install) @api', () => {
+    test('Proclaim and its webservices plugin are installed and enabled', async ({ page }) => {
+        await page.goto(
+            '/administrator/index.php?option=com_plugins&filter[search]=proclaim&filter[folder]=webservices',
+            { waitUntil: 'networkidle' },
+        );
+
+        const rows = page.locator('#pluginList tbody tr');
+
+        expect(
+            await rows.count(),
+            'plg_webservices_proclaim is not in the Plugins screen. If this site has no '
+            + 'Proclaim at all, run `composer test:install` first — this suite asserts the '
+            + 'state that harness produces.',
+        ).toBeGreaterThan(0);
+
+        // The publish toggle in the row reports state via its icon/task.
+        const firstRow = rows.first();
+        await expect(firstRow).toContainText(/proclaim/i);
+        await expect(
+            firstRow.locator('.tbody-icon .icon-publish, a[data-bs-original-title*="Unpublish"], .icon-publish'),
+            'plg_webservices_proclaim exists but is disabled — a clean install must come up '
+            + 'with the API reachable (#1331).',
+        ).toHaveCount(1);
+    });
+
+    test('unauthenticated request is denied with 401, not 404', async ({ request }) => {
+        const response = await request.get(API_SERMONS);
+
+        expect(
+            response.status(),
+            '404 from the sermons route means the API routes were never registered — the '
+            + 'failure signature of #1309/#1310, which shipped in 10.3.0–10.3.3. 401 is the '
+            + 'only acceptable "no" here.',
+        ).not.toBe(404);
+
+        expect(response.status()).toBe(401);
+    });
+
+    test('a token from the admin profile reaches the API and gets JSON:API', async ({ page, request }) => {
+        // Obtain the token the way an administrator does: from their own
+        // account, reached through the header user menu's own "Edit Account"
+        // link — the URL shape varies across Joomla versions (com_admin's
+        // profile view 404s on J6), the link is always there. The token
+        // field shows the full header-ready value; a first-ever visit shows
+        // it empty until the account is saved once (the token plugin
+        // generates on save).
+        await page.goto('/administrator/index.php', { waitUntil: 'networkidle' });
+
+        const editAccount = page.locator('a[href*="task=user.edit"]', { hasText: 'Edit Account' }).first();
+        await expect(editAccount, 'No "Edit Account" link in the admin header').toBeAttached();
+        await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'networkidle' });
+
+        const tokenField = page.locator('#jform_joomlatoken_token');
+        await expect(
+            tokenField,
+            'No Joomla API Token field on the profile — is the "User - Token" plugin disabled?',
+        ).toBeAttached();
+
+        let token = await tokenField.inputValue();
+
+        if (!token) {
+            await page.click('.button-apply');
+            await page.waitForLoadState('networkidle');
+            token = await page.locator('#jform_joomlatoken_token').inputValue();
+        }
+
+        expect(token, 'The profile never produced a token value').not.toBe('');
+
+        const response = await request.get(API_SERMONS, {
+            headers: { 'X-Joomla-Token': token },
+        });
+
+        expect(response.status()).toBe(200);
+
+        const body = await response.json();
+
+        // A JSON:API document carries its resources under `data`.
+        expect(Array.isArray(body.data), 'Expected a JSON:API document with a data array').toBe(true);
+    });
+
+    test('public_reads set through the plugin UI opens and closes anonymous reads', async ({ page, request }) => {
+        // Open the plugin's edit form from the Plugins screen — the same
+        // path an administrator walks.
+        await page.goto(
+            '/administrator/index.php?option=com_plugins&filter[search]=proclaim&filter[folder]=webservices',
+            { waitUntil: 'networkidle' },
+        );
+        await page.locator('#pluginList tbody tr a[href*="task=plugin.edit"]').first().click();
+        await page.waitForLoadState('networkidle');
+
+        const setPublicReads = async (value) => {
+            await page.locator(`label[for="jform_params_public_reads${value}"]`).click();
+            await page.click('.button-apply');
+            await page.waitForLoadState('networkidle');
+        };
+
+        // Open anonymous reads…
+        await setPublicReads(1);
+        let response = await request.get(API_SERMONS);
+        expect(
+            response.status(),
+            'public_reads=Yes saved through the UI, but an anonymous read is still rejected',
+        ).toBe(200);
+
+        // …and restore the shipped default, which must close them again.
+        await setPublicReads(0);
+        response = await request.get(API_SERMONS);
+        expect(
+            response.status(),
+            'public_reads=No saved through the UI, but anonymous reads stayed open',
+        ).toBe(401);
+    });
+});

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -28,32 +28,7 @@
 const fs = require('fs');
 const path = require('path');
 const { chromium } = require('@playwright/test');
-
-function parseProperties(filePath) {
-    const props = {};
-    if (!fs.existsSync(filePath)) {
-        return props;
-    }
-    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
-    for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith('#')) {
-            continue;
-        }
-        const eq = trimmed.indexOf('=');
-        if (eq === -1) {
-            continue;
-        }
-        props[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
-    }
-    return props;
-}
-
-function loadProps(root) {
-    const dist = parseProperties(path.join(root, 'build.dist.properties'));
-    const local = parseProperties(path.join(root, 'build.properties'));
-    return { ...dist, ...local };
-}
+const { loadProps, installForRole } = require('./helpers/properties');
 
 /**
  * Project names passed on the command line, e.g. --project=admin-j6.
@@ -97,13 +72,16 @@ async function stateStillValid(browser, baseUrl, storageStatePath) {
             timeout: 15000,
         });
 
-        // The login form appearing means the session expired; treat any
-        // navigation failure the same way and fall through to a fresh login.
-        const loginVisible = await page.locator('#form-login')
-            .isVisible({ timeout: 3000 })
-            .catch(() => true);
+        // Valid means the sidebar toggle rendered — a positive signal only an
+        // authenticated backend produces (the login page has no sidebar). "No
+        // login form" would also be true of an error page, and treating that
+        // as a live session skips the login that would surface the problem.
+        //
+        // waitFor, not isVisible: isVisible() answers for the instant it is
+        // called and ignores its timeout option.
+        await page.locator('#menu-collapse').waitFor({ state: 'visible', timeout: 5000 });
 
-        return !loginVisible;
+        return true;
     } catch {
         return false;
     } finally {
@@ -120,12 +98,20 @@ async function loginAdmin(browser, baseUrl, username, password, storageStatePath
         // Load the login page
         await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'networkidle' });
 
-        // Confirm the login form is present
-        const loginVisible = await page.locator('#form-login').isVisible({ timeout: 10000 }).catch(() => false);
+        // Confirm the login form is present. Already-authenticated is only
+        // claimed on the positive signal (the admin sidebar), never on the
+        // form's mere absence.
+        const loginVisible = await page.locator('#form-login').isVisible().catch(() => false);
         if (!loginVisible) {
-            console.log(`  Already authenticated at ${baseUrl}, saving state.`);
-            await ctx.storageState({ path: storageStatePath });
-            return;
+            const authed = await page.locator('#menu-collapse')
+                .waitFor({ state: 'visible', timeout: 5000 })
+                .then(() => true, () => false);
+            if (authed) {
+                console.log(`  Already authenticated at ${baseUrl}, saving state.`);
+                await ctx.storageState({ path: storageStatePath });
+                return;
+            }
+            throw new Error(`Neither the login form nor the admin UI rendered at ${baseUrl}/administrator/`);
         }
 
         // Fill credentials
@@ -137,15 +123,27 @@ async function loginAdmin(browser, baseUrl, username, password, storageStatePath
         // onsubmit handler but correctly includes all hidden fields (CSRF token).
         await page.evaluate(() => document.getElementById('form-login').submit());
 
-        // Wait for the resulting page to be fully loaded
-        await page.waitForLoadState('networkidle', { timeout: 25000 });
+        // Success must be a POSITIVE signal — the sidebar toggle, which only
+        // an authenticated backend renders (the login page has no sidebar).
+        // "The login form is gone" is not enough: mid-redirect the form is
+        // absent from a page that is not logged in either, and that false
+        // success once saved a guest session as auth state while the real
+        // problem (stale credentials in build.properties) went unreported.
+        //
+        // waitFor, not waitForLoadState-then-isVisible: networkidle can
+        // resolve on the *old* page before the submit's navigation begins,
+        // and isVisible() answers for that instant without waiting.
+        const authed = await page.locator('#menu-collapse')
+            .waitFor({ state: 'visible', timeout: 25000 })
+            .then(() => true, () => false);
 
-        // Verify we're no longer on the login page
-        const stillOnLogin = await page.locator('#form-login').isVisible({ timeout: 2000 }).catch(() => false);
-        if (stillOnLogin) {
+        if (!authed) {
+            const rejected = await page.locator('#form-login').isVisible().catch(() => false);
             throw new Error(
-                `Login failed for ${baseUrl} — credentials rejected or form not submitted.\n` +
-                `Check builder.j5dev.username / builder.j5dev.password (or j6dev) in build.properties.\n` +
+                `Login failed for ${baseUrl} — ` +
+                (rejected
+                    ? 'credentials rejected (check this site\'s username/password in build.properties).\n'
+                    : 'no admin UI appeared after submit.\n') +
                 `Current URL: ${page.url()}`
             );
         }
@@ -193,7 +191,11 @@ module.exports = async function globalSetup(config) {
     }
 
     // The sites this repo can authenticate against, keyed by the storage
-    // state file the Playwright projects reference.
+    // state file the Playwright projects reference. The two dev sites have
+    // fixed property keys; the test site is discovered by role, because
+    // install naming is local to each build.properties.
+    const testInstall = installForRole(props, 'test');
+
     const sites = [
         {
             label: 'j5-dev',
@@ -209,6 +211,13 @@ module.exports = async function globalSetup(config) {
             password: props['builder.j6dev.password'] || props['builder.joomla_password'],
             stateFile: 'admin-j6.json',
         },
+        ...(testInstall ? [{
+            label: testInstall.id,
+            url: testInstall.url,
+            username: testInstall.username,
+            password: testInstall.password,
+            stateFile: 'admin-test.json',
+        }] : []),
     ];
 
     // Authenticate only the sites the selected projects consume. A project

--- a/tests/e2e/helpers/properties.js
+++ b/tests/e2e/helpers/properties.js
@@ -1,0 +1,94 @@
+/**
+ * build.properties access for the E2E suite.
+ *
+ * One parser shared by playwright.config.js and global-setup.js, with the
+ * same two-layer resolution the PHP tooling uses:
+ *   1. build.dist.properties — defaults (committed)
+ *   2. build.properties      — local overrides for credentials (gitignored)
+ *
+ * Nothing here assumes what an install is named. Sites are discovered from
+ * `builder.installs` and their `builder.<id>.role`, mirroring
+ * PropertiesReader::installsFor() on the PHP side — someone whose test
+ * install is called `trunk-test` gets exactly the same behaviour as one
+ * whose install is called `j6-test`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function parseProperties(filePath) {
+    const props = {};
+    if (!fs.existsSync(filePath)) {
+        return props;
+    }
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) {
+            continue;
+        }
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) {
+            continue;
+        }
+        props[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+    return props;
+}
+
+/**
+ * @param {string} root Repo root.
+ * @returns {object} Merged properties, build.properties winning.
+ */
+function loadProps(root) {
+    const dist = parseProperties(path.join(root, 'build.dist.properties'));
+    const local = parseProperties(path.join(root, 'build.properties'));
+    return { ...dist, ...local };
+}
+
+/**
+ * The install ids listed in builder.installs.
+ *
+ * @param {object} props
+ * @returns {string[]}
+ */
+function installIds(props) {
+    return (props['builder.installs'] || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+/**
+ * Connection details for one named install.
+ *
+ * @param {object} props
+ * @param {string} id
+ * @returns {{id: string, role: string, url: string, username: string, password: string}}
+ */
+function installById(props, id) {
+    return {
+        id,
+        role: props[`builder.${id}.role`] || '',
+        url: props[`builder.${id}.url`] || '',
+        username: props[`builder.${id}.username`] || props['builder.joomla_username'] || '',
+        password: props[`builder.${id}.password`] || props['builder.joomla_password'] || '',
+    };
+}
+
+/**
+ * The first install marked with the given role, or null. The role=test
+ * install is the one `composer test:install` provisions from the built
+ * package; the API acceptance suite runs there and nowhere else.
+ *
+ * @param {object} props
+ * @param {string} role
+ * @returns {object|null}
+ */
+function installForRole(props, role) {
+    const id = installIds(props).find((name) => (props[`builder.${name}.role`] || '') === role);
+
+    return id ? installById(props, id) : null;
+}
+
+module.exports = { parseProperties, loadProps, installIds, installById, installForRole };


### PR DESCRIPTION
Builds the guard #1330 asked for — the one test that would have caught #1309, #1310 and #1328, which together left the API unreachable from 10.3.0–10.3.3 while every existing test layer stayed green. Every assertion targets the state **the installer produces**, on the role=test install — never a dev site assembled by symlinks or `reset-testsite` file copies, which is precisely what hid the bugs.

## The install-side half — `build/verify-api-install.php`

Now step 6 of `composer test:install`:

| Assertion | Guards |
|---|---|
| `plg_webservices_proclaim` has an enabled `#__extensions` row | #1309 |
| `api/components/com_proclaim/src/Controller/SermonsController.php` on disk | #1310 |
| plugin params seeded at install (`public_reads` present) | #1331 |

## The admin/wire half — `tests/e2e/api/api-acceptance.spec.js` (new `api-test` project)

1. The plugin is visible and enabled in the **Plugins screen**
2. Unauthenticated GET → **401, explicitly not 404** — 404 is the routes-never-registered signature all three shipped bugs produce
3. A token obtained the way an admin obtains one (via the header's own **Edit Account** link — the profile URL shape varies across Joomla versions) reaches the API → **200 + JSON:API document**
4. `public_reads` flipped **through the plugin's edit form** opens anonymous reads (200), and restored to the shipped default closes them (401). #1328's lesson applied: the setting is exercised through the UI, never written to the database, so a broken UI path fails the test.

`composer test:api` chains the clean install and the spec. Full chain verified from a bare reset: package build → install → all verifications → fresh login → **4/4 passed**.

## Nothing hardcodes this machine's setup

Per review feedback: the test site is discovered by **`role = test`** in build.properties (`tests/e2e/helpers/properties.js`, mirroring `PropertiesReader::installsFor()` on the PHP side), the Playwright project only exists when such an install is configured, and the shared parser replaces the duplicated copies in `playwright.config.js` and `global-setup.js`. Someone whose test install is named `trunk-test` gets identical behaviour.

## Bug found along the way: false-positive login success

The login flow's success check was "the login form is gone" — which passes mid-redirect on a page that is *not* logged in. A guest session got saved as auth state while the real failure (stale credentials) went unreported. Success is now a **positive signal** (`#menu-collapse`, which only an authenticated backend renders) awaited with `waitFor` — `networkidle` can resolve on the old page before `form.submit()`'s navigation begins, and `isVisible()` answers for an instant without waiting. Fresh logins verified against all three sites (j5-dev, j6-dev, and the test install).

Closes #1330. Also closes the remaining scope of #1342's part 2 that this repo can address locally (the suite still needs a laptop; a CI disposable install remains future work — noted on #1342).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR