### PR TITLE
fix: CwmcommentController::batch() references nonexistent 'Comment' model

### DIFF
--- a/admin/src/Controller/CwmcommentController.php
+++ b/admin/src/Controller/CwmcommentController.php
@@ -61,7 +61,7 @@ class CwmcommentController extends FormController
     {
         // Set the model
         if ($model === null) {
-            $model = $this->getModel('Comment', '', []);
+            $model = $this->getModel('Cwmcomment', '', []);
         }
 
         // Preset the redirect

--- a/tests/unit/Admin/Controller/CwmcommentControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmcommentControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Unit tests for CwmcommentController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmcommentController;
+use CWM\Component\Proclaim\Administrator\Model\CwmcommentModel;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for CwmcommentController
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmcommentControllerTest extends ProclaimTestCase
+{
+    /**
+     * Regression test for #1439: batch() called $this->getModel('Comment', ...),
+     * but there is no CommentModel — only CwmcommentModel, matching the
+     * Cwm-prefixed naming every other controller in this codebase uses.
+     *
+     * @return void
+     */
+    public function testBatchResolvesRealModelName(): void
+    {
+        $reflection = new \ReflectionMethod(CwmcommentController::class, 'batch');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringNotContainsString(
+            "getModel('Comment'",
+            $body,
+            "batch() must not reference the nonexistent 'Comment' model — see #1439"
+        );
+
+        $this->assertStringContainsString(
+            "getModel('Cwmcomment'",
+            $body,
+            'batch() must reference the real CwmcommentModel class — see #1439'
+        );
+
+        $this->assertTrue(
+            class_exists(CwmcommentModel::class),
+            'CwmcommentModel must exist for batch() to resolve it correctly'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`$this->getModel('Comment', '', [])` resolved a class that doesn't exist — the real model is `CwmcommentModel`, matching the `Cwm`-prefixed naming every other controller in this codebase uses. Batch operations on comments were broken or silently resolving the wrong model as a result.

Found during a broader controller MVC audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying `batch()` references the real model name — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 921/921 passing (920 + 1 new)
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1439