### PR TITLE
fix: escape hex value in ColorPickerField.php

### DIFF
--- a/admin/src/Field/ColorPickerField.php
+++ b/admin/src/Field/ColorPickerField.php
@@ -223,6 +223,11 @@ class ColorPickerField extends FormField
             $hexValue = '#FFFFFF';
         }
 
+        // Not a recognized CSS color name, so the raw stored value reaches
+        // here unvalidated — escape before it's interpolated into the two
+        // value="..." attributes below.
+        $hexValue = htmlspecialchars($hexValue, ENT_QUOTES, 'UTF-8');
+
         $html = '<div class="colorpicker-field-wrapper" style="position:relative;">';
 
         // Main container with flex layout - clickable to open dropdown

--- a/tests/unit/Admin/Field/ColorPickerFieldTest.php
+++ b/tests/unit/Admin/Field/ColorPickerFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Unit tests for ColorPickerField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\ColorPickerField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for ColorPickerField
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ColorPickerFieldTest extends ProclaimTestCase
+{
+    /**
+     * Regression test for #1458: when the stored value isn't a recognized
+     * CSS named color, $hexValue was derived from the raw field value and
+     * interpolated unescaped into two value="..." attributes (the
+     * <input type="color"> and the hex text input).
+     *
+     * @return void
+     */
+    public function testHexValueIsEscapedBeforeInterpolation(): void
+    {
+        $reflection = new \ReflectionMethod(ColorPickerField::class, 'getInput');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/htmlspecialchars\(\$hexValue/',
+            $body,
+            'getInput() must escape $hexValue before interpolating into value="..." — see #1458'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

When the stored value isn't a recognized CSS named color, `$hexValue` was derived from the raw field value and interpolated unescaped into two `value="..."` attributes (the `<input type="color">` and the hex text input). Escaped once at the point `$hexValue` is finalized, so both later interpolations are automatically safe.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added a regression test verifying the escape call is present — **verified it fails against the original code and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's `composer test`) — 1111/1111 passing
- [x] `php -l` on both touched files

Fixes #1458