### PR TITLE
fix: correct inverted conditional in MediaFileField option labels

### DIFF
--- a/admin/src/Field/MediaFileField.php
+++ b/admin/src/Field/MediaFileField.php
@@ -71,8 +71,7 @@ class MediaFileField extends ListField
                 $options[]       = HTMLHelper::_(
                     'select.option',
                     $message->id,
-                    $message->params->get('filename') ? $message->id . ' - ' .
-                        $message->params->get('mimetext') : $message->params->get('filename')
+                    self::buildOptionLabel($message->id, $message->params)
                 );
             }
         }
@@ -80,5 +79,23 @@ class MediaFileField extends ListField
         $options = array_merge(parent::getOptions(), $options);
 
         return $options;
+    }
+
+    /**
+     * Build the dropdown label for one media file option.
+     *
+     * Prefers the stored filename; falls back to "id - mimetype" when no
+     * filename is set, so the option is still identifiable.
+     *
+     * @param   int       $id      The media file id.
+     * @param   Registry  $params  The media file's parsed params.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function buildOptionLabel(int $id, Registry $params): string
+    {
+        return $params->get('filename') ?: ($id . ' - ' . $params->get('mimetext'));
     }
 }

--- a/tests/unit/Admin/Field/MediaFileFieldTest.php
+++ b/tests/unit/Admin/Field/MediaFileFieldTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Unit tests for MediaFileField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\MediaFileField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\Registry\Registry;
+
+/**
+ * Test class for MediaFileField's option-label logic.
+ *
+ * Regression test for #1459: getOptions() built its dropdown label with
+ * `filename ? "id - mimetext" : filename` — backwards. When a filename
+ * existed, the label showed "id - mimetype" (never the filename); when it
+ * didn't, the label was blank.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MediaFileFieldTest extends ProclaimTestCase
+{
+    /**
+     * Invoke the field's private static label builder.
+     */
+    private static function buildOptionLabel(int $id, Registry $params): string
+    {
+        $reflection = new \ReflectionMethod(MediaFileField::class, 'buildOptionLabel');
+
+        return $reflection->invoke(null, $id, $params);
+    }
+
+    public function testLabelShowsFilenameWhenPresent(): void
+    {
+        $params = new Registry(['filename' => 'sermon.mp3', 'mimetext' => 'audio/mpeg']);
+
+        $this->assertSame('sermon.mp3', self::buildOptionLabel(42, $params));
+    }
+
+    public function testLabelFallsBackToIdAndMimetextWhenFilenameMissing(): void
+    {
+        $params = new Registry(['mimetext' => 'audio/mpeg']);
+
+        $this->assertSame('42 - audio/mpeg', self::buildOptionLabel(42, $params));
+    }
+}


### PR DESCRIPTION
## Summary

The label expression in `getOptions()` was backwards: when a filename existed, the dropdown showed `"id - mimetype"` (never the filename itself); when it didn't, it showed the empty filename (a blank option).

Extracted the label logic into a private static `buildOptionLabel()` method so it's directly testable, and fixed the condition: filename is shown when present, falling back to `"id - mimetype"` when it's not.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added tests covering both branches — verified they can't even run against the original code (the method didn't exist yet, `ReflectionException`) and pass against the fix.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's `composer test`) — 1113/1113 passing
- [x] `php -l` on both touched files

Fixes #1459