### PR TITLE
fix: escape interpolated values in Modal/ServerTypeField.php

### DIFF
--- a/admin/src/Field/Modal/ServerTypeField.php
+++ b/admin/src/Field/Modal/ServerTypeField.php
@@ -132,7 +132,8 @@ class ServerTypeField extends FormField
 
         $text = (string)ArrayHelper::getValue($rlu_type, $this->value);
 
-        $html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $text . '" readonly size="35">';
+        $html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="'
+            . htmlspecialchars($text, ENT_QUOTES, 'UTF-8') . '" readonly size="35">';
 
         // Select Message button
         if ($allowSelect) {
@@ -264,7 +265,8 @@ class ServerTypeField extends FormField
 
         $html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int)$this->required
             . '" name="' . $this->name . '" data-text="' .
-            htmlspecialchars(Text::_('JBS_CMN_SELECT_SERVERTYPE'), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
+            htmlspecialchars(Text::_('JBS_CMN_SELECT_SERVERTYPE'), ENT_COMPAT, 'UTF-8') . '" value="'
+            . htmlspecialchars($value, ENT_QUOTES, 'UTF-8') . '">';
 
         return $html;
     }

--- a/tests/unit/Admin/Field/ServerTypeFieldTest.php
+++ b/tests/unit/Admin/Field/ServerTypeFieldTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Unit tests for Modal/ServerTypeField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\Modal\ServerTypeField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for Modal/ServerTypeField
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ServerTypeFieldTest extends ProclaimTestCase
+{
+    /**
+     * Regression test for #1457: getInput() interpolated the reverse-lookup
+     * display name ($text) and the raw field value ($value) directly into
+     * HTML value="..." attributes with no escaping. Every sibling field in
+     * Modal/ (LocationField, TeacherDisplayField, StudyField) already
+     * htmlspecialchars()'s this exact pattern — ServerTypeField was the one
+     * that dropped it.
+     *
+     * @return void
+     */
+    public function testGetInputEscapesInterpolatedValues(): void
+    {
+        $reflection = new \ReflectionMethod(ServerTypeField::class, 'getInput');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/htmlspecialchars\(\$text/',
+            $body,
+            'getInput() must escape $text before interpolating into value="..." — see #1457'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/htmlspecialchars\(\$value/',
+            $body,
+            'getInput() must escape $value before interpolating into value="..." — see #1457'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`getInput()` interpolated the reverse-lookup display name (`$text`) and the raw field value (`$value`) directly into HTML `value="..."` attributes with no escaping. This is a **live, reachable field** — referenced as `type="Modal_ServerType"` in `admin/forms/server.xml`.

Every sibling field in `Modal/` (`LocationField.php`, `TeacherDisplayField.php`, `StudyField.php`) already `htmlspecialchars()`s this exact pattern — `ServerTypeField` was the one that dropped it.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying both interpolations are escaped — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's `composer test`) — 1110/1110 passing
- [x] `php -l` on both touched files

Fixes #1457