### PR TITLE
fix(site): sermons filter panel always open, and two AJAX requests per filter change

### DIFF
--- a/build/media_source/js/sermon-filters.es6.js
+++ b/build/media_source/js/sermon-filters.es6.js
@@ -734,6 +734,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     /**
+     * Drop the inline onchange="this.form.submit();" the filter form XML puts on
+     * every select.  It is there for the simple/expert/custom sermon templates,
+     * which never load this script and still need an immediate submit.  Here it
+     * would fire alongside the change listeners below, costing a second AJAX
+     * request that the first one immediately aborts.  See #1389.
+     */
+    form.querySelectorAll('select[name^="filter_"], select[name^="filter["], select[name^="list_"], select[name^="list["]').forEach((select) => {
+        select.removeAttribute('onchange');
+        select.onchange = null;
+    });
+
+    /**
      * Intercept filter dropdown changes.
      * Suppressed while searchtools Clear is resetting fields — the
      * form submit at the end of clear() handles the single AJAX call.

--- a/site/src/Helper/UpdateFiltersTrait.php
+++ b/site/src/Helper/UpdateFiltersTrait.php
@@ -51,23 +51,34 @@ trait UpdateFiltersTrait
             $this->params->set('show_language_search', (int) $lang);
         }
 
+        $this->activeFilters ??= [];
+
         foreach ($filters as $filter) {
-            $set  = $input->getInt('filter_' . $filter);
+            // Default to 0 explicitly: Input::getInt() hands back null when the request has
+            // no such key, and null passes the "was it set?" test below, which would blank
+            // out every filter the form had loaded from the user state.
+            $set  = $input->getInt('filter_' . $filter, 0);
             $from = $this->filterForm->getValue($filter, 'filter');
 
             // Update the value from a landing page call.
             if ($set !== 0) {
                 $this->filterForm->setValue($filter, 'filter', $set);
+                $from = $set;
             }
 
-            // Catch active filters and update them.
-            if ($from !== null) {
-                $this->activeFilters[] = $filter;
+            // Catch active filters and update them. Keep the shape ListModel::getActiveFilters()
+            // uses — an associative array of field name => value — because the searchtools layout
+            // keys off it. The filter form is populated from user state, which holds an empty
+            // string for every unused filter, so only a real selection counts as active here;
+            // 0 is the component's "nothing selected" marker for the id based filters.
+            if ($from !== null && $from !== '' && $from !== '0' && $from !== 0 && $from !== []) {
+                $this->activeFilters[$filter] = $from;
             }
 
             // Remove from view if set to hide in the template.
             if ((int) $this->params->get('show_' . $filter . '_search', 1) === 0 && $filter !== 'language') {
                 $this->filterForm->removeField($filter, 'filter');
+                unset($this->activeFilters[$filter]);
             }
         }
 

--- a/site/src/View/Cwmsermons/HtmlView.php
+++ b/site/src/View/Cwmsermons/HtmlView.php
@@ -290,13 +290,12 @@ class HtmlView extends BaseHtmlView
                 'showPagination'  => $params->get('show_pagination', '2'),
             ]);
 
+            // Joomla's searchtools stays loaded on purpose: it owns the Filter Options
+            // toggle, the Clear button and the sortable column headers, all of which
+            // sermon-filters hooks into. Its submit paths run through form.submit(),
+            // which sermon-filters overrides to fetch over AJAX instead. See #1389.
             $wa->useScript('com_proclaim.sermon-filters');
             $wa->useStyle('com_proclaim.sermon-filters-css');
-
-            // Disable Joomla's searchtools — it auto-submits the form on keystroke,
-            // conflicting with Proclaim's AJAX-based filtering which handles the
-            // same form without page reloads.
-            $wa->disableScript('searchtools');
         }
 
         // Load scripture tooltip assets (per-element controlled; JS is a no-op

--- a/tests/js/sermon-filters.test.js
+++ b/tests/js/sermon-filters.test.js
@@ -28,7 +28,9 @@ function setupModule(fetchMock, extraOpts) {
     let html = '<div id="proclaim-main-content">' +
             '<form id="adminForm">' +
                 '<input name="filter_search" type="text" value="" />' +
-                '<select name="filter_teacher">' +
+                // The inline onchange mirrors what site/forms/filter_cwmsermons.xml
+                // renders — without it the fixture cannot catch double submits (#1389).
+                '<select name="filter_teacher" onchange="this.form.submit();">' +
                     '<option value="">All Teachers</option>' +
                     '<option value="5">Pastor John</option>' +
                 '</select>' +
@@ -314,6 +316,30 @@ describe('sermon-filters.es6.js', () => {
             expect(mockFetch.mock.calls.length).toBeGreaterThan(baselineCount);
 
             jest.useRealTimers();
+        });
+    });
+
+    describe('Filter change', () => {
+        // Regression guard for #1389: the form XML puts onchange="this.form.submit();"
+        // on every select for the non-AJAX templates. Left in place it fires alongside
+        // the module's own change listener, so a single change issued two requests —
+        // the second aborting the first, with the server having run both queries.
+        test('should issue exactly one request per dropdown change', async () => {
+            const mockFetch = jest.fn().mockResolvedValue(mockAjaxResponse());
+            setupModule(mockFetch);
+            mockFetch.mockClear();
+
+            const select = document.querySelector('select[name="filter_teacher"]');
+
+            expect(select.getAttribute('onchange')).toBeNull();
+
+            select.value = '5';
+            select.dispatchEvent(new Event('change'));
+
+            await new Promise(function (r) { setTimeout(r, 0); });
+            await new Promise(function (r) { setTimeout(r, 0); });
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/unit/Site/Helper/UpdateFiltersTraitTest.php
+++ b/tests/unit/Site/Helper/UpdateFiltersTraitTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\UpdateFiltersTrait;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
+use Joomla\Registry\Registry;
+
+/**
+ * Tests for UpdateFiltersTrait.
+ *
+ * The searchtools layout decides whether the filter bar renders open purely from
+ * `empty($view->activeFilters)`, so the shape and contents of that array are the
+ * contract under test here.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class UpdateFiltersTraitTest extends ProclaimTestCase
+{
+    /**
+     * Filter form XML mirroring the groups site/forms/filter_cwmsermons.xml declares.
+     *
+     * @var string
+     */
+    private const FORM_XML = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fields name="filter">
+        <field name="search" type="text" />
+        <field name="book" type="text" />
+        <field name="teacher" type="text" />
+        <field name="series" type="text" />
+        <field name="messagetype" type="text" />
+        <field name="year" type="text" />
+        <field name="topic" type="text" />
+        <field name="location" type="text" />
+        <field name="language" type="text" />
+    </fields>
+    <fields name="list">
+        <field name="fullordering" type="text" />
+        <field name="limit" type="text" />
+    </fields>
+</form>
+XML;
+
+    /**
+     * Request keys the trait reads, cleared between tests.
+     *
+     * @var string[]
+     */
+    private const REQUEST_KEYS = [
+        'filter_search',
+        'filter_book',
+        'filter_teacher',
+        'filter_series',
+        'filter_messagetype',
+        'filter_year',
+        'filter_topic',
+        'filter_location',
+        'filter_language',
+    ];
+
+    /**
+     * Reset the shared CLI input between tests.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $input = Factory::getApplication()->getInput();
+
+        foreach (self::REQUEST_KEYS as $key) {
+            $input->set($key, null);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Filters left at their user-state default of '' must not count as active,
+     * otherwise the searchtools panel renders open on every request.
+     *
+     * @return void
+     */
+    public function testEmptyFilterValuesAreNotActive(): void
+    {
+        $host = $this->makeHost(array_fill_keys(
+            ['search', 'book', 'teacher', 'series', 'messagetype', 'year', 'topic', 'location', 'language'],
+            ''
+        ));
+
+        $host->run();
+
+        $this->assertSame([], $host->activeFilters);
+    }
+
+    /**
+     * A filter carrying a real value is reported as active, keyed by field name
+     * with its value — the shape ListModel::getActiveFilters() produces.
+     *
+     * @return void
+     */
+    public function testSelectedFilterIsActiveAndKeyedByName(): void
+    {
+        $host = $this->makeHost(['search' => 'grace', 'teacher' => '5', 'book' => '', 'series' => '0']);
+
+        $host->run();
+
+        $this->assertSame(['search' => 'grace', 'teacher' => '5'], $host->activeFilters);
+    }
+
+    /**
+     * A landing page call (?filter_teacher=3) sets the form value and marks the
+     * filter active so the panel opens showing what was pre-selected.
+     *
+     * @return void
+     */
+    public function testLandingPageValueIsAppliedAndActive(): void
+    {
+        Factory::getApplication()->getInput()->set('filter_teacher', 3);
+
+        $host = $this->makeHost(['teacher' => '', 'book' => '']);
+        $host->run();
+
+        $this->assertSame(3, $host->filterForm->getValue('teacher', 'filter'));
+        $this->assertSame(['teacher' => 3], $host->activeFilters);
+    }
+
+    /**
+     * Filters absent from the request keep whatever the user state loaded — an
+     * unset request key must not blank the form value.
+     *
+     * @return void
+     */
+    public function testAbsentRequestKeyDoesNotClearExistingValue(): void
+    {
+        $host = $this->makeHost(['teacher' => '5']);
+
+        $host->run();
+
+        $this->assertSame('5', $host->filterForm->getValue('teacher', 'filter'));
+    }
+
+    /**
+     * A filter hidden by template params is dropped from both the form and the
+     * active list, so a hidden filter cannot force the panel open.
+     *
+     * @return void
+     */
+    public function testHiddenFilterIsRemovedFromFormAndActiveFilters(): void
+    {
+        $host = $this->makeHost(['teacher' => '5'], ['show_teacher_search' => 0]);
+
+        $host->run();
+
+        $this->assertFalse($host->filterForm->getField('teacher', 'filter'));
+        $this->assertSame([], $host->activeFilters);
+    }
+
+    /**
+     * Build an object using the trait, standing in for the site list views.
+     *
+     * @param   array  $filterValues  Values bound into the form's filter group.
+     * @param   array  $params        Template params driving the show_*_search toggles.
+     *
+     * @return  object
+     */
+    private function makeHost(array $filterValues, array $params = []): object
+    {
+        $form = new Form('filter_cwmsermons', ['control' => '']);
+        $form->load(self::FORM_XML);
+        $form->bind(['filter' => $filterValues]);
+
+        return new class ($form, new Registry($params)) {
+            use UpdateFiltersTrait;
+
+            public ?Form $filterForm = null;
+
+            public ?array $activeFilters = null;
+
+            protected ?Registry $params = null;
+
+            public function __construct(Form $filterForm, Registry $params)
+            {
+                $this->filterForm = $filterForm;
+                $this->params     = $params;
+            }
+
+            public function run(): void
+            {
+                $this->updateFilters();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1389

Two front-end sermons-list defects, found while tracking down why the filter panel renders open on the site but collapsed in the admin.

## 1. The filter panel was always open (not in #1389)

`UpdateFiltersTrait` marked a filter active whenever its form value was not `null`:

```php
if ($from !== null) {
    $this->activeFilters[] = $filter;
}
```

The filter form is hydrated from user state, which holds `''` for every unused filter — never `null`. So `activeFilters` was never empty, and `layouts/joomla/searchtools/default.php` always stamped the container with `js-stools-container-filters-visible`. The admin lists take `getActiveFilters()` as-is and behave like core, hence the difference.

Only a real selection counts now, and the array keeps the `field => value` shape `ListModel::getActiveFilters()` produces instead of a numerically indexed list of field names (which also made the layout's `unset($activeFilters[$selectorFieldName])` a silent no-op).

While testing this, a second bug in the same loop surfaced: `Input::getInt()` returns `null`, not `0`, when the request has no such key — and `null !== 0` passed the "was it set?" test, so `setValue($filter, 'filter', null)` ran for every filter absent from the current request, blanking values the user state had just loaded. Now defaulted to `0`.

Covered by 5 new tests in `tests/unit/Site/Helper/UpdateFiltersTraitTest.php`, including the landing-page path (`?filter_teacher=3`). All 5 fail against the previous code.

## 2. Two AJAX requests per filter change (#1389)

`site/forms/filter_cwmsermons.xml` puts `onchange="this.form.submit();"` on all eight filter selects plus `list[fullordering]` and `list[limit]`. On the default template that fired alongside `sermon-filters.es6.js`'s own `change` listener:

1. inline handler → `form.submit()` → the module's override → `fetchResults()`
2. the module's `change` listener → `fetchResults()`

`fetchResults()` aborts the in-flight request, so #1 was cancelled client-side — after the server had already run the full query. Every filter, sort and limit change cost two round trips.

The inline handler is now stripped at init. It has to stay in the form XML: the simple / expert / custom sermon templates never load this script and still rely on it for immediate submit.

### The `disableScript('searchtools')` call is also gone

It never took effect — `display()` disabled the asset, then the searchtools layout called `useStyle('searchtools')->useScript('searchtools')` and `WebAssetManager::useAsset()` re-activated it.

Its stated reason ("auto-submits the form on keystroke") isn't a behaviour searchtools has: J5/J6 `searchtools.js` has zero `keyup` / `keypress` / `input` handlers. Its only submit paths are fields carrying `js-select-submit-on-change` (Proclaim's declare no `class`), the Clear button, and column-header sorts — all of which route through `form.submit()`, which `sermon-filters.es6.js` deliberately overrides.

Searchtools must stay loaded: the module hooks `.js-stools-btn-clear` and guards against searchtools' `clear()` sequence, and searchtools owns the Filter Options toggle and the sortable headers. Had the disable ever worked, all of that would have broken.

`cwmseriesdisplays` uses the same form but `series-scroll.es6.js` binds no change handlers, so that page does an ordinary submit — unaffected.

## Testing

- `npm test` — 230 tests, 16 suites, all pass. The new `Filter change` test fails against the unfixed module (the fixture previously omitted the `onchange` attribute the real form renders, which is why this was never caught).
- `./libraries/vendor/bin/phpunit --testsuite "Site Helper Tests"` — 94 pass.
- ESLint and php-cs-fixer clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
