### PR TITLE
docs: add PR Hygiene section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,14 @@ Include:
 - **Multi-issue features**: apply the `epic` label and use an `epic/{N}-{slug}` integration branch, with sub-PRs targeting that branch instead of `development`.
 - **Link branches to their issue**: don't just name a branch after the issue number — run `gh issue develop <issue-number> --branch <name>` (or use the issue's "Create a branch" button) so the branch and its PR show up under the issue's Development section automatically.
 
+### PR Hygiene
+
+PRs need the same metadata as issues — a linked branch alone isn't enough:
+
+- **Mirror the linked issue's labels** (`priority:*`, `area:*`, `bug`/`enhancement`) onto the PR. Docs-only or other PRs with no linked issue just skip labels.
+- **Assign the PR** (and its linked issue, if not already) to whoever is doing the work.
+- **Milestone**: use the milestone matching `active_development` in `build/versions.json` (e.g. `10.5.6`) for patch/bugfix work; create it if it doesn't exist yet. Larger breaking work goes in the next major milestone (e.g. `v11.0.0`) instead.
+
 ## Versioning
 
 Check `build/versions.json` for version numbers:


### PR DESCRIPTION
## Summary
- Adds a "PR Hygiene" section alongside the existing "Issue Hygiene" one: mirror the linked issue's labels onto the PR, assign the PR (and issue) to whoever's doing the work, and use the milestone matching `active_development` for patch/bugfix work.
- Prompted by tonight's 4 PRs merging with none of labels/assignee/milestone set, despite their linked issues having all three — caught from a PR sidebar screenshot.

## Test plan
- [x] Docs-only change, no code touched.