### PR TITLE
fix: restore ACL check in CwmsermonController::allowEdit()

### DIFF
--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -378,6 +378,11 @@ class CwmsermonController extends FormController
     /**
      * Method override to check if you can edit an existing record.
      *
+     * Mirrors the admin-side CwmmessageController::allowEdit() for the same
+     * underlying #__bsms_studies table/asset scope (com_proclaim.message.*) —
+     * this override used to unconditionally return true, letting any caller
+     * edit any sermon regardless of ACL. See #1437.
+     *
      * @param   array   $data  An array of input data.
      * @param   string  $key   The name of the key for the primary key.
      *
@@ -387,7 +392,32 @@ class CwmsermonController extends FormController
      */
     protected function allowEdit($data = [], $key = 'id'): bool
     {
-        return true;
+        $recordId = (int) ($data[$key] ?? 0);
+        $user     = Factory::getApplication()->getIdentity();
+
+        if ($user->authorise('core.edit', 'com_proclaim.message.' . $recordId)) {
+            return true;
+        }
+
+        if ($user->authorise('core.edit.own', 'com_proclaim.message.' . $recordId)) {
+            $ownerId = (int) ($data['created_by'] ?? 0);
+
+            if (empty($ownerId) && $recordId) {
+                $record = $this->getModel()->getItem($recordId);
+
+                if (empty($record)) {
+                    return false;
+                }
+
+                $ownerId = (int) $record->created_by;
+            }
+
+            if ($ownerId === (int) $user->id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/Site/Controller/CwmsermonControllerTest.php
+++ b/tests/unit/Site/Controller/CwmsermonControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Unit tests for CwmsermonController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Controller;
+
+use CWM\Component\Proclaim\Site\Controller\CwmsermonController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for CwmsermonController
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmsermonControllerTest extends ProclaimTestCase
+{
+    /**
+     * allowEdit() must perform a real ACL check, not unconditionally allow
+     * editing. Regression test for #1437: this method used to `return true;`
+     * unconditionally, letting any caller edit any sermon regardless of ACL.
+     *
+     * @return void
+     */
+    public function testAllowEditPerformsRealAclCheck(): void
+    {
+        $reflection = new \ReflectionMethod(CwmsermonController::class, 'allowEdit');
+        $body       = $this->getMethodSource($reflection);
+
+        $this->assertStringContainsString(
+            'authorise(',
+            $body,
+            'allowEdit() must check permissions via authorise() — see #1437'
+        );
+
+        // The bug was a body of exactly `{ return true; }` — no conditional logic
+        // at all. Requiring an `if (` proves the authorise() call actually gates
+        // something, rather than the method just happening to mention the word.
+        $this->assertMatchesRegularExpression(
+            '/\bif\s*\(/',
+            $body,
+            'allowEdit() must contain conditional ACL logic, not an unconditional return — see #1437'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testAllowEditReturnType(): void
+    {
+        $reflection = new \ReflectionMethod(CwmsermonController::class, 'allowEdit');
+        $this->assertReturnTypeName('bool', $reflection);
+    }
+
+    /**
+     * Extract a reflected method's source, including its body.
+     *
+     * @param   \ReflectionMethod  $reflection  The method to read.
+     *
+     * @return  string
+     */
+    private function getMethodSource(\ReflectionMethod $reflection): string
+    {
+        $lines     = file($reflection->getFileName());
+        $startLine = $reflection->getStartLine() - 1;
+        $endLine   = $reflection->getEndLine();
+
+        return implode('', \array_slice($lines, $startLine, $endLine - $startLine));
+    }
+}


### PR DESCRIPTION
## Summary

`allowEdit()` unconditionally returned `true`, discarding the `core.edit`/`core.edit.own` checks `access.xml` explicitly defines for this asset type. `save()`/`edit()` call straight into Joomla core's `FormController` with no other guard, so any caller reaching `task=cwmsermon.edit&a_id=<id>` / `task=cwmsermon.save` could edit **any** sermon record regardless of permission. Confirmed via `git blame`: in place since 2023-11-20 — a long-standing bug, not a recent regression.

Fix mirrors the admin-side `CwmmessageController::allowEdit()` for the same underlying `#__bsms_studies` table/asset scope (`com_proclaim.message.*`): `core.edit` first, then `core.edit.own` gated by `created_by` ownership, otherwise deny.

Found during a broader controller MVC audit (2026-08-03).

## Test plan
- [x] Added a regression test (`CwmsermonControllerTest::testAllowEditPerformsRealAclCheck`) asserting the method performs a real `authorise()` check with conditional logic — **verified it fails against the original code and passes against the fix** (temporarily reverted just the controller file, confirmed red, restored, confirmed green).
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 917/917 passing (915 + 2 new)
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1437