### PR TITLE
fix(podcast): guard the download-tracking proxy against SSRF (#1426)

### DIFF
--- a/site/src/Controller/CwmpodcastController.php
+++ b/site/src/Controller/CwmpodcastController.php
@@ -364,6 +364,23 @@ class CwmpodcastController extends BaseController
             Factory::getApplication()->redirect($url, 302);
         }
 
+        // SSRF guard (#1426): this method makes the request itself and relays
+        // the response to an unauthenticated caller — unlike the redirect it
+        // replaces, which only ever sent the *client's* browser/app to fetch
+        // $url. $url is admin-configured (server.params.path), not
+        // request-supplied, but a compromised/misconfigured admin account
+        // could still point it at an internal host (localhost services,
+        // cloud metadata, etc.) and turn this endpoint into a standing,
+        // public, unauthenticated proxy into the internal network. Refuse
+        // outright rather than falling back to anything — an internal host
+        // has nothing safe to fall back to.
+        $host   = (string) (parse_url($url, PHP_URL_HOST) ?? '');
+        $safeIp = $host !== '' ? self::resolveSafeRemoteIp($host) : null;
+
+        if ($safeIp === null) {
+            $this->fail(Factory::getApplication(), 404);
+        }
+
         $this->flushBuffers();
 
         $requestHeaders = [];
@@ -380,13 +397,26 @@ class CwmpodcastController extends BaseController
             $requestHeaders[] = 'If-None-Match: ' . $ifNoneMatch;
         }
 
+        $port = parse_url($url, PHP_URL_PORT) ?? (str_starts_with($url, 'https://') ? 443 : 80);
+
         $ch = curl_init($url);
 
         curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER     => $requestHeaders,
-            CURLOPT_NOBODY         => $headOnly,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_MAXREDIRS      => 3,
+            CURLOPT_HTTPHEADER => $requestHeaders,
+            CURLOPT_NOBODY     => $headOnly,
+            // A redirect chain could point anywhere, including back at an
+            // internal host this check never sees — the live nfsda.org
+            // target this was built for is a direct file, not a redirect,
+            // so not following one costs nothing real here.
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            // Pin resolution to the IP already validated above — curl would
+            // otherwise re-resolve the hostname itself at connect time, and
+            // DNS could answer differently between the check and the fetch
+            // (DNS rebinding) and land on an internal address anyway. The
+            // hostname is kept in the URL/Host header/TLS SNI for virtual
+            // hosting and certificate validation to keep working correctly.
+            CURLOPT_RESOLVE        => [$host . ':' . $port . ':' . $safeIp],
             CURLOPT_CONNECTTIMEOUT => 15,
             CURLOPT_TIMEOUT        => 0,
             CURLOPT_HEADERFUNCTION => static function ($curlHandle, string $headerLine): int {
@@ -508,6 +538,47 @@ class CwmpodcastController extends BaseController
         $targetHost = strtolower((string) (parse_url($target, PHP_URL_HOST) ?: ''));
 
         return $hostOnly !== '' && $targetHost !== '' && $hostOnly === $targetHost;
+    }
+
+    /**
+     * SSRF guard for streamRemoteFile() (#1426): resolve a hostname to an IP
+     * that is safe to fetch on this server's behalf, or null if it isn't.
+     *
+     * "Safe" means a public, routable address — not loopback (127.0.0.1,
+     * ::1), not a private/RFC1918 range (10/8, 172.16/12, 192.168/16), and
+     * not link-local (169.254.0.0/16, which is where cloud metadata
+     * endpoints like AWS's 169.254.169.254 live). streamRemoteFile() proxies
+     * the fetch to an unauthenticated caller, so an admin-configured server
+     * path pointing here — whether by mistake or a compromised account —
+     * would otherwise turn this endpoint into a standing, public gateway
+     * into the internal network.
+     *
+     * Only IPv4 is resolved (gethostbyname()); a host that only has an AAAA
+     * record fails safe (returns null) rather than being fetched unchecked.
+     *
+     * @param   string  $host  Hostname or IP literal to validate
+     *
+     * @return  ?string  A safe IP to connect to, or null to refuse the fetch entirely
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function resolveSafeRemoteIp(string $host): ?string
+    {
+        $flags = \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE;
+
+        if (filter_var($host, \FILTER_VALIDATE_IP) !== false) {
+            // A literal IP was given directly — validate it as-is.
+            return filter_var($host, \FILTER_VALIDATE_IP, $flags) !== false ? $host : null;
+        }
+
+        $ip = gethostbyname($host);
+
+        // gethostbyname() returns its input unchanged when resolution fails.
+        if ($ip === $host) {
+            return null;
+        }
+
+        return filter_var($ip, \FILTER_VALIDATE_IP, $flags) !== false ? $ip : null;
     }
 
     /**

--- a/tests/unit/Site/Controller/CwmpodcastControllerTest.php
+++ b/tests/unit/Site/Controller/CwmpodcastControllerTest.php
@@ -293,4 +293,112 @@ class CwmpodcastControllerTest extends ProclaimTestCase
             'The actual curl_init($url) call must come after the availability guard, never before it'
         );
     }
+
+    // -------------------------------------------------------------------------
+    // resolveSafeRemoteIp() — SSRF guard (#1426)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return \ReflectionMethod
+     */
+    private function resolveSafeRemoteIpMethod(): \ReflectionMethod
+    {
+        return new \ReflectionMethod(CwmpodcastController::class, 'resolveSafeRemoteIp');
+    }
+
+    /**
+     * streamRemoteFile() makes the request itself and relays the response to
+     * an unauthenticated caller — unlike the redirect it replaces, which only
+     * ever sent the client's own browser/app to fetch the URL. $url is
+     * admin-configured (server.params.path), not request-supplied, but a
+     * compromised or misconfigured admin account pointing it at an internal
+     * host would otherwise turn this endpoint into a standing, public,
+     * unauthenticated gateway into the internal network — localhost
+     * services, and cloud metadata endpoints in particular (AWS/GCP/Azure
+     * all use 169.254.169.254, a link-local address).
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function unsafeRemoteHostProvider(): iterable
+    {
+        yield 'IPv4 loopback' => ['127.0.0.1'];
+        yield 'IPv4 loopback, alternate form' => ['127.1.2.3'];
+        yield 'RFC1918 10/8' => ['10.0.0.1'];
+        yield 'RFC1918 172.16/12' => ['172.16.5.1'];
+        yield 'RFC1918 192.168/16' => ['192.168.1.1'];
+        yield 'link-local / cloud metadata (AWS/GCP/Azure)' => ['169.254.169.254'];
+        yield 'IPv6 loopback' => ['::1'];
+        yield 'unresolvable hostname' => ['this-host-does-not-exist.invalid'];
+    }
+
+    /**
+     * @param   string  $host  A host that must never be fetched
+     *
+     * @return void
+     */
+    #[DataProvider('unsafeRemoteHostProvider')]
+    public function testUnsafeRemoteHostsAreRejected(string $host): void
+    {
+        $result = $this->resolveSafeRemoteIpMethod()->invoke(null, $host);
+
+        $this->assertNull($result, "\"{$host}\" must be refused, not resolved to a fetchable IP");
+    }
+
+    /**
+     * A genuine public IP literal must resolve to itself unchanged — the
+     * guard must not be so aggressive it breaks the actual, intended use
+     * case (an admin-configured external media host).
+     *
+     * @return void
+     */
+    public function testPublicIpLiteralIsAccepted(): void
+    {
+        // 8.8.8.8 — Google Public DNS. Stable, well-known, unambiguously
+        // public; used here only as a fixed literal, never actually
+        // contacted by this test.
+        $result = $this->resolveSafeRemoteIpMethod()->invoke(null, '8.8.8.8');
+
+        $this->assertSame('8.8.8.8', $result);
+    }
+
+    /**
+     * streamRemoteFile() must run this check before doing anything curl-
+     * related, and must refuse (not fall back to anything) when it fails —
+     * an internal host has nothing safe to fall back to. Source-level rather
+     * than behavioral: exercising the live-network resolution path in a unit
+     * test would make it non-deterministic and environment-dependent.
+     *
+     * @return void
+     */
+    public function testStreamRemoteFileGuardsAgainstUnsafeHostsBeforeCurl(): void
+    {
+        $method = new \ReflectionMethod(CwmpodcastController::class, 'streamRemoteFile');
+        $source = file($method->getFileName());
+        $body   = implode('', \array_slice(
+            $source,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $guardPos = strpos($body, 'resolveSafeRemoteIp(');
+        $this->assertNotFalse($guardPos, 'streamRemoteFile() must call resolveSafeRemoteIp() before fetching $url');
+
+        $failPos = strpos($body, 'fail(', $guardPos);
+        $this->assertNotFalse($failPos, 'An unsafe host must be refused via fail(), not redirected or silently allowed');
+
+        $firstCurlCallPos = strpos($body, 'curl_init($url)');
+        $this->assertNotFalse($firstCurlCallPos);
+        $this->assertGreaterThan(
+            $guardPos,
+            $firstCurlCallPos,
+            'curl_init($url) must never run before the SSRF guard has had a chance to refuse the request'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/CURLOPT_FOLLOWLOCATION\s*=>\s*true/',
+            $body,
+            'Following redirects would fetch a host this guard never validated — a malicious origin could '
+            . '302 to an internal address and bypass the check entirely'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

#1425 (shipped in 10.5.4) replaced the tracking redirect with a server-side proxy for externally-hosted media — `streamRemoteFile()` now fetches the media itself via curl and relays the response to the caller, instead of sending the client a 302 to fetch it themselves. That's a real change in blast radius: the old code told the *client's* browser/app to fetch a URL; the new code has *the server itself* make the request and relay the response back to anyone, unauthenticated.

The fetched URL is built from admin-configured data (server path, media filename), never directly from the request — but a compromised or misconfigured admin account pointing a server's path at an internal host (`127.0.0.1`, `10.x`, the `169.254.169.254` cloud metadata address, etc.) would turn this public endpoint into a standing SSRF gateway into the internal network. Local media streaming is unaffected — it never makes a network request.

**Fix:**
- `resolveSafeRemoteIp()` resolves the target host and refuses anything that isn't a public, routable IP (`FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`) before any curl activity runs, failing outright (404) rather than falling back to anything — an internal host has nothing safe to fall back to.
- `CURLOPT_RESOLVE` pins the connection to the already-validated IP, closing the DNS-rebinding gap between the check and the actual fetch.
- `CURLOPT_FOLLOWLOCATION` is now `false` — a redirect chain could point anywhere the guard never validated.
- `CURLOPT_PROTOCOLS` restricted to HTTP/HTTPS, so a stored `file://`/`gopher://` scheme can't reach curl.

**10.5.4 already shipped with the vulnerable proxy and won't be amended** — this lands as 10.5.5.

## Test plan

- [x] `composer test:unit` — 915 tests, 1868 assertions, all passing
- [x] `php-cs-fixer` clean
- [x] New unit tests: `resolveSafeRemoteIp()` rejects loopback (v4/v6), RFC1918 ranges, link-local/cloud-metadata (`169.254.169.254`), and unresolvable hosts; accepts a genuine public IP literal
- [x] Source-level regression test: `streamRemoteFile()` must call the guard before `curl_init($url)`, must `fail()` (not redirect/proceed) when it fails, and `CURLOPT_FOLLOWLOCATION => true` must never reappear

Closes #1426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)