### PR TITLE
chore(language): sync the stream-mode OAuth notice to all locales

### DIFF
--- a/admin/src/Addons/Servers/Youtube/language/cs-CZ/cs-CZ.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/cs-CZ/cs-CZ.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."

--- a/admin/src/Addons/Servers/Youtube/language/de-DE/de-DE.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/de-DE/de-DE.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."

--- a/admin/src/Addons/Servers/Youtube/language/es-ES/es-ES.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/es-ES/es-ES.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."

--- a/admin/src/Addons/Servers/Youtube/language/hu-HU/hu-HU.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/hu-HU/hu-HU.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."

--- a/admin/src/Addons/Servers/Youtube/language/nl-NL/nl-NL.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/nl-NL/nl-NL.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."

--- a/admin/src/Addons/Servers/Youtube/language/no-NO/no-NO.jbs_addon_youtube.ini
+++ b/admin/src/Addons/Servers/Youtube/language/no-NO/no-NO.jbs_addon_youtube.ini
@@ -153,3 +153,4 @@ JBS_ADDON_YOUTUBE_STREAM_KEY_DESC_NOTE="Keep this secret — anyone holding it c
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START="Go live when the encoder starts"
 JBS_ADDON_YOUTUBE_LIVE_AUTO_START_DESC="When on, a scheduled broadcast goes live automatically the moment your encoder starts sending — no YouTube Studio visit needed. Leave off if you start the encoder early for sound checks: with auto-start on, that would go live too."
 JBS_ADDON_YOUTUBE_LIVE_KEPT="The YouTube broadcast was left in place — its status is '%s', so removing it could destroy a stream or recording. Manage it in YouTube Studio if needed."
+JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED="Direct streaming is disabled: it requires this server's YouTube account connection (OAuth) to work. Enter a Client ID and Client Secret in the YouTube OAuth 2.0 section, connect the account, then return here."


### PR DESCRIPTION
Follow-up to #1362: syncs `JBS_ADDON_YOUTUBE_STREAM_MODE_OAUTH_REQUIRED` into cs-CZ/de-DE/es-ES/hu-HU/nl-NL/no-NO as English fallbacks. The sync ran without the Google Translate key (1Password unavailable remotely); the script treats keys matching the en-GB source as untranslated, so the next keyed `composer sync-languages` run will translate exactly these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBsju3MSzptws5njS14NaR