### PR TITLE
chore(deps): update cwm/build-tools to v1.13.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b628b29fadc077996c3cdf01bf2fa294",
+    "content-hash": "8dceded82880cabf2c7229cb5d0fc041",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "abfe913276c90b3bfeb67edc0c851783c84e32c3"
+                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/abfe913276c90b3bfeb67edc0c851783c84e32c3",
-                "reference": "abfe913276c90b3bfeb67edc0c851783c84e32c3",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/45301cfbb189e69298ab30cf9800ca76d507e28d",
+                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d",
                 "shasum": ""
             },
             "require": {
@@ -657,10 +657,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.12.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.13.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-30T03:23:06+00:00"
+            "time": "2026-07-30T20:37:58+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm/build-tools v1.13.1](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.13.1), which fixes `cwm-changelog` splicing generated entries into the changelog file's header comment — either losing the entry silently or leaving the document unparseable.

`build/proclaim-changelog.xml` parses today and its header does not name the root element, so this is preventative here rather than a live fix.

Lock only, v1.12.0 → v1.13.1 — the `^1.12.0` constraint already permitted it. Dev dependency, so no effect on the built artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)