### PR TITLE
fix: make CwmsermonController::commentsEmail() private

### DIFF
--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -282,6 +282,10 @@ class CwmsermonController extends FormController
     /**
      * Email comment out.
      *
+     * Private: only meant to be called internally from comment(). Public
+     * visibility made `task=cwmsermon.commentsEmail` a directly dispatchable
+     * Joomla task with no CSRF token check of its own — see #1441.
+     *
      * @param   Registry  $params  Params to parse
      *
      * @return void
@@ -289,7 +293,7 @@ class CwmsermonController extends FormController
      * @throws Exception|\Exception
      * @since 7.0
      */
-    public function commentsEmail($params): void
+    private function commentsEmail($params): void
     {
         $input = Factory::getApplication()->getInput();
 

--- a/tests/unit/Site/Controller/CwmsermonControllerTest.php
+++ b/tests/unit/Site/Controller/CwmsermonControllerTest.php
@@ -59,6 +59,24 @@ class CwmsermonControllerTest extends ProclaimTestCase
     }
 
     /**
+     * Regression test for #1441: commentsEmail() was public, making
+     * task=cwmsermon.commentsEmail a directly dispatchable Joomla task with
+     * no CSRF token check of its own. It's only meant to be called
+     * internally from comment().
+     *
+     * @return void
+     */
+    public function testCommentsEmailIsNotPubliclyDispatchable(): void
+    {
+        $reflection = new \ReflectionMethod(CwmsermonController::class, 'commentsEmail');
+
+        $this->assertFalse(
+            $reflection->isPublic(),
+            'commentsEmail() must not be public — see #1441'
+        );
+    }
+
+    /**
      * Extract a reflected method's source, including its body.
      *
      * @param   \ReflectionMethod  $reflection  The method to read.


### PR DESCRIPTION
## Summary

`commentsEmail()` was declared `public`, making `task=cwmsermon.commentsEmail` a directly dispatchable Joomla task. It's only meant to be called internally from `comment()`, which already validates the submission before invoking it, and has no CSRF token check of its own.

Found during a broader controller MVC audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying the method isn't public — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 923/923 passing (922 + 1 new)
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1441