### PR TITLE
fix: add MultiCampusAccessTrait to CwmplaylistController

### DIFF
--- a/admin/src/Controller/CwmplaylistController.php
+++ b/admin/src/Controller/CwmplaylistController.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -28,6 +29,8 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
  */
 class CwmplaylistController extends FormController
 {
+    use MultiCampusAccessTrait;
+
     /**
      * The URL view list variable.
      *
@@ -35,6 +38,40 @@ class CwmplaylistController extends FormController
      * @since  10.3.3
      */
     protected $view_list = 'cwmplaylists';
+
+    /**
+     * The database table for access level checks.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $accessTable = '#__bsms_playlists';
+
+    /**
+     * Method override to check if you can edit an existing record.
+     *
+     * Without this, a non-admin editor in a multi-campus install could edit
+     * any playlist regardless of its access level — every other ACL-scoped
+     * singular controller (Location, Serie, Topic) already uses this trait.
+     * See #1438.
+     *
+     * @param   array   $data  An array of input data.
+     * @param   string  $key   The name of the key for the primary key.
+     *
+     * @return  bool
+     *
+     * @throws \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowEdit($data = [], $key = 'id'): bool
+    {
+        $denied = $this->checkRecordAccessLevel((int) ($data[$key] ?? 0));
+        if ($denied === false) {
+            return false;
+        }
+
+        return parent::allowEdit($data, $key);
+    }
 
     /**
      * Method to run after a successful save — records the action in Joomla's logs.

--- a/tests/unit/Admin/Controller/CwmplaylistControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmplaylistControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Unit tests for CwmplaylistController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmplaylistController;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for CwmplaylistController
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmplaylistControllerTest extends ProclaimTestCase
+{
+    /**
+     * Regression test for #1438: this controller was the only ACL-scoped
+     * singular FormController not using MultiCampusAccessTrait, letting a
+     * non-admin editor in a multi-campus install edit any playlist regardless
+     * of its access level.
+     *
+     * @return void
+     */
+    public function testUsesMultiCampusAccessTrait(): void
+    {
+        $this->assertContains(
+            MultiCampusAccessTrait::class,
+            class_uses(CwmplaylistController::class),
+            'CwmplaylistController must use MultiCampusAccessTrait — see #1438'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testAccessTableIsSet(): void
+    {
+        $reflection = new \ReflectionProperty(CwmplaylistController::class, 'accessTable');
+        $reflection->setAccessible(true);
+
+        $instance = $reflection->getDeclaringClass()->newInstanceWithoutConstructor();
+
+        $this->assertSame('#__bsms_playlists', $reflection->getValue($instance));
+    }
+
+    /**
+     * allowEdit() must actually call into the trait's access-level check, not
+     * just declare `use MultiCampusAccessTrait;` without wiring it up.
+     *
+     * @return void
+     */
+    public function testAllowEditCallsAccessLevelCheck(): void
+    {
+        $reflection = new \ReflectionMethod(CwmplaylistController::class, 'allowEdit');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString(
+            'checkRecordAccessLevel(',
+            $body,
+            'allowEdit() must call checkRecordAccessLevel() — see #1438'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`CwmplaylistController` was the only ACL-scoped singular `FormController` not using `MultiCampusAccessTrait`, even though `#__bsms_playlists` has an `access` column identical in shape to Location/Serie/Topic (which all use the trait). A non-admin editor in a multi-campus install could edit any playlist regardless of its access level.

Mirrors `CwmlocationController`'s exact pattern: the trait, `$accessTable`, and an `allowEdit()` override gated by `checkRecordAccessLevel()`.

Found during a broader controller MVC audit (2026-08-03).

## Test plan
- [x] Added 3 regression tests verifying the trait is used, `$accessTable` is set correctly, and `allowEdit()` actually calls into the trait rather than just declaring `use` without wiring it up — **verified all three fail against the original code and pass against the fix** (temporarily reverted just the controller file, confirmed red, restored, confirmed green).
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 920/920 passing (917 + 3 new)
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1438