### PR TITLE
ci(e2e): run the package-install + API acceptance chain against a disposable Joomla

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,6 +131,13 @@ jobs:
           # and $live_site is the supported way to stop it guessing.
           sed -i "s#public \$live_site = '';#public \$live_site = '${SITE_URL}';#" "$SITE_DIR/configuration.php"
           grep -n "live_site" "$SITE_DIR/configuration.php"
+          # A fresh install auto-starts the "Welcome to Joomla!" guided tour
+          # on first admin visit, and the tour JS navigates every page back
+          # to its step-1 location (the dashboard) — which read exactly like
+          # "all form views bounce to home" until the failure screenshot
+          # showed the tour modal. No tours for a disposable site.
+          mysql -h 127.0.0.1 -u root -pjoomla_ci joomla_ci \
+            -e "UPDATE jos_extensions SET enabled = 0 WHERE folder = 'system' AND element = 'guidedtours';"
 
       - name: Write build.properties for the disposable site
         # The harness discovers the test site by role, not by name (#1353),

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,6 +125,12 @@ jobs:
             --db-prefix=jos_ \
             --db-encryption=0
           rm -rf "$SITE_DIR/installation"
+          # Pin the site URL. Under PHP's built-in server Joomla mis-derives
+          # its root — admin pages emitted assets under /administrator/media/
+          # and the login form POSTed to /administrator/administrator/ —
+          # and $live_site is the supported way to stop it guessing.
+          sed -i "s#public \$live_site = '';#public \$live_site = '${SITE_URL}';#" "$SITE_DIR/configuration.php"
+          grep -n "live_site" "$SITE_DIR/configuration.php"
 
       - name: Write build.properties for the disposable site
         # The harness discovers the test site by role, not by name (#1353),

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,186 @@
+# E2E against a disposable Joomla install (#1342).
+#
+# The browser and API suites always ran against hand-configured dev sites on
+# one laptop, so between releases regressions accumulated unseen — the suite
+# had rotted for months before the WCAG work revived it, and the REST API
+# shipped broken three releases running because nothing installed the real
+# package anywhere automatic.
+#
+# This job stands up everything from nothing: a MySQL service, a Joomla site
+# installed headlessly by core's own CLI installer, the built pkg_proclaim
+# zip deployed by the same `composer test:install` harness a release uses,
+# and the API acceptance suite (#1330) driven by Playwright against PHP's
+# built-in server. No secrets, no persistent state, reproducible by any
+# contributor's fork.
+#
+# Scheduled nightly (regressions surface within a day, not at release time),
+# manually dispatchable, and run on pull requests that touch what it guards.
+
+name: E2E
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly, 05:17 UTC — off the busy top-of-hour cron load.
+    - cron: '17 5 * * *'
+  pull_request:
+    branches: [ "development", "10.x" ]
+    paths:
+      - 'api/**'
+      - 'plugins/webservices/**'
+      - 'tests/e2e/**'
+      - 'build/test-install.sh'
+      - 'build/build-package.sh'
+      - 'build/build-subpackages.sh'
+      - 'build/reset-testsite.php'
+      - 'build/verify-api-install.php'
+      - 'build/verify-migrations.php'
+      - 'playwright.config.js'
+      - '.github/workflows/e2e.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JOOMLA_VERSION: '5.4.3'
+  SITE_DIR: /home/runner/joomla-site
+  SITE_URL: http://127.0.0.1:8890
+
+jobs:
+  api-acceptance:
+    name: Package install + API acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: joomla_ci
+          MYSQL_DATABASE: joomla_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, json, xml, mysqli, zip, gd, intl, curl
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/composer/files
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --dev --no-interaction --prefer-dist
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install npm dependencies and build assets
+        # media/ is generated and gitignored; the package build zips it.
+        run: |
+          npm ci
+          npm run build
+
+      - name: Download and install Joomla ${{ env.JOOMLA_VERSION }}
+        # Core's own CLI installer (4.3+) — the same install path a site
+        # admin's web install runs, headless. The installation directory is
+        # removed afterwards so Joomla serves the site, not the installer.
+        run: |
+          mkdir -p "$SITE_DIR"
+          curl -sSL -o /tmp/joomla.zip \
+            "https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip"
+          unzip -q /tmp/joomla.zip -d "$SITE_DIR"
+          php "$SITE_DIR/installation/joomla.php" install -n \
+            --site-name="Proclaim CI" \
+            --admin-user="CI Admin" \
+            --admin-username=admin \
+            --admin-password=admin1234567 \
+            --admin-email=admin@example.com \
+            --db-type=mysqli \
+            --db-host=127.0.0.1 \
+            --db-user=root \
+            --db-pass=joomla_ci \
+            --db-name=joomla_ci \
+            --db-prefix=jos_ \
+            --db-encryption=0
+          rm -rf "$SITE_DIR/installation"
+
+      - name: Write build.properties for the disposable site
+        # The harness discovers the test site by role, not by name (#1353),
+        # so this one file is the only wiring the whole chain needs.
+        run: |
+          cat > build.properties <<EOF
+          builder.joomla_dir=${GITHUB_WORKSPACE}/../joomla-cms
+          builder.installs=ci
+          builder.ci.role=test
+          builder.ci.path=${SITE_DIR}
+          builder.ci.url=${SITE_URL}
+          builder.ci.db_host=127.0.0.1
+          builder.ci.db_user=root
+          builder.ci.db_pass=joomla_ci
+          builder.ci.db_name=joomla_ci
+          builder.ci.username=admin
+          builder.ci.password=admin1234567
+          builder.ci.email=admin@example.com
+          builder.ci.version=${JOOMLA_VERSION}
+          EOF
+
+      - name: Serve the site
+        run: |
+          PHP_CLI_SERVER_WORKERS=4 php -S 127.0.0.1:8890 -t "$SITE_DIR" &> /tmp/php-server.log &
+          sleep 2
+          curl -sSf -o /dev/null "$SITE_URL/index.php"
+
+      - name: Clean install of the built package
+        # reset → build pkg_proclaim zip → install via Joomla's CLI → verify
+        # extension registration, migrations, and the REST API assertions
+        # (#1309/#1310/#1331 guards) — build/test-install.sh, unchanged.
+        run: composer test:install
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: REST API acceptance suite
+        # The #1330 spec: plugin visible in the admin UI, 401-not-404 without
+        # a token, 200 + JSON:API with one obtained through the admin
+        # profile, public_reads round-tripped through the plugin edit form.
+        run: npx playwright test --project=api-test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report
+          path: |
+            build/reports/e2e
+            test-results
+          retention-days: 7
+
+      - name: Upload PHP server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: php-server-log
+          path: /tmp/php-server.log
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,6 @@ jobs:
         # so this one file is the only wiring the whole chain needs.
         run: |
           cat > build.properties <<EOF
-          builder.joomla_dir=${GITHUB_WORKSPACE}/../joomla-cms
           builder.installs=ci
           builder.ci.role=test
           builder.ci.path=${SITE_DIR}

--- a/build/build-subpackages.sh
+++ b/build/build-subpackages.sh
@@ -35,13 +35,21 @@ fi
 # gitignored, so a fresh clone (CI, a new contributor) has none, and each
 # submodule's ensure-minified gate rightly refuses to package without them.
 # Local working trees usually carry them already — then this is just the
-# submodule's incremental `npm run build`. npm ci only when node_modules is
-# absent, so the local loop stays fast.
+# submodule's incremental `npm run build`. The dependency installs run only
+# when their targets are absent, so the local loop stays fast:
+#   - composer install: the submodule's rollup/css build configs live in its
+#     own vendored cwm/build-tools (a require-dev), not the parent's
+#   - npm ci: rollup and friends
 build_npm_assets() {
     local dir="$1"
 
     if [ ! -f "${dir}/package.json" ]; then
         return 0
+    fi
+
+    if [ -f "${dir}/composer.json" ] && [ ! -d "${dir}/vendor/cwm/build-tools" ]; then
+        echo "   composer install (${dir#"${ROOT}"/})"
+        ( cd "${dir}" && composer install --no-interaction --prefer-dist --quiet )
     fi
 
     if [ ! -d "${dir}/node_modules" ]; then

--- a/build/build-subpackages.sh
+++ b/build/build-subpackages.sh
@@ -24,14 +24,45 @@ export CWM_NONINTERACTIVE=1
 
 LIB_DIR="${ROOT}/libraries/lib_cwmscripture"
 PLG_DIR="${ROOT}/plugins/content/scripturelinks"
+NESTED_LIB_DIR="${PLG_DIR}/libraries/lib_cwmscripture"
 
 if [ ! -f "${LIB_DIR}/cwm-build.config.json" ] || [ ! -f "${PLG_DIR}/cwm-build.config.json" ]; then
     echo "ERROR: submodules not populated — run 'git submodule update --init --recursive' first." >&2
     exit 1
 fi
 
-echo "-- building lib_cwmscripture (cwm-build)"
+# Build a submodule's npm assets when it has them. The min files are
+# gitignored, so a fresh clone (CI, a new contributor) has none, and each
+# submodule's ensure-minified gate rightly refuses to package without them.
+# Local working trees usually carry them already — then this is just the
+# submodule's incremental `npm run build`. npm ci only when node_modules is
+# absent, so the local loop stays fast.
+build_npm_assets() {
+    local dir="$1"
+
+    if [ ! -f "${dir}/package.json" ]; then
+        return 0
+    fi
+
+    if [ ! -d "${dir}/node_modules" ]; then
+        echo "   npm ci (${dir#"${ROOT}"/})"
+        ( cd "${dir}" && npm ci --no-audit --no-fund --silent )
+    fi
+
+    ( cd "${dir}" && npm run --silent build )
+}
+
+echo "-- building lib_cwmscripture (npm + cwm-build)"
+build_npm_assets "${LIB_DIR}"
 ( cd "${LIB_DIR}" && "${BIN}/cwm-build" )
+
+# scripturelinks bundles its own nested lib_cwmscripture checkout as a
+# `prebuilt` include — so that nested submodule must be built first, or a
+# clean clone dies with "no zip matched" (or worse, silently bundles a
+# stale zip a local tree happened to retain).
+echo "-- building scripturelinks' nested lib_cwmscripture (npm + cwm-build)"
+build_npm_assets "${NESTED_LIB_DIR}"
+( cd "${NESTED_LIB_DIR}" && "${BIN}/cwm-build" )
 
 echo "-- building content/scripturelinks (cwm-package)"
 ( cd "${PLG_DIR}" && "${BIN}/cwm-package" )

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,9 +2,11 @@
 
 Browser tests (Playwright) covering the admin and site halves of the
 component, including the WCAG 2.2 AA accessibility gate. They run against
-**real local Joomla installs**, not fixtures — which is why they are not in
-CI (nothing there to point them at) and instead gate releases via
-`composer test:release`.
+**real Joomla installs**, not fixtures. Locally that means the dev sites
+below, gating releases via `composer test:release`; in CI, the
+`.github/workflows/e2e.yml` job stands up a disposable Joomla + MySQL from
+nothing and runs the package-install + API acceptance chain nightly, on
+dispatch, and on pull requests that touch what it guards (#1342).
 
 ## Prerequisites
 

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -68,22 +68,37 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
 
     test('a token from the admin profile reaches the API and gets JSON:API', async ({ page, request }) => {
         // Obtain the token the way an administrator does: from their own
-        // account, reached through the header user menu's own "Edit Account"
-        // link — the URL shape varies across Joomla versions (com_admin's
-        // profile view 404s on J6), the link is always there. The token
-        // field shows the full header-ready value; a first-ever visit shows
-        // it empty until the account is saved once (the token plugin
-        // generates on save).
+        // account. Two routes, because Joomla moved the furniture: the
+        // header's "Edit Account" link (all versions; on some fresh installs
+        // the direct GET bounces back to the dashboard), and com_admin's own
+        // profile view (J4/J5; removed in J6). Try the link first, fall back
+        // to the profile view. The token field shows the full header-ready
+        // value; a first-ever visit shows it empty until the account is
+        // saved once (the token plugin generates on save).
         await page.goto('/administrator/index.php', { waitUntil: 'networkidle' });
 
         const editAccount = page.locator('a[href*="task=user.edit"]', { hasText: 'Edit Account' }).first();
         await expect(editAccount, 'No "Edit Account" link in the admin header').toBeAttached();
         await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'networkidle' });
 
+        if (!(await page.locator('#jform_joomlatoken_token').count())) {
+            await page.goto('/administrator/index.php?option=com_admin&view=profile&layout=edit', {
+                waitUntil: 'networkidle',
+            });
+        }
+
         const tokenField = page.locator('#jform_joomlatoken_token');
+
+        // Diagnostics worth their weight when this fails on a machine no one
+        // can attach a debugger to: where each route actually landed, and
+        // what Joomla had to say about it.
+        const alerts = (await page.locator('joomla-alert, .alert').allInnerTexts())
+            .join(' | ').replace(/\s+/g, ' ').slice(0, 300);
+
         await expect(
             tokenField,
-            'No Joomla API Token field on the profile — is the "User - Token" plugin disabled?',
+            'No Joomla API Token field via either the Edit Account link or the com_admin profile view. '
+            + `Landed on: ${page.url()} — messages: ${alerts || '(none)'}`,
         ).toBeAttached();
 
         let token = await tokenField.inputValue();

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -68,13 +68,15 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
 
     test('a token from the admin profile reaches the API and gets JSON:API', async ({ page, request }) => {
         // Obtain the token the way an administrator does: from their own
-        // account. Two routes, because Joomla moved the furniture: the
-        // header's "Edit Account" link (all versions; on some fresh installs
-        // the direct GET bounces back to the dashboard), and com_admin's own
-        // profile view (J4/J5; removed in J6). Try the link first, fall back
-        // to the profile view. The token field shows the full header-ready
-        // value; a first-ever visit shows it empty until the account is
-        // saved once (the token plugin generates on save).
+        // account, via the header's "Edit Account" link (the com_users.user
+        // form — the only backend context the token plugin injects into;
+        // com_admin's profile view is not on its list).
+        //
+        // On a pristine account the plugin REMOVES its token fields from the
+        // form entirely — the seed they display is only generated when the
+        // user is saved with the plugin active, so a fresh install's
+        // installer-created admin has no field at all until saved once.
+        // That is the state every CI run starts from.
         await page.goto('/administrator/index.php', { waitUntil: 'networkidle' });
 
         const editAccount = page.locator('a[href*="task=user.edit"]', { hasText: 'Edit Account' }).first();
@@ -82,32 +84,27 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
         await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'networkidle' });
 
         if (!(await page.locator('#jform_joomlatoken_token').count())) {
-            await page.goto('/administrator/index.php?option=com_admin&view=profile&layout=edit', {
-                waitUntil: 'networkidle',
-            });
+            // Pristine account: save once to generate the seed, which lands
+            // back on the edit form with the token fields present.
+            await page.click('.button-apply');
+            await page.waitForLoadState('networkidle');
         }
 
         const tokenField = page.locator('#jform_joomlatoken_token');
 
         // Diagnostics worth their weight when this fails on a machine no one
-        // can attach a debugger to: where each route actually landed, and
-        // what Joomla had to say about it.
+        // can attach a debugger to: where we actually landed, and what
+        // Joomla had to say about it.
         const alerts = (await page.locator('joomla-alert, .alert').allInnerTexts())
             .join(' | ').replace(/\s+/g, ' ').slice(0, 300);
 
         await expect(
             tokenField,
-            'No Joomla API Token field via either the Edit Account link or the com_admin profile view. '
+            'No Joomla API Token field on the account form, even after a seed-generating save. '
             + `Landed on: ${page.url()} — messages: ${alerts || '(none)'}`,
         ).toBeAttached();
 
-        let token = await tokenField.inputValue();
-
-        if (!token) {
-            await page.click('.button-apply');
-            await page.waitForLoadState('networkidle');
-            token = await page.locator('#jform_joomlatoken_token').inputValue();
-        }
+        const token = await tokenField.inputValue();
 
         expect(token, 'The profile never produced a token value').not.toBe('');
 


### PR DESCRIPTION
Closes the structural half of #1342 — the suites only ran on one configured laptop.

## What the job does

Stands up everything from nothing on `ubuntu-latest`:

1. **MySQL 8.4** service container
2. **Joomla 5.4.3** downloaded and installed headlessly by **core's own CLI installer** — the same install path a site admin's web install runs, then `installation/` removed
3. One generated `build.properties` wiring a `role = test` install — the harness discovers the site **by role, not by name** (#1353), so this file is the only glue the chain needs
4. `composer test:install` **unchanged**: reset → build `pkg_proclaim` (submodule sub-packages included) → install via Joomla's CLI → extension/migration/**API** assertions (#1309/#1310/#1331 guards)
5. The **#1330 Playwright acceptance suite** against `php -S`: plugin visible in the admin UI, 401-not-404 without a token, 200 + JSON:API with a profile-obtained token, `public_reads` round-tripped through the plugin edit form

## Triggers

- **Nightly** (05:17 UTC) — drift surfaces within a day, not at release time
- **workflow_dispatch** — on demand
- **Pull requests** touching `api/`, the webservices plugin, the harness scripts, or `tests/e2e/` — including this PR, which is therefore its own first validation run

No secrets, no persistent state; runs identically on any contributor's fork. Playwright report + PHP server log uploaded as artifacts on failure.

## Scope note

The full local suites (a11y scans, functional specs, J5×J6 matrix) still need the dev sites — this covers the highest-consequence slice off-laptop: *the shipped package produces a working, authenticated API on a clean install.* Closes #1342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR