### PR TITLE
fix: escape group title in FiltersField.php

### DIFF
--- a/admin/src/Field/FiltersField.php
+++ b/admin/src/Field/FiltersField.php
@@ -112,7 +112,7 @@ class FiltersField extends FormField
             $html[] = '			' . LayoutHelper::render(
                 'joomla.html.treeprefix',
                 ['level' => $group->level + 1]
-            ) . $group->text;
+            ) . htmlspecialchars($group->text, ENT_QUOTES);
             $html[] = '		</th>';
             $html[] = '		<td>';
             $html[] = '			<label for="' . $this->id . $group->value . '_filter_type" class="visually-hidden">'

--- a/tests/unit/Admin/Field/FiltersFieldTest.php
+++ b/tests/unit/Admin/Field/FiltersFieldTest.php
@@ -178,4 +178,27 @@ class FiltersFieldTest extends ProclaimTestCase
         $this->assertIsString(htmlspecialchars($groupFilter['filter_tags'], ENT_QUOTES));
         $this->assertIsString(htmlspecialchars($groupFilter['filter_attributes'], ENT_QUOTES));
     }
+
+    /**
+     * Regression test for #1456: getInput() interpolated $group->text (a
+     * #__usergroups.title) directly into HTML with no escaping, unlike the
+     * filter_tags/filter_attributes values two lines below it.
+     *
+     * @return void
+     */
+    public function testGroupTitleIsEscaped(): void
+    {
+        $reflection = new \ReflectionMethod(FiltersField::class, 'getInput');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/htmlspecialchars\(\$group->text/',
+            $body,
+            'getInput() must escape $group->text — see #1456'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`$group->text` (a `#__usergroups.title`) was interpolated directly into HTML with no escaping in `getInput()`, unlike `filter_tags`/`filter_attributes` two lines below which correctly `htmlspecialchars()` values of the same trust level. Any user with group-management ACL could set a group title containing HTML/script content and have it render unescaped here.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying `getInput()` escapes `$group->text` — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] `composer test:unit` — 923/923 passing, plus confirmed the "Admin Field Tests" suite (19/19, including the new test) — noting that suite isn't in `composer test:unit`'s `--testsuite` filter, though it *is* covered by CI's actual `composer test` (bare phpunit, all suites). Filed as a separate minor DX note, not blocking this PR.
- [x] `composer test:integration` — 155/155 passing
- [x] `php -l` on both touched files

Fixes #1456