### PR TITLE
fix(media): give Font Awesome brand icons the brand family

### DIFF
--- a/admin/sql/updates/mysql/10.4.1-20260729.sql
+++ b/admin/sql/updates/mysql/10.4.1-20260729.sql
@@ -1,0 +1,157 @@
+-- Repair Font Awesome brand icons that 10.3.0-20260322.sql damaged.
+--
+-- That migration rewrote the FA4 prefix in stored params:
+--
+--     REPLACE(params, '"fa fa-', '"fa-solid fa-')
+--
+-- which is wrong for brand icons. The family comes from the style class, not the
+-- icon name: .fa-solid selects "Font Awesome 6 Free" at weight 900, and the Free
+-- font has no glyph at a brand codepoint. So "fa-solid fa-youtube" renders as
+-- tofu even though .fa-youtube exists and carries the right codepoint.
+--
+-- Worse, the FA4 value was working before the rewrite. Joomla's v4 shim
+--
+--     .fa.fa-youtube { font-family: "Font Awesome 6 Brands"; font-weight: 400 }
+--
+-- keys on the bare .fa class that the rewrite strips.
+--
+-- Separately, some FA4 names exist ONLY as shims. fa-video-camera has no plain
+-- rule in joomla-fontawesome.css, only .fa.fa-video-camera, so re-prefixing it
+-- was never enough — it has to become the FA6 name fa-video.
+--
+-- Each pattern below includes the closing quote so it matches a whole JSON value.
+-- That matters: fa-vimeo is a prefix of fa-vimeo-v, and an unanchored REPLACE
+-- would corrupt the latter while fixing the former.
+--
+-- This migration deliberately repeats the FA4/FA5 prefix conversions from
+-- 10.3.0-20260322.sql instead of assuming they ran. On a site whose database was
+-- imported into a fresh install, Joomla stamps #__schemas with the newest update
+-- file without executing the intermediate ones — so the recorded version claims
+-- the conversion happened while the data shows otherwise. Observed on a real
+-- install reporting 10.3.3-20260711 with 1,378 rows still on legacy prefixes and
+-- only 2 on FA6. All statements are idempotent, so re-running them is harmless.
+
+-- ---------------------------------------------------------------------------
+-- Step 1: FA4/FA5 prefixes -> FA6 style classes (repeat of 10.3.0, see above)
+-- ---------------------------------------------------------------------------
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fab ', '"fa-brands ')
+WHERE `params` LIKE '%"fab %';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fas ', '"fa-solid ')
+WHERE `params` LIKE '%"fas %';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"far ', '"fa-regular ')
+WHERE `params` LIKE '%"far %';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa fa-', '"fa-solid fa-')
+WHERE `params` LIKE '%"fa fa-%';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fab ', '"fa-brands ')
+WHERE `media` LIKE '%"fab %';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fas ', '"fa-solid ')
+WHERE `media` LIKE '%"fas %';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fa fa-', '"fa-solid fa-')
+WHERE `media` LIKE '%"fa fa-%';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fab ', '"fa-brands ')
+WHERE `params` LIKE '%"fab %';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fas ', '"fa-solid ')
+WHERE `params` LIKE '%"fas %';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fa fa-', '"fa-solid fa-')
+WHERE `params` LIKE '%"fa fa-%';
+
+-- ---------------------------------------------------------------------------
+-- Step 2: brand icons wrongly left on a non-brand family by step 1
+-- ---------------------------------------------------------------------------
+
+-- Media files: media_icon_type stored in params JSON
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-youtube"', '"fa-brands fa-youtube"')
+WHERE `params` LIKE '%"fa-solid fa-youtube"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-youtube-play"', '"fa-brands fa-youtube"')
+WHERE `params` LIKE '%"fa-solid fa-youtube-play"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-youtube-square"', '"fa-brands fa-square-youtube"')
+WHERE `params` LIKE '%"fa-solid fa-youtube-square"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-vimeo-v"', '"fa-brands fa-vimeo-v"')
+WHERE `params` LIKE '%"fa-solid fa-vimeo-v"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-vimeo"', '"fa-brands fa-vimeo"')
+WHERE `params` LIKE '%"fa-solid fa-vimeo"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-vimeo-square"', '"fa-brands fa-square-vimeo"')
+WHERE `params` LIKE '%"fa-solid fa-vimeo-square"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa-solid fa-video-camera"', '"fa-solid fa-video"')
+WHERE `params` LIKE '%"fa-solid fa-video-camera"%';
+
+-- Any FA4 brand values the 10.3.0 migration never reached (e.g. rows written
+-- afterwards by an older form, or an install that skipped that update)
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa fa-youtube"', '"fa-brands fa-youtube"')
+WHERE `params` LIKE '%"fa fa-youtube"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa fa-vimeo"', '"fa-brands fa-vimeo"')
+WHERE `params` LIKE '%"fa fa-vimeo"%';
+
+UPDATE `#__bsms_mediafiles`
+SET `params` = REPLACE(`params`, '"fa fa-video-camera"', '"fa-solid fa-video"')
+WHERE `params` LIKE '%"fa fa-video-camera"%';
+
+-- Server media defaults
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fa-solid fa-youtube"', '"fa-brands fa-youtube"')
+WHERE `media` LIKE '%"fa-solid fa-youtube"%';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fa-solid fa-vimeo-v"', '"fa-brands fa-vimeo-v"')
+WHERE `media` LIKE '%"fa-solid fa-vimeo-v"%';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fa-solid fa-vimeo"', '"fa-brands fa-vimeo"')
+WHERE `media` LIKE '%"fa-solid fa-vimeo"%';
+
+UPDATE `#__bsms_servers`
+SET `media` = REPLACE(`media`, '"fa-solid fa-video-camera"', '"fa-solid fa-video"')
+WHERE `media` LIKE '%"fa-solid fa-video-camera"%';
+
+-- Admin params
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fa-solid fa-youtube"', '"fa-brands fa-youtube"')
+WHERE `params` LIKE '%"fa-solid fa-youtube"%';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fa-solid fa-vimeo-v"', '"fa-brands fa-vimeo-v"')
+WHERE `params` LIKE '%"fa-solid fa-vimeo-v"%';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fa-solid fa-vimeo"', '"fa-brands fa-vimeo"')
+WHERE `params` LIKE '%"fa-solid fa-vimeo"%';
+
+UPDATE `#__bsms_admin`
+SET `params` = REPLACE(`params`, '"fa-solid fa-video-camera"', '"fa-solid fa-video"')
+WHERE `params` LIKE '%"fa-solid fa-video-camera"%';

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -74,6 +74,15 @@ $EXPECTATIONS = [
         ],
         'schemaMin' => '10.3.3',
     ],
+    // 10.4.1-20260729.sql repairs Font Awesome brand icons in stored params. It is
+    // pure DML — REPLACE() over #__bsms_mediafiles.params, #__bsms_servers.media and
+    // #__bsms_admin.params — so there is no table, column or index to assert; only
+    // that the migration ran and #__schemas advanced. Asserting the repair itself
+    // needs a damaged-row fixture seeded before the upgrade, which this gate has no
+    // vocabulary for yet.
+    '10.4.1' => [
+        'schemaMin' => '10.4.1',
+    ],
 ];
 
 // ---------------------------------------------------------------------------

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -44,11 +44,56 @@ class Cwmmedia
     private int $fsize = 0;
 
     /**
-     * Normalize a Font Awesome icon class from FA5 shorthand to FA6 canonical.
+     * Icon names that live in the Font Awesome Brands font, not Free/solid.
      *
-     * Converts legacy DB values like "fas fa-play" or "fab fa-youtube" to
-     * their FA6 equivalents ("fa-solid fa-play", "fa-brands fa-youtube").
-     * Safe to call on values that are already FA6 — returns them unchanged.
+     * The family comes from the style class, not the icon name: `.fa-brands`
+     * selects "Font Awesome 6 Brands" while `.fa-solid` selects "Font Awesome 6
+     * Free" at weight 900. A brand codepoint has no glyph in the Free font, so
+     * `fa-solid fa-youtube` renders as tofu even though `.fa-youtube` exists and
+     * carries the right codepoint.
+     *
+     * Extend this when a new brand icon starts being stored.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private const BRAND_ICONS = [
+        'fa-youtube', 'fa-square-youtube', 'fa-vimeo', 'fa-vimeo-v', 'fa-square-vimeo',
+        'fa-apple', 'fa-itunes', 'fa-itunes-note', 'fa-spotify', 'fa-soundcloud',
+        'fa-google', 'fa-google-drive', 'fa-google-play', 'fa-facebook', 'fa-facebook-f',
+        'fa-square-facebook', 'fa-twitter', 'fa-x-twitter', 'fa-instagram', 'fa-twitch',
+        'fa-dropbox', 'fa-amazon', 'fa-mixcloud', 'fa-deezer', 'fa-rumble',
+    ];
+
+    /**
+     * Style classes that select a non-brand family, and so must be replaced when
+     * the icon turns out to be a brand.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private const NON_BRAND_STYLES = ['fa-solid', 'fa-regular', 'fa-light', 'fa-thin', 'fa', 'fas', 'far'];
+
+    /**
+     * Normalize a Font Awesome icon class from FA4/FA5 shorthand to FA6 canonical.
+     *
+     * Converts legacy DB values like "fas fa-play" or "fab fa-youtube" to their
+     * FA6 equivalents ("fa-solid fa-play", "fa-brands fa-youtube"). Safe to call
+     * on values that are already FA6 — returns them unchanged.
+     *
+     * Two things this has to get right, both of which it originally did not:
+     *
+     * 1. Brands need the brand family. Rewriting the FA4 prefix `fa fa-` to
+     *    `fa-solid fa-` produced `fa-solid fa-youtube`, which is tofu — the Free
+     *    font has no glyph at the YouTube codepoint. Worse, the FA4 form was
+     *    *working* before the rewrite, because Joomla's v4 shim
+     *    (`.fa.fa-youtube { font-family: "Font Awesome 6 Brands" }`) keys on the
+     *    bare `.fa` class that the rewrite strips.
+     * 2. Some FA4 names only exist as shims. `fa-video-camera` has no plain rule
+     *    in joomla-fontawesome.css, only `.fa.fa-video-camera`, so it must be
+     *    renamed to the FA6 name `fa-video` rather than merely re-prefixed.
+     *
+     * Because the brand fix-up runs on the final token list, it also repairs
+     * values already damaged in the database by the 10.3.0 migration: a stored
+     * `fa-solid fa-youtube` comes back out as `fa-brands fa-youtube`.
      *
      * @param   string  $class  Icon CSS class string
      *
@@ -86,9 +131,53 @@ class Cwmmedia
             'fa-bible'                => 'fa-book-bible',
             'fa-sticky-note'          => 'fa-note-sticky',
             'fa-word'                 => 'fa-file-word',
+            // FA4 names with no plain FA6 rule — shim-only, so they must be renamed
+            'fa-video-camera'    => 'fa-video',
+            'fa-youtube-play'    => 'fa-youtube',
+            'fa-youtube-square'  => 'fa-square-youtube',
+            'fa-vimeo-square'    => 'fa-square-vimeo',
+            'fa-facebook-square' => 'fa-square-facebook',
         ];
 
-        return strtr($class, $renames);
+        $class = strtr($class, $renames);
+
+        return self::applyBrandFamily($class);
+    }
+
+    /**
+     * Force the brand family when the icon is a brand.
+     *
+     * Operates on whole class tokens rather than substrings: `fa-vimeo` is a
+     * prefix of `fa-vimeo-v`, so a naive str_replace would corrupt one while
+     * fixing the other.
+     *
+     * @param   string  $class  Icon CSS class string, already prefix- and rename-normalized
+     *
+     * @return  string  Class string whose style token is fa-brands when appropriate
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function applyBrandFamily(string $class): string
+    {
+        $tokens = preg_split('/\s+/', trim($class), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        if ($tokens === [] || array_intersect($tokens, self::BRAND_ICONS) === []) {
+            return $class;
+        }
+
+        foreach ($tokens as &$token) {
+            if (\in_array($token, self::NON_BRAND_STYLES, true)) {
+                $token = 'fa-brands';
+            }
+        }
+
+        unset($token);
+
+        if (!\in_array('fa-brands', $tokens, true)) {
+            array_unshift($tokens, 'fa-brands');
+        }
+
+        return implode(' ', array_values(array_unique($tokens)));
     }
 
     /**

--- a/tests/unit/Site/Helper/CwmmediaTest.php
+++ b/tests/unit/Site/Helper/CwmmediaTest.php
@@ -36,4 +36,96 @@ class CwmmediaTest extends ProclaimTestCase
         $this->assertFalse(Cwmmedia::isExternal('images/local.jpg'));
         $this->assertFalse(Cwmmedia::isExternal('/images/local.jpg'));
     }
+
+    /**
+     * A brand icon stored in FA4 form must end up in the brand family.
+     *
+     * This is the regression that broke ~263 media rows: `fa fa-youtube` was
+     * rewritten to `fa-solid fa-youtube`, which is tofu because the Free font has
+     * no glyph at the YouTube codepoint. The FA4 form had been rendering fine via
+     * Joomla's shim `.fa.fa-youtube { font-family: "Font Awesome 6 Brands" }`,
+     * which keys on the bare `.fa` class the rewrite removed.
+     *
+     * @return void
+     */
+    public function testFa4BrandIconGetsBrandFamily(): void
+    {
+        $this->assertSame('fa-brands fa-youtube', Cwmmedia::normalizeIconClass('fa fa-youtube'));
+        $this->assertSame('fa-brands fa-vimeo', Cwmmedia::normalizeIconClass('fa fa-vimeo'));
+    }
+
+    /**
+     * Values already damaged in the database must self-heal at render time.
+     *
+     * The 10.3.0 migration rewrote stored params in place, so sites carry
+     * `fa-solid fa-youtube` on disk. Normalizing must repair it rather than
+     * faithfully reproduce it.
+     *
+     * @return void
+     */
+    public function testAlreadyBrokenSolidBrandIsRepaired(): void
+    {
+        $this->assertSame('fa-brands fa-youtube', Cwmmedia::normalizeIconClass('fa-solid fa-youtube'));
+        $this->assertSame('fa-brands fa-vimeo-v', Cwmmedia::normalizeIconClass('fa-solid fa-vimeo-v'));
+    }
+
+    /**
+     * fa-vimeo is a prefix of fa-vimeo-v, so token-wise matching matters.
+     *
+     * @return void
+     */
+    public function testPrefixOverlappingBrandNamesAreNotCorrupted(): void
+    {
+        $this->assertSame('fa-brands fa-vimeo-v', Cwmmedia::normalizeIconClass('fab fa-vimeo-v'));
+        $this->assertSame('fa-brands fa-vimeo', Cwmmedia::normalizeIconClass('fab fa-vimeo'));
+    }
+
+    /**
+     * FA4 names that exist only as a shim must be renamed, not just re-prefixed.
+     *
+     * `fa-video-camera` has no plain rule in joomla-fontawesome.css — only
+     * `.fa.fa-video-camera` — so `fa-solid fa-video-camera` is tofu. Affected
+     * ~181 media rows.
+     *
+     * @return void
+     */
+    public function testShimOnlyFa4NamesAreRenamedToFa6(): void
+    {
+        $this->assertSame('fa-solid fa-video', Cwmmedia::normalizeIconClass('fa fa-video-camera'));
+        $this->assertSame('fa-brands fa-youtube', Cwmmedia::normalizeIconClass('fa fa-youtube-play'));
+        $this->assertSame('fa-brands fa-square-youtube', Cwmmedia::normalizeIconClass('fab fa-youtube-square'));
+    }
+
+    /**
+     * Non-brand icons must keep the solid family, and already-FA6 values must be
+     * returned untouched.
+     *
+     * @return void
+     */
+    public function testNonBrandIconsAndIdempotence(): void
+    {
+        $this->assertSame('fa-solid fa-play', Cwmmedia::normalizeIconClass('fa fa-play'));
+        $this->assertSame('fa-solid fa-play', Cwmmedia::normalizeIconClass('fas fa-play'));
+        $this->assertSame('fa-solid fa-file-pdf', Cwmmedia::normalizeIconClass('fas fa-file-pdf'));
+
+        // Idempotent — normalizing twice changes nothing
+        $this->assertSame('fa-solid fa-play', Cwmmedia::normalizeIconClass('fa-solid fa-play'));
+        $this->assertSame(
+            'fa-brands fa-youtube',
+            Cwmmedia::normalizeIconClass(Cwmmedia::normalizeIconClass('fa fa-youtube'))
+        );
+    }
+
+    /**
+     * The JBS_MED_CUSTOM sentinel must pass through untouched.
+     *
+     * getIcons() maps 'JBS_MED_CUSTOM' => '1', and the caller branches on it to
+     * read media_custom_icon instead. It is a marker, not a class.
+     *
+     * @return void
+     */
+    public function testCustomIconSentinelIsUntouched(): void
+    {
+        $this->assertSame('1', Cwmmedia::normalizeIconClass('1'));
+    }
 }


### PR DESCRIPTION
Fixes the media icons rendering as tofu — the broken-glyph box where a YouTube or Vimeo icon should be.

## Cause

`10.3.0-20260322.sql` migrated stored icon params from FA4 to FA6 with a blanket prefix rewrite:

```sql
REPLACE(params, '"fa fa-', '"fa-solid fa-')
```

That is wrong for brand icons. In Font Awesome 6 the **family comes from the style class, not the icon name**: `.fa-solid` selects "Font Awesome 6 Free" at weight 900, and the Free font carries no glyph at a brand codepoint. So `fa-solid fa-youtube` renders as tofu even though `.fa-youtube` exists and has the right codepoint.

Worse, the FA4 value was working before that rewrite. Joomla's v4 shim keys on the bare `.fa` class:

```css
.fa.fa-youtube { font-family: "Font Awesome 6 Brands"; font-weight: 400 }
```

and the rewrite stripped exactly that class. Separately, some FA4 names exist *only* as shims — `fa-video-camera` has no plain rule in `joomla-fontawesome.css`, only `.fa.fa-video-camera` — so re-prefixing it was never enough; it has to become the FA6 name `fa-video`.

## Changes

**Runtime** — `Cwmmedia::normalizeIconClass()` now knows which icon names live in the Brands font and emits `fa-brands` for them, so values arriving from the database or from a template override are rendered correctly regardless of what is stored.

**Data** — `admin/sql/updates/mysql/10.4.1-20260729.sql` repairs stored params across `#__bsms_mediafiles.params`, `#__bsms_servers.media` and `#__bsms_admin.params`.

Two details worth flagging in that migration:

- Each pattern includes the closing quote, so it matches a whole JSON value. That matters: `fa-vimeo` is a prefix of `fa-vimeo-v`, and an unanchored `REPLACE` would corrupt the latter while fixing the former.
- It deliberately repeats the FA4/FA5 prefix conversions from `10.3.0-20260322.sql` rather than assuming they ran. On a site whose database was imported into a fresh install, Joomla stamps `#__schemas` with the newest update file without executing the intermediate ones — so the recorded version claims the conversion happened while the data shows otherwise. Observed on a real install reporting `10.3.3-20260711` with 1,378 rows still on legacy prefixes and only 2 on FA6. All statements are idempotent, so re-running is harmless.

**Release gate** — `build/verify-migrations.php` gains the `10.4.1` entry. That file fails by design when a version ships update SQL no `$EXPECTATIONS` entry describes, so without this `composer test:upgrade` aborts at phase 7 before any later assertion runs. The migration is pure DML, so there is no table, column or index to assert — only that it ran and `#__schemas` advanced.

## Tests

`CwmmediaTest` — 7 tests, 19 assertions covering the brand-family mapping. Full unit suite: 805 tests, 1653 assertions green.

## Note on this branch

Rebased onto `development` after #1369 merged. It previously carried that PR's four scripture commits as well; since #1369 was squash-merged, replaying them would have shown already-merged work. Only the two FA6 commits remain, and the diff against `development` is now exactly four files.

## Not covered

The repair is verified by unit tests on the normaliser, not by rendering a page. The `$EXPECTATIONS` entry asserts the migration ran, not that it corrected any particular row — the gate has no vocabulary for data assertions. Proving the repair end to end needs a damaged-row fixture seeded before the upgrade, the same shape as the scripture probe in `build/verify-scripture-upgrade.php`; worth adding if this class of migration recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq
