### PR TITLE
fix: define BIBLESTUDY_* path constants in every application

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -68,19 +68,10 @@ if ($app->isClient('administrator')) {
     \define('BIBLESTUDY_VERSION', '');
 }
 
-// Default values
-const BIBLESTUDY_COMPONENT_NAME = 'com_proclaim';
-
-// File system paths
-const BIBLESTUDY_COMPONENT_RELPATH = 'components' . DIRECTORY_SEPARATOR . BIBLESTUDY_COMPONENT_NAME;
-
-// Root system paths
-const BIBLESTUDY_ROOT_PATH       = JPATH_ROOT;
-const BIBLESTUDY_ROOT_PATH_ADMIN = JPATH_ADMINISTRATOR;
-const BIBLESTUDY_MEDIA_PATH      = JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'com_proclaim';
-
-// Admin Component paths
-const BIBLESTUDY_PATH_ADMIN         = BIBLESTUDY_ROOT_PATH_ADMIN . DIRECTORY_SEPARATOR . BIBLESTUDY_COMPONENT_RELPATH;
+// File system paths — defined in ProclaimComponent::boot(), which runs in every
+// application. This call is for the paths that reach this file without booting
+// the component, such as the postinstall messages. It is guarded/idempotent.
+CwmproclaimHelper::defineLegacyPathConstants();
 
 // If a phrase is not found in a specific language file, load the English language file:
 $language = $app->getLanguage();

--- a/admin/src/Extension/ProclaimComponent.php
+++ b/admin/src/Extension/ProclaimComponent.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Proclaim\Administrator\Extension;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
 use CWM\Component\Proclaim\Administrator\Service\HTML\CWMAdministratorService;
 use Joomla\CMS\Component\Router\RouterServiceInterface;
 use Joomla\CMS\Component\Router\RouterServiceTrait;
@@ -123,6 +124,14 @@ class ProclaimComponent extends MVCComponent implements
 
     public function boot(ContainerInterface $container): void
     {
+        // Define the legacy BIBLESTUDY_* path constants before anything else runs.
+        //
+        // These previously only existed if admin/api.php had been included, which
+        // never happens in the API application — code reachable from the API saw
+        // them as undefined and fatalled (see #1428). Defining them here means
+        // every application (administrator, site, API) gets them for real.
+        CwmproclaimHelper::defineLegacyPathConstants();
+
         // Register Proclaim's log categories before anything else runs.
         //
         // Log::addLogEntry() only dispatches to loggers matching an entry's

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -50,6 +50,52 @@ class CwmproclaimHelper
     public static string $extension = 'com_proclaim';
 
     /**
+     * Define the legacy BIBLESTUDY_* path constants, if not already defined.
+     *
+     * These used to be declared with `const` in admin/api.php, which is only
+     * included in the administrator and site applications — the API application
+     * never loads it, so code reachable from the API saw the constants as
+     * undefined and fatalled. Calling this from ProclaimComponent::boot()
+     * (which runs in every application) fixes that at the source.
+     *
+     * admin/api.php still calls this too, guarded, for the paths that reach
+     * that file without booting the component (e.g. postinstall messages).
+     *
+     * @return void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function defineLegacyPathConstants(): void
+    {
+        if (!\defined('BIBLESTUDY_COMPONENT_NAME')) {
+            \define('BIBLESTUDY_COMPONENT_NAME', 'com_proclaim');
+        }
+
+        if (!\defined('BIBLESTUDY_COMPONENT_RELPATH')) {
+            \define('BIBLESTUDY_COMPONENT_RELPATH', 'components' . DIRECTORY_SEPARATOR . BIBLESTUDY_COMPONENT_NAME);
+        }
+
+        if (!\defined('BIBLESTUDY_ROOT_PATH')) {
+            \define('BIBLESTUDY_ROOT_PATH', JPATH_ROOT);
+        }
+
+        if (!\defined('BIBLESTUDY_ROOT_PATH_ADMIN')) {
+            \define('BIBLESTUDY_ROOT_PATH_ADMIN', JPATH_ADMINISTRATOR);
+        }
+
+        if (!\defined('BIBLESTUDY_MEDIA_PATH')) {
+            \define(
+                'BIBLESTUDY_MEDIA_PATH',
+                JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'com_proclaim'
+            );
+        }
+
+        if (!\defined('BIBLESTUDY_PATH_ADMIN')) {
+            \define('BIBLESTUDY_PATH_ADMIN', BIBLESTUDY_ROOT_PATH_ADMIN . DIRECTORY_SEPARATOR . BIBLESTUDY_COMPONENT_RELPATH);
+        }
+    }
+
+    /**
      * Update View and Controller to work with Namespace Case-Sensitive
      *
      * @param   string  $defaultController  Default Controller


### PR DESCRIPTION
## Summary
- `CWMAddon` (and anything else referencing `BIBLESTUDY_PATH_ADMIN`) fatalled when reached from the API application, because the constant was only declared in `admin/api.php`, which never loads in the API app. This broke every media-file write through the JSON:API with a 500 before the record saved.
- Moves the `BIBLESTUDY_*` path constant definitions into a guarded `CwmproclaimHelper::defineLegacyPathConstants()`, called from `ProclaimComponent::boot()` (runs in every application: admin, site, API) and still from `admin/api.php` for paths that reach it without booting the component.
- Mirrors the same fix already applied to log registration (see the comment in `admin/api.php`), rather than patching call sites one at a time — an audit of the other two `BIBLESTUDY_PATH_ADMIN` references (`CwmserverMigrationHelper.php`, `LoadLanguageFileField.php`) found they aren't currently reachable from the API, but this closes the whole bug class instead of relying on that staying true.

Fixes #1428

## Test plan
- [x] `composer lint` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 915/915 passing
- [x] `composer test:integration` — 155/155 passing against real Joomla (j5-dev), confirming `boot()` fires and defines the constants correctly
- [x] `php -l` on all touched files

## Follow-up
Filing a separate issue for `BIBLESTUDY_VERSION` and language-file loading in `admin/api.php`, which have the same client-gated pattern (ties into #1429).