### PR TITLE
Drop redundant per-location usage query in LocationGroupMappingField

### DIFF
--- a/admin/src/Field/LocationGroupMappingField.php
+++ b/admin/src/Field/LocationGroupMappingField.php
@@ -16,7 +16,6 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
@@ -124,11 +123,10 @@ class LocationGroupMappingField extends FormField
         foreach ($locations as $location) {
             $locId      = (int) $location->id;
             $mappedGids = array_map('intval', $currentMapping[(string) $locId] ?? []);
-            $usage      = CwmlocationHelper::getLocationUsage($locId);
 
             $html .= '<tr>';
             $html .= '<td><strong>' . $this->escape($location->location_text) . '</strong></td>';
-            $html .= '<td class="text-center">' . (int) $usage['messages'] . '</td>';
+            $html .= '<td class="text-center">' . (int) $location->message_count . '</td>';
             $html .= '<td>';
 
             // Hidden zero-value field so unchecked locations produce an empty array

--- a/tests/unit/Admin/Field/LocationGroupMappingFieldTest.php
+++ b/tests/unit/Admin/Field/LocationGroupMappingFieldTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Unit tests for LocationGroupMappingField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\LocationGroupMappingField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1466: getInput() ran the main location query (which
+ * already computes a per-location message_count via a LEFT JOIN + COUNT +
+ * GROUP BY), then called CwmlocationHelper::getLocationUsage($locId) inside
+ * the per-row loop -- an extra COUNT(*) query per location re-deriving the
+ * exact same number the main query already had.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LocationGroupMappingFieldTest extends ProclaimTestCase
+{
+    /**
+     * @return string
+     */
+    private function getInputMethodBody(): string
+    {
+        $reflection = new \ReflectionMethod(LocationGroupMappingField::class, 'getInput');
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetInputDoesNotRunPerRowUsageQuery(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/CwmlocationHelper::getLocationUsage/',
+            $this->getInputMethodBody(),
+            'getInput() must not re-query a count per location the main query already computed — see #1466'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetInputUsesMessageCountFromTheMainQuery(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\$location->message_count/',
+            $this->getInputMethodBody(),
+            'getInput() must read message_count from the already-computed main query result — see #1466'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1466. Part of #1463.

## Summary

`LocationGroupMappingField::getInput()`'s main query already computes each location's message count via a `LEFT JOIN #__bsms_studies` + `COUNT(s.id) AS message_count` + `GROUP BY l.id`. The per-row loop then called `CwmlocationHelper::getLocationUsage($locId)` for every location -- an extra `SELECT COUNT(*) FROM #__bsms_studies WHERE location_id = ...` query per row re-deriving the exact same number the main query already had (an N+1 query pattern).

## Fix

Read `$location->message_count` directly from the main query's result and drop the per-row helper call. `CwmlocationHelper::getLocationUsage()` itself is untouched -- it's still used by `CwmlocationModel`.

## Test plan

- [x] New `LocationGroupMappingFieldTest.php`: asserts `getInput()` no longer calls `CwmlocationHelper::getLocationUsage`, and asserts it reads `$location->message_count` instead.
- [x] Verified both assertions fail against the pre-fix code (git stash) and pass against the fix.
- [x] `composer test:unit` -- 974 tests, all green.
- [x] `php-cs-fixer` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)