### PR TITLE
Migrate ServerTypeField to core ModalSelectField

### DIFF
--- a/admin/src/Field/Modal/ServerTypeField.php
+++ b/admin/src/Field/Modal/ServerTypeField.php
@@ -17,22 +17,25 @@ namespace CWM\Component\Proclaim\Administrator\Field\Modal;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Form\FormField;
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Form\Field\ModalSelectField;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Utilities\ArrayHelper;
 
 /**
- * ServerType Field class
+ * Supports a modal server-type picker using Joomla's ModalSelectField (PostMessage + JoomlaDialog).
  *
- * @package  Proclaim.Admin
- * @since    7.0.0
+ * The field's value is a lowercased server-addon type key (e.g. "youtube",
+ * "local"), not a numeric id, so its title comes from
+ * CwmserversModel::getTypeReverseLookup() rather than a SQL row lookup.
+ *
+ * @since  __DEPLOY_VERSION__
  */
-class ServerTypeField extends FormField
+class ServerTypeField extends ModalSelectField
 {
     /**
-     * Set Modal_Study
+     * The form field type.
      *
      * @var string
      *
@@ -41,246 +44,110 @@ class ServerTypeField extends FormField
     protected $type = 'Modal_ServerType';
 
     /**
-     * Get Input
+     * Method to attach a Form object to the field.
      *
-     * @return string
+     * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag.
+     * @param   mixed              $value    The form field value to validate.
+     * @param   string             $group    The field name group control value.
      *
-     * @throws \Exception
-     * @since 7.0
+     * @return  bool  True on success.
+     *
+     * @since   __DEPLOY_VERSION__
      */
     #[\Override]
-    protected function getInput(): string
+    public function setup(\SimpleXMLElement $element, $value, $group = null)
     {
-        $allowNew       = ((string)$this->element['new'] === 'true');
-        $allowEdit      = ((string)$this->element['edit'] === 'true');
-        $allowClear     = ((string)$this->element['clear'] !== 'false');
-        $allowSelect    = ((string)$this->element['select'] !== 'false');
-        $allowPropagate = ((string)$this->element['propagate'] === 'true');
+        // The value is a server-addon type key, not a numeric id — normalize case only.
+        $value = strtolower((string) $value);
 
-        $recordId = (int)$this->form->getValue('id');
+        $result = parent::setup($element, $value, $group);
 
-        // Load language
-        Factory::getApplication()->getLanguage()->load('com_proclaim', JPATH_ADMINISTRATOR);
-
-        // The active server id field making sure it uses the lower case naming for namespace corrections.
-        $value       = (string)strtolower($this->value) ?: '';
-        $this->value = strtolower($this->value);
-
-        // Create the modal id.
-        $modalId = 'types_' . $this->id;
-
-        /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
-        // Add the modal field script to the document head.
-        $wa->useScript('field.modal-fields');
-
-        // Script to proxy the select modal function to the modal-fields.js file.
-        if ($allowSelect) {
-            static $scriptSelect = null;
-
-            if (\is_null($scriptSelect)) {
-                $scriptSelect = [];
-            }
-
-            if (!isset($scriptSelect[$this->id])) {
-                $wa->addInlineScript(
-                    "
-				window.jSelectType_" . $this->id . " = function (id, title, object) {
-					window.processModalSelect('Type', '" . $this->id . "', id, title, '', object);
-				}",
-                    [],
-                    ['type' => 'module']
-                );
-
-                Text::script('JGLOBAL_ASSOCIATIONS_PROPAGATE_FAILED');
-
-                $scriptSelect[$this->id] = true;
-            }
+        if (!$result) {
+            return $result;
         }
 
-        // Setup variables for display.
-        $linkSeries = 'index.php?option=com_proclaim&amp;view=cwmservers&amp;layout=types&amp;tmpl=component&amp;recordId=' .
-            $recordId . '&amp;' . Session::getFormToken() . '=1';
-        $linkSerie  = 'index.php?option=com_proclaim&amp;view=cwmserver&amp;layout=modal&amp;tmpl=component&amp;recordId=' .
-            $recordId . '&amp;' . Session::getFormToken() . '=1';
+        Factory::getApplication()->getLanguage()->load('com_proclaim', JPATH_ADMINISTRATOR);
 
-        if (isset($this->element['language'])) {
-            $linkSeries .= '&amp;forcedLanguage=' . $this->element['language'];
-            $linkSerie .= '&amp;forcedLanguage=' . $this->element['language'];
-            $modalTitle = Text::_('JBS_CMN_SELECT_SERVERTYPE') . ' &#8212; ' . $this->element['label'];
+        $language = (string) $this->element['language'];
+        $recordId = (int) $this->form->getValue('id');
+
+        // Build URLs using Uri objects (no &amp; encoding issues)
+        $linkSelect = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkSelect->setQuery([
+            'option'                => 'com_proclaim',
+            'view'                  => 'cwmservers',
+            'layout'                => 'types',
+            'tmpl'                  => 'component',
+            'recordId'              => $recordId,
+            Session::getFormToken() => 1,
+        ]);
+        $linkServer = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkServer->setQuery([
+            'option'                => 'com_proclaim',
+            'view'                  => 'cwmserver',
+            'layout'                => 'modal',
+            'tmpl'                  => 'component',
+            'recordId'              => $recordId,
+            Session::getFormToken() => 1,
+        ]);
+
+        if ($language) {
+            $linkSelect->setVar('forcedLanguage', $language);
+            $linkServer->setVar('forcedLanguage', $language);
+
+            $modalTitle = Text::_('JBS_CMN_SELECT_SERVERTYPE') . ' &#8212; ' . $this->getTitle();
+
+            $this->dataAttributes['data-language'] = $language;
         } else {
             $modalTitle = Text::_('JBS_CMN_SELECT_SERVERTYPE');
         }
 
-        $urlSelect = $linkSeries . '&amp;function=jSelectType_' . $this->id;
-        $urlEdit   = $linkSerie . '&amp;task=cwmserver.edit&amp;id=\' + document.getElementById(&quot;' . $this->id . '_id&quot;).value + \'';
-        $urlNew    = $linkSerie . '&amp;task=cwmserver.add';
+        $urlSelect = $linkSelect;
+        $urlEdit   = clone $linkServer;
+        $urlEdit->setVar('task', 'cwmserver.edit');
+        $urlNew    = clone $linkServer;
+        $urlNew->setVar('task', 'cwmserver.add');
 
-        // The current series display field.
-        $html = '';
+        $this->urls['select'] = (string) $urlSelect;
+        $this->urls['new']    = (string) $urlNew;
+        $this->urls['edit']   = (string) $urlEdit;
 
-        if ($allowSelect || $allowNew || $allowEdit || $allowClear) {
-            $html .= '<span class="input-group">';
-        }
+        // Modal titles
+        $this->modalTitles['select'] = $modalTitle;
+        $this->modalTitles['new']    = Text::_('JBS_STY_NEW_SERVERTYPE');
+        $this->modalTitles['edit']   = Text::_('JBS_STY_EDIT_SERVERTYPE');
 
-        // Get a reverse lookup of the endpoint type to endpoint name
-        /** @var \CWM\Component\Proclaim\Administrator\Model\CwmserversModel $model */
-        $model    = Factory::getApplication()->bootComponent('com_proclaim')
-            ->getMVCFactory()->createModel('Cwmservers', 'Administrator');
-        $rlu_type = $model->getTypeReverseLookup();
+        $this->hint = $this->hint ?: Text::_('JBS_CMN_SELECT_SERVERTYPE');
 
-        $text = (string)ArrayHelper::getValue($rlu_type, $this->value);
-
-        $html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="'
-            . htmlspecialchars($text, ENT_QUOTES, 'UTF-8') . '" readonly size="35">';
-
-        // Select Message button
-        if ($allowSelect) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_select"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalSelect' . $modalId . '">'
-                . '<span class="icon-file" aria-hidden="true"></span> ' . Text::_('JSELECT')
-                . '</button>';
-        }
-
-        // New Message button
-        if ($allowNew) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_new"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalNew' . $modalId . '">'
-                . '<span class="icon-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
-                . '</button>';
-        }
-
-        // Edit message button
-        if ($allowEdit) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_edit"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalEdit' . $modalId . '">'
-                . '<span class="icon-pen-square" aria-hidden="true"></span> ' . Text::_('JACTION_EDIT')
-                . '</button>';
-        }
-
-        // Clear message button
-        if ($allowClear) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_clear"'
-                . ' type="button"'
-                . ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-                . '<span class="icon-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
-                . '</button>';
-        }
-
-        if ($allowSelect || $allowNew || $allowEdit || $allowClear) {
-            $html .= '</span>';
-        }
-
-        // Select message modal
-        if ($allowSelect) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalSelect' . $modalId,
-                [
-                    'title'      => $modalTitle,
-                    'url'        => $urlSelect,
-                    'height'     => '400px',
-                    'width'      => '800px',
-                    'bodyHeight' => 70,
-                    'modalWidth' => 80,
-                    'footer'     => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'
-                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
-                ]
-            );
-        }
-
-        // New message modal
-        if ($allowNew) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalNew' . $modalId,
-                [
-                    'title'       => Text::_('JBS_STY_NEW_SERVERTYPE'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlNew,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'cwmmessage\', \'cancel\', \'item-form\'); return false;">'
-                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                        . '<button type="button" class="btn btn-primary"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'cwmmessage\', \'save\', \'item-form\'); return false;">'
-                        . Text::_('JSAVE') . '</button>'
-                        . '<button type="button" class="btn btn-success"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'cwmmessage\', \'apply\', \'item-form\'); return false;">'
-                        . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Edit message modal
-        if ($allowEdit) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalEdit' . $modalId,
-                [
-                    'title'       => Text::_('JBS_STY_EDIT_SERVERTYPE'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlEdit,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'cwmmessage\', \'cancel\', \'item-form\'); return false;">'
-                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                        . '<button type="button" class="btn btn-primary"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'cwmmessage\', \'save\', \'item-form\'); return false;">'
-                        . Text::_('JSAVE') . '</button>'
-                        . '<button type="button" class="btn btn-success"'
-                        . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'cwmmessage\', \'apply\', \'item-form\'); return false;">'
-                        . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Note: class='required' for client side validation.
-        $class = $this->required ? ' class="required modal-value"' : '';
-
-        $html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int)$this->required
-            . '" name="' . $this->name . '" data-text="' .
-            htmlspecialchars(Text::_('JBS_CMN_SELECT_SERVERTYPE'), ENT_COMPAT, 'UTF-8') . '" value="'
-            . htmlspecialchars($value, ENT_QUOTES, 'UTF-8') . '">';
-
-        return $html;
+        return $result;
     }
 
     /**
-     * Method to get the field label markup.
+     * Method to retrieve the title of a selected item.
      *
-     * @return  string  The field label markup.
+     * Not a SQL lookup: the value is a server-addon type key resolved
+     * against the addon-XML-derived reverse lookup built by
+     * CwmserversModel::getTypeReverseLookup().
      *
-     * @since   3.4
+     * @return int|string
+     *
+     * @throws \Exception
+     * @since   __DEPLOY_VERSION__
      */
     #[\Override]
-    protected function getLabel(): string
+    protected function getValueTitle(): int|string
     {
-        return str_replace($this->id, $this->id . '_name', parent::getLabel());
+        $value = (string) $this->value;
+
+        if ($value === '') {
+            return '';
+        }
+
+        /** @var \CWM\Component\Proclaim\Administrator\Model\CwmserversModel $model */
+        $model         = Factory::getApplication()->bootComponent('com_proclaim')
+            ->getMVCFactory()->createModel('Cwmservers', 'Administrator');
+        $reverseLookup = $model->getTypeReverseLookup();
+
+        return ArrayHelper::getValue($reverseLookup, $value) ?: $value;
     }
 }

--- a/tests/unit/Admin/Field/ServerTypeFieldTest.php
+++ b/tests/unit/Admin/Field/ServerTypeFieldTest.php
@@ -13,43 +13,91 @@ namespace CWM\Component\Proclaim\Tests\Admin\Field;
 
 use CWM\Component\Proclaim\Administrator\Field\Modal\ServerTypeField;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Form\Field\ModalSelectField;
+use Joomla\CMS\Form\Form;
 
 /**
- * Test class for Modal/ServerTypeField
+ * Regression test for #1480: ServerTypeField hand-rolled ~250 lines of manual
+ * modal HTML/JS via a fully overridden getInput() extending plain FormField —
+ * the same pattern that produced the XSS in this exact file (#1457). It now
+ * extends Joomla core's ModalSelectField, matching Modal/SeriesField.php,
+ * Modal/StudyField.php and Modal/TeacherDisplayField.php (#1465/#1479).
+ *
+ * The old #1457 regression test (asserting getInput() escaped its
+ * interpolated values) no longer applies: getInput() isn't overridden at
+ * all anymore, so there is no hand-rolled HTML left to escape.
  *
  * @since  __DEPLOY_VERSION__
  */
 class ServerTypeFieldTest extends ProclaimTestCase
 {
     /**
-     * Regression test for #1457: getInput() interpolated the reverse-lookup
-     * display name ($text) and the raw field value ($value) directly into
-     * HTML value="..." attributes with no escaping. Every sibling field in
-     * Modal/ already htmlspecialchars()'s this exact pattern (or, since
-     * #1465, no longer hand-rolls HTML at all) — ServerTypeField was the
-     * one that dropped it.
-     *
+     * Build a field instance with a bound Form supplying id=5 for
+     * $this->form->getValue('id'), without going through the constructor
+     * (which needs a full Form already attached).
+     */
+    private function makeField(mixed $value): ServerTypeField
+    {
+        $field = (new \ReflectionClass(ServerTypeField::class))->newInstanceWithoutConstructor();
+
+        $form = new Form('test');
+        $form->load('<form><fields><field name="id" type="text" /></fields></form>');
+        $form->bind(['id' => 5]);
+
+        (new \ReflectionProperty($field, 'form'))->setValue($field, $form);
+        (new \ReflectionProperty($field, 'fieldname'))->setValue($field, 'test');
+
+        $xml = new \SimpleXMLElement('<field name="test" />');
+        (new \ReflectionMethod(ServerTypeField::class, 'setup'))->invoke($field, $xml, $value);
+
+        return $field;
+    }
+
+    /**
      * @return void
      */
-    public function testGetInputEscapesInterpolatedValues(): void
+    public function testFieldExtendsModalSelectFieldAndBuildsCorrectUrls(): void
     {
-        $reflection = new \ReflectionMethod(ServerTypeField::class, 'getInput');
-        $lines      = file($reflection->getFileName());
-        $body       = implode(
-            '',
-            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        $this->assertTrue(
+            is_subclass_of(ServerTypeField::class, ModalSelectField::class),
+            'ServerTypeField must extend ModalSelectField — see #1480'
         );
 
-        $this->assertMatchesRegularExpression(
-            '/htmlspecialchars\(\$text/',
-            $body,
-            'getInput() must escape $text before interpolating into value="..." — see #1457'
-        );
+        $field = $this->makeField('YouTube');
 
-        $this->assertMatchesRegularExpression(
-            '/htmlspecialchars\(\$value/',
-            $body,
-            'getInput() must escape $value before interpolating into value="..." — see #1457'
-        );
+        $urls = (new \ReflectionProperty($field, 'urls'))->getValue($field);
+
+        $this->assertStringContainsString('view=cwmservers', $urls['select'], 'Select URL must target cwmservers');
+        $this->assertStringContainsString('layout=types', $urls['select'], 'Select URL must use the types layout');
+        $this->assertStringContainsString('recordId=5', $urls['select'], 'Select URL must carry the current record id');
+
+        $this->assertStringContainsString('view=cwmserver', $urls['edit'], 'Edit URL must target cwmserver');
+        $this->assertStringContainsString('task=cwmserver.edit', $urls['edit'], 'Edit URL must use task=cwmserver.edit — not cwmmessage, see #1480');
+        $this->assertStringContainsString('task=cwmserver.add', $urls['new'], 'New URL must use task=cwmserver.add — not cwmmessage, see #1480');
+    }
+
+    /**
+     * @return void
+     */
+    public function testValueIsNormalizedToLowercase(): void
+    {
+        $field = $this->makeField('YouTube');
+
+        $value = (new \ReflectionProperty($field, 'value'))->getValue($field);
+
+        $this->assertSame('youtube', $value, 'ServerTypeField must lowercase its type-key value — see #1480');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetValueTitleUsesReverseLookupNotSqlQuery(): void
+    {
+        $field = $this->makeField('');
+
+        $getValueTitle = new \ReflectionMethod(ServerTypeField::class, 'getValueTitle');
+
+        // Empty value must short-circuit to '' without touching the reverse-lookup model.
+        $this->assertSame('', $getValueTitle->invoke($field));
     }
 }


### PR DESCRIPTION
Fixes #1480. Part of #1463.

## Summary

`Modal/ServerTypeField.php` migrated from a hand-rolled `FormField` override (~250 lines of manual HTML/JS via `getInput()`) to extend Joomla core's `ModalSelectField`, matching `Modal/SeriesField.php`, `Modal/StudyField.php` and `Modal/TeacherDisplayField.php` (#1465/#1479).

This field didn't fit the same template as the other three: its value is a lowercased server-addon **type key** (e.g. `"youtube"`), not a numeric id, so `ModalSelectField`'s default SQL-based `getValueTitle()` doesn't apply. `getValueTitle()` is overridden to call `CwmserversModel::getTypeReverseLookup()` instead, which resolves the key against addon XML files, not a database row.

## Bonus fix

The legacy New/Edit modal footer buttons called `window.processModalEdit(..., 'cwmmessage', ...)` where `'cwmserver'` was correct, even though the task URLs themselves already said `cwmserver.edit`/`cwmserver.add` -- almost certainly a copy-paste artifact from `StudyField.php`. Confirmed by reading Joomla core's `modal-select/buttons.php`: the modern layout has no separate "object name" parameter at all -- each button carries the full route URL (`task=` included) in a `data-modal-config` attribute -- so this bug class structurally can't reoccur after migration.

## Joomla 5 compatibility

Verified `ModalSelectField`, its `joomla.form.field.modal-select` layout, and the `modal-content-select-field` JS asset all ship natively in a Joomla 5 checkout, not just J6 (the class itself is tagged `@since 5.0.0`). The legacy `field.modal-fields` asset this field used before is itself marked deprecated in J5's `joomla.asset.json`, slated for removal in Joomla 6 -- so this migration is required forward-compat work, not just cleanup.

## Test plan

- [x] Rewrote `ServerTypeFieldTest.php` (its prior #1457 escaping-focused test no longer applies -- `getInput()` isn't overridden anymore, so there's no hand-rolled HTML left to escape): asserts the field extends `ModalSelectField`, verifies `setup()` builds correct select/edit/new URLs including `task=cwmserver.edit`/`task=cwmserver.add` (not `cwmmessage`), verifies value normalizes to lowercase, and verifies `getValueTitle()` short-circuits on an empty value without touching the reverse-lookup model.
- [x] Verified the new tests fail against the pre-migration code (git stash) and pass against the fix.
- [x] `composer test:unit` -- 972 tests, all green.
- [x] `php-cs-fixer` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)