### PR TITLE
fix: read Proclaim version from manifest_cache, load language files everywhere

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -12,7 +12,6 @@
 use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -39,33 +38,6 @@ if ($app->isClient('administrator') || $app->getInput()->getInt('jbsmdbg', 0) ==
     }
 } else {
     \define('JBSMDEBUG', 0);
-}
-
-// Version information — defer XML parsing to admin only (the only consumer
-// is CwminstallModel). On the front end, set a placeholder to avoid the
-// cost of file_get_contents + simplexml on every page load.
-if ($app->isClient('administrator')) {
-    $manifestFile    = JPATH_ADMINISTRATOR . '/components/com_proclaim/proclaim.xml';
-    $manifestVersion = '0.0.0';
-
-    if (is_file($manifestFile) && is_readable($manifestFile)) {
-        libxml_use_internal_errors(true);
-        $xml = simplexml_load_string(file_get_contents($manifestFile));
-
-        if ($xml instanceof \SimpleXMLElement && isset($xml->version)) {
-            $manifestVersion = trim((string) $xml->version);
-        } else {
-            foreach (libxml_get_errors() as $error) {
-                Log::add('XML Error in proclaim.xml: ' . trim($error->message), Log::WARNING, 'com_proclaim');
-            }
-        }
-
-        libxml_clear_errors();
-    }
-
-    \define('BIBLESTUDY_VERSION', $manifestVersion);
-} else {
-    \define('BIBLESTUDY_VERSION', '');
 }
 
 // File system paths — defined in ProclaimComponent::boot(), which runs in every

--- a/admin/src/Extension/ProclaimComponent.php
+++ b/admin/src/Extension/ProclaimComponent.php
@@ -132,6 +132,16 @@ class ProclaimComponent extends MVCComponent implements
         // every application (administrator, site, API) gets them for real.
         CwmproclaimHelper::defineLegacyPathConstants();
 
+        // Load Proclaim's language files before anything else runs.
+        //
+        // This previously only happened via admin/api.php, which is not included
+        // in the API application, so language strings were never loaded in that
+        // context (see #1431). Language::load() is idempotent, so this and
+        // admin/api.php's own calls (for paths that reach it without booting the
+        // component) do not double-load anything.
+        Factory::getApplication()->getLanguage()->load('com_proclaim', BIBLESTUDY_PATH_ADMIN, 'en-GB', true);
+        Factory::getApplication()->getLanguage()->load('com_proclaim', BIBLESTUDY_PATH_ADMIN, null, true);
+
         // Register Proclaim's log categories before anything else runs.
         //
         // Log::addLogEntry() only dispatches to loggers matching an entry's

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -50,6 +50,54 @@ class CwmproclaimHelper
     public static string $extension = 'com_proclaim';
 
     /**
+     * Cached installed component version.
+     *
+     * @var  ?string
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static ?string $version = null;
+
+    /**
+     * Get the installed Proclaim version.
+     *
+     * Reads `#__extensions.manifest_cache`, which every Joomla application
+     * (site, admin, API, CLI) can query. This replaces the old
+     * BIBLESTUDY_VERSION constant, which admin/api.php only populated by
+     * parsing proclaim.xml off the filesystem, and only when the current
+     * client was 'administrator' — everywhere else, including the API
+     * application, it was an empty string. See #1429.
+     *
+     * @return  string  Semver version string, or '0.0.0' if unavailable
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function getVersion(): string
+    {
+        if (self::$version !== null) {
+            return self::$version;
+        }
+
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('manifest_cache'))
+                ->from($db->quoteName('#__extensions'))
+                ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'));
+            $db->setQuery($query);
+            $cache = $db->loadResult();
+
+            $manifest      = $cache ? json_decode($cache, true) : null;
+            self::$version = $manifest['version'] ?? '0.0.0';
+        } catch (\Throwable) {
+            self::$version = '0.0.0';
+        }
+
+        return self::$version;
+    }
+
+    /**
      * Define the legacy BIBLESTUDY_* path constants, if not already defined.
      *
      * These used to be declared with `const` in admin/api.php, which is only

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -80,7 +80,7 @@ class CwmproclaimHelper
 
         try {
             $db    = Factory::getContainer()->get(DatabaseInterface::class);
-            $query = $db->getQuery(true)
+            $query = $db->createQuery()
                 ->select($db->quoteName('manifest_cache'))
                 ->from($db->quoteName('#__extensions'))
                 ->where($db->quoteName('type') . ' = ' . $db->quote('component'))

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmguidedtourHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmtemplatemigrationHelper;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmbackup;
@@ -338,7 +339,7 @@ class CwminstallModel extends ListModel
             $this->callstack['install_type'] = 'install';
         } else {
             $installedMajor                  = (int) $this->callstack['subversiontype_version'];
-            $currentMajor                    = (int) BIBLESTUDY_VERSION;
+            $currentMajor                    = (int) CwmproclaimHelper::getVersion();
             $this->callstack['install_type'] = ($installedMajor < $currentMajor) ? 'migration' : 'upgrade';
         }
 
@@ -1097,7 +1098,7 @@ class CwminstallModel extends ListModel
     /**
      * Returns the current schema version from #__schemas
      *
-     * @return string The schema version for Proclaim, or BIBLESTUDY_VERSION as fallback
+     * @return string The schema version for Proclaim, or CwmproclaimHelper::getVersion() as fallback
      *
      * @since 10.1.0
      */
@@ -1128,7 +1129,7 @@ class CwminstallModel extends ListModel
             }
         }
 
-        return BIBLESTUDY_VERSION;
+        return CwmproclaimHelper::getVersion();
     }
 
     /**
@@ -1214,7 +1215,7 @@ class CwminstallModel extends ListModel
         $this->getDatabase()->execute();
         Factory::getApplication()->enqueueMessage(
             '<h2>' . Text::_('JBS_INS_UNINSTALLED') . ' ' .
-            BIBLESTUDY_VERSION . '</h2> <div>' . $drop_result . '</div>'
+            CwmproclaimHelper::getVersion() . '</h2> <div>' . $drop_result . '</div>'
         );
 
         // Remove Guided Tours


### PR DESCRIPTION
## Summary
- `BIBLESTUDY_VERSION` was only populated when `admin/api.php` ran with `isClient('administrator')` — empty everywhere else, including the API application. This is the root cause of #1429: external tooling reading the version over the API fell back to the DB schema version, which legitimately lags releases with no schema changes and reported stale numbers.
- Adds `CwmproclaimHelper::getVersion()`, reading `#__extensions.manifest_cache` directly — works in every application (site, admin, API, CLI), matching the existing `LibraryVersion::getInstalledVersion()` pattern in `lib_cwmscripture`. Replaces all `BIBLESTUDY_VERSION` usages in `CwminstallModel` and removes the constant's defining block from `admin/api.php` entirely (no longer needed as a constant since it's DB-driven now).
- Moves Proclaim's language-file loading into `ProclaimComponent::boot()`, which runs in every application — same reasoning as the path-constants fix in #1428, since `admin/api.php` never runs in the API app. `Language::load()` is idempotent, so the existing calls left in `admin/api.php` (for paths that reach it without booting the component) don't double-load anything.

Fixes #1431

## Test plan
- [x] `composer lint` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 915/915 passing
- [x] `composer test:integration` — 155/155 passing against real Joomla (j5-dev)
- [x] Manually verified `CwmproclaimHelper::getVersion()` against the live j5-dev DB — correctly returns the actually-installed manifest version (10.3.5, reflecting that dev site's known install drift), not a hardcoded/stale value
- [x] `php -l` on all touched files

## Follow-up
The `GET /v1/proclaim/info` endpoint proposal from #1429 (exposing the version over JSON:API) is separate scope — this PR only fixes the version *source*, not the API surface for it.