### PR TITLE
chore: add missing suites to composer test:unit script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Api Tests,Integration Admin Table Tests,Integration Admin Addon Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",


### PR DESCRIPTION
## Summary

"Admin Field Tests" and "Asset Contract Tests" are both defined in `phpunit.xml` but were missing from `test:unit`'s `--testsuite` filter, so local devs running `composer test:unit` for fast feedback silently skipped both (26 tests total). CI itself was never affected — it runs bare `composer test` (no `--testsuite` flag), which `phpunit.xml`'s own comment confirms runs every suite.

Found while adding a regression test under `tests/unit/Admin/Field/` and noticing the count didn't move after the addition.

## Test plan
- [x] `jq empty composer.json` — valid JSON
- [x] `composer test:unit` — now 949/949 passing (up from 923; +26 = the 2 previously-missing suites)
- [x] `composer check` (lint step) — no new findings