### PR TITLE
fix(a11y): stop buttons inside alerts inheriting the alert's text colour

### DIFF
--- a/build/media_source/css/cwmcore.css
+++ b/build/media_source/css/cwmcore.css
@@ -1105,3 +1105,40 @@ p.expand {
     padding-bottom: 0;
   }
 }
+
+/*
+ * Buttons inside alerts must keep their own text colour.
+ *
+ * Atum colours links inside an alert with the alert's emphasis colour:
+ *
+ *     .alert.alert-warning a { color: var(--state-warning-text) }   (0,2,1)
+ *
+ * A `.btn` rendered as an anchor is caught by that rule, and Atum sets no
+ * explicit colour on several button variants, so the button ends up wearing the
+ * alert's text colour over its own background. Inside .alert-warning that gives
+ * #996901 on #ffb514 — 2.71:1 — which is how the control panel's schema-fix
+ * button failed WCAG AA (#1375), and #996901 on the secondary blue is worse
+ * still at 1.32:1.
+ *
+ * The colours below are the ones each variant already computes when rendered
+ * outside an alert, read off a live admin page — so this restores the intended
+ * appearance rather than inventing one, and buttons look the same wherever they
+ * sit. Specificity is (0,3,0) to clear Atum's (0,2,1); `a.btn` would also work
+ * but would leave `<button>` elements out if Atum ever colours those too.
+ *
+ * tests/e2e/admin/a11y.spec.js scans every variant in every alert context, so a
+ * combination that regresses here is caught even though no view renders it yet.
+ */
+.alert .btn.btn-warning,
+.alert .btn.btn-light {
+  color: #000000;
+}
+
+.alert .btn.btn-primary,
+.alert .btn.btn-secondary,
+.alert .btn.btn-success,
+.alert .btn.btn-danger,
+.alert .btn.btn-info,
+.alert .btn.btn-dark {
+  color: #ffffff;
+}

--- a/tests/e2e/admin/a11y.spec.js
+++ b/tests/e2e/admin/a11y.spec.js
@@ -109,6 +109,68 @@ const WIZARDS = [
 ];
 
 test.describe('Admin accessibility (WCAG 2.2 AA) @a11y', () => {
+    /**
+     * Button contrast, scanned as a matrix rather than wherever buttons happen to
+     * appear.
+     *
+     * The page scans below only judge markup that actually renders. The
+     * .btn-warning that failed first — the control panel's schema-fix action — sits
+     * in a block that renders only when a site's database is behind the component,
+     * so this suite never saw it until a new migration file put a dev site in that
+     * state. Every user whose schema was behind had been seeing it.
+     *
+     * The mechanism turned out to be inheritance, not the variant: Atum sets no
+     * explicit `color` on .btn-warning, so standalone it takes the body colour
+     * (black on #ffb514, 11.9:1, fine) while inside .alert-warning it takes the
+     * alert's #996901 and drops to 2.71:1. A scan of a bare button therefore proves
+     * nothing about the case that fails.
+     *
+     * So every variant is injected in every alert context as well as bare, into a
+     * real admin page so the whole Atum + Bootstrap + com_proclaim cascade applies,
+     * and axe judges the result. That covers combinations no view uses yet.
+     */
+    test('button variants meet WCAG AA contrast in every alert context', async ({ page }) => {
+        await page.goto('/administrator/index.php?option=com_proclaim&view=cwmcpanel', {
+            waitUntil: 'networkidle',
+        });
+
+        await expect(page.locator(PROCLAIM_CONTENT)).toBeVisible({ timeout: 15000 });
+
+        await page.evaluate(() => {
+            const variants = ['warning', 'primary', 'secondary', 'success', 'danger', 'info', 'light', 'dark'];
+            const contexts = ['', 'alert alert-warning', 'alert alert-info', 'alert alert-danger', 'alert alert-success'];
+            const host = document.createElement('div');
+            host.id = 'a11y-button-contrast-probe';
+
+            for (const context of contexts) {
+                const wrap = document.createElement('div');
+
+                if (context) {
+                    wrap.className = context;
+                    wrap.appendChild(document.createTextNode('context text '));
+                }
+
+                for (const variant of variants) {
+                    // Both sizes: the thresholds differ (4.5:1 normal, 3:1 large)
+                    // and the original failure was on a btn-sm.
+                    for (const size of ['', 'btn-sm']) {
+                        const btn = document.createElement('a');
+                        btn.href = '#';
+                        btn.className = ['btn', `btn-${variant}`, size].filter(Boolean).join(' ');
+                        btn.textContent = `${variant} ${size || 'default'}`;
+                        wrap.appendChild(btn);
+                    }
+                }
+
+                host.appendChild(wrap);
+            }
+
+            document.querySelector('section#content').appendChild(host);
+        });
+
+        await expectNoViolations(page, expect, { include: '#a11y-button-contrast-probe' });
+    });
+
     for (const [label, view] of SCREENS) {
         test(`${label} meets WCAG AA`, async ({ page }) => {
             await page.goto(`/administrator/index.php?option=com_proclaim&view=${view}`, {


### PR DESCRIPTION
Follow-up to #1375 — and a correction to what that PR claimed.

## I was wrong about the scope

#1375 said `btn-warning` failed contrast wherever it appeared, and named three other templates as latent instances of the same defect. Measured on a live admin page, that is not true:

| Context | Computed | Ratio |
|---|---|---|
| bare `.btn-warning` | black on `#ffb514` | **11.9:1** ✅ |
| inside `.alert-warning` | `#996901` on `#ffb514` | **2.71:1** ❌ |

The three templates I flagged — image recovery, cleanup pipeline, server cleanup, podcast fix-problems — sit in plain `div`s, inherit the body colour, and were never violations. Changing them would have been churn based on my own bad inference.

## The real mechanism

Atum colours links inside an alert with the alert's emphasis colour:

```css
.alert.alert-warning a { color: var(--state-warning-text) }   /* (0,2,1) */
```

A `.btn` rendered as an anchor is caught by that rule, and Atum sets no explicit `color` on several button variants — so the button wears the *alert's* text colour over its own background. That produced #1375's 2.71:1, and also a worse case nobody had noticed:

```
→ .alert-warning.alert > .btn-secondary.btn
  insufficient color contrast of 1.32 (foreground #996901, background #3d618f)
```

## The fix

Pin each variant to the colour it already computes outside an alert — values read off a live admin page rather than guessed — at specificity `(0,3,0)` to clear Atum's `(0,2,1)`. Buttons therefore look the same wherever they sit; nothing changes visually except inside alerts, where the text becomes legible.

**A first attempt set `--bs-btn-color` instead.** That does nothing here: Atum's button styles never read the property (it computes empty on a rendered `.btn`). I only found out because the negative control still failed — the fix "worked" in the sense that the test passed, but the test passed for the wrong reason.

## The test is the point

`button variants meet WCAG AA contrast in every alert context` injects **8 variants × 5 alert contexts × 2 sizes** into a real admin page, so the whole Atum + Bootstrap + com_proclaim cascade applies, and lets axe judge.

That covers the gap which let #1375 ship broken for months: its button lives in a block that renders only when a site's database schema is behind the component, so no page scan ever saw it — while every user in that state was looking at it. Scanning the variant matrix directly does not depend on a view happening to render the combination.

## Verified both ways

- Rules removed → matrix fails on exactly the three real combinations (warning-in-warning at both sizes, secondary-in-warning).
- Rules restored → 41 admin `@a11y` tests green; full e2e **71 passed, 4 skipped, 0 failed**.

## Note

#1375's markup change (`btn-warning` → `btn-primary` on the schema-fix button) is left as-is. With this CSS it could go back to `btn-warning` for the stronger semantics, but that is cosmetic churn on a merged fix rather than a correctness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq