### PR TITLE
fix(assets): register the lib_cwmscripture asset registry file

### DIFF
--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -217,6 +217,7 @@ class Cwmshowscripture
     public function renderTextPassage(BiblePassageResult $result, int $choice, Registry $params, string $switcherHtml = ''): string
     {
         $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
         $wa->useStyle('lib_cwmscripture.scripture-text');
 
         $copyrightHtml = '';
@@ -363,6 +364,7 @@ class Cwmshowscripture
     {
         $app = Factory::getApplication();
         $wa  = $app->getDocument()->getWebAssetManager();
+        $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
         $wa->useScript('lib_cwmscripture.scripture-switcher');
         $wa->useStyle('lib_cwmscripture.scripture-switcher-css');
 
@@ -631,6 +633,7 @@ class Cwmshowscripture
     private function renderUnavailableNotice(object $row, string $reference, string $version): string
     {
         $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
         $wa->useScript('lib_cwmscripture.scripture-switcher');
         $wa->useStyle('lib_cwmscripture.scripture-text');
 

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -500,6 +500,7 @@ class HtmlView extends BaseHtmlView
         // Load scripture tooltip assets (per-element controlled; JS is a no-op
         // if no elements have show_tooltip enabled). Skip in print mode.
         if (empty($this->print)) {
+            $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
             $wa->useScript('lib_cwmscripture.scripture-tooltip');
             $wa->useStyle('lib_cwmscripture.scripture-tooltip');
 

--- a/site/src/View/Cwmsermons/HtmlView.php
+++ b/site/src/View/Cwmsermons/HtmlView.php
@@ -301,6 +301,7 @@ class HtmlView extends BaseHtmlView
 
         // Load scripture tooltip assets (per-element controlled; JS is a no-op
         // if no elements have show_tooltip enabled)
+        $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
         $wa->useScript('lib_cwmscripture.scripture-tooltip');
         $wa->useStyle('lib_cwmscripture.scripture-tooltip');
 


### PR DESCRIPTION
## Problem

The scripture version switcher is non-functional on site views, and the same defect kills the scripture tooltips.

`com_proclaim` enqueues `lib_cwmscripture.*` assets by name, but never registers `media/lib_cwmscripture/joomla.asset.json` — the file that defines those names. Joomla's `WebAssetRegistry` auto-loads registry files for core, the active template and the active **extension** only; a library's file is never discovered on its own. `WebAssetRegistry::get()` then throws `UnknownAssetException` for the unregistered name, so the result is either a bubbled exception or — where one of the surrounding `try/catch (\Exception)` blocks swallows it — markup rendered with no JS or CSS behind it.

The only correct call site in the repo was in the plugin (`plugins/content/scripturelinks/src/Extension/ScriptureLinks.php:1134`). That meant the assets resolved only on pages where `content - scripturelinks` had already run; on a sermon view rendered by the component, they did not.

This is consistent with the switcher having worked before: these assets used to live under `media/com_proclaim/` (still in the cleanup list at `proclaim.script.php:234`/`:245`) and were moved into lib_cwmscripture. Under the old paths the component *was* the active extension, so registration was automatic.

## Change

Adds the idempotent `$wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');` ahead of all five affected enqueue sites — 5 added lines, no other changes:

| Location | Assets |
|---|---|
| `Cwmshowscripture::renderTextPassage()` | `scripture-text` |
| `Cwmshowscripture::renderVersionSwitcher()` | switcher JS + CSS |
| `Cwmshowscripture::renderUnavailableNotice()` | switcher JS, `scripture-text` |
| `Cwmsermon\HtmlView` | tooltip JS + CSS |
| `Cwmsermons\HtmlView` | tooltip JS + CSS |

Registering directly (rather than calling the library's new helper) keeps this fix independent of the bundled library version, so it works against the currently shipped lib_cwmscripture.

## Testing

`php -l` clean on all three files. Grep confirms every `useScript('lib_cwmscripture`/`useStyle('lib_cwmscripture` call in `site/` is now preceded by a registration.

Worth verifying on a live sermon view with **Allow version switch** (`allow_version_switch = 1`) enabled, since `renderVersionSwitcher()` is gated on that param.

## Related

Library-side hardening: Joomla-Bible-Study/lib_cwmscripture#14 makes `ScriptureRenderer` self-sufficient and adds `loadSwitcherAssets()`, so consumers cannot forget this step. These call sites can migrate to it once the bundled library is bumped past that release.

Closes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)