### PR TITLE
fix: correct base class for 9 fields extending ListField without a real list

### DIFF
--- a/admin/src/Field/DateFormatField.php
+++ b/admin/src/Field/DateFormatField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Date format dropdown — single source of truth for date display options.
@@ -28,7 +26,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    10.2.0
  */
-class DateFormatField extends ListField
+class DateFormatField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -40,26 +38,22 @@ class DateFormatField extends ListField
     protected $type = 'DateFormat';
 
     /**
-     * Get the field options.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  Array of HTMLHelper option objects
+     * @var  array
      *
-     * @since   10.2.0
+     * @since __DEPLOY_VERSION__
      */
-    protected function getOptions(): array
-    {
-        $options   = parent::getOptions();
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_DATE_FORMAT_MMM_D_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_DATE_FORMAT_MMM_D'));
-        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_DATE_FORMAT_M_D_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_DATE_FORMAT_M_D'));
-        $options[] = HTMLHelper::_('select.option', '4', Text::_('JBS_TPL_DATE_FORMAT_WD_MMMM_D_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '5', Text::_('JBS_TPL_DATE_FORMAT_MMMM_D_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '6', Text::_('JBS_TPL_DATE_FORMAT_D_MMMM_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '7', Text::_('JBS_TPL_DATE_FORMAT_D_M_YYYY'));
-        $options[] = HTMLHelper::_('select.option', '8', Text::_('JBS_TPL_DATE_FORMAT_USE_GLOBAL'));
-        $options[] = HTMLHelper::_('select.option', '9', Text::_('JBS_TPL_DATE_FORMAT_YYYY_MM_DD'));
-
-        return $options;
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_TPL_DATE_FORMAT_MMM_D_YYYY',
+        '1' => 'JBS_TPL_DATE_FORMAT_MMM_D',
+        '2' => 'JBS_TPL_DATE_FORMAT_M_D_YYYY',
+        '3' => 'JBS_TPL_DATE_FORMAT_M_D',
+        '4' => 'JBS_TPL_DATE_FORMAT_WD_MMMM_D_YYYY',
+        '5' => 'JBS_TPL_DATE_FORMAT_MMMM_D_YYYY',
+        '6' => 'JBS_TPL_DATE_FORMAT_D_MMMM_YYYY',
+        '7' => 'JBS_TPL_DATE_FORMAT_D_M_YYYY',
+        '8' => 'JBS_TPL_DATE_FORMAT_USE_GLOBAL',
+        '9' => 'JBS_TPL_DATE_FORMAT_YYYY_MM_DD',
+    ];
 }

--- a/admin/src/Field/ElementOptionsField.php
+++ b/admin/src/Field/ElementOptionsField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Books List Form Field class for the Proclaim component
@@ -26,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    7.0.4
  */
-class ElementOptionsField extends ListField
+class ElementOptionsField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -38,25 +36,21 @@ class ElementOptionsField extends ListField
     protected $type = 'ElementOptions';
 
     /**
-     * Method to get a list of options for a list input.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array   An array of HTMLHelper options.
+     * @var  array
      *
-     * @since 7.0
+     * @since __DEPLOY_VERSION__
      */
-    #[\Override]
-    protected function getOptions(): array
-    {
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_CMN_NONE'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_PARAGRAPH'));
-        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_HEADER1'));
-        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_HEADER2'));
-        $options[] = HTMLHelper::_('select.option', '4', Text::_('JBS_TPL_HEADER3'));
-        $options[] = HTMLHelper::_('select.option', '5', Text::_('JBS_TPL_HEADER4'));
-        $options[] = HTMLHelper::_('select.option', '6', Text::_('JBS_TPL_HEADER5'));
-        $options[] = HTMLHelper::_('select.option', '7', Text::_('JBS_TPL_BLOCKQUOTE'));
-        $options[] = HTMLHelper::_('select.option', '8', Text::_('JBS_TPL_DIV'));
-
-        return array_merge(parent::getOptions(), $options);
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_CMN_NONE',
+        '1' => 'JBS_TPL_PARAGRAPH',
+        '2' => 'JBS_TPL_HEADER1',
+        '3' => 'JBS_TPL_HEADER2',
+        '4' => 'JBS_TPL_HEADER3',
+        '5' => 'JBS_TPL_HEADER4',
+        '6' => 'JBS_TPL_HEADER5',
+        '7' => 'JBS_TPL_BLOCKQUOTE',
+        '8' => 'JBS_TPL_DIV',
+    ];
 }

--- a/admin/src/Field/FilesizeField.php
+++ b/admin/src/Field/FilesizeField.php
@@ -16,16 +16,20 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 
 /**
  * Form Field class for the FileSize
  *
+ * Renders a plain text input, never a <select> — extends FormField rather
+ * than ListField, which it never actually used (getOptions() was never
+ * called; getInput() is fully overridden). See #1464.
+ *
  * @package  Proclaim.Admin
  * @since    7.0.0
  */
-class FilesizeField extends ListField
+class FilesizeField extends FormField
 {
     /**
      *  Set Naming of type
@@ -34,7 +38,7 @@ class FilesizeField extends ListField
      *
      * @since 9.0.0
      */
-    public $type = 'Filesize';
+    protected $type = 'Filesize';
 
     /**
      * Get impute of form

--- a/admin/src/Field/LinkOptionsField.php
+++ b/admin/src/Field/LinkOptionsField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Books List Form Field class for the Proclaim component
@@ -26,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    7.0.4
  */
-class LinkOptionsField extends ListField
+class LinkOptionsField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -38,25 +36,21 @@ class LinkOptionsField extends ListField
     protected $type = 'LinkOptions';
 
     /**
-     * Method to get a list of options for a list input.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  An array of HTMLHelper options.
+     * @var  array
      *
-     * @since 7.0
+     * @since __DEPLOY_VERSION__
      */
-    #[\Override]
-    protected function getOptions(): array
-    {
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_NO_LINK'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_LINK_TO_DETAILS'));
-        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_LINK_TO_MEDIA'));
-        $options[] = HTMLHelper::_('select.option', '9', Text::_('JBS_TPL_LINK_TO_DOWNLOAD'));
-        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_LINK_TO_TEACHERS_PROFILE'));
-        $options[] = HTMLHelper::_('select.option', '6', Text::_('JBS_TPL_LINK_TO_FIRST_ARTICLE'));
-        $options[] = HTMLHelper::_('select.option', '7', Text::_('JBS_TPL_LINK_TO_VIRTUEMART'));
-        $options[] = HTMLHelper::_('select.option', '8', Text::_('JBS_TPL_LINK_TO_DOCMAN'));
-        $options[] = HTMLHelper::_('select.option', '10', Text::_('JBS_TPL_LINK_TO_SERIES'));
-
-        return array_merge(parent::getOptions(), $options);
-    }
+    protected $predefinedOptions = [
+        '0'  => 'JBS_TPL_NO_LINK',
+        '1'  => 'JBS_TPL_LINK_TO_DETAILS',
+        '2'  => 'JBS_TPL_LINK_TO_MEDIA',
+        '9'  => 'JBS_TPL_LINK_TO_DOWNLOAD',
+        '3'  => 'JBS_TPL_LINK_TO_TEACHERS_PROFILE',
+        '6'  => 'JBS_TPL_LINK_TO_FIRST_ARTICLE',
+        '7'  => 'JBS_TPL_LINK_TO_VIRTUEMART',
+        '8'  => 'JBS_TPL_LINK_TO_DOCMAN',
+        '10' => 'JBS_TPL_LINK_TO_SERIES',
+    ];
 }

--- a/admin/src/Field/RowOptionsField.php
+++ b/admin/src/Field/RowOptionsField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Books List Form Field class for the Proclaim component
@@ -26,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    7.0.4
  */
-class RowOptionsField extends ListField
+class RowOptionsField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -38,23 +36,19 @@ class RowOptionsField extends ListField
     protected $type = 'RowOptions';
 
     /**
-     * Method to get a list of options for a list input.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  An array of JHtml options.
+     * @var  array
      *
-     * @since 7.0
+     * @since __DEPLOY_VERSION__
      */
-    #[\Override]
-    protected function getOptions(): array
-    {
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_CMN_HIDE'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_ROW1'));
-        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_ROW2'));
-        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_ROW3'));
-        $options[] = HTMLHelper::_('select.option', '4', Text::_('JBS_TPL_ROW4'));
-        $options[] = HTMLHelper::_('select.option', '5', Text::_('JBS_TPL_ROW5'));
-        $options[] = HTMLHelper::_('select.option', '6', Text::_('JBS_TPL_ROW6'));
-
-        return array_merge(parent::getOptions(), $options);
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_CMN_HIDE',
+        '1' => 'JBS_TPL_ROW1',
+        '2' => 'JBS_TPL_ROW2',
+        '3' => 'JBS_TPL_ROW3',
+        '4' => 'JBS_TPL_ROW4',
+        '5' => 'JBS_TPL_ROW5',
+        '6' => 'JBS_TPL_ROW6',
+    ];
 }

--- a/admin/src/Field/ScriptureSeparatorField.php
+++ b/admin/src/Field/ScriptureSeparatorField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Scripture separator dropdown — single source of truth for separator options.
@@ -28,7 +26,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    10.2.0
  */
-class ScriptureSeparatorField extends ListField
+class ScriptureSeparatorField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -40,20 +38,16 @@ class ScriptureSeparatorField extends ListField
     protected $type = 'ScriptureSeparator';
 
     /**
-     * Get the field options.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  Array of HTMLHelper option objects
+     * @var  array
      *
-     * @since   10.2.0
+     * @since __DEPLOY_VERSION__
      */
-    protected function getOptions(): array
-    {
-        $options   = parent::getOptions();
-        $options[] = HTMLHelper::_('select.option', 'newline', Text::_('JBS_TPL_SEPARATOR_STACKED'));
-        $options[] = HTMLHelper::_('select.option', 'middot', Text::_('JBS_TPL_SEPARATOR_MIDDOT'));
-        $options[] = HTMLHelper::_('select.option', 'pipe', Text::_('JBS_TPL_SEPARATOR_PIPE'));
-        $options[] = HTMLHelper::_('select.option', 'semicolon', Text::_('JBS_TPL_SEPARATOR_SEMICOLON'));
-
-        return $options;
-    }
+    protected $predefinedOptions = [
+        'newline'   => 'JBS_TPL_SEPARATOR_STACKED',
+        'middot'    => 'JBS_TPL_SEPARATOR_MIDDOT',
+        'pipe'      => 'JBS_TPL_SEPARATOR_PIPE',
+        'semicolon' => 'JBS_TPL_SEPARATOR_SEMICOLON',
+    ];
 }

--- a/admin/src/Field/SeriesLinkOptionsField.php
+++ b/admin/src/Field/SeriesLinkOptionsField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Books List Form Field class for the Proclaim component
@@ -26,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    7.0.4
  */
-class SeriesLinkOptionsField extends ListField
+class SeriesLinkOptionsField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -38,18 +36,14 @@ class SeriesLinkOptionsField extends ListField
     protected $type = 'SeriesLinkOptions';
 
     /**
-     * Method to get a list of options for a list input.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  An array of JHtml options.
+     * @var  array
      *
-     * @since    7.0.4
+     * @since __DEPLOY_VERSION__
      */
-    #[\Override]
-    protected function getOptions(): array
-    {
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_NO_LINK'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_LINK_TO_DETAILS'));
-
-        return array_merge(parent::getOptions(), $options);
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_TPL_NO_LINK',
+        '1' => 'JBS_TPL_LINK_TO_DETAILS',
+    ];
 }

--- a/admin/src/Field/ShowVersesField.php
+++ b/admin/src/Field/ShowVersesField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Show Verses dropdown — single source of truth for verse display options.
@@ -28,7 +26,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    10.2.0
  */
-class ShowVersesField extends ListField
+class ShowVersesField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -40,19 +38,15 @@ class ShowVersesField extends ListField
     protected $type = 'ShowVerses';
 
     /**
-     * Get the field options.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  Array of HTMLHelper option objects
+     * @var  array
      *
-     * @since   10.2.0
+     * @since __DEPLOY_VERSION__
      */
-    protected function getOptions(): array
-    {
-        $options   = parent::getOptions();
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_SHOW_ONLY_CHAPTERS'));
-        $options[] = HTMLHelper::_('select.option', '1', Text::_('JBS_TPL_SHOW_VERSES_AND_CHAPTERS'));
-        $options[] = HTMLHelper::_('select.option', '2', Text::_('JBS_TPL_SHOW_ONLY_BOOKS'));
-
-        return $options;
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_TPL_SHOW_ONLY_CHAPTERS',
+        '1' => 'JBS_TPL_SHOW_VERSES_AND_CHAPTERS',
+        '2' => 'JBS_TPL_SHOW_ONLY_BOOKS',
+    ];
 }

--- a/admin/src/Field/TeacherLinkOptionsField.php
+++ b/admin/src/Field/TeacherLinkOptionsField.php
@@ -16,9 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Form\Field\ListField;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Form\Field\PredefinedlistField;
 
 /**
  * Books List Form Field class for the Proclaim component
@@ -26,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @package  Proclaim.Admin
  * @since    7.0.4
  */
-class TeacherLinkOptionsField extends ListField
+class TeacherLinkOptionsField extends PredefinedlistField
 {
     /**
      * The field type.
@@ -38,18 +36,14 @@ class TeacherLinkOptionsField extends ListField
     protected $type = 'TeacherLinkOptions';
 
     /**
-     * Method to get a list of options for a list input.
+     * A fixed set of options, not DB-backed. See #1464.
      *
-     * @return  array  An array of JHtml options.
+     * @var  array
      *
-     * @since 7.0
+     * @since __DEPLOY_VERSION__
      */
-    #[\Override]
-    protected function getOptions(): array
-    {
-        $options[] = HTMLHelper::_('select.option', '0', Text::_('JBS_TPL_NO_LINK'));
-        $options[] = HTMLHelper::_('select.option', '3', Text::_('JBS_TPL_LINK_TO_TEACHERS_PROFILE'));
-
-        return array_merge(parent::getOptions(), $options);
-    }
+    protected $predefinedOptions = [
+        '0' => 'JBS_TPL_NO_LINK',
+        '3' => 'JBS_TPL_LINK_TO_TEACHERS_PROFILE',
+    ];
 }

--- a/tests/unit/Admin/Field/PredefinedOptionsFieldsTest.php
+++ b/tests/unit/Admin/Field/PredefinedOptionsFieldsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Unit tests for the fields converted from ListField to PredefinedlistField.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\DateFormatField;
+use CWM\Component\Proclaim\Administrator\Field\ElementOptionsField;
+use CWM\Component\Proclaim\Administrator\Field\FilesizeField;
+use CWM\Component\Proclaim\Administrator\Field\LinkOptionsField;
+use CWM\Component\Proclaim\Administrator\Field\RowOptionsField;
+use CWM\Component\Proclaim\Administrator\Field\ScriptureSeparatorField;
+use CWM\Component\Proclaim\Administrator\Field\SeriesLinkOptionsField;
+use CWM\Component\Proclaim\Administrator\Field\ShowVersesField;
+use CWM\Component\Proclaim\Administrator\Field\TeacherLinkOptionsField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Form\Field\PredefinedlistField;
+use Joomla\CMS\Form\FormField;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression test for #1464: 8 fields extended ListField with a getOptions()
+ * that never queried the DB — always the same hardcoded array — which is
+ * exactly what PredefinedlistField is for. FilesizeField went the other
+ * direction: it extended ListField but overrode getInput() entirely,
+ * never calling getOptions() or rendering a <select> — it should extend
+ * FormField instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PredefinedOptionsFieldsTest extends ProclaimTestCase
+{
+    /**
+     * @return array<string, array{0: class-string, 1: array<string, string>}>
+     */
+    public static function fieldProvider(): array
+    {
+        return [
+            'LinkOptionsField' => [LinkOptionsField::class, [
+                '0' => 'JBS_TPL_NO_LINK', '10' => 'JBS_TPL_LINK_TO_SERIES',
+            ]],
+            'RowOptionsField' => [RowOptionsField::class, [
+                '0' => 'JBS_CMN_HIDE', '6' => 'JBS_TPL_ROW6',
+            ]],
+            'TeacherLinkOptionsField' => [TeacherLinkOptionsField::class, [
+                '0' => 'JBS_TPL_NO_LINK', '3' => 'JBS_TPL_LINK_TO_TEACHERS_PROFILE',
+            ]],
+            'DateFormatField' => [DateFormatField::class, [
+                '0' => 'JBS_TPL_DATE_FORMAT_MMM_D_YYYY', '9' => 'JBS_TPL_DATE_FORMAT_YYYY_MM_DD',
+            ]],
+            'ScriptureSeparatorField' => [ScriptureSeparatorField::class, [
+                'newline' => 'JBS_TPL_SEPARATOR_STACKED', 'semicolon' => 'JBS_TPL_SEPARATOR_SEMICOLON',
+            ]],
+            'ShowVersesField' => [ShowVersesField::class, [
+                '0' => 'JBS_TPL_SHOW_ONLY_CHAPTERS', '2' => 'JBS_TPL_SHOW_ONLY_BOOKS',
+            ]],
+            'ElementOptionsField' => [ElementOptionsField::class, [
+                '0' => 'JBS_CMN_NONE', '8' => 'JBS_TPL_DIV',
+            ]],
+            'SeriesLinkOptionsField' => [SeriesLinkOptionsField::class, [
+                '0' => 'JBS_TPL_NO_LINK', '1' => 'JBS_TPL_LINK_TO_DETAILS',
+            ]],
+        ];
+    }
+
+    /**
+     * @param   class-string           $fieldClass       The field class under test.
+     * @param   array<string, string>  $expectedOptions  A representative sample of value => language-key pairs.
+     */
+    #[DataProvider('fieldProvider')]
+    public function testFieldExtendsPredefinedlistFieldAndKeepsItsOptions(string $fieldClass, array $expectedOptions): void
+    {
+        $this->assertTrue(
+            is_subclass_of($fieldClass, PredefinedlistField::class),
+            $fieldClass . ' must extend PredefinedlistField — see #1464'
+        );
+
+        $field = (new \ReflectionClass($fieldClass))->newInstanceWithoutConstructor();
+        (new \ReflectionProperty($field, 'element'))->setValue($field, new \SimpleXMLElement('<field/>'));
+        (new \ReflectionProperty($field, 'fieldname'))->setValue($field, 'test');
+
+        $options = (new \ReflectionMethod($fieldClass, 'getOptions'))->invoke($field);
+        $byValue = [];
+
+        foreach ($options as $option) {
+            $byValue[(string) $option->value] = $option;
+        }
+
+        foreach ($expectedOptions as $value => $langKey) {
+            $this->assertArrayHasKey($value, $byValue, "$fieldClass must still offer option value \"$value\"");
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testFilesizeFieldExtendsFormFieldNotListField(): void
+    {
+        $this->assertTrue(
+            is_subclass_of(FilesizeField::class, FormField::class),
+            'FilesizeField must extend FormField — see #1464'
+        );
+
+        $this->assertFalse(
+            is_subclass_of(FilesizeField::class, PredefinedlistField::class)
+                || is_a(FilesizeField::class, \Joomla\CMS\Form\Field\ListField::class, true),
+            'FilesizeField must not extend ListField — it never renders a <select> — see #1464'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

8 fields extended `ListField` with a `getOptions()` that never queried the database — always the same hardcoded array of value => language-key pairs. Converted to extend `PredefinedlistField` instead, which is exactly what it's for (and gets Joomla core's per-instance-XML-hash caching for free): `LinkOptionsField`, `RowOptionsField`, `TeacherLinkOptionsField`, `DateFormatField`, `ScriptureSeparatorField`, `ShowVersesField`, `ElementOptionsField`, `SeriesLinkOptionsField`.

`FilesizeField` went the other direction: it extended `ListField` but overrode `getInput()` entirely, never calling `getOptions()` or rendering a `<select>` at all. Now extends `FormField`, and `public $type` corrected to `protected` to match every other field's convention.

Found during a Field-files audit (2026-08-03).

## Test plan
- [x] Added a data-provider test covering all 9 — **verified it fails against the original code** (wrong base class, or options missing after conversion) **and passes against the fix**.
- [x] `composer lint` / `lint:queries` — no new findings (3 pre-existing, unrelated files)
- [x] Full bare `phpunit` (matches CI's `composer test`) — 1128/1128 passing
- [x] `php -l` on all touched files

Fixes #1464