### PR TITLE
chore(deps): cwm/build-tools 1.9.1 — ARS publish refuses null environments

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.9.0",
+            "version": "v1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "368bcfed99427dfc39f1d4472b1feb069e84d4b9"
+                "reference": "cf9dde7d9a91b7ff3f0f795548d808d92223b8ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/368bcfed99427dfc39f1d4472b1feb069e84d4b9",
-                "reference": "368bcfed99427dfc39f1d4472b1feb069e84d4b9",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/cf9dde7d9a91b7ff3f0f795548d808d92223b8ea",
+                "reference": "cf9dde7d9a91b7ff3f0f795548d808d92223b8ea",
                 "shasum": ""
             },
             "require": {
@@ -626,13 +626,17 @@
             "scripts": {
                 "test": [
                     "@test:php",
-                    "@test:python"
+                    "@test:python",
+                    "@test:shell"
                 ],
                 "test:php": [
                     "phpunit"
                 ],
                 "test:python": [
                     "python3 -m unittest discover -s tests/python -v"
+                ],
+                "test:shell": [
+                    "rc=0; for t in tests/shell/*.test.sh; do bash \"$t\" || rc=1; done; exit $rc"
                 ]
             },
             "license": [
@@ -653,10 +657,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.9.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.9.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-27T11:11:44+00:00"
+            "time": "2026-07-28T03:10:00+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Completes the ARS environments fix chain: Joomla-Bible-Study/cwm-build-tools#59 shipped in v1.9.1; this lock bump makes the vendored `cwm-ars-publish` refuse to publish when `ars.environments` is missing — the failure that made 10.3.4–10.4.0 advertise PHP 8.5 / Joomla 6.1+ requirements. With #1360 (config pin) + this guard, the next release cannot repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR