### PR TITLE
fix(admin): hide Choose Playlist(s) for servers that cannot host playlists

### DIFF
--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -379,6 +379,10 @@ class CwmmediafileController extends FormController
                 'generalHtml' => $generalHtml,
                 'optionsHtml' => $optionsHtml,
                 'serverType'  => $serverType,
+                // The playlist picker lives outside the swapped containers, so the
+                // capability has to travel with the response for the client to
+                // show or hide it on a server change. See #1392.
+                'supportsPlaylists' => $addon->supportsPlaylists(),
             ]);
         } catch (\Exception $e) {
             CWMAddon::outputJson(['success' => false, 'error' => $e->getMessage()]);

--- a/admin/tmpl/cwmmediafile/edit.php
+++ b/admin/tmpl/cwmmediafile/edit.php
@@ -126,7 +126,18 @@ echo 'index.php?option=com_proclaim&view=cwmmediafile&layout=edit&id=' . (int)$t
                 <?php echo $this->form->renderField('study_id', null, $study_id); ?>
                 <?php echo $this->form->renderField('server_id', null, $this->item->server_id); ?>
                 <?php echo $this->form->renderField('podcast_id', null, $podcast_id); ?>
-                <?php echo $this->form->renderField('playlist_id', null, $playlist_id); ?>
+
+                <?php
+                // Playlists exist only for platforms whose addon reports the capability
+                // (YouTube, Vimeo) — elsewhere the picker can only ever come up empty.
+                // Rendered hidden rather than omitted so an existing assignment still
+                // posts back instead of being silently cleared, and so the server-change
+                // handler can reveal it without a page reload. See #1392.
+                $supportsPlaylists = $this->addon !== null && $this->addon->supportsPlaylists();
+                ?>
+                <div id="playlist-field-container"<?php echo $supportsPlaylists ? '' : ' class="d-none"'; ?>>
+                    <?php echo $this->form->renderField('playlist_id', null, $playlist_id); ?>
+                </div>
 
                 <div id="addon-general-container">
                     <?php if ($this->addon !== null) : ?>

--- a/build/media_source/js/mediafile-edit.es6.js
+++ b/build/media_source/js/mediafile-edit.es6.js
@@ -261,6 +261,13 @@
                             optionsContent.innerHTML = data.optionsHtml || '';
                         }
 
+                        // The playlist picker sits outside both swapped containers, so
+                        // follow the new server's capability explicitly (#1392).
+                        const playlistContainer = document.getElementById('playlist-field-container');
+                        if (playlistContainer) {
+                            playlistContainer.classList.toggle('d-none', !data.supportsPlaylists);
+                        }
+
                         // Update tracked server type
                         const serverTypes = getServerTypes();
                         previousServerType = serverTypes[serverId] || '';

--- a/tests/integration/Admin/Addons/CwmplaylistCapabilityTest.php
+++ b/tests/integration/Admin/Addons/CwmplaylistCapabilityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Integration tests for the addon playlist capability contract.
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Addons;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * supportsPlaylists() is the single source of truth for which platforms the
+ * playlist system reaches — the sync helper, the server picker and (since
+ * #1392) the Choose Playlist(s) field on the media file edit form all consult
+ * it instead of hardcoding "youtube".
+ *
+ * A platform silently flipping to true would put an unusable, permanently
+ * empty picker back on every media file of that type, so the roster is pinned
+ * here rather than left to the addon classes to agree among themselves.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(CWMAddon::class)]
+class CwmplaylistCapabilityTest extends IntegrationTestCase
+{
+    /**
+     * Every shipped server type and whether it can host playlists.
+     *
+     * @return  array<string, array{0: string, 1: bool}>
+     */
+    public static function serverTypeProvider(): array
+    {
+        return [
+            'youtube'     => ['youtube', true],
+            'vimeo'       => ['vimeo', true],
+            'local'       => ['local', false],
+            'direct'      => ['direct', false],
+            'legacy'      => ['legacy', false],
+            'embed'       => ['embed', false],
+            'article'     => ['article', false],
+            'docman'      => ['docman', false],
+            'facebook'    => ['facebook', false],
+            'rumble'      => ['rumble', false],
+            'soundcloud'  => ['soundcloud', false],
+            'resi'        => ['resi', false],
+            'wistia'      => ['wistia', false],
+            'dailymotion' => ['dailymotion', false],
+            'googledrive' => ['googledrive', false],
+            'virtuemart'  => ['virtuemart', false],
+        ];
+    }
+
+    /**
+     * Each addon reports the capability the playlist system expects of it.
+     *
+     * @param   string  $type      Server type as stored in #__bsms_servers.
+     * @param   bool    $expected  Whether the platform hosts playlists.
+     *
+     * @return  void
+     */
+    #[Test]
+    #[DataProvider('serverTypeProvider')]
+    public function addonReportsItsPlaylistCapability(string $type, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            CWMAddon::getInstance($type)->supportsPlaylists(),
+            \sprintf('Addon "%s" reported the wrong playlist capability', $type)
+        );
+    }
+
+    /**
+     * The capability is opt-in: the base class denies it, so the fourteen
+     * platforms above inherit false rather than each restating it, and a new
+     * addon cannot pick up a picker it has no way to fill.
+     *
+     * @return  void
+     */
+    #[Test]
+    public function capabilityIsOptInAtTheBaseClass(): void
+    {
+        foreach (['supportsPlaylists', 'supportsPlaylistWriteback'] as $name) {
+            $method = new \ReflectionMethod(CWMAddon::class, $name);
+
+            $this->assertSame(
+                CWMAddon::class,
+                $method->getDeclaringClass()->getName(),
+                \sprintf('%s() must be declared on the base class', $name)
+            );
+
+            // The body is a bare `return false;` — read it rather than
+            // instantiate, since CWMAddon is abstract and its constructor
+            // resolves addon paths off disk.
+            $source = file($method->getFileName());
+            $body   = implode('', \array_slice(
+                $source,
+                $method->getStartLine() - 1,
+                $method->getEndLine() - $method->getStartLine() + 1
+            ));
+
+            $this->assertMatchesRegularExpression(
+                '/return\s+false\s*;/',
+                $body,
+                \sprintf('%s() must default to false', $name)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1392

The media file edit form rendered **Choose Playlist(s)** for every server type. Playlists only exist for platforms whose addon reports `supportsPlaylists()` — YouTube and Vimeo — and `MediaPlaylistsField::getOptions()` scopes its query to the media file's own server, so on a local file the picker could only ever render empty.

`CWMAddon::supportsPlaylists()` already describes itself as *"the single source of truth the playlist system consults so the feature can expand to other platforms without hardcoding youtube"*, and both `CwmplaylistSyncHelper` and `getPlaylistCapableServers()` honour it. The edit form simply never asked. Now it does — no platform names hardcoded, so a future playlist-capable addon gets the field for free.

## Reproduction (before)

Driven against j5-dev with Playwright:

| media | server | `playlist_id` in DOM | visible | options |
|---|---|---|---|---|
| 2453 | NFSDA Audio (`local`) | yes | yes | **0** |
| 2470 | YouTube | yes | yes | 0 |

## Changes

- `admin/tmpl/cwmmediafile/edit.php` — the field renders inside `#playlist-field-container`, carrying `d-none` when the current addon denies the capability. Hidden rather than omitted, so an existing assignment still posts back instead of being silently cleared on the next save.
- `CwmmediafileController::getAddonHtml()` — returns `supportsPlaylists`. The field sits outside `#addon-general-container` / `#addon-options-content`, the only regions a server change swaps, so the capability has to travel with the response.
- `build/media_source/js/mediafile-edit.es6.js` — toggles the wrapper from that flag after a server swap, so switching Local → YouTube reveals the field without a page reload.
- `tests/integration/Admin/Addons/CwmplaylistCapabilityTest.php` — pins the capability roster across all sixteen shipped addons, and asserts the default lives on the base class as opt-in. A platform silently flipping to `true` would put the empty picker back on every media file of that type.

## Testing

- `phpunit --testsuite "Integration Admin Addon Tests"` — 32 pass (16 new).
- `npm test` — 229 tests, 16 suites, all pass.
- php-cs-fixer and ESLint clean on all changed files.

**Not yet verified in a browser.** The dev site symlinks a working tree that is currently on another branch, so the before/after could not be re-driven end to end. The reproduction above is the confirmed "before"; the "after" is reasoned from the same DOM. Worth a manual check on a local media file (field gone) and a YouTube one (field present), plus a Local → YouTube switch without saving (field appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
