### PR TITLE
Field rendering-style cleanup: fix 3 correctness bugs from #1467 audit

### DIFF
--- a/admin/src/Field/MediaFileField.php
+++ b/admin/src/Field/MediaFileField.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
 /**
@@ -49,12 +50,15 @@ class MediaFileField extends ListField
     #[\Override]
     protected function getOptions(): array
     {
-        if ($this->form->getValue('id')) {
+        $studyId = (int) $this->form->getValue('id');
+
+        if ($studyId > 0) {
             $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->createQuery();
             $query->select($db->quoteName(['a.id', 'a.params']));
             $query->from($db->quoteName('#__bsms_mediafiles', 'a'));
-            $query->where($db->quoteName('a.study_id') . ' = ' . (int) $this->form->getValue('id'));
+            $query->where($db->quoteName('a.study_id') . ' = :studyId')
+                ->bind(':studyId', $studyId, ParameterType::INTEGER);
             $db->setQuery((string)$query);
             $messages = $db->loadObjectList();
         } else {

--- a/admin/src/Field/MediaFileImagesField.php
+++ b/admin/src/Field/MediaFileImagesField.php
@@ -53,7 +53,7 @@ class MediaFileImagesField extends ListField
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery();
-        $query->select('*');
+        $query->select($db->quoteName('params'));
         $query->from($db->quoteName('#__bsms_mediafiles'));
         $db->setQuery((string)$query);
         $mediafiles = $db->loadObjectList();
@@ -75,15 +75,7 @@ class MediaFileImagesField extends ListField
                                 ': ' . $media->params->get('media_button_text');
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                '{"media_use_button_icon":"' .
-                                $media->params->get('media_use_button_icon') .
-                                '","media_button_type":"' . $media->params->get(
-                                    'media_button_type'
-                                ) . '","media_button_text":"' .
-                                $media->params->get(
-                                    'media_button_text'
-                                ) . '","media_icon_type":"' . $media->params->get('media_icon_type') .
-                                '","media_image":""}',
+                                $this->buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
@@ -95,15 +87,7 @@ class MediaFileImagesField extends ListField
                             ) . ': ' . $icon;
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                '{"media_use_button_icon":"' .
-                                $media->params->get('media_use_button_icon') .
-                                '","media_button_type":"' . $media->params->get(
-                                    'media_button_type'
-                                ) . '","media_button_text":"' .
-                                $media->params->get(
-                                    'media_button_text'
-                                ) . '","media_icon_type":"' . $media->params->get('media_icon_type') .
-                                '","media_image":""}',
+                                $this->buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
@@ -112,15 +96,7 @@ class MediaFileImagesField extends ListField
                             $media->media_image = Text::_('JBS_MED_ICON') . ': ' . $icon;
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                '{"media_use_button_icon":"' .
-                                $media->params->get('media_use_button_icon') .
-                                '","media_button_type":"' . $media->params->get(
-                                    'media_button_type'
-                                ) . '","media_button_text":"' .
-                                $media->params->get(
-                                    'media_button_text'
-                                ) . '","media_icon_type":"' . $media->params->get('media_icon_type') .
-                                '","media_image":""}',
+                                $this->buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
@@ -133,15 +109,7 @@ class MediaFileImagesField extends ListField
                     $media->media_image = Text::_('JBS_MED_IMAGE') . ': ' . substr($image, $slash + 1, $imagecount);
                     $options[]          = HTMLHelper::_(
                         'select.option',
-                        '{"media_use_button_icon":"' . $media->params->get('media_use_button_icon') .
-                        '","media_button_type":"' . $media->params->get(
-                            'media_button_type'
-                        ) . '","media_button_text":"' .
-                        $media->params->get('media_button_text') . '","media_icon_type":"' . $media->params->get(
-                            'media_icon_type'
-                        ) .
-                        '","media_image":"' .
-                        $media->params->get('media_image') . '"}',
+                        $this->buildOptionValueJson($media->params, $media->params->get('media_image')),
                         $media->media_image
                     );
                 }
@@ -176,6 +144,28 @@ class MediaFileImagesField extends ListField
         }
 
         return array_merge(parent::getOptions(), $options);
+    }
+
+    /**
+     * Build the option value: a JSON blob of the media params this option
+     * represents, re-applied to the target field on selection.
+     *
+     * @param   Registry  $params      The media file's params.
+     * @param   string    $mediaImage  The media_image value to embed (empty for button/icon options).
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function buildOptionValueJson(Registry $params, string $mediaImage = ''): string
+    {
+        return json_encode([
+            'media_use_button_icon' => (string) $params->get('media_use_button_icon'),
+            'media_button_type'     => (string) $params->get('media_button_type'),
+            'media_button_text'     => (string) $params->get('media_button_text'),
+            'media_icon_type'       => (string) $params->get('media_icon_type'),
+            'media_image'           => $mediaImage,
+        ]) ?: '{}';
     }
 
     /**

--- a/admin/src/Field/SpanOptionsField.php
+++ b/admin/src/Field/SpanOptionsField.php
@@ -46,7 +46,7 @@ class SpanOptionsField extends ListField
     #[\Override]
     protected function getOptions(): array
     {
-        $options[] = HTMLHelper::_('select.option', 'None', 0);
+        $options[] = HTMLHelper::_('select.option', 0, 'None');
         $options[] = HTMLHelper::_('select.option', '1', 1);
         $options[] = HTMLHelper::_('select.option', '2', 2);
         $options[] = HTMLHelper::_('select.option', '3', 3);

--- a/tests/unit/Admin/Field/MediaFileFieldTest.php
+++ b/tests/unit/Admin/Field/MediaFileFieldTest.php
@@ -50,4 +50,27 @@ class MediaFileFieldTest extends ProclaimTestCase
 
         $this->assertSame('42 - audio/mpeg', self::buildOptionLabel(42, $params));
     }
+
+    /**
+     * Regression test for #1467: getOptions() interpolated an int-cast
+     * study id directly into the query string instead of binding it, unlike
+     * the equivalent lookup in MediaPlaylistsField.php. Not a security fix
+     * (the value was already (int)-cast) -- a consistency fix so this file
+     * matches the project's established query-building convention.
+     */
+    public function testGetOptionsBindsStudyIdInsteadOfInterpolating(): void
+    {
+        $reflection = new \ReflectionMethod(MediaFileField::class, 'getOptions');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/->bind\(.*ParameterType::INTEGER\)/s',
+            $body,
+            'getOptions() must bind the study id via ParameterType::INTEGER rather than interpolating it — see #1467'
+        );
+    }
 }

--- a/tests/unit/Admin/Field/MediaFileImagesFieldTest.php
+++ b/tests/unit/Admin/Field/MediaFileImagesFieldTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Unit tests for MediaFileImagesField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\MediaFileImagesField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\Registry\Registry;
+
+/**
+ * Regression test for #1467: getOptions() built the option value as a JSON
+ * blob via raw string concatenation ('{"media_button_text":"' . $text .
+ * '"}'), so a media_button_text containing a double quote (or backslash)
+ * produced invalid JSON that the client-side consumer can't parse.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MediaFileImagesFieldTest extends ProclaimTestCase
+{
+    private function buildOptionValueJson(Registry $params, string $mediaImage = ''): string
+    {
+        $field = (new \ReflectionClass(MediaFileImagesField::class))->newInstanceWithoutConstructor();
+
+        return (new \ReflectionMethod(MediaFileImagesField::class, 'buildOptionValueJson'))
+            ->invoke($field, $params, $mediaImage);
+    }
+
+    public function testButtonTextContainingDoubleQuoteProducesValidJson(): void
+    {
+        $params = new Registry([
+            'media_use_button_icon' => '1',
+            'media_button_type'     => 'btn-primary',
+            'media_button_text'     => 'Watch "Live"',
+            'media_icon_type'       => '',
+        ]);
+
+        $json    = $this->buildOptionValueJson($params);
+        $decoded = json_decode($json, true);
+
+        $this->assertNotNull($decoded, 'Option value must be valid, parseable JSON even when media_button_text contains a double quote — see #1467');
+        $this->assertSame('Watch "Live"', $decoded['media_button_text']);
+    }
+
+    public function testMediaImageIsEmbeddedWhenProvided(): void
+    {
+        $params = new Registry([
+            'media_use_button_icon' => '0',
+            'media_button_type'     => '',
+            'media_button_text'     => '',
+            'media_icon_type'       => '',
+            'media_image'           => 'images/sermon.jpg',
+        ]);
+
+        $json    = $this->buildOptionValueJson($params, 'images/sermon.jpg');
+        $decoded = json_decode($json, true);
+
+        $this->assertSame('images/sermon.jpg', $decoded['media_image']);
+    }
+}

--- a/tests/unit/Admin/Field/SpanOptionsFieldTest.php
+++ b/tests/unit/Admin/Field/SpanOptionsFieldTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Unit tests for SpanOptionsField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\SpanOptionsField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1467: the "None" option was built as
+ * HTMLHelper::_('select.option', 'None', 0) -- value/text reversed relative
+ * to every other row in the same array (e.g. ('1', 1) is value='1',
+ * text=1). Submitting "None" posted the literal string "None" instead of 0,
+ * which downstream consumers (e.g. Cwmlisting.php's colspan handling) treat
+ * as a truthy, non-numeric value rather than "no span override".
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SpanOptionsFieldTest extends ProclaimTestCase
+{
+    public function testNoneOptionHasNumericZeroValue(): void
+    {
+        $field = (new \ReflectionClass(SpanOptionsField::class))->newInstanceWithoutConstructor();
+        (new \ReflectionProperty($field, 'element'))->setValue($field, new \SimpleXMLElement('<field/>'));
+        (new \ReflectionProperty($field, 'fieldname'))->setValue($field, 'test');
+
+        $options = (new \ReflectionMethod(SpanOptionsField::class, 'getOptions'))->invoke($field);
+
+        $none = null;
+
+        foreach ($options as $option) {
+            if ($option->text === 'None') {
+                $none = $option;
+                break;
+            }
+        }
+
+        $this->assertNotNull($none, 'Expected a "None" option to be present');
+        $this->assertSame(0, $none->value, '"None" must submit the numeric value 0, not the string "None" — see #1467');
+    }
+}


### PR DESCRIPTION
Part of #1467, part of #1463.

## Summary

#1467 bundled ~10 disparate items from a Field-files audit. This PR fixes the four that are one-file, low-risk correctness/consistency items; the larger rendering-architecture conversions are split into follow-ups #1483 and #1484 since they need new layout files and browser re-verification rather than lint+unit-test.

### Fixed

- **\`SpanOptionsField.php\`**: the "None" option was built as \`HTMLHelper::_('select.option', 'None', 0)\` -- value/text reversed relative to every other row in the array. Submitting "None" posted the literal string \`"None"\` instead of \`0\`. Confirmed live: \`Cwmlisting.php\`'s colspan handling does \`\$r->colspan > 0 ? (int) \$r->colspan : 1\`; under PHP 8's string/number comparison rules \`"None" > 0\` evaluates true, then \`(int) "None"\` casts to \`0\` -- so selecting "None" produced \`colspan=0\` instead of the intended fallback of \`1\`. Checked the local dev DB for any stored template rows carrying the literal string \`"None"\` -- none found, though that can't be verified across all deployments.
- **\`MediaFileImagesField.php\`**: \`getOptions()\` built its option value as a JSON blob via raw string concatenation, so a \`media_button_text\` containing a double quote produced invalid JSON. Extracted the three near-identical switch arms plus the else branch into one \`buildOptionValueJson()\` helper using \`json_encode()\`. Also narrowed \`SELECT *\` to the one column (\`params\`) the method actually reads.
- **\`MediaFileField.php\`**: \`getOptions()\` interpolated an int-cast study id directly into the query string instead of binding it, unlike the equivalent lookup in \`MediaPlaylistsField.php\`. Consistency fix, not a security fix -- the value was already \`(int)\`-cast before interpolation.

### Confirmed stale, no fix needed

- \`DateFormatField.php:49\`'s missing \`#[\Override]\` finding: #1464 (earlier this cycle) already converted this field to a declarative \`\$predefinedOptions\` array on \`PredefinedlistField\`, which has no \`getOptions()\` method left to annotate.

### Deferred to follow-ups

- #1483 -- raw \`getInput()\` HTML → \`\$layout\` + \`getLayoutData()\` conversions (6 files, up to 621 lines each).
- #1484 -- inline \`<script>\` → \`WebAssetManager\` migrations + \`BibleVersionField.php\` business-logic extraction.

## Test plan

- [x] New \`SpanOptionsFieldTest.php\`: asserts the "None" option's value is the int \`0\`, not the string \`"None"\`.
- [x] New \`MediaFileImagesFieldTest.php\`: asserts a \`media_button_text\` containing a double quote round-trips through \`json_decode()\` correctly.
- [x] Extended \`MediaFileFieldTest.php\`: asserts \`getOptions()\` binds the study id via \`ParameterType::INTEGER\` rather than interpolating it.
- [x] Verified all three new/modified assertions fail against the pre-fix code (git stash) and pass against the fix.
- [x] \`composer test:unit\` -- 978 tests, all green.
- [x] \`php-cs-fixer\` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)