### PR TITLE
fix(a11y): give the schema-fix button enough contrast to pass WCAG AA

### DIFF
--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -299,8 +299,15 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                     <p class="mb-1">
                         <?php echo Text::sprintf('JBS_CPL_SCHEMA_OUT_OF_SYNC_DESC', $schemaGap['current'], $schemaGap['expected']); ?>
                     </p>
+                    <?php
+                        // btn-primary, not btn-warning: Atum's warning yellow (#ffb514) with
+                        // Bootstrap's derived text colour (#996901) is 2.71:1, which fails WCAG
+                        // AA at this size — @a11y catches it. The alert already carries the
+                        // warning semantics, so the action inside it does not need to repeat
+                        // them, and core uses primary the same way.
+                    ?>
                     <a href="<?php echo Route::_('index.php?option=com_installer&view=database'); ?>"
-                       class="btn btn-warning btn-sm">
+                       class="btn btn-primary btn-sm">
                         <?php echo Text::_('JBS_CPL_SCHEMA_FIX_BUTTON'); ?>
                     </a>
                 </div>


### PR DESCRIPTION
Found by `composer test:release` — the only failure in the gate after today's merges.

## The violation

```
[serious] color-contrast — Elements must meet minimum color contrast ratio thresholds
  wcag2aa, wcag143
  → .btn-warning
    Element has insufficient color contrast of 2.71 (foreground #996901,
    background #ffb514, font size 9.6pt (12.8px)). Expected 4.5:1
```

The control panel's "database schema out of sync" alert carried its action as `btn-warning`. Atum's warning yellow with the text colour Bootstrap derives from it is 2.71:1 at that size.

## Why it appeared today

Latent, not new. That block renders only when a site's schema is behind the component, so the `@a11y` scan had never rendered the button. #1372 added `admin/sql/updates/mysql/10.4.1-20260729.sql`, and on a symlinked dev site that file is visible with no install:

| | |
|---|---|
| Newest migration in the repo | `10.4.1-20260729.sql` |
| j6-dev's recorded schema | `10.3.3-20260711` |

So `isSchemaOutOfDate()` went true and the scan finally saw the button. The uncomfortable implication is that real users have only ever encountered this button in the state where it fails — whenever their database is behind.

## The fix

`btn-primary` instead of a CSS override. The alert already carries the warning semantics, the action inside it needn't repeat them, and core uses primary the same way. Overriding `.btn-warning` globally would diverge from Atum for every button Proclaim renders.

## Verified

- The previously failing test passes, **with the alert still rendering** — so the button is being scanned, not skipped because the block disappeared.
- Full e2e suite green afterwards: **70 passed, 4 skipped, 0 failed** (the 4 skips are pre-existing).

## Left alone deliberately

`btn-warning` also appears in `cwmpodcasts/validation.php`, `cwmadmin/edit.php` and `cwmadmin/edit_servermigration.php`. Same latent defect, but the scan does not currently render those and I have not confirmed each fails, so I have not changed markup on speculation. Worth a sweep — and if it turns out to be all of them, a single CSS override is the better answer than four markup edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq