### PR TITLE
fix(podcast): absolute channel link, and season/episode tags Apple reads

### DIFF
--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -286,21 +286,27 @@ class Cwmpodcast
                 // Podcasting 2.0: person/speaker tags for all teachers
                 $episodedetail .= $this->getPersonXml($episode, $podinfo->website, $protocol);
 
-                // Podcasting 2.0: season (from series)
+                // Podcasting 2.0: season (from series). Emitted alongside
+                // itunes:season, which Apple reads and the podcast: namespace it
+                // ignores — a feed carrying only the latter groups nowhere in
+                // Apple Podcasts.
                 if (!empty($episode->series_text) && ($episode->series_id ?? -1) > 0) {
                     $episodedetail .= '
 		<podcast:season name="' . $this->escapeHTML($episode->series_text) . '">'
-                        . (int) $episode->series_id . '</podcast:season>';
+                        . (int) $episode->series_id . '</podcast:season>
+		<itunes:season>' . (int) $episode->series_id . '</itunes:season>';
                 }
 
-                // Podcasting 2.0: episode number (from studynumber)
+                // Podcasting 2.0: episode number (from studynumber), likewise
+                // paired with the itunes: tag Apple actually reads.
                 if (!empty($episode->studynumber)) {
                     $epNum = preg_replace('/[^0-9]/', '', $episode->studynumber);
 
                     if ($epNum !== '' && (int) $epNum > 0) {
                         $episodedetail .= '
 		<podcast:episode display="' . $this->escapeHTML($episode->studynumber) . '">'
-                            . (int) $epNum . '</podcast:episode>';
+                            . (int) $epNum . '</podcast:episode>
+		<itunes:episode>' . (int) $epNum . '</itunes:episode>';
                     }
                 }
 
@@ -404,9 +410,12 @@ class Cwmpodcast
             return rtrim($value, '/');
         }
 
-        // Numeric = Joomla menu item ID
+        // Numeric = Joomla menu item ID. Route::link()'s $absolute parameter
+        // defaults to false, which returns a site-relative SEF path — and RSS 2.0
+        // requires absolute URLs, so validators reject the channel <link> and
+        // <image><link> built from it. Ask for the absolute form.
         if (ctype_digit($value)) {
-            return Route::link('site', 'index.php?Itemid=' . $value);
+            return Route::link('site', 'index.php?Itemid=' . $value, true, Route::TLS_IGNORE, true);
         }
 
         // Root-relative path — the admin field accepts these, and concatenating

--- a/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
+++ b/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
@@ -454,4 +454,56 @@ class CwmpodcastFeedSpecTest extends ProclaimTestCase
             'The mismatch check must be gated on the record not being a YouTube URL'
         );
     }
+
+    // -------------------------------------------------------------------------
+    // 6. absolute URLs and Apple-readable season/episode tags
+    // -------------------------------------------------------------------------
+
+    /**
+     * A podcast link stored as a menu item id must resolve to an absolute URL.
+     *
+     * RSS 2.0 requires absolute URLs, and validators reject the channel <link>
+     * and <image><link> otherwise. Route::link()'s $absolute parameter defaults
+     * to false, so the numeric branch silently produced a site-relative path —
+     * a live feed audit found "/resources/sermons.html" in both tags.
+     *
+     * @return  void
+     */
+    public function testMenuItemIdResolvesToAnAbsoluteUrl(): void
+    {
+        $method = new \ReflectionMethod(Cwmpodcast::class, 'resolveUrl');
+        $source = file($method->getFileName());
+        $body   = implode('', \array_slice(
+            $source,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $this->assertMatchesRegularExpression(
+            '/Route::link\(\s*\x27site\x27.*?,\s*true\s*\)/s',
+            $body,
+            'The menu-item branch must request the absolute form from Route::link()'
+        );
+    }
+
+    /**
+     * Season and episode are emitted in both namespaces.
+     *
+     * Apple ignores the podcast: namespace, so a feed carrying only those tags
+     * groups nowhere in Apple Podcasts.
+     *
+     * @return  void
+     */
+    public function testSeasonAndEpisodeAreEmittedForAppleToo(): void
+    {
+        $source = file_get_contents(\dirname(__DIR__, 4) . '/site/src/Helper/Cwmpodcast.php');
+
+        foreach (['itunes:season', 'itunes:episode'] as $tag) {
+            $this->assertStringContainsString(
+                '<' . $tag . '>',
+                $source,
+                \sprintf('%s must be emitted alongside its podcast: counterpart', $tag)
+            );
+        }
+    }
 }


### PR DESCRIPTION
Two generator faults found auditing a production feed. Both are in the shipped 10.5.0.

## The channel link is site-relative — validators reject the feed

`<link>` and `<image><link>` came out as `/resources/sermons.html`. RSS 2.0 requires absolute URLs; the W3C validator and Apple's feed checks flag it.

The cause is the **menu-item branch** of `resolveUrl()`:

```php
if (ctype_digit($value)) {
    return Route::link('site', 'index.php?Itemid=' . $value);   // relative
}
```

`Route::link($client, $url, $xhtml = true, $tls = TLS_IGNORE, $absolute = false)` — the last parameter defaults to **false**, so a podcast whose link is stored as a menu item id gets a site-relative SEF path.

Worth noting why this survived #1391: that PR added a root-relative branch to the same method, but the numeric branch returns before it ever runs. The two look alike in the output and are entirely different code paths — a root-relative *string* was fixed, a *menu item id* was not.

## Season and episode grouped nowhere in Apple Podcasts

The feed emitted `podcast:season` and `podcast:episode` only. Apple ignores the `podcast:` namespace, so seasons had no effect there. Both now emit the `itunes:` tag alongside — the `podcast:` ones stay, since apps that read them use the richer `name`/`display` attributes.

## Not fixed here — site data, not generator faults

The same audit raised several things that are content or configuration on the site rather than Proclaim bugs, listed so they are not lost:

- "Deparetment" misspelled in `itunes:name`, `managingEditor`, `webMaster`
- `<language>en-GB</language>` on a US church
- pubDates carrying Pacific offsets, suggesting the site timezone is `America/Los_Angeles` rather than `America/Chicago`
- `<copyright>© (2026) All rights reserved.</copyright>` — no owner, stray parentheses
- Three "A Bad TRANSaction" parts all numbered episode 1; Part V has no season/episode at all
- An episode whose article alias no longer matches its title
- Two episodes with empty descriptions
- One 25-minute m4a encoded at roughly double the bitrate of the rest
- `lastBuildDate` eight months newer than the newest episode, which can mark the show inactive

## Testing

Two tests added to `CwmpodcastFeedSpecTest` (46 total, all pass); `Site Helper Tests` 143 pass.

Not verified here: that the tracking-redirect enclosure URLs answer byte-range requests, which Apple requires. Needs a `curl -I -r 0-1` against a live feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)