### PR TITLE
fix(install): stop the cache notice repeating itself and alarming on success

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -717,6 +717,64 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
+     * Run a cache operation without its housekeeping noise reaching the user.
+     *
+     * Joomla's file cache cannot always remove a cache directory during a live
+     * request — administrator/cache/language is in use by the very request doing
+     * the clearing — and reports it with
+     * `Log::add(..., Log::WARNING, 'jerror')`, which Joomla routes into the
+     * message queue. The administrator sees a red
+     * "Could not delete folder" beside a successful update (#1407).
+     *
+     * It cannot be caught: FileStorage::_deleteFolder() logs and returns false
+     * rather than throwing, so the try/catch around clean() never sees it.
+     *
+     * Only that one message is dropped, and only if the operation itself
+     * produced it. Anything else the queue gains — including messages from
+     * plugins reacting to the cache events — is put back untouched, in order.
+     *
+     * @param   callable  $operation  The cache operation to run.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function withoutCacheHousekeepingNoise(callable $operation): void
+    {
+        $app = Factory::getApplication();
+
+        if (!method_exists($app, 'getMessageQueue')) {
+            $operation();
+
+            return;
+        }
+
+        $before = $app->getMessageQueue();
+
+        try {
+            $operation();
+        } finally {
+            $after = $app->getMessageQueue(true);
+            $noise = Text::_('JLIB_FILESYSTEM_ERROR_FOLDER_DELETE');
+            // The string is a sprintf template; compare on the part before the
+            // path placeholder so the message matches whatever path it names.
+            $needle = trim((string) strstr($noise, '%', true)) ?: $noise;
+
+            foreach ($after as $index => $message) {
+                $isNew   = !\array_key_exists($index, $before);
+                $isNoise = $needle !== ''
+                    && str_contains((string) ($message['message'] ?? ''), $needle);
+
+                if ($isNew && $isNoise) {
+                    continue;
+                }
+
+                $app->enqueueMessage($message['message'] ?? '', $message['type'] ?? 'message');
+            }
+        }
+    }
+
+    /**
      * Clear caches after an install or update, and say so when something outside
      * our reach still needs clearing.
      *
@@ -759,7 +817,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
         try {
             // No group argument = every group, matching com_cache's Delete all.
-            Factory::getCache('')->clean();
+            $this->withoutCacheHousekeepingNoise(static fn () => Factory::getCache('')->clean());
         } catch (\Throwable $e) {
             Log::add('Proclaim: cache clean skipped — ' . $e->getMessage(), Log::WARNING, 'com_proclaim');
         }
@@ -813,10 +871,16 @@ class com_proclaimInstallerScript extends InstallerScript
                 ->whereIn($db->quoteName('element'), array_keys($known), ParameterType::STRING);
             $db->setQuery($query);
 
-            $found = array_map(
+            // Deduplicate: the query filters on element but not folder, and a
+            // suite like JCH Optimize registers several plugins under the same
+            // element — which printed "JCH Optimize, JCH Optimize" (#1407). Any
+            // one of them being enabled is reason enough to warn, so collapsing
+            // to distinct names is the right answer rather than filtering by
+            // folder, whose names vary between releases.
+            $found = array_values(array_unique(array_map(
                 static fn (string $element): string => $known[$element] ?? $element,
                 (array) $db->loadColumn()
-            );
+            )));
 
             if ($found === []) {
                 return;

--- a/tests/unit/Admin/Lib/ProclaimScriptCacheTest.php
+++ b/tests/unit/Admin/Lib/ProclaimScriptCacheTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Tests for the update script's cache-clearing behaviour.
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Both faults here were reported from a real update, and both are visible to
+ * every administrator on every update: the external-cache notice named the same
+ * plugin twice, and clearing the cache surfaced a red "Could not delete folder"
+ * warning beside a successful update (#1407).
+ *
+ * The install script is a `return new class` file rather than a named class, so
+ * these assert against its source. That is weaker than calling the methods, but
+ * the alternative is instantiating an installer script outside an install.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class ProclaimScriptCacheTest extends ProclaimTestCase
+{
+    /**
+     * The install script's source.
+     *
+     * @return  string
+     */
+    private function script(): string
+    {
+        return file_get_contents(\dirname(__DIR__, 4) . '/proclaim.script.php');
+    }
+
+    /**
+     * The plugin list is deduplicated before it is printed.
+     *
+     * JCH Optimize registers more than one plugin under the element
+     * `jchoptimize`, and the query filters on element but not folder, so the
+     * name appeared twice in one sentence.
+     *
+     * @return  void
+     */
+    public function testExternalCacheNamesAreDeduplicated(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/array_unique\s*\(\s*array_map/',
+            $this->script(),
+            'Names must be collapsed to distinct values before being joined'
+        );
+    }
+
+    /**
+     * Deduplication mirrors what the script does, pinned so the behaviour is
+     * described rather than merely present.
+     *
+     * @return  void
+     */
+    public function testDeduplicationCollapsesRepeatedPlugins(): void
+    {
+        $known = [
+            'jchoptimize'    => 'JCH Optimize',
+            'litespeedcache' => 'LiteSpeed Cache',
+            'cache'          => 'System - Page Cache',
+        ];
+
+        // What loadColumn() returns when a suite registers several plugins
+        // under one element.
+        $rows = ['jchoptimize', 'jchoptimize', 'cache'];
+
+        $found = array_values(array_unique(array_map(
+            static fn (string $element): string => $known[$element] ?? $element,
+            $rows
+        )));
+
+        $this->assertSame(['JCH Optimize', 'System - Page Cache'], $found);
+        $this->assertStringNotContainsString(
+            'JCH Optimize, JCH Optimize',
+            implode(', ', $found)
+        );
+    }
+
+    /**
+     * The folder-delete warning is filtered rather than left to alarm.
+     *
+     * It cannot be caught: FileStorage::_deleteFolder() logs to the `jerror`
+     * category and returns false rather than throwing, so the try/catch around
+     * clean() never sees it. Joomla routes that category into the message queue.
+     *
+     * @return  void
+     */
+    public function testCacheClearFiltersItsOwnHousekeepingWarning(): void
+    {
+        $source = $this->script();
+
+        $this->assertStringContainsString(
+            'withoutCacheHousekeepingNoise',
+            $source,
+            'The cache clean must run inside the message-queue filter'
+        );
+        $this->assertStringContainsString(
+            'JLIB_FILESYSTEM_ERROR_FOLDER_DELETE',
+            $source,
+            'The filter should key on the specific message, not drop the queue'
+        );
+    }
+
+    /**
+     * Only that one message is dropped — anything else the operation queues,
+     * including messages from plugins reacting to the cache events, is put back.
+     *
+     * @return  void
+     */
+    public function testFilterPreservesOtherMessages(): void
+    {
+        $source = $this->script();
+
+        $this->assertMatchesRegularExpression(
+            '/\$app->enqueueMessage\(\s*\$message\[.message.\]/',
+            $source,
+            'Messages that are not the folder-delete warning must be re-queued'
+        );
+        $this->assertStringContainsString(
+            '$before = $app->getMessageQueue()',
+            $source,
+            'Pre-existing messages must be distinguished from ones the clean added'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1407

Both faults were reported from a real 10.5.0 update, and both are visible to every administrator on every update.

## "JCH Optimize, JCH Optimize"

The query filters on `element` and `enabled`, but **not `folder`** — and a suite like JCH Optimize registers several plugins under the same element. `loadColumn()` returned it twice, both rows mapped to the same display name, and `implode(', ', $found)` printed it twice.

Deduplicated. Filtering by folder would also work but is more brittle: any one of those plugins being enabled is reason enough to warn, and folder names vary between releases.

## "Could not delete folder: administrator/cache/language"

Joomla's file cache cannot remove a cache directory the running request is still using, and reports it with:

```php
Log::add(Text::sprintf('JLIB_FILESYSTEM_ERROR_FOLDER_DELETE', $path), Log::WARNING, 'jerror');
```

Joomla routes the `jerror` category into the message queue, which is why a red warning appeared beside a successful update.

**The existing `try/catch` could never have caught it** — `FileStorage::_deleteFolder()` logs and returns `false` rather than throwing, so nothing propagates to the `catch (\Throwable)` around `clean()`. That is worth stating plainly, because the method's docblock already promised *"Never fatal: an update must not fail over cache hygiene"* and looked like it was keeping that promise.

The clean now runs inside a filter that:

- captures the queue before and after, so only messages **the operation itself added** are considered;
- drops only the folder-delete message, matched on the translated string's stable prefix so it works in any locale;
- re-queues everything else in order — including messages from plugins reacting to `onContentCleanCache` / `onAfterPurge`, which an administrator does want to see.

Falls back to running the operation unfiltered if the application has no message queue, so a CLI install is unaffected.

## Testing

Four tests in `ProclaimScriptCacheTest` (Admin Lib 13 total). The install script is a `return new class` file rather than a named class, so these assert against its source and pin the deduplication behaviour with a worked example — weaker than calling the methods, but the alternative is instantiating an installer script outside an install.

Suites: Admin Lib 13, Admin Helper 521, Site Helper 150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)