### PR TITLE
Migrate PopupCodeField/DescriptionFormatField scripts to WebAssetManager

### DIFF
--- a/admin/src/Field/DescriptionFormatField.php
+++ b/admin/src/Field/DescriptionFormatField.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 
@@ -105,28 +106,23 @@ class DescriptionFormatField extends FormField
 
         $html .= '</div></div>';
 
-        // Add JavaScript (once per page)
-        $html .= $this->buildJavaScript();
+        $this->registerJavaScript();
 
         return $html;
     }
 
     /**
-     * Build the JavaScript for token insertion at cursor position.
+     * Register the token-insertion script via WebAssetManager. The asset
+     * manager keys inline scripts by a content hash, so repeated calls
+     * across multiple field instances on the same page register the same
+     * asset name and render once -- no manual "added" flag needed.
      *
-     * @return  string  The script tag
+     * @return  void
      *
-     * @since 10.2.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function buildJavaScript(): string
+    private function registerJavaScript(): void
     {
-        static $jsAdded = false;
-
-        if ($jsAdded) {
-            return '';
-        }
-        $jsAdded = true;
-
         $js = <<<'JS'
 document.addEventListener('click', function(e) {
     var btn = e.target.closest('.cwm-desc-token-btn');
@@ -145,6 +141,6 @@ document.addEventListener('click', function(e) {
 });
 JS;
 
-        return '<script>' . $js . '</script>';
+        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript($js);
     }
 }

--- a/admin/src/Field/PopupCodeField.php
+++ b/admin/src/Field/PopupCodeField.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\TextField;
 use Joomla\CMS\Language\Text;
 
@@ -86,10 +87,24 @@ class PopupCodeField extends TextField
 
         $buttons .= '</div>';
 
-        // Add the JavaScript for code insertion (only once per page)
-        static $jsAdded = false;
-        if (!$jsAdded) {
-            $js = <<<'JS'
+        $this->registerJavaScript();
+
+        return $html . $buttons;
+    }
+
+    /**
+     * Register the code-insertion script via WebAssetManager. The asset
+     * manager keys inline scripts by a content hash, so repeated calls
+     * across multiple field instances on the same page register the same
+     * asset name and render once -- no manual "added" flag needed.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function registerJavaScript(): void
+    {
+        $js = <<<'JS'
 document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('click', function(e) {
         if (e.target.classList.contains('popup-code-btn')) {
@@ -110,10 +125,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 JS;
-            $html .= '<script>' . $js . '</script>';
-            $jsAdded = true;
-        }
 
-        return $html . $buttons;
+        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript($js);
     }
 }

--- a/tests/unit/Admin/Field/DescriptionFormatFieldTest.php
+++ b/tests/unit/Admin/Field/DescriptionFormatFieldTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Unit tests for DescriptionFormatField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\DescriptionFormatField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1484: getInput() built its token-insertion script's
+ * `<script>` tag as a raw string returned from buildJavaScript(), bypassing
+ * WebAssetManager -- unlike VttUploadField.php's correct
+ * $wa->useScript()/addScriptOptions() pattern. Now registered via
+ * WebAssetManager::addInlineScript() instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class DescriptionFormatFieldTest extends ProclaimTestCase
+{
+    private function getClassSource(): string
+    {
+        return file_get_contents((new \ReflectionClass(DescriptionFormatField::class))->getFileName());
+    }
+
+    public function testDoesNotEmitRawScriptTag(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\'"]<script>[\'"]/',
+            $this->getClassSource(),
+            'DescriptionFormatField must not return a raw <script> tag string — see #1484'
+        );
+    }
+
+    public function testRegistersScriptViaWebAssetManager(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/->addInlineScript\(/',
+            $this->getClassSource(),
+            'DescriptionFormatField must register its script via WebAssetManager::addInlineScript() — see #1484'
+        );
+    }
+}

--- a/tests/unit/Admin/Field/PopupCodeFieldTest.php
+++ b/tests/unit/Admin/Field/PopupCodeFieldTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Unit tests for PopupCodeField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\PopupCodeField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1484: getInput() emitted its code-insertion script as
+ * a raw `<script>` tag concatenated into the returned HTML, bypassing
+ * WebAssetManager -- unlike VttUploadField.php's correct
+ * $wa->useScript()/addScriptOptions() pattern. Now registered via
+ * WebAssetManager::addInlineScript() instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PopupCodeFieldTest extends ProclaimTestCase
+{
+    private function getClassSource(): string
+    {
+        return file_get_contents((new \ReflectionClass(PopupCodeField::class))->getFileName());
+    }
+
+    public function testDoesNotEmitRawScriptTag(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\'"]<script>[\'"]/',
+            $this->getClassSource(),
+            'PopupCodeField must not concatenate a raw <script> tag into its returned HTML — see #1484'
+        );
+    }
+
+    public function testRegistersScriptViaWebAssetManager(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/->addInlineScript\(/',
+            $this->getClassSource(),
+            'PopupCodeField must register its script via WebAssetManager::addInlineScript() — see #1484'
+        );
+    }
+}


### PR DESCRIPTION
Part of #1484, part of #1463.

## Summary

The first (lowest-risk) group from #1484: `PopupCodeField.php` and `DescriptionFormatField.php` both emitted their code/token-insertion JavaScript as a raw \`<script>\` tag concatenated into \`getInput()\`'s returned HTML, bypassing \`WebAssetManager\` -- unlike \`VttUploadField.php\`'s correct \`useScript()\`/\`addScriptOptions()\` pattern.

## Fix

Both now register their script via \`WebAssetManager::addInlineScript()\`. Neither script interpolates any per-field PHP data (both are static nowdoc strings), so \`addInlineScript()\`'s own content-hash-based asset naming (\`'inline.' . md5(\$content)\`) deduplicates repeated calls across multiple field instances on the same page automatically -- the manual \`static \$jsAdded\` guards were removed as no longer needed.

This group deliberately excludes \`LocationGroupMappingField.php\` (its script has interpolated field names and submit-timing risk -- needs a live save-round-trip test, tracked as its own PR) and \`CustomField.php\`/\`ColorPickerField.php\` (their own PR, found during #1483's triage).

## Test plan

- [x] New \`PopupCodeFieldTest.php\` / \`DescriptionFormatFieldTest.php\`: assert the class source no longer contains a raw \`'<script>'\` string and does call \`->addInlineScript(\`.
- [x] Verified all 4 new assertions fail against the pre-fix code (git stash) and pass against the fix.
- [x] \`composer test:unit\` -- 982 tests, all green.
- [x] \`php-cs-fixer\` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)