### PR TITLE
fix(podcast): write feed dates in the site's time zone, not the server's

### DIFF
--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -86,10 +86,17 @@ class Cwmpodcast
      */
     public function makePodcasts(): string
     {
-        $msg  = [];
-        $db   = Factory::getContainer()->get(DatabaseInterface::class);
-        $year = '(' . date('Y') . ')';
-        $date = date('r');
+        $msg = [];
+        $db  = Factory::getContainer()->get(DatabaseInterface::class);
+
+        // Dates are written in the site's configured time zone, not the server's.
+        // PHP's default zone is whatever php.ini says — Joomla never sets it
+        // globally, and Joomla\CMS\Date\Date restores it after each use — so a
+        // bare date() reports the host's zone and ignores Global Configuration
+        // entirely. See the comment on formatFeedDate().
+        $siteTz = new \DateTimeZone(Factory::getApplication()->get('offset', 'UTC'));
+        $year   = '(' . Factory::getDate('now', $siteTz)->format('Y', true, false) . ')';
+        $date   = $this->formatFeedDate('now', $siteTz);
 
         // Get English language file as fallback
         $language = Factory::getApplication()->getLanguage();
@@ -232,7 +239,7 @@ class Cwmpodcast
             $episodedetail = '';
 
             foreach ($episodes as $episode) {
-                $episodedate   = date('r', strtotime($episode->createdate));
+                $episodedate   = $this->formatFeedDate($episode->createdate, $siteTz);
                 $scripture     = $this->getListing()->getScripture($params, $episode, 0, 1);
                 $episode->size = $episode->params->get('size', '30000000');
 
@@ -391,6 +398,33 @@ class Cwmpodcast
                 return $episode->bookname . ' ' . $episode->chapter_begin;
         }
         return '';
+    }
+
+    /**
+     * Format a stored date as an RFC 2822 feed date in the site's time zone.
+     *
+     * `date('r', strtotime($stored))` gets this wrong twice over. Joomla stores
+     * dates in UTC, but strtotime() reads them in PHP's default zone — the
+     * host's, since Joomla never sets one globally — so the instant shifts by
+     * the host's offset. date() then labels it with that same wrong zone. On a
+     * site configured for Chicago but hosted in Los Angeles, every pubDate came
+     * out claiming -0800.
+     *
+     * @param   string         $stored  A UTC date string from the database, or 'now'.
+     * @param   \DateTimeZone  $siteTz  The site's configured time zone.
+     *
+     * @return  string  RFC 2822 date, e.g. Sat, 15 Nov 2025 10:00:00 -0600
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function formatFeedDate(string $stored, \DateTimeZone $siteTz): string
+    {
+        // $translate = false: Date::format() localises day and month names by
+        // default, but RFC 2822 requires the English abbreviations. A translated
+        // pubDate is unparseable to feed readers.
+        return Factory::getDate($stored, 'UTC')
+            ->setTimezone($siteTz)
+            ->format(\DateTimeInterface::RFC2822, true, false);
     }
 
     /**

--- a/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
+++ b/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
@@ -13,6 +13,7 @@ namespace CWM\Component\Proclaim\Tests\Site\Helper;
 
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
 use Joomla\Registry\Registry;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -40,6 +41,19 @@ class CwmpodcastFeedSpecTest extends ProclaimTestCase
     {
         parent::setUp();
         $this->podcast = new Cwmpodcast();
+
+        // Factory::getDate() reaches for the language tag, and the test
+        // application's Language carries null metadata — a documented CI-only
+        // warning. Force a tag on so date formatting can run.
+        $lang = Factory::getApplication()->getLanguage();
+        $prop = new \ReflectionProperty($lang, 'metadata');
+        $meta = $prop->getValue($lang);
+
+        if (!\is_array($meta) || ($meta['tag'] ?? null) === null) {
+            $prop->setValue($lang, array_merge(\is_array($meta) ? $meta : [], ['tag' => 'en-GB']));
+        }
+
+        Factory::$language = $lang;
     }
 
     // -------------------------------------------------------------------------
@@ -505,5 +519,81 @@ class CwmpodcastFeedSpecTest extends ProclaimTestCase
                 \sprintf('%s must be emitted alongside its podcast: counterpart', $tag)
             );
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. feed dates follow the site time zone, not the server's
+    // -------------------------------------------------------------------------
+
+    /**
+     * A stored UTC date renders in the site's zone, at the right instant.
+     *
+     * The old `date('r', strtotime($stored))` was wrong twice: strtotime() read
+     * the UTC value in PHP's default zone — the host's, since Joomla never sets
+     * one globally — and date() then labelled it with that same zone. On a site
+     * configured Chicago but hosted Los Angeles, every pubDate claimed -0800 and
+     * sat eight hours from the real instant.
+     *
+     * @return  void
+     */
+    public function testFeedDateUsesTheSiteTimeZone(): void
+    {
+        $ref = new \ReflectionMethod(Cwmpodcast::class, 'formatFeedDate');
+
+        $result = $ref->invoke(
+            $this->podcast,
+            '2025-11-15 16:00:00',
+            new \DateTimeZone('America/Chicago')
+        );
+
+        $this->assertStringContainsString('-0600', $result, 'Should carry the Chicago offset');
+        $this->assertStringContainsString('10:00:00', $result, '16:00 UTC is 10:00 in Chicago');
+        $this->assertSame(
+            strtotime('2025-11-15 16:00:00 UTC'),
+            strtotime($result),
+            'The instant must survive the conversion'
+        );
+    }
+
+    /**
+     * The same stored value in a different site zone moves the wall clock but
+     * not the instant.
+     *
+     * @return  void
+     */
+    public function testFeedDateConvertsRatherThanRelabels(): void
+    {
+        $ref      = new \ReflectionMethod(Cwmpodcast::class, 'formatFeedDate');
+        $stored   = '2025-11-15 16:00:00';
+        $expected = strtotime($stored . ' UTC');
+
+        foreach (['America/Chicago', 'America/Los_Angeles', 'UTC', 'Europe/London'] as $zone) {
+            $this->assertSame(
+                $expected,
+                strtotime($ref->invoke($this->podcast, $stored, new \DateTimeZone($zone))),
+                \sprintf('Instant changed when rendered for %s', $zone)
+            );
+        }
+    }
+
+    /**
+     * No naive date() call should reach the feed again.
+     *
+     * @return  void
+     */
+    public function testFeedDoesNotFormatDatesWithTheServerZone(): void
+    {
+        // Scan code only — the docblock on formatFeedDate() quotes the old call
+        // to explain why it was wrong, and must not trip this.
+        $code = array_filter(
+            file(\dirname(__DIR__, 4) . '/site/src/Helper/Cwmpodcast.php'),
+            static fn (string $line): bool => !preg_match('/^\s*(\*|\/\/|\/\*)/', $line)
+        );
+
+        $this->assertStringNotContainsString(
+            "date('r', strtotime(",
+            implode('', $code),
+            "date('r', strtotime(...)) reads and labels dates in the server's zone"
+        );
     }
 }


### PR DESCRIPTION
A site with **Global Configuration → Website Time Zone set to Chicago**, hosted on a server in Los Angeles, published every `pubDate` with a Pacific offset. Joomla's setting was being ignored entirely.

## Not just a wrong label — the wrong instant

```php
$episodedate = date('r', strtotime($episode->createdate));
```

Wrong twice over:

1. Joomla stores dates in **UTC**, but `strtotime()` reads them in PHP's default zone. Joomla never sets one globally — `Joomla\CMS\Date\Date` forces UTC and then *restores* whatever was active — so PHP's default stays whatever `php.ini` says: the host's.
2. `date()` then labels the result with that same host zone.

Demonstrated with the reported mismatch:

```
stored (UTC):    2025-11-15 16:00:00
old  date('r'):  Sat, 15 Nov 2025 16:00:00 -0800   ← wrong instant AND wrong zone
new (site tz):   Sat, 15 Nov 2025 10:00:00 -0600   ← correct
instant differs by: -8 hours
```

Feed readers sort by `pubDate`, so this reorders episodes and can move an evening sermon across a day boundary.

Dates now convert from UTC into the configured zone through a shared `formatFeedDate()`. `lastBuildDate` and the copyright year take the same path — both used bare `date()` too.

## A second fault the tests caught

`Date::format()` **localises day and month names by default**, and RFC 2822 requires the English abbreviations. My first version left translation on, which would have published `Sa, 15 Nov` on a German site — unparseable to every feed reader, and a fault the original `date('r')` did not have.

Found by asserting the formatted value survives a round trip through `strtotime()`, which is the assertion that earns its keep here: checking only for `-0600` in the output would have passed.

## Testing

Three tests in `CwmpodcastFeedSpecTest` (49 total, all pass):

- the instant survives conversion, and the offset is the site's
- the same stored value in four zones yields four wall-clock times but **one instant**
- no naive `date('r', strtotime(...))` returns to the file — scanning code only, since the new docblock quotes the old call to explain it

`Site Helper Tests` 146 pass.

## Still open from the same audit

The `<language>` tag is a separate problem, and not one a site can fix: Joomla ships **en-GB** and en-US is not installed by default, so the podcast Language field has no en-US to choose and the feed declares en-GB for every US church. That needs a dedicated feed-language field rather than deriving from the CMS content language — filed separately, as it needs a schema column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)