### PR TITLE
fix(podcast): give tracked enclosure URLs a real file extension (#1424)

### DIFF
--- a/admin/src/Helper/CwmpodcastTrackHelper.php
+++ b/admin/src/Helper/CwmpodcastTrackHelper.php
@@ -143,6 +143,38 @@ class CwmpodcastTrackHelper
     }
 
     /**
+     * Look up a published media file's params for the tracking endpoint, joined
+     * with its server's params (needed to resolve the live media URL).
+     *
+     * Kept here rather than inline in CwmpodcastController so the controller
+     * stays limited to HTTP concerns — request parsing, headers, streaming —
+     * with data access alongside the rest of this feature's DB logic.
+     *
+     * @param   DatabaseInterface  $db       Database driver.
+     * @param   integer            $mediaId  Media file ID.
+     *
+     * @return  ?object  Row with ->params and ->sparams, or null if not found/unpublished.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function findPublishedMedia(DatabaseInterface $db, int $mediaId): ?object
+    {
+        $query = $db->createQuery()
+            ->select($db->quoteName('mf.params'))
+            ->select($db->quoteName('sr.params', 'sparams'))
+            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_servers', 'sr')
+                . ' ON ' . $db->quoteName('sr.id') . ' = ' . $db->quoteName('mf.server_id')
+            )
+            ->where($db->quoteName('mf.id') . ' = :mid')
+            ->where($db->quoteName('mf.published') . ' = 1')
+            ->bind(':mid', $mediaId, ParameterType::INTEGER);
+
+        return $db->setQuery($query)->loadObject();
+    }
+
+    /**
      * Count a download unless this client already counted within the 24h window.
      *
      * Slides the client's window to $nowSql, increments the per-episode counter,

--- a/site/src/Controller/CwmpodcastController.php
+++ b/site/src/Controller/CwmpodcastController.php
@@ -17,12 +17,13 @@ namespace CWM\Component\Proclaim\Site\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmpodcastTrackHelper;
+use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
 /**
@@ -91,19 +92,27 @@ class CwmpodcastController extends BaseController
     }
 
     /**
-     * Download tracking redirect (#1281).
+     * Download tracking endpoint (#1281, byte-range support #1424).
      *
      * The podcast feed points <enclosure> URLs here (when the podcast has
      * track_downloads enabled) instead of at the live media. This counts the
-     * download IAB-style (one per client per 24h, bots excluded), then 302-
-     * redirects to the live media URL — which may be on this server OR an
-     * external host (the common case, given storage limits). Counting is
-     * best-effort and never blocks the redirect.
+     * download IAB-style (one per client per 24h, bots excluded), then serves
+     * the live media — which may be on this server OR an external host (the
+     * common case, given storage limits). Counting is best-effort and never
+     * blocks playback.
+     *
+     * A 302 redirect can never itself answer a Range request with 206 —
+     * redirects have no body — and Apple's crawler/validators were found to
+     * test the enclosure URL directly rather than following it first. So this
+     * proxies the response (honoring Range/HEAD/If-Modified-Since) instead of
+     * redirecting, for both local files and external hosts.
      *
      * URL: index.php?option=com_proclaim&task=cwmpodcast.track&media_id={id}
+     * URL: /component/proclaim/podcast-download/{media_id}/{any-name}.{ext}
      *
      * @return  void
      *
+     * @throws \Exception
      * @since   10.3.3
      */
     public function track(): void
@@ -116,28 +125,16 @@ class CwmpodcastController extends BaseController
         }
 
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery()
-            ->select($db->quoteName('mf.params'))
-            ->select($db->quoteName('sr.params', 'sparams'))
-            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->leftJoin(
-                $db->quoteName('#__bsms_servers', 'sr')
-                . ' ON ' . $db->quoteName('sr.id') . ' = ' . $db->quoteName('mf.server_id')
-            )
-            ->where($db->quoteName('mf.id') . ' = :mid')
-            ->where($db->quoteName('mf.published') . ' = 1')
-            ->bind(':mid', $mediaId, ParameterType::INTEGER);
-
-        $media = $db->setQuery($query)->loadObject();
+        $media = CwmpodcastTrackHelper::findPublishedMedia($db, $mediaId);
 
         if (!$media) {
             $this->fail($app, 404);
         }
 
         // Reconstruct the exact live URL the enclosure would have used, so the
-        // redirect target matches (local OR external host). Derived server-side
-        // from the media id only — the target URL is never taken from the request
-        // (that would be an open redirect).
+        // served target matches (local OR external host). Derived server-side
+        // from the media id only — the target URL is never taken from the
+        // request (that would be an open redirect/proxy).
         $config = new Registry();
         $config->loadString(Cwmparams::getAdmin()->params);
         $config->merge(Cwmparams::getTemplateparams()->params);
@@ -174,13 +171,389 @@ class CwmpodcastController extends BaseController
             // Swallow — counting is non-critical.
         }
 
-        $app->redirect($target, 302);
+        $mimeType = Cwmmime::fromExtension($path);
+
+        if ($mimeType === null) {
+            $storedMime = (string) $mreg->get('mime_type');
+            $mimeType   = $storedMime !== '' ? $storedMime : 'application/octet-stream';
+        }
+
+        $this->serveMedia($target, $mimeType);
+    }
+
+    /**
+     * Serve the tracked media directly (local disk or a proxied fetch from an
+     * external host), honoring Range/HEAD/If-Modified-Since so the URL Apple's
+     * crawler sees answers correctly without needing to follow a redirect
+     * first (#1424).
+     *
+     * @param   string  $target    Absolute URL of the live media
+     * @param   string  $mimeType  Content-Type to declare
+     *
+     * @return  void
+     *
+     * @throws \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    private function serveMedia(string $target, string $mimeType): void
+    {
+        @set_time_limit(0);
+
+        $host    = (string) $this->input->server->getString('HTTP_HOST', '');
+        $isLocal = self::isLocalHost($host, $target);
+
+        $range           = (string) $this->input->server->getString('HTTP_RANGE', '');
+        $ifModifiedSince = (string) $this->input->server->getString('HTTP_IF_MODIFIED_SINCE', '');
+        $ifNoneMatch     = (string) $this->input->server->getString('HTTP_IF_NONE_MATCH', '');
+        $headOnly        = strtoupper((string) $this->input->getMethod()) === 'HEAD';
+
+        if ($isLocal) {
+            $localPath = $this->resolveLocalPath($target);
+
+            if ($localPath !== null) {
+                $this->streamLocalFile($localPath, $mimeType, $range, $ifModifiedSince, $headOnly);
+
+                return;
+            }
+        }
+
+        $this->streamRemoteFile($target, $range, $ifModifiedSince, $ifNoneMatch, $headOnly);
+    }
+
+    /**
+     * Map a same-host target URL back to a filesystem path, refusing anything
+     * that resolves outside the web root (defense in depth — $target is
+     * server-derived, never request-supplied, but this keeps that guarantee
+     * even if a future caller changes that).
+     *
+     * @param   string  $target  Absolute URL known to share this request's host
+     *
+     * @return  ?string  Absolute filesystem path, or null if it can't be served locally
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function resolveLocalPath(string $target): ?string
+    {
+        $urlPath = parse_url($target, PHP_URL_PATH);
+
+        if (empty($urlPath)) {
+            return null;
+        }
+
+        $webRoot = rtrim(JPATH_ROOT, '/');
+        $real    = realpath($webRoot . '/' . ltrim(rawurldecode($urlPath), '/'));
+
+        if ($real === false || !str_starts_with($real, $webRoot . '/') || !is_readable($real)) {
+            return null;
+        }
+
+        return $real;
+    }
+
+    /**
+     * Stream a local file, honoring Range/If-Modified-Since/HEAD.
+     *
+     * @param   string  $filePath         Absolute filesystem path (already validated)
+     * @param   string  $mimeType         Content-Type to declare
+     * @param   string  $rangeHeader      Raw incoming Range header, if any
+     * @param   string  $ifModifiedSince  Raw incoming If-Modified-Since header, if any
+     * @param   bool    $headOnly         True for a HEAD request
+     *
+     * @return  void
+     *
+     * @throws \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    private function streamLocalFile(
+        string $filePath,
+        string $mimeType,
+        string $rangeHeader,
+        string $ifModifiedSince,
+        bool $headOnly
+    ): void {
+        $size  = filesize($filePath);
+        $mtime = filemtime($filePath);
+
+        if ($size === false || $mtime === false) {
+            $this->fail(Factory::getApplication(), 404);
+        }
+
+        $this->flushBuffers();
+
+        if ($ifModifiedSince !== '') {
+            $since = strtotime($ifModifiedSince);
+
+            if ($since !== false && $since >= $mtime) {
+                http_response_code(304);
+                $this->terminate();
+            }
+        }
+
+        [$start, $end, $status] = self::resolveRange($rangeHeader, $size);
+
+        header('Accept-Ranges: bytes');
+        header('Content-Type: ' . $mimeType);
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $mtime) . ' GMT');
+
+        if ($status === 416) {
+            header('Content-Range: bytes */' . $size);
+            http_response_code(416);
+            $this->terminate();
+        }
+
+        http_response_code($status);
+        header('Content-Length: ' . ($end - $start + 1));
+
+        if ($status === 206) {
+            header('Content-Range: bytes ' . $start . '-' . $end . '/' . $size);
+        }
+
+        if ($headOnly) {
+            $this->terminate();
+        }
+
+        $handle = fopen($filePath, 'rb');
+
+        if ($handle === false) {
+            $this->terminate();
+        }
+
+        fseek($handle, $start);
+        $remaining = $end - $start + 1;
+
+        while ($remaining > 0 && !feof($handle) && !connection_aborted()) {
+            $read = (int) min(8192, $remaining);
+            echo fread($handle, $read);
+            flush();
+            $remaining -= $read;
+        }
+
+        fclose($handle);
+        $this->terminate();
+    }
+
+    /**
+     * Proxy a fetch from an external media host, relaying its status, the
+     * caching/range-relevant headers, and (unless HEAD) its body — streamed
+     * in chunks rather than buffered whole, so this stays memory-safe for
+     * arbitrarily large episodes.
+     *
+     * Falls back to a plain redirect if curl isn't available, or if the
+     * upstream fetch fails before any response reached the client — matches
+     * this endpoint's pre-#1424 behavior in both cases rather than hanging.
+     *
+     * @param   string  $url              Absolute URL of the external media
+     * @param   string  $rangeHeader      Raw incoming Range header, if any
+     * @param   string  $ifModifiedSince  Raw incoming If-Modified-Since header, if any
+     * @param   string  $ifNoneMatch      Raw incoming If-None-Match header, if any
+     * @param   bool    $headOnly         True for a HEAD request
+     *
+     * @return  void
+     *
+     * @throws \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    private function streamRemoteFile(
+        string $url,
+        string $rangeHeader,
+        string $ifModifiedSince,
+        string $ifNoneMatch,
+        bool $headOnly
+    ): void {
+        if (!\function_exists('curl_init')) {
+            Factory::getApplication()->redirect($url, 302);
+        }
+
+        $this->flushBuffers();
+
+        $requestHeaders = [];
+
+        if ($rangeHeader !== '') {
+            $requestHeaders[] = 'Range: ' . $rangeHeader;
+        }
+
+        if ($ifModifiedSince !== '') {
+            $requestHeaders[] = 'If-Modified-Since: ' . $ifModifiedSince;
+        }
+
+        if ($ifNoneMatch !== '') {
+            $requestHeaders[] = 'If-None-Match: ' . $ifNoneMatch;
+        }
+
+        $ch = curl_init($url);
+
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER     => $requestHeaders,
+            CURLOPT_NOBODY         => $headOnly,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS      => 3,
+            CURLOPT_CONNECTTIMEOUT => 15,
+            CURLOPT_TIMEOUT        => 0,
+            CURLOPT_HEADERFUNCTION => static function ($curlHandle, string $headerLine): int {
+                $trimmed = trim($headerLine);
+
+                if ($trimmed === '') {
+                    return \strlen($headerLine);
+                }
+
+                if (preg_match('#^HTTP/\S+\s+(\d{3})#', $trimmed, $statusMatch)) {
+                    http_response_code((int) $statusMatch[1]);
+
+                    return \strlen($headerLine);
+                }
+
+                if (preg_match('/^(Content-Type|Content-Length|Content-Range|Accept-Ranges|Last-Modified|ETag|Cache-Control|Expires):/i', $trimmed)) {
+                    header($trimmed);
+                }
+
+                return \strlen($headerLine);
+            },
+        ]);
+
+        if (!$headOnly) {
+            curl_setopt(
+                $ch,
+                CURLOPT_WRITEFUNCTION,
+                static function ($curlHandle, string $data): int {
+                    echo $data;
+                    flush();
+
+                    return \strlen($data);
+                }
+            );
+        }
+
+        curl_exec($ch);
+        $failed = curl_errno($ch) !== 0;
+        curl_close($ch);
+
+        // redirect() always terminates the script itself on success, so this
+        // only actually returns when curl succeeded (nothing left to do but
+        // stop Joomla's own dispatch from continuing below) or failed after
+        // already sending part of a response (too late to redirect).
+        if ($failed && !headers_sent()) {
+            Factory::getApplication()->redirect($url, 302);
+        }
+
+        $this->terminate();
+    }
+
+    /**
+     * Stop Joomla's normal dispatch/render cycle from continuing after this
+     * controller has already written a response directly (headers and,
+     * usually, streamed body) via raw PHP functions.
+     *
+     * Every method in this class that answers HTTP requests itself instead of
+     * returning control to Joomla's MVC render pipeline — fail(), sendJson(),
+     * and the streaming methods here — must call this (or redirect(), which
+     * already does) before returning. Skipping it lets Joomla continue on to
+     * render its own page on top of/after the real response: headers set via
+     * header() are only queued by PHP until the first byte of output or
+     * script end, so any code path that sets headers without ever echoing a
+     * body (a HEAD request, a 304, a 416) sends nothing to the client until
+     * Joomla's own later render forces the flush — silently replacing the
+     * intended response with Joomla's default page. This was caught live,
+     * not by a unit test: it's a whole-request-lifecycle interaction no
+     * PHPUnit test in this suite exercises directly (see
+     * testEveryStreamingBranchTerminatesInsteadOfReturning for the source-
+     * level regression guard).
+     *
+     * @return  never
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function terminate(): never
+    {
+        Factory::getApplication()->close();
+        exit;
+    }
+
+    /**
+     * Discard any active output buffers before taking manual control of
+     * headers/body — Joomla's own response body abstraction buffers a
+     * complete string rather than streaming, which defeats the point here.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function flushBuffers(): void
+    {
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * Is the media target on this same site, so it can be streamed directly
+     * off local disk rather than proxied from an external host?
+     *
+     * parse_url()'s PHP_URL_HOST never includes a port, but the raw Host
+     * header does whenever the site isn't on the default port (every local
+     * dev site this was tested against runs on :8890) — comparing them
+     * as-is always mismatched on those sites and silently sent every local
+     * file down the remote-proxy path instead. Strip the port from both
+     * sides before comparing.
+     *
+     * @param   string  $requestHost  Raw incoming Host header (may include a port)
+     * @param   string  $target       Absolute URL of the live media
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function isLocalHost(string $requestHost, string $target): bool
+    {
+        $hostOnly   = strtolower(explode(':', $requestHost, 2)[0]);
+        $targetHost = strtolower((string) (parse_url($target, PHP_URL_HOST) ?: ''));
+
+        return $hostOnly !== '' && $targetHost !== '' && $hostOnly === $targetHost;
+    }
+
+    /**
+     * Resolve a Range header against a known content length.
+     *
+     * @param   string  $rangeHeader  Raw incoming Range header, e.g. "bytes=0-1023"
+     * @param   int     $size         Total content length in bytes
+     *
+     * @return  array{0:int,1:int,2:int}  [start, end, status] — status is 200, 206, or 416
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function resolveRange(string $rangeHeader, int $size): array
+    {
+        if ($size <= 0 || $rangeHeader === '' || !preg_match('/^bytes=(\d*)-(\d*)$/', trim($rangeHeader), $matches)) {
+            return [0, max(0, $size - 1), 200];
+        }
+
+        $rawStart = $matches[1];
+        $rawEnd   = $matches[2];
+
+        if ($rawStart === '' && $rawEnd === '') {
+            return [0, $size - 1, 200];
+        }
+
+        if ($rawStart === '') {
+            // Suffix range: the last N bytes.
+            $length = (int) $rawEnd;
+            $start  = max(0, $size - $length);
+            $end    = $size - 1;
+        } else {
+            $start = (int) $rawStart;
+            $end   = $rawEnd === '' ? $size - 1 : min((int) $rawEnd, $size - 1);
+        }
+
+        if ($start < 0 || $start > $end || $start >= $size) {
+            return [0, $size - 1, 416];
+        }
+
+        return [$start, $end, 206];
     }
 
     /**
      * Send a bare HTTP error status and terminate.
      *
-     * @param   \Joomla\CMS\Application\CMSApplication  $app   Application.
+     * @param   CMSApplication  $app   Application.
      * @param   int                                     $code  HTTP status code.
      *
      * @return  never

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -26,6 +26,7 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
@@ -870,8 +871,16 @@ class Cwmpodcast
             // The <guid> above is deliberately left as the direct URL so toggling
             // this on/off never changes item identity.
             if ($trackDownloads && $website !== '') {
-                $enclosureUrl = $this->resolveUrl($website, $protocol)
-                    . '/index.php?option=com_proclaim&amp;task=cwmpodcast.track&amp;media_id=' . (int) $episode->mfid;
+                $tracked = $this->buildTrackedEnclosureUrl($website, $protocol, $episode, $path);
+
+                // #1424: a bare "?...&task=cwmpodcast.track&media_id=N" URL has
+                // no file extension anywhere in it, and Apple's own RSS guide
+                // says that determines whether an episode is even ingested —
+                // this isn't validator pickiness. buildTrackedEnclosureUrl()
+                // only returns a URL when it can give it a real extension; when
+                // it can't (SEF off, or an unrecognized media extension), a
+                // working direct URL beats a broken extensionless one.
+                $enclosureUrl = $tracked ?? $url;
             }
         }
 
@@ -891,6 +900,59 @@ class Cwmpodcast
         return '
 		<enclosure url="' . $enclosureUrl . '" length="' . $size . '" type="' . $this->escapeHTML($type) . '" />
 		<guid isPermaLink="false">' . $guid . '</guid>';
+    }
+
+    /**
+     * Build the download-tracking enclosure URL as a real, extension-bearing
+     * path instead of a bare task query string (#1424).
+     *
+     * Apple's Podcaster's Guide to RSS is explicit that the enclosure's file
+     * extension "determines whether or not content appears in the podcast
+     * directory" — a production feed audited against this exact fix reported
+     * 0% of tracked episodes with a valid extension, and Apple had stopped
+     * ingesting new episodes and delisted previously-published ones.
+     *
+     * When the site has SEF routing on, Router::parse() (site/src/Service/
+     * Router.php) understands the resulting `/component/proclaim/
+     * podcast-download/{media_id}/{name}.{ext}` path and maps it straight
+     * back to the track task using only the media id — the filename segment
+     * is cosmetic, never trusted for routing, mirroring the rule
+     * CwmpodcastTrackHelper already follows for the redirect target itself.
+     *
+     * Returns null when a real extension can't be produced: SEF disabled
+     * (there is no router to understand the pretty path — Route::link()
+     * isn't used here specifically to avoid falling back to the same bare
+     * query string this method exists to replace), or an unrecognized media
+     * extension. The caller falls back to the direct media URL in both
+     * cases, which already carries a real extension.
+     *
+     * @param   string  $website  Podcast website (tracking-redirect base)
+     * @param   string  $protocol URL protocol
+     * @param   object  $episode  Episode info (uses ->mfid and ->alias)
+     * @param   string  $path     Direct media path/URL (source of the extension)
+     *
+     * @return  ?string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function buildTrackedEnclosureUrl(string $website, string $protocol, $episode, string $path): ?string
+    {
+        if (!Factory::getApplication()->getConfig()->get('sef')) {
+            return null;
+        }
+
+        $extPath   = parse_url($path, PHP_URL_PATH) ?: $path;
+        $extension = strtolower(pathinfo((string) $extPath, PATHINFO_EXTENSION));
+
+        if ($extension === '') {
+            return null;
+        }
+
+        $slug = !empty($episode->alias) ? OutputFilter::stringURLSafe((string) $episode->alias) : '';
+        $slug = $slug !== '' ? $slug : 'episode';
+
+        return $this->resolveUrl($website, $protocol)
+            . '/component/proclaim/podcast-download/' . (int) $episode->mfid . '/' . $slug . '.' . $extension;
     }
 
     /**

--- a/site/src/Service/Router.php
+++ b/site/src/Service/Router.php
@@ -138,6 +138,38 @@ class Router extends RouterView
     }
 
     /**
+     * Recognizes the cosmetic podcast download-tracking path (#1424) and maps
+     * it back to the track task from the media id alone. The trailing
+     * filename segment is decorative only — it exists so the enclosure URL
+     * carries a real file extension for Apple's ingestion crawler — and is
+     * never used for routing, mirroring the rule CwmpodcastTrackHelper
+     * already follows: the redirect target always comes from a server-side
+     * lookup by media id, never from request-supplied data.
+     *
+     * URL shape: /component/proclaim/podcast-download/{media_id}/{any-name}.{ext}
+     *
+     * @param   array  &$segments  Array of URL string-segments
+     *
+     * @return  array  Associative array of query values
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function parse(&$segments)
+    {
+        if (($segments[0] ?? null) === 'podcast-download' && isset($segments[1]) && ctype_digit((string) $segments[1])) {
+            $mediaId  = (int) $segments[1];
+            $segments = [];
+
+            return [
+                'task'     => 'cwmpodcast.track',
+                'media_id' => $mediaId,
+            ];
+        }
+
+        return parent::parse($segments);
+    }
+
+    /**
      * Method to get the segment(s) for a sermon
      *
      * @param   Integer|string  $id     ID of the article to retrieve the segments for

--- a/tests/unit/Site/Controller/CwmpodcastControllerTest.php
+++ b/tests/unit/Site/Controller/CwmpodcastControllerTest.php
@@ -244,4 +244,53 @@ class CwmpodcastControllerTest extends ProclaimTestCase
             );
         }
     }
+
+    // -------------------------------------------------------------------------
+    // curl availability — some hosts disable ext-curl entirely
+    // -------------------------------------------------------------------------
+
+    /**
+     * Some hosts disable ext-curl outright, or block curl_init() specifically
+     * via disable_functions in php.ini — common on restrictive shared hosting.
+     * streamRemoteFile() is the only method that touches curl (local media
+     * never does), and it must check availability before calling any curl_*
+     * function, falling back to the pre-#1424 redirect rather than fataling.
+     *
+     * Source-level rather than behavioral: function_exists() isn't mockable
+     * without changing the call convention this codebase uses consistently
+     * (\function_exists, leading-backslash global resolution) purely to
+     * accommodate one test, so this pins the guard's presence and position
+     * instead of simulating curl's absence.
+     *
+     * @return void
+     */
+    public function testStreamRemoteFileGuardsCurlAvailability(): void
+    {
+        $method = new \ReflectionMethod(CwmpodcastController::class, 'streamRemoteFile');
+        $source = file($method->getFileName());
+        $body   = implode('', \array_slice(
+            $source,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $guardPos = strpos($body, "function_exists('curl_init')");
+        $this->assertNotFalse($guardPos, 'streamRemoteFile() must check curl_init availability before using it');
+
+        $redirectPos = strpos($body, 'redirect(', $guardPos);
+        $this->assertNotFalse($redirectPos, 'The curl-unavailable branch must fall back to redirect()');
+        $this->assertLessThan(
+            200,
+            $redirectPos - $guardPos,
+            'redirect() must be the immediate fallback for the curl-unavailable branch, not just present somewhere later in the method'
+        );
+
+        $firstCurlCallPos = strpos($body, 'curl_init($url)');
+        $this->assertNotFalse($firstCurlCallPos);
+        $this->assertGreaterThan(
+            $redirectPos,
+            $firstCurlCallPos,
+            'The actual curl_init($url) call must come after the availability guard, never before it'
+        );
+    }
 }

--- a/tests/unit/Site/Controller/CwmpodcastControllerTest.php
+++ b/tests/unit/Site/Controller/CwmpodcastControllerTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * Unit tests for CwmpodcastController::resolveRange() (#1424).
+ *
+ * A 302 redirect can never itself answer a Range request with 206 — Apple's
+ * crawler/validators were found to test the enclosure URL directly rather
+ * than following it first, so track() now proxies media instead of
+ * redirecting. resolveRange() is the pure piece of that logic: it turns an
+ * incoming Range header and a known content length into the byte window and
+ * HTTP status to serve, and every edge case here is a real interoperability
+ * risk if wrong (a player asking for the last N bytes to read ID3 tags, an
+ * out-of-bounds seek after a scrub, a malformed header from some client).
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Controller;
+
+use CWM\Component\Proclaim\Site\Controller\CwmpodcastController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmpodcastControllerTest extends ProclaimTestCase
+{
+    /**
+     * @return \ReflectionMethod
+     */
+    private function resolveRangeMethod(): \ReflectionMethod
+    {
+        return new \ReflectionMethod(CwmpodcastController::class, 'resolveRange');
+    }
+
+    /**
+     * No Range header at all — the ordinary full-file case — must still be
+     * declared correctly so the response advertises Accept-Ranges from a
+     * plain GET/HEAD, not only when a Range header happens to be present.
+     *
+     * @return void
+     */
+    public function testNoRangeHeaderReturnsWholeFileAs200(): void
+    {
+        [$start, $end, $status] = $this->resolveRangeMethod()->invoke(null, '', 1000);
+
+        $this->assertSame(0, $start);
+        $this->assertSame(999, $end);
+        $this->assertSame(200, $status);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: int, 2: array{0:int,1:int,2:int}}>
+     */
+    public static function rangeProvider(): iterable
+    {
+        yield 'first 1024 bytes' => ['bytes=0-1023', 43314624, [0, 1023, 206]];
+        yield 'open-ended from an offset' => ['bytes=1000-', 2000, [1000, 1999, 206]];
+        yield 'suffix range: last 500 bytes' => ['bytes=-500', 2000, [1500, 1999, 206]];
+        yield 'suffix range larger than the file: clamps to 0' => ['bytes=-5000', 2000, [0, 1999, 206]];
+        yield 'end beyond size clamps to the last byte' => ['bytes=1000-999999', 2000, [1000, 1999, 206]];
+        yield 'bytes=0- covers the whole file' => ['bytes=0-', 2000, [0, 1999, 206]];
+    }
+
+    /**
+     * @param   string  $rangeHeader  Raw incoming Range header
+     * @param   int     $size         Known content length
+     * @param   array   $expected     [start, end, status]
+     *
+     * @return void
+     */
+    #[DataProvider('rangeProvider')]
+    public function testValidRangesResolveCorrectly(string $rangeHeader, int $size, array $expected): void
+    {
+        $result = $this->resolveRangeMethod()->invoke(null, $rangeHeader, $size);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: int}>
+     */
+    public static function unsatisfiableRangeProvider(): iterable
+    {
+        yield 'start beyond the end of the file' => ['bytes=5000-6000', 2000];
+        yield 'start equal to size (no valid last byte)' => ['bytes=2000-2000', 2000];
+        yield 'inverted range (start after end)' => ['bytes=500-100', 2000];
+    }
+
+    /**
+     * A Range that can't be satisfied must produce 416 with the start/end
+     * reset to the whole file — RFC 7233 requires the accompanying
+     * Content-Range to state the full size ("bytes *\/{size}"), and the
+     * caller (streamLocalFile/streamRemoteFile) relies on status===416 alone
+     * to decide that, not on start/end, but they must still be sane values
+     * rather than something that would corrupt a fallback response.
+     *
+     * @param   string  $rangeHeader  Raw incoming Range header
+     * @param   int     $size         Known content length
+     *
+     * @return void
+     */
+    #[DataProvider('unsatisfiableRangeProvider')]
+    public function testUnsatisfiableRangesReturn416(string $rangeHeader, int $size): void
+    {
+        [, , $status] = $this->resolveRangeMethod()->invoke(null, $rangeHeader, $size);
+
+        $this->assertSame(416, $status);
+    }
+
+    /**
+     * A header that isn't a "bytes=" range at all (some other unit, or
+     * garbage) must be treated as if there were no Range header — never
+     * crash, never silently miscount bytes.
+     *
+     * @return void
+     */
+    public function testMalformedRangeHeaderFallsBackToWholeFile(): void
+    {
+        foreach (['items=0-5', 'bytes=', 'not-a-range', 'bytes=abc-def'] as $malformed) {
+            [$start, $end, $status] = $this->resolveRangeMethod()->invoke(null, $malformed, 1000);
+
+            $this->assertSame(0, $start, "malformed header \"$malformed\" must not shift the start");
+            $this->assertSame(999, $end, "malformed header \"$malformed\" must not shift the end");
+            $this->assertSame(200, $status, "malformed header \"$malformed\" must fall back to 200");
+        }
+    }
+
+    /**
+     * A zero-byte file (size metadata missing/wrong) must never produce a
+     * negative end offset that would corrupt a Content-Range header.
+     *
+     * @return void
+     */
+    public function testZeroSizeNeverProducesANegativeEnd(): void
+    {
+        [$start, $end, $status] = $this->resolveRangeMethod()->invoke(null, '', 0);
+
+        $this->assertSame(0, $start);
+        $this->assertGreaterThanOrEqual(0, $end);
+        $this->assertSame(200, $status);
+    }
+
+    // -------------------------------------------------------------------------
+    // isLocalHost() — local vs. external-host detection
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return \ReflectionMethod
+     */
+    private function isLocalHostMethod(): \ReflectionMethod
+    {
+        return new \ReflectionMethod(CwmpodcastController::class, 'isLocalHost');
+    }
+
+    /**
+     * Caught live against a real dev site running on a non-default port
+     * (:8890): parse_url()'s PHP_URL_HOST never includes a port, but the raw
+     * Host header does whenever the site isn't on the default port — so
+     * comparing them as-is always mismatched, silently sending every local
+     * file down the remote-proxy path (which then hit an unrelated curl/TLS
+     * failure and fell back to the pre-#1424 redirect, masking the bug
+     * behind seemingly-correct behavior). Any site not on :80/:443 hits this.
+     *
+     * @return void
+     */
+    public function testPortInHostHeaderDoesNotDefeatLocalDetection(): void
+    {
+        $isLocal = $this->isLocalHostMethod()->invoke(
+            null,
+            'j5-dev.local:8890',
+            'https://j5-dev.local:8890/images/biblestudy/media/episode.mp3'
+        );
+
+        $this->assertTrue($isLocal, 'A matching host with a port must still be detected as local');
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: bool}>
+     */
+    public static function localHostProvider(): iterable
+    {
+        yield 'same host, both plain' => ['example.com', 'https://example.com/media/ep.mp3', true];
+        yield 'same host, request has a port, target does not' => ['example.com:8890', 'https://example.com/media/ep.mp3', true];
+        yield 'same host, case-insensitive' => ['Example.COM', 'https://example.com/media/ep.mp3', true];
+        yield 'different host is remote' => ['example.com', 'https://cdn.example.net/media/ep.mp3', false];
+        yield 'subdomain is not the same host' => ['example.com', 'https://media.example.com/ep.mp3', false];
+        yield 'empty request host' => ['', 'https://example.com/media/ep.mp3', false];
+        yield 'unparseable target' => ['example.com', 'not a url', false];
+    }
+
+    /**
+     * @param   string  $requestHost  Raw incoming Host header
+     * @param   string  $target       Absolute URL of the live media
+     * @param   bool    $expected     Expected local/remote classification
+     *
+     * @return void
+     */
+    #[DataProvider('localHostProvider')]
+    public function testLocalHostDetection(string $requestHost, string $target, bool $expected): void
+    {
+        $this->assertSame($expected, $this->isLocalHostMethod()->invoke(null, $requestHost, $target));
+    }
+
+    // -------------------------------------------------------------------------
+    // terminate() — every response-writing branch must stop Joomla's dispatch
+    // -------------------------------------------------------------------------
+
+    /**
+     * Caught live, not by a unit test that existed before this one: headers
+     * set via header() are only queued by PHP until the first byte of output
+     * or script end. Any branch here that sets headers without ever echoing a
+     * body (HEAD, a 304, a 416) sent nothing to the client until Joomla's own
+     * later page render forced the flush — silently replacing the intended
+     * response with Joomla's default page. A bare `return;` is exactly that
+     * bug; every terminal branch in streamLocalFile()/streamRemoteFile() must
+     * call terminate() (or redirect(), which already self-terminates)
+     * instead. This test pins that invariant at the source level so a future
+     * edit can't reintroduce a bare return by accident.
+     *
+     * @return void
+     */
+    public function testEveryStreamingBranchTerminatesInsteadOfReturning(): void
+    {
+        foreach (['streamLocalFile', 'streamRemoteFile'] as $methodName) {
+            $method = new \ReflectionMethod(CwmpodcastController::class, $methodName);
+            $source = file($method->getFileName());
+            $body   = implode('', \array_slice(
+                $source,
+                $method->getStartLine() - 1,
+                $method->getEndLine() - $method->getStartLine() + 1
+            ));
+
+            $this->assertDoesNotMatchRegularExpression(
+                '/^\s*return;\s*$/m',
+                $body,
+                "{$methodName}() must call \$this->terminate() (or redirect(), which self-terminates) on every "
+                . 'branch instead of a bare return — otherwise Joomla continues its normal render afterward and '
+                . 'silently replaces the response.'
+            );
+        }
+    }
+}

--- a/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
+++ b/tests/unit/Site/Helper/CwmpodcastFeedSpecTest.php
@@ -693,4 +693,101 @@ class CwmpodcastFeedSpecTest extends ProclaimTestCase
         $this->assertStringContainsString('name="language" type="FeedLanguage"', $xml);
         $this->assertStringContainsString('name="copyright"', $xml);
     }
+
+    // -------------------------------------------------------------------------
+    // 5. Tracked enclosure URL carries a real extension (#1424)
+    // -------------------------------------------------------------------------
+
+    /**
+     * A bare "?...&task=cwmpodcast.track&media_id=N" URL has no file extension
+     * anywhere in it. Apple's RSS guide says that determines whether an episode
+     * is even ingested — a production feed audited against this exact defect
+     * had 0% of tracked episodes with a valid extension and Apple had stopped
+     * ingesting new episodes and delisted previously-published ones. When SEF
+     * is on, the URL must be a real path carrying the media's own extension.
+     *
+     * @return  void
+     */
+    public function testTrackedEnclosureUrlCarriesRealExtensionWhenSefEnabled(): void
+    {
+        $config  = Factory::getApplication()->getConfig();
+        $wasSef  = $config->get('sef');
+        $config->set('sef', 1);
+
+        try {
+            $ref     = new \ReflectionMethod(Cwmpodcast::class, 'buildTrackedEnclosureUrl');
+            $episode = (object) ['mfid' => 2498, 'alias' => 'What about God'];
+
+            $result = $ref->invoke(
+                $this->podcast,
+                'https://example.com',
+                'https://',
+                $episode,
+                'media/what-about-god.mp3'
+            );
+
+            $this->assertNotNull($result, 'SEF is on and the extension is known — a tracked URL must be produced');
+            $this->assertStringEndsWith('.mp3', $result, 'The URL must carry the real media extension');
+            $this->assertStringContainsString('/component/proclaim/podcast-download/2498/', $result);
+        } finally {
+            $config->set('sef', $wasSef);
+        }
+    }
+
+    /**
+     * Without SEF there is no router to understand a pretty path, and
+     * Route::link() would fall back to the same bare query string this method
+     * exists to replace — so it must return null rather than a URL that looks
+     * extension-bearing but isn't actually routable.
+     *
+     * @return  void
+     */
+    public function testTrackedEnclosureUrlReturnsNullWhenSefDisabled(): void
+    {
+        $config = Factory::getApplication()->getConfig();
+        $wasSef = $config->get('sef');
+        $config->set('sef', 0);
+
+        try {
+            $ref     = new \ReflectionMethod(Cwmpodcast::class, 'buildTrackedEnclosureUrl');
+            $episode = (object) ['mfid' => 2498, 'alias' => 'what-about-god'];
+
+            $result = $ref->invoke(
+                $this->podcast,
+                'https://example.com',
+                'https://',
+                $episode,
+                'media/what-about-god.mp3'
+            );
+
+            $this->assertNull($result, 'A working direct URL beats an unroutable pretty path');
+        } finally {
+            $config->set('sef', $wasSef);
+        }
+    }
+
+    /**
+     * An unrecognized/missing extension can't be turned into a meaningful
+     * extension-bearing path either — the caller must fall back to the direct
+     * media URL rather than emit a path with a blank or wrong extension.
+     *
+     * @return  void
+     */
+    public function testTrackedEnclosureUrlReturnsNullForUnknownExtension(): void
+    {
+        $config = Factory::getApplication()->getConfig();
+        $wasSef = $config->get('sef');
+        $config->set('sef', 1);
+
+        try {
+            $ref     = new \ReflectionMethod(Cwmpodcast::class, 'buildTrackedEnclosureUrl');
+            $episode = (object) ['mfid' => 2498, 'alias' => 'what-about-god'];
+
+            $result = $ref->invoke($this->podcast, 'https://example.com', 'https://', $episode, 'media/what-about-god');
+
+            $this->assertNull($result, 'No extension to give the path — fall back to the direct URL instead');
+        } finally {
+            $config->set('sef', $wasSef);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

**Part 1 — enclosure URL extension.** The download-tracking redirect emitted enclosure URLs shaped like `?option=com_proclaim&task=cwmpodcast.track&media_id=N` — no file extension anywhere in the path. Apple's [Podcaster's Guide to RSS](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) states the enclosure's file extension "determines whether or not content appears in the podcast directory" — an ingestion gate, not a cosmetic nit.

Confirmed live on nfsda.org's production feed: 0% of tracked episodes had a valid enclosure extension (Blubrry Cast Feed Validator), Apple Podcasts had stopped ingesting new episodes after 8+ days, and previously-published episodes were showing as "no longer available."

When SEF is enabled, tracked enclosures now route through `/component/proclaim/podcast-download/{media_id}/{cosmetic-name}.{ext}` — `Router::parse()` maps this straight back to the existing `cwmpodcast.track` task using only the media id; the filename segment is decorative and never trusted for routing, same principle `CwmpodcastTrackHelper` already applies to the redirect target itself. When a real extension can't be produced (SEF disabled, or an unrecognized media extension) the enclosure falls back to the direct media URL — which already carries a real extension — rather than emit the broken query-string form.

**Part 2 — byte-range support.** A 302 redirect can never itself answer a Range request with 206 — redirects have no body. Testing the enclosure URL exactly as published (not following the redirect) confirmed this matters: `curl` with a `Range` header against the tracking URL returned a bare `302` with no `Accept-Ranges` header, while the same request against the final media host (after following the redirect) returned a correct `206`. Apple's crawler was found to test the enclosure URL directly rather than following it first.

`CwmpodcastController::track()` now proxies the response (honoring Range, HEAD, and If-Modified-Since) instead of redirecting, for both locally-hosted media (streamed directly off disk in 8KB chunks) and externally-hosted media (proxied via curl, also chunked — never buffered whole, so this stays memory-safe for arbitrarily large episodes). Falls back to the original redirect when curl is unavailable or an upstream fetch fails before any response reached the client.

The raw DB lookup that used to live inline in the controller moved to `CwmpodcastTrackHelper::findPublishedMedia()`, alongside the rest of this feature's data access, keeping the controller limited to HTTP concerns.

**Known tradeoff:** full (non-Range) downloads of externally-hosted media now flow through this server's PHP process for the whole transfer instead of an instant redirect, tying up a PHP-FPM worker for the transfer's duration (measured ~103s for a 187MB file over a real connection). Chosen deliberately — the delisting this fixes is worse than the added resource cost — but worth knowing for sites on hosts with small worker pools. `X-Sendfile`/`X-Accel-Redirect` would avoid this but isn't reliably available across Proclaim's range of hosting environments, so it wasn't used.

## Test plan

- [x] `composer test:unit` — 904 tests, 1849 assertions, all passing
- [x] `php-cs-fixer` clean on all changed files
- [x] Unit tests: `resolveRange()` (valid/suffix/open-ended/malformed/unsatisfiable ranges), `isLocalHost()` (including the port-stripping regression), and a source-level regression test asserting no bare `return` remains in either streaming method (see "caught live" below)
- [x] **Live-verified against a real Joomla dispatch** (not just unit tests) on a local SEF-enabled dev site, both local and external-host media:
  - Plain GET, Range, HEAD, 304 (If-Modified-Since), and 416 (unsatisfiable range) all produce correct, byte-exact responses
  - New pretty router path (`/component/proclaim/podcast-download/{id}/{name}.mp3`) round-trips correctly through `Router::parse()`
  - Full 187MB download from the real external nfsda.org host completed byte-exact
  - Confirmed the underlying redirect/byte-range mechanics were already correct at the final media host before this change (`curl -L` with a Range header → 206) — only the tracking layer's own response shape was broken
- [x] Two real bugs found only by this live testing, now covered by regression tests:
  - `parse_url()`'s `PHP_URL_HOST` never includes a port, but the raw Host header does on non-default-port sites — the local/external comparison always mismatched and silently sent local files down the remote-proxy path
  - Several branches did a bare `return` instead of terminating the request — PHP only flushes queued headers on first body output or script end, so any header-only response (HEAD, 304, 416) sent nothing until Joomla's own later page render forced the flush, silently replacing the real response with Joomla's default page
- [ ] Re-check the live feed / Apple Podcasts a few days after deploy to confirm both ingestion and full-catalog listing are restored

Closes #1424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)