### PR TITLE
fix: derive hardcoded jform[...] names from field state in 2 fields

### DIFF
--- a/admin/src/Field/LayoutEditorField.php
+++ b/admin/src/Field/LayoutEditorField.php
@@ -144,6 +144,8 @@ class LayoutEditorField extends FormField
         // Register all Layout Editor script options via centralized layout
         $this->registerScriptOptions($elementDefinitions, $params);
 
+        $paramsPrefix = $this->computeParamsPrefix();
+
         // Build the HTML with data attributes for the external JS to read
         $html = [];
 
@@ -153,7 +155,7 @@ class LayoutEditorField extends FormField
             . ' data-context="' . htmlspecialchars($context) . '"'
             . ' data-show-view-settings="' . ($showViewSettings ? 'true' : 'false') . '"'
             . ' data-lazy-init="' . ($lazyLoad ? 'true' : 'false') . '"'
-            . ' data-params-prefix="jform[params]">';
+            . ' data-params-prefix="' . htmlspecialchars($paramsPrefix) . '">';
         $html[] = '    <div id="layout-editor-loading" class="text-center py-4">';
         $html[] = '        <span class="spinner-border spinner-border-sm" role="status"></span>';
         $html[] = '        <span class="ms-2">' . Text::_('JBS_TPL_LOADING') . '</span>';
@@ -247,4 +249,29 @@ class LayoutEditorField extends FormField
         ];
     }
 
+    /**
+     * Compute the form-control + group prefix (e.g. "jform[params]") — NOT
+     * this field's own name. The external JS uses it to build names for the
+     * dynamic sub-fields the layout editor generates.
+     *
+     * Derived from the field's own form state instead of a hardcoded
+     * "jform[params]", which broke silently outside the one hardcoded
+     * form/group. See #1461.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function computeParamsPrefix(): string
+    {
+        $prefix = (string) $this->formControl;
+
+        if ($this->group) {
+            foreach (explode('.', $this->group) as $group) {
+                $prefix .= '[' . $group . ']';
+            }
+        }
+
+        return $prefix;
+    }
 }

--- a/admin/src/Field/TopicsFormField.php
+++ b/admin/src/Field/TopicsFormField.php
@@ -167,9 +167,13 @@ class TopicsFormField extends FormField
     {
         $hint = Text::_('JBS_CMN_TOPIC_TAG');
 
-        // Hidden input to store actual values for form submission
-        // Use a specific name that won't conflict with fancy-select
-        $html = '<input type="hidden" id="' . $this->id . '_input" name="jform[topic_ids]" value="' . implode(',', $selectedIds) . '">';
+        // Hidden input to store actual values for form submission. Uses
+        // $this->name (the field's own computed name) rather than a
+        // hardcoded "jform[topic_ids]" — the visible <select> below has no
+        // name at all, so this hidden input is what a subform or any other
+        // non-top-level form context would actually submit. See #1461.
+        $html = '<input type="hidden" id="' . $this->id . '_input" name="' . $this->name . '" value="'
+            . implode(',', $selectedIds) . '">';
 
         // Start with Joomla's fancy-select web component wrapper
         $html .= '<joomla-field-fancy-select>';

--- a/tests/unit/Admin/Field/LayoutEditorFieldTest.php
+++ b/tests/unit/Admin/Field/LayoutEditorFieldTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Unit tests for LayoutEditorField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\LayoutEditorField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for LayoutEditorField's params-prefix computation.
+ *
+ * Regression test for #1461: getInput() hardcoded
+ * data-params-prefix="jform[params]" instead of deriving it from the
+ * field's own form-control/group state — breaking silently outside that
+ * one hardcoded form/group.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LayoutEditorFieldTest extends ProclaimTestCase
+{
+    /**
+     * Build a field instance with given formControl/group state, without
+     * going through the constructor (which needs a full Form object).
+     */
+    private function makeField(string $formControl, ?string $group): LayoutEditorField
+    {
+        $field = (new \ReflectionClass(LayoutEditorField::class))->newInstanceWithoutConstructor();
+
+        (new \ReflectionProperty($field, 'formControl'))->setValue($field, $formControl);
+        (new \ReflectionProperty($field, 'group'))->setValue($field, $group);
+
+        return $field;
+    }
+
+    /**
+     * Invoke the field's protected prefix computation.
+     */
+    private function computePrefix(LayoutEditorField $field): string
+    {
+        return (new \ReflectionMethod(LayoutEditorField::class, 'computeParamsPrefix'))->invoke($field);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCommonCaseMatchesTheOldHardcodedValue(): void
+    {
+        $field = $this->makeField('jform', 'params');
+
+        $this->assertSame('jform[params]', $this->computePrefix($field));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDifferentGroupIsNotForcedToParams(): void
+    {
+        $field = $this->makeField('jform', 'settings');
+
+        $this->assertSame(
+            'jform[settings]',
+            $this->computePrefix($field),
+            'A field outside the "params" group must not be hardcoded to jform[params] — see #1461'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testNestedGroupProducesEachLevel(): void
+    {
+        $field = $this->makeField('jform', 'params.layout');
+
+        $this->assertSame('jform[params][layout]', $this->computePrefix($field));
+    }
+
+    /**
+     * @return void
+     */
+    public function testNoGroupIsJustTheFormControl(): void
+    {
+        $field = $this->makeField('jform', null);
+
+        $this->assertSame('jform', $this->computePrefix($field));
+    }
+}

--- a/tests/unit/Admin/Field/TopicsFormFieldTest.php
+++ b/tests/unit/Admin/Field/TopicsFormFieldTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Unit tests for TopicsFormField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\TopicsFormField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Test class for TopicsFormField.
+ *
+ * Regression test for #1461: buildSelectHtml() hardcoded
+ * name="jform[topic_ids]" on its hidden input instead of deriving it from
+ * the field's own computed name — breaking silently outside that one
+ * hardcoded form/group (e.g. a subform).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TopicsFormFieldTest extends ProclaimTestCase
+{
+    /**
+     * @return void
+     */
+    public function testHiddenInputUsesFieldsOwnComputedName(): void
+    {
+        $field = (new \ReflectionClass(TopicsFormField::class))->newInstanceWithoutConstructor();
+
+        // A name a subform context would produce — deliberately not
+        // "jform[topic_ids]", to prove the hidden input isn't hardcoded.
+        $distinctName = 'jform[subform][0][topic_ids]';
+
+        (new \ReflectionProperty($field, 'name'))->setValue($field, $distinctName);
+        (new \ReflectionProperty($field, 'id'))->setValue($field, 'jform_subform_0_topic_ids');
+
+        $method = new \ReflectionMethod(TopicsFormField::class, 'buildSelectHtml');
+        $html   = $method->invoke($field, [['id' => 5, 'text' => 'Grace']], [5]);
+
+        $this->assertStringContainsString(
+            'name="' . $distinctName . '"',
+            $html,
+            'The hidden input must use the field\'s own computed name — see #1461'
+        );
+
+        $this->assertStringNotContainsString(
+            'name="jform[topic_ids]"',
+            $html,
+            'The hidden input must not hardcode name="jform[topic_ids]" — see #1461'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Both fields hardcoded the outer form's field-name convention instead of deriving it from the field's own state, breaking silently outside the one hardcoded form/group:

- `TopicsFormField.php`: the hidden input's `name="jform[topic_ids]"` is now `$this->name` (the field's own computed name) — the visible `<select>` has no name at all, so this hidden input is what a subform or any other non-top-level context would actually submit.
- `LayoutEditorField.php`: `data-params-prefix="jform[params]"` is now computed from `$this->formControl` + `$this->group` via a new `computeParamsPrefix()` method, extracted for testability.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added tests for both — `TopicsFormField`'s fails against the original hardcoded name; `LayoutEditorField`'s errors against the original code (`computeParamsPrefix()` didn't exist yet) and covers the common case (matches the old hardcoded value), a different group, a nested group, and no group at all.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's `composer test`) — 1119/1119 passing
- [x] `php -l` on all touched files

Fixes #1461