### PR TITLE
chore(install): drop the dead $release property

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -94,14 +94,6 @@ class com_proclaimInstallerScript extends InstallerScript
     public string $filePath = '/components/com_proclaim/install/sql/updates/mysql';
 
     /**
-     * The version number of the extension. Max 20 characters
-     *
-     * @var    string
-     * @since  3.6
-     */
-    protected $release = '10.1.0';
-
-    /**
      * @var   DatabaseInterface|null
      *
      * @since 7.2.0


### PR DESCRIPTION
`proclaim.script.php` declared `protected $release = '10.1.0'` and never used it.

## Why it is dead, not just unused

Three things, in order of finality:

1. **Nothing in this repo reads it.** The only occurrence of `$release` anywhere is the declaration itself — no `$this->release`.
2. **Joomla overwrites it before it could be read.** `InstallerScript::preflight()` does `$this->release = $parent->getManifest()->version;`, and our `preflight()` ends with `return parent::preflight($type, $parent);`. So on every install the value became the real manifest version and the literal was discarded unread.
3. **The property is used only inside that one method**, for the core downgrade guard (`JLIB_INSTALLER_INCORRECT_SEQUENCE`). No other inherited member touches it, so the stale default had no path to leak out.

## Why remove it rather than update it

It reads as a version declaration that needs maintaining, and it was three releases stale — 10.1.0 against a 10.4.1 manifest. Anyone auditing "where is the version declared?", exactly the exercise just done for Joomla-Bible-Study/lib_cwmscripture#15, would add it to the list of things to bump and then discover bumping it changes nothing. Updating it would preserve that trap; deleting it removes it.

The parent still declares `protected $release;`, so inherited behaviour is unchanged.

## Checks

805 unit tests / 1653 assertions green, php-cs-fixer clean, `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti98Cc63bmWcXva2G4GdNq