### PR TITLE
build: fail the build when media output has no source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.9.0",
+    "cwm/build-tools": "^1.12.0",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.9.1",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "cf9dde7d9a91b7ff3f0f795548d808d92223b8ea"
+                "reference": "abfe913276c90b3bfeb67edc0c851783c84e32c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/cf9dde7d9a91b7ff3f0f795548d808d92223b8ea",
-                "reference": "cf9dde7d9a91b7ff3f0f795548d808d92223b8ea",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/abfe913276c90b3bfeb67edc0c851783c84e32c3",
+                "reference": "abfe913276c90b3bfeb67edc0c851783c84e32c3",
                 "shasum": ""
             },
             "require": {
@@ -657,10 +657,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.9.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.12.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-28T03:10:00+00:00"
+            "time": "2026-07-30T03:23:06+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -85,6 +85,11 @@
             "command": "npm install && npm run build"
         },
         "verifyAssets": true,
+        "_verifyMediaSources_comment": "The inverse of verifyAssets: catches built files whose source is gone. media/js and media/css only — media/vendor, media/images, media/fancybox, media/backup, media/captions and media/youtube_cache are copied or runtime dirs with no media_source counterpart. Needs cwm/build-tools >= 1.12; older versions ignore the key and the check silently does not run. Background: lib_cwmscripture#25.",
+        "verifyMediaSources": [
+            { "source": "build/media_source/js",  "output": "media/js" },
+            { "source": "build/media_source/css", "output": "media/css" }
+        ],
         "versionPrompt": {
             "enabled": true,
             "timeout": 10


### PR DESCRIPTION
Wires up the build check added for Joomla-Bible-Study/lib_cwmscripture#25, so this repo cannot ship the same class of stale artifact.

## What it catches

The inverse of the existing `verifyAssets`. That one fails when the manifest references an asset the build never produced; this one fails when `media/` holds a built file whose source is gone.

Minified output is gitignored, so renaming or deleting a source leaves its old output in `media/` where no checkout, branch switch or pull removes it — and the packager ships whatever is there. That is how lib_cwmscripture published three files no build could reproduce for months. The damage is not the dead bytes: the release artifact stops being a function of the source and becomes a function of the source *plus that machine's build history*, so two developers on the same tag produce different packages.

```json
"verifyMediaSources": [
    { "source": "build/media_source/js",  "output": "media/js" },
    { "source": "build/media_source/css", "output": "media/css" }
]
```

Scoped to the two directories this build owns. `media/vendor`, `media/images`, `media/fancybox`, `media/backup`, `media/captions` and `media/youtube_cache` are copied or runtime dirs with no `media_source` counterpart — pointing the check at them would produce noise and teach people to switch it off.

## Verified both ways

- Planted `media/js/zz-removed-source.min.js` → build fails naming it.
- Normal build passes: `Files: 1929`. So nothing currently in `media/js` or `media/css` is orphaned.
- `composer test:unit` — 799 tests, 1638 assertions, green.

## `^1.12.0`, not `^1.9.0`

`BuildConfig` ignores unknown keys, so on an older toolchain this config is accepted and the check silently never runs — the same silent-no-op failure mode it exists to catch. The constraint makes the dependency real rather than aspirational.

## Heads-up for merge order

#1370 deletes `build/media_source/js/scripture-autocomplete.es6.js` (an orphaned copy left behind when that script moved into lib_cwmscripture at 10.3.0). Its four build products — `scripture-autocomplete.js`, `.min.js`, `.min.js.gz`, `.min.js.map` — are still sitting in `media/js` on any machine that built before that merge, and this check will fail on them until they are cleaned:

```
git clean -Xfd media/js && npm run build
```

That is the check working as designed on genuinely stale output, not a regression from either PR. CI builds from a fresh checkout, so it only affects existing working copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq
