### PR TITLE
fix: route saveChapters() through Table save instead of raw SQL

### DIFF
--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -455,6 +455,12 @@ class CwmmediafileController extends FormController
             return;
         }
 
+        if (!$this->allowEdit(['id' => $mediaId])) {
+            CWMAddon::outputJson(['success' => false, 'error' => Text::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED')]);
+
+            return;
+        }
+
         // Parse chapters from POST body (JSON)
         $rawBody = file_get_contents('php://input');
 
@@ -498,29 +504,36 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery()
-            ->select($db->quoteName('params'))
-            ->from($db->quoteName('#__bsms_mediafiles'))
-            ->where($db->quoteName('id') . ' = ' . (int) $mediaId);
-        $db->setQuery($query);
-        $paramsJson = $db->loadResult();
+        /** @var CwmmediafileTable $table */
+        $table = $this->getModel('Cwmmediafile', 'Administrator', [])->getTable();
 
-        if ($paramsJson === null) {
+        if (!$table->load($mediaId)) {
             CWMAddon::outputJson(['success' => false, 'error' => 'Media file not found']);
 
             return;
         }
 
-        $params = new \Joomla\Registry\Registry($paramsJson ?: '{}');
+        if ($table->isCheckedOut((int) $app->getIdentity()->id)) {
+            CWMAddon::outputJson(['success' => false, 'error' => Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH')]);
+
+            return;
+        }
+
+        $params = new \Joomla\Registry\Registry($table->params ?: '{}');
         $params->set('chapters', $clean);
 
-        $update = $db->createQuery()
-            ->update($db->quoteName('#__bsms_mediafiles'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = ' . (int) $mediaId);
-        $db->setQuery($update);
-        $db->execute();
+        if (!$table->bind(['id' => $mediaId, 'params' => $params->toString()]) || !$table->check() || !$table->store()) {
+            CWMAddon::outputJson(['success' => false, 'error' => $table->getError() ?: 'Unable to save chapters']);
+
+            return;
+        }
+
+        CwmactionlogHelper::log(
+            'COM_PROCLAIM_ACTION_LOG_ITEM_UPDATED',
+            $params->get('filename', '#' . $mediaId),
+            'mediafile',
+            $mediaId
+        );
 
         CWMAddon::outputJson(['success' => true, 'count' => \count($clean)]);
     }

--- a/tests/unit/Admin/Controller/CwmmediafileControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmmediafileControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Unit tests for CwmmediafileController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmmediafileController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for CwmmediafileController
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmediafileControllerTest extends ProclaimTestCase
+{
+    /**
+     * Regression test for #1440: saveChapters() used to run a raw SELECT then
+     * UPDATE directly against #__bsms_mediafiles, bypassing Table::store()
+     * (and its checkout/check() validation) and the action-log entry every
+     * other media file edit produces.
+     *
+     * @return void
+     */
+    public function testSaveChaptersRoutesThroughTableSave(): void
+    {
+        $body = $this->getMethodSource(CwmmediafileController::class, 'saveChapters');
+
+        $this->assertStringNotContainsString(
+            'DatabaseInterface::class',
+            $body,
+            'saveChapters() must not build raw SQL — see #1440'
+        );
+
+        $this->assertStringContainsString(
+            '->store()',
+            $body,
+            'saveChapters() must save through Table::store() — see #1440'
+        );
+
+        $this->assertStringContainsString(
+            '->check()',
+            $body,
+            'saveChapters() must validate through Table::check() — see #1440'
+        );
+
+        $this->assertStringContainsString(
+            'isCheckedOut(',
+            $body,
+            'saveChapters() must respect an existing checkout — see #1440'
+        );
+
+        $this->assertStringContainsString(
+            'allowEdit(',
+            $body,
+            'saveChapters() must perform an ACL check — see #1440'
+        );
+
+        $this->assertStringContainsString(
+            'CwmactionlogHelper::log(',
+            $body,
+            'saveChapters() must record an action-log entry, matching every other media file edit — see #1440'
+        );
+    }
+
+    /**
+     * Extract a reflected method's source, including its body.
+     *
+     * @param   class-string  $class   The class to reflect.
+     * @param   string        $method  The method name.
+     *
+     * @return  string
+     */
+    private function getMethodSource(string $class, string $method): string
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+        $lines      = file($reflection->getFileName());
+        $startLine  = $reflection->getStartLine() - 1;
+        $endLine    = $reflection->getEndLine();
+
+        return implode('', \array_slice($lines, $startLine, $endLine - $startLine));
+    }
+}


### PR DESCRIPTION
## Summary

`saveChapters()` ran a raw SELECT then UPDATE directly against `#__bsms_mediafiles`, bypassing:
- Joomla's checkout system (no concurrent-edit protection)
- `Table::check()` validation
- The action-log entry every other media file edit produces
- Any ACL check at all — no `core.edit`/`core.edit.own` gate, unlike the controller's normal `save()`/`edit()` flow, which goes through `allowEdit()` (this controller already has a proper multi-campus-aware `allowEdit()` override; `saveChapters()` just never called it)

Now loads the row through `CwmmediafileTable`, checks the existing `allowEdit()` ACL gate and checkout state, and saves via `bind()`/`check()`/`store()`, followed by the same `CwmactionlogHelper::log()` call the normal save path already produces.

Found during a broader controller MVC audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying the method no longer builds raw SQL and does go through `Table::store()`/`check()`/`isCheckedOut()`/`allowEdit()`/action-log — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 922/922 passing (921 + 1 new)
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1440