### PR TITLE
feat: add GET /v1/proclaim/info API endpoint

### DIFF
--- a/admin/src/Model/CwminfoModel.php
+++ b/admin/src/Model/CwminfoModel.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Administrator\Model;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Model backing the `/v1/proclaim/info` API resource.
+ *
+ * Not a database entity — a singleton item exposing metadata a caller cannot
+ * otherwise reliably obtain over the API. See #1429: external tooling reading
+ * the DB schema version to guess the installed release got stale answers,
+ * because the schema version only advances on releases that ship DB changes.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwminfoModel extends BaseDatabaseModel
+{
+    /**
+     * Get the singleton info item.
+     *
+     * @param   ?int  $pk  Ignored — there is only one info item.
+     *
+     * @return  \stdClass
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getItem($pk = null): \stdClass
+    {
+        $item          = new \stdClass();
+        $item->id      = 1;
+        $item->version = CwmproclaimHelper::getVersion();
+
+        return $item;
+    }
+}

--- a/api/src/Controller/InfoController.php
+++ b/api/src/Controller/InfoController.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * API controller for component metadata.
+ *
+ * GET /api/index.php/v1/proclaim/info — the installed Proclaim version.
+ *
+ * A singleton resource, not a database entity — see CwminfoModel. Only
+ * displayItem is ever routed to this controller (see the webservices plugin);
+ * there is no list variant and no :id segment.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class InfoController extends AbstractReadOnlyController
+{
+    protected $contentType = 'info';
+
+    protected $default_view = 'info';
+
+    /**
+     * Get the model, mapping the API name to the Cwm-prefixed Proclaim class.
+     *
+     * @param   string  $name    Model name
+     * @param   string  $prefix  Model prefix
+     * @param   array   $config  Configuration
+     *
+     * @return  BaseDatabaseModel|false
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        $map = [
+            'info' => 'Cwminfo',
+        ];
+
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/src/View/Info/JsonapiView.php
+++ b/api/src/View/Info/JsonapiView.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Api\View\Info;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * JSON:API view for component metadata.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * The fields to render in the item response.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $fieldsToRenderItem = [
+        'id',
+        'version',
+    ];
+}

--- a/plugins/webservices/proclaim/src/Extension/Proclaim.php
+++ b/plugins/webservices/proclaim/src/Extension/Proclaim.php
@@ -48,6 +48,10 @@ use Joomla\Router\Route;
  * view levels by the underlying model, so a public read never returns rows a
  * user could not see in the site itself.
  *
+ * One extra singleton endpoint, not a RESOURCES entry — component metadata, not
+ * a database resource:
+ *   GET  /api/index.php/v1/proclaim/info — installed Proclaim version
+ *
  * @since  10.3.0
  */
 class Proclaim extends CMSPlugin implements SubscriberInterface
@@ -147,6 +151,8 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
                 $this->createWriteRoutes($router, "v1/proclaim/$resource", $resource);
             }
         }
+
+        $this->createInfoRoute($router, $isPublic);
 
         $this->explainUnroutableRequest();
     }
@@ -289,6 +295,31 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
         ];
 
         $router->addRoutes($routes);
+    }
+
+    /**
+     * Register the info route.
+     *
+     * Not a RESOURCES entry: info is a singleton (component metadata, not a
+     * database entity — see CwminfoModel), so it gets one GET route straight to
+     * displayItem rather than the list + list/:id pair createReadOnlyRoutes()
+     * registers for real resources. See #1429.
+     *
+     * @param   ApiRouter  $router    The API router
+     * @param   bool       $isPublic  Whether the route is publicly accessible
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function createInfoRoute(ApiRouter $router, bool $isPublic): void
+    {
+        $router->addRoutes([
+            new Route(['GET'], 'v1/proclaim/info', 'info.displayItem', [], [
+                'component' => 'com_proclaim',
+                'public'    => $isPublic,
+            ]),
+        ]);
     }
 
 }

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -26,6 +26,7 @@
 const { test, expect } = require('@playwright/test');
 
 const API_SERMONS = '/api/index.php/v1/proclaim/sermons';
+const API_INFO = '/api/index.php/v1/proclaim/info';
 
 test.describe.serial('REST API acceptance (package install) @api', () => {
     test('Proclaim and its webservices plugin are installed and enabled', async ({ page }) => {
@@ -63,6 +64,16 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
             + 'only acceptable "no" here.',
         ).not.toBe(404);
 
+        expect(response.status()).toBe(401);
+    });
+
+    test('unauthenticated request to info is denied with 401, not 404', async ({ request }) => {
+        // info is a singleton route registered outside the RESOURCES loop
+        // (#1429) — its own regression check that route registration for it
+        // actually happened, same reasoning as the sermons check above.
+        const response = await request.get(API_INFO);
+
+        expect(response.status()).not.toBe(404);
         expect(response.status()).toBe(401);
     });
 
@@ -118,6 +129,21 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
 
         // A JSON:API document carries its resources under `data`.
         expect(Array.isArray(body.data), 'Expected a JSON:API document with a data array').toBe(true);
+
+        // info is a singleton item, not a list — same token, no re-auth needed.
+        const infoResponse = await request.get(API_INFO, {
+            headers: { 'X-Joomla-Token': token },
+        });
+
+        expect(infoResponse.status()).toBe(200);
+
+        const infoBody = await infoResponse.json();
+
+        expect(infoBody.data?.type).toBe('info');
+        expect(
+            infoBody.data?.attributes?.version,
+            'Expected a non-empty version string from CwmproclaimHelper::getVersion()',
+        ).not.toBe('');
     });
 
     test('public_reads set through the plugin UI opens and closes anonymous reads', async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Closes the remaining half of #1429: external tooling had no reliable way to read Proclaim's installed version over the API. #1431/PR #1433 fixed the version *source* (`CwmproclaimHelper::getVersion()`, reading `#__extensions.manifest_cache`); this exposes it as `GET /v1/proclaim/info`.
- `info` is a singleton resource, not a database entity, so it's wired up a bit differently from the other API resources:
  - `CwminfoModel` (new) returns a synthetic `stdClass` instead of a Table-backed row.
  - `InfoController` (new) extends `AbstractReadOnlyController` — no writes make sense for this resource.
  - The webservices plugin registers one `GET` route directly to `info.displayItem`, rather than looping it through the `RESOURCES`-driven list/item pair (which would also register a nonsensical `/info/:id` and a list variant).
- Same auth policy as every other resource — gated by the plugin's `public_reads` setting, no special-casing for this endpoint.

## Test plan
- [x] `composer lint` / `lint:queries` — no new findings
- [x] `composer test:unit` — 915/915 passing
- [x] `composer test:integration` — 155/155 passing
- [x] Verified against j5-dev: unauthenticated `GET /v1/proclaim/info` returns `401` (not `404`), matching the existing `/v1/proclaim/messagetypes` signature — confirms the route is actually registered.
- [x] Added Playwright coverage to `tests/e2e/api/api-acceptance.spec.js` (unauthenticated 401-not-404 check, plus an authenticated request asserting the JSON:API payload shape and a non-empty `version` attribute). This PR's diff touches `api/**`, `plugins/webservices/**`, and `tests/e2e/**`, so `e2e.yml` will run the full disposable-install + Playwright suite automatically.

Fixes #1429