### PR TITLE
fix(release): pin ars.environments so published items carry real requirements

### DIFF
--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -146,6 +146,8 @@
         "endpoint": "https://www.christianwebministries.org",
         "categoryId": 1,
         "updateStreamId": 1,
+        "_environments_comment": "ARS environment ids driving the update XML: Joomla 5 + Joomla 6 + PHP 8.3/8.4/8.5. Publishing with NO environments makes ARS emit php_minimum 8.5 / Joomla 6.1+ requirements that block every real site (bit us for 10.3.4-10.4.0).",
+        "environments": ["45", "46", "48", "49", "50"],
         "tokenItem": "CWM ARS API Token",
         "tokenVault": "CWM",
         "itemDescription": "pkg_proclaim download"


### PR DESCRIPTION
Post-release verification on j6-test found 10.4.0 (and 10.3.4–10.3.6) advertised as **requires PHP 8.5 / Joomla 6.1+** — the new ARS publish script sent `"environments": null` because `cwm-build.config.json` never set `ars.environments`, and ARS's fallback emits bogus requirements.

- The four live items were repaired by PATCHing them with the environment ids from the known-good 10.3.3 item (`["45","46","48","49","50"]` → PHP 8.3, Joomla (5)|(6)); j6-test now offers 10.4.0 cleanly.
- This PR pins those ids in the config so every future publish carries them.
- Joomla-Bible-Study/cwm-build-tools#59 makes the publish refuse to run without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR