### PR TITLE
fix: replace dark-mode-unsafe classes in 5 admin fields

### DIFF
--- a/admin/src/Field/DescriptionFormatField.php
+++ b/admin/src/Field/DescriptionFormatField.php
@@ -87,14 +87,14 @@ class DescriptionFormatField extends FormField
 
         // Build placeholder badge row
         $html .= '<div class="mt-2">';
-        $html .= '<small class="text-muted d-block mb-1">'
+        $html .= '<small class="text-body-secondary d-block mb-1">'
             . Text::_('JBS_ADDON_DESC_FORMAT_INSERT') . '</small>';
         $html .= '<div class="d-flex flex-wrap gap-1">';
 
         foreach (self::PLACEHOLDERS as $token => $langKey) {
             $label = Text::_($langKey);
             $html .= \sprintf(
-                '<button type="button" class="btn btn-outline-secondary btn-sm cwm-desc-token-btn" '
+                '<button type="button" class="btn btn-secondary btn-sm cwm-desc-token-btn" '
                 . 'data-token="%s" data-target="%s" title="%s">%s</button>',
                 htmlspecialchars($token, ENT_QUOTES, 'UTF-8'),
                 htmlspecialchars($this->id, ENT_QUOTES, 'UTF-8'),

--- a/admin/src/Field/IntegrationToggleField.php
+++ b/admin/src/Field/IntegrationToggleField.php
@@ -133,7 +133,7 @@ class IntegrationToggleField extends RadioField
 
         // If not installed, add visual indicator to label
         if (!$this->isExtensionInstalled()) {
-            $label = str_replace('</label>', ' <em class="text-muted">(' . Text::_('JBS_ADM_UNAVAILABLE') . ')</em></label>', $label);
+            $label = str_replace('</label>', ' <em class="text-body-secondary">(' . Text::_('JBS_ADM_UNAVAILABLE') . ')</em></label>', $label);
         }
 
         return $label;

--- a/admin/src/Field/LocationGroupMappingField.php
+++ b/admin/src/Field/LocationGroupMappingField.php
@@ -160,7 +160,7 @@ class LocationGroupMappingField extends FormField
         $html .= '</tbody></table>';
 
         // Explanation note
-        $html .= '<p class="form-text text-muted mt-2">'
+        $html .= '<p class="form-text text-body-secondary mt-2">'
             . Text::_('JBS_CONFIG_LOCATION_MAPPING_NOTE') . '</p>';
 
         $html .= '</div>';

--- a/admin/src/Field/PopupCodeField.php
+++ b/admin/src/Field/PopupCodeField.php
@@ -70,12 +70,12 @@ class PopupCodeField extends TextField
 
         // Build the code buttons
         $buttons = '<div class="popup-code-buttons mt-2">';
-        $buttons .= '<small class="text-muted me-2">' . Text::_('JBS_TPL_INSERT_CODE') . ':</small>';
+        $buttons .= '<small class="text-body-secondary me-2">' . Text::_('JBS_TPL_INSERT_CODE') . ':</small>';
 
         foreach ($this->codes as $code => $labelKey) {
             $label = Text::_($labelKey);
             $buttons .= \sprintf(
-                '<button type="button" class="btn btn-outline-secondary btn-sm me-1 mb-1 popup-code-btn" '
+                '<button type="button" class="btn btn-secondary btn-sm me-1 mb-1 popup-code-btn" '
                 . 'data-code="%s" data-target="%s" title="%s">%s</button>',
                 htmlspecialchars($code, ENT_QUOTES, 'UTF-8'),
                 htmlspecialchars($this->id, ENT_QUOTES, 'UTF-8'),

--- a/admin/src/Field/VttUploadField.php
+++ b/admin/src/Field/VttUploadField.php
@@ -82,7 +82,7 @@ class VttUploadField extends FormField
 
         // Upload button
         $html .= \sprintf(
-            '<button type="button" class="btn btn-outline-secondary cwm-vtt-upload-btn"'
+            '<button type="button" class="btn btn-secondary cwm-vtt-upload-btn"'
             . ' title="%s"%s>'
             . '<span class="icon-upload" aria-hidden="true"></span> %s</button>',
             htmlspecialchars($uploadLabel, ENT_QUOTES, 'UTF-8'),
@@ -103,7 +103,7 @@ class VttUploadField extends FormField
             $filename     = basename((string) $this->value);
             $downloadable = (bool) preg_match('/^caption_\d+_[A-Za-z0-9_-]+\.vtt$/', $filename);
 
-            $html .= '<small class="text-muted mt-1 d-block cwm-vtt-current">'
+            $html .= '<small class="text-body-secondary mt-1 d-block cwm-vtt-current">'
                 . '<span class="icon-file" aria-hidden="true"></span> '
                 . htmlspecialchars($filename, ENT_QUOTES, 'UTF-8');
 

--- a/tests/unit/Admin/Field/DarkModeCurrencyTest.php
+++ b/tests/unit/Admin/Field/DarkModeCurrencyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Dark-mode class currency tests for admin form fields.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression test for #1469: Joomla 5+ admin uses Bootstrap 5.3 dark mode via
+ * data-bs-theme="dark". `btn-outline-*` has very low contrast against the
+ * dark theme (should be a solid `btn-*` variant), and `text-muted` is a fixed
+ * gray that doesn't adapt to the theme (should be `text-body-secondary`).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class DarkModeCurrencyTest extends ProclaimTestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function fieldFileProvider(): array
+    {
+        $base = \dirname(__DIR__, 4) . '/admin/src/Field/';
+
+        return [
+            'PopupCodeField'            => [$base . 'PopupCodeField.php'],
+            'VttUploadField'            => [$base . 'VttUploadField.php'],
+            'DescriptionFormatField'    => [$base . 'DescriptionFormatField.php'],
+            'IntegrationToggleField'    => [$base . 'IntegrationToggleField.php'],
+            'LocationGroupMappingField' => [$base . 'LocationGroupMappingField.php'],
+        ];
+    }
+
+    #[DataProvider('fieldFileProvider')]
+    public function testFieldDoesNotUseDarkModeUnsafeClasses(string $file): void
+    {
+        $this->assertFileExists($file);
+
+        $source = file_get_contents($file);
+
+        $this->assertStringNotContainsString(
+            'btn-outline-',
+            $source,
+            basename($file) . ' must not use btn-outline-* (low contrast in dark mode) — see #1469'
+        );
+
+        $this->assertStringNotContainsString(
+            'text-muted',
+            $source,
+            basename($file) . ' must not use text-muted (not theme-adaptive) — see #1469'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`btn-outline-secondary` has very low contrast against Joomla's Bootstrap 5.3 dark admin theme (`data-bs-theme="dark"`) — replaced with the solid `btn-secondary` variant. `text-muted` is a fixed gray that doesn't adapt to the theme — replaced with `text-body-secondary`, the color-adaptive equivalent. Pure class-name swap, no logic or markup structure change.

Files: `PopupCodeField.php`, `VttUploadField.php`, `DescriptionFormatField.php`, `IntegrationToggleField.php`, `LocationGroupMappingField.php`.

Found during a Field-files audit (2026-08-03), prompted by a follow-up question on whether the audit checked Joomla 6+ design currency (it hadn't — this closes that gap for the dark-mode dimension specifically).

## Test plan
- [x] Added a regression test covering all 5 files — **verified it fails against the original classes and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's actual `composer test` invocation, all suites) — 1109/1109 passing
- [x] `php -l` on all touched files

Fixes #1469