### PR TITLE
chore(ci): enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot version updates.
+#
+# Security updates run without this file; version updates need it.
+#
+# Minor and patch bumps are grouped into a single PR per ecosystem — most of
+# the Composer dev dependencies are joomla/* packages that move together, and
+# ungrouped they would open nine PRs for one Joomla release. Major bumps stay
+# separate, since those want reading.
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      composer-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # cwm/build-tools is sourced from a Composer VCS repository (see
+      # composer.json "repositories"). Dependabot's Composer support does not
+      # resolve VCS repositories — it looks the package up on Packagist, where
+      # it does not exist — so it would never open a PR for it regardless.
+      # Listed explicitly so its absence reads as a decision, not an oversight.
+      # Bump it by hand: composer update cwm/build-tools
+      - dependency-name: "cwm/build-tools"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Security updates already run without a config file; **version updates need one**.

Covers `composer` (Packagist dependencies), `npm` (build-pipeline devDependencies) and `github-actions` (action versions across the six workflows). Weekly, Mondays, 5 PRs per ecosystem max.

Minor and patch bumps are **grouped into one PR per ecosystem**, so a single upstream release doesn't open a PR per package. Major bumps stay separate, since those want reading. Commit prefixes `chore(deps)` / `chore(deps-dev)` / `ci` to match the conventional-commit history here.

Targets `development`, this repo's default and trunk branch.

`cwm/build-tools` is explicitly listed under `ignore`: it's sourced from a Composer **VCS repository**, which Dependabot's Composer support doesn't resolve — it looks the package up on Packagist, where it doesn't exist, so no config would make it work. Listing it makes the gap read as a decision rather than an oversight. It stays a manual `composer update cwm/build-tools`, as done in #1379 today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)