### PR TITLE
Migrate CustomField/ColorPickerField script and style to WebAssetManager

### DIFF
--- a/admin/src/Field/ColorPickerField.php
+++ b/admin/src/Field/ColorPickerField.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -360,9 +361,8 @@ class ColorPickerField extends FormField
 
         $html .= '</div>';
 
-        // Add JavaScript and CSS
-        $html .= $this->buildStyles();
-        $html .= $this->buildJavaScript();
+        $this->registerStyles();
+        $this->registerJavaScript();
 
         return $html;
     }
@@ -448,37 +448,40 @@ class ColorPickerField extends FormField
     }
 
     /**
-     * Build the CSS styles
+     * Register the CSS styles via WebAssetManager. The asset manager keys
+     * inline styles by a content hash, so repeated calls across multiple
+     * field instances on the same page register the same asset name and
+     * render once -- no manual "added" flag needed.
      *
-     * @return  string  The style tag
+     * @return  void
      *
-     * @since 10.1.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function buildStyles(): string
+    protected function registerStyles(): void
     {
-        static $stylesAdded = false;
-
-        if ($stylesAdded) {
-            return '';
-        }
-        $stylesAdded = true;
-
-        return '<style>
+        $css = <<<'CSS'
 .colorpicker-swatch:hover { transform: scale(1.1); border-color: #666 !important; }
 .colorpicker-swatch:focus { outline: 2px solid #0d6efd; outline-offset: 2px; }
 .colorpicker-selected { border-color: #0d6efd !important; box-shadow: 0 0 0 2px rgba(13,110,253,0.5); }
 .colorpicker-swatch[data-hidden="true"] { display: none !important; }
-</style>';
+CSS;
+
+        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineStyle($css);
     }
 
     /**
-     * Build the JavaScript for color selection and filtering
+     * Register the JavaScript for color selection and filtering via
+     * WebAssetManager. Unlike registerStyles(), this is per-field-instance
+     * (the function names are scoped to $id), so each instance registers
+     * its own distinctly-named asset rather than being deduplicated -- the
+     * same behaviour as before, where each instance emitted its own
+     * <script> block inline.
      *
-     * @return  string  The script tag with JavaScript
+     * @return  void
      *
-     * @since 10.1.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function buildJavaScript(): string
+    protected function registerJavaScript(): void
     {
         $id = $this->id;
 
@@ -621,6 +624,6 @@ document.addEventListener('click', function(e) {
 });
 JS;
 
-        return '<script>' . $js . '</script>';
+        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript($js);
     }
 }

--- a/admin/src/Field/CustomField.php
+++ b/admin/src/Field/CustomField.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -41,15 +42,6 @@ class CustomField extends FormField
      * @since 10.1.0
      */
     protected $type = 'Custom';
-
-    /**
-     * Flag to track if modal HTML has been added to the page
-     *
-     * @var  bool
-     *
-     * @since 10.1.0
-     */
-    protected static bool $modalAdded = false;
 
     /**
      * Podcast codes for insertion (single braces)
@@ -123,8 +115,7 @@ class CustomField extends FormField
         // Add modal HTML (only once per codeset type)
         $html .= $this->buildModalHtml($modalId, $codeset, $codes);
 
-        // Add JavaScript (only once per page)
-        $html .= $this->buildJavaScript();
+        $this->registerJavaScript();
 
         return $html;
     }
@@ -272,21 +263,17 @@ class CustomField extends FormField
     }
 
     /**
-     * Build the JavaScript for code insertion
+     * Register the code-insertion script via WebAssetManager. The asset
+     * manager keys inline scripts by a content hash, so repeated calls
+     * across multiple field instances on the same page register the same
+     * asset name and render once -- no manual "added" flag needed.
      *
-     * @return  string  The script tag with JavaScript
+     * @return  void
      *
-     * @since 10.1.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function buildJavaScript(): string
+    protected function registerJavaScript(): void
     {
-        static $jsAdded = false;
-
-        if ($jsAdded) {
-            return '';
-        }
-        $jsAdded = true;
-
         $js = <<<'JS'
 document.addEventListener('DOMContentLoaded', function() {
     // Track which input field triggered the modal
@@ -333,6 +320,6 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 JS;
 
-        return '<script>' . $js . '</script>';
+        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript($js);
     }
 }

--- a/tests/unit/Admin/Field/ColorPickerFieldTest.php
+++ b/tests/unit/Admin/Field/ColorPickerFieldTest.php
@@ -44,4 +44,75 @@ class ColorPickerFieldTest extends ProclaimTestCase
             'getInput() must escape $hexValue before interpolating into value="..." — see #1458'
         );
     }
+
+    /**
+     * Regression test for #1484: buildStyles()/buildJavaScript() returned
+     * raw <style>/<script> tags concatenated into getInput()'s HTML,
+     * bypassing WebAssetManager. Now registered via
+     * WebAssetManager::addInlineStyle()/addInlineScript() instead.
+     *
+     * @return void
+     */
+    public function testStylesAndScriptAreRegisteredViaWebAssetManagerNotRawTags(): void
+    {
+        $reflection = new \ReflectionClass(ColorPickerField::class);
+        $source     = file_get_contents($reflection->getFileName());
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\'"]<style>/',
+            $source,
+            'ColorPickerField must not concatenate a raw <style> tag — see #1484'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\'"]<script>[\'"]/',
+            $source,
+            'ColorPickerField must not concatenate a raw <script> tag — see #1484'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/->addInlineStyle\(/',
+            $source,
+            'ColorPickerField must register its styles via WebAssetManager::addInlineStyle() — see #1484'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/->addInlineScript\(/',
+            $source,
+            'ColorPickerField must register its script via WebAssetManager::addInlineScript() — see #1484'
+        );
+    }
+
+    /**
+     * Confirms the registered CSS/JS content (selectors, function names,
+     * the $id interpolation) survived the WebAssetManager migration
+     * unchanged -- checked against the method source directly, since the
+     * test suite's CLI application has no Document/WebAssetManager to
+     * invoke the real registration against.
+     *
+     * @return void
+     */
+    public function testStylesAndScriptContentIsUnchanged(): void
+    {
+        $stylesReflection = new \ReflectionMethod(ColorPickerField::class, 'registerStyles');
+        $stylesLines      = file($stylesReflection->getFileName());
+        $stylesBody       = implode(
+            '',
+            \array_slice($stylesLines, $stylesReflection->getStartLine() - 1, $stylesReflection->getEndLine() - $stylesReflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString('.colorpicker-swatch:hover', $stylesBody);
+        $this->assertStringContainsString('.colorpicker-selected', $stylesBody);
+
+        $jsReflection = new \ReflectionMethod(ColorPickerField::class, 'registerJavaScript');
+        $jsLines      = file($jsReflection->getFileName());
+        $jsBody       = implode(
+            '',
+            \array_slice($jsLines, $jsReflection->getStartLine() - 1, $jsReflection->getEndLine() - $jsReflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString('function toggleColorPalette_{$id}()', $jsBody);
+        $this->assertStringContainsString('function selectColor_{$id}(name, hex)', $jsBody);
+        $this->assertStringContainsString('function filterColors_{$id}(query)', $jsBody);
+    }
 }

--- a/tests/unit/Admin/Field/CustomFieldTest.php
+++ b/tests/unit/Admin/Field/CustomFieldTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Unit tests for CustomField
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Field;
+
+use CWM\Component\Proclaim\Administrator\Field\CustomField;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1484: buildJavaScript() returned a raw
+ * <script>...</script> string concatenated into getInput()'s HTML,
+ * bypassing WebAssetManager. Now registered via
+ * WebAssetManager::addInlineScript() instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CustomFieldTest extends ProclaimTestCase
+{
+    public function testDoesNotEmitRawScriptTag(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(CustomField::class))->getFileName());
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\'"]<script>[\'"]/',
+            $source,
+            'CustomField must not concatenate a raw <script> tag — see #1484'
+        );
+    }
+
+    public function testRegistersScriptViaWebAssetManager(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(CustomField::class))->getFileName());
+
+        $this->assertMatchesRegularExpression(
+            '/->addInlineScript\(/',
+            $source,
+            'CustomField must register its script via WebAssetManager::addInlineScript() — see #1484'
+        );
+    }
+
+    /**
+     * Confirms the actual JS content (event delegation, code insertion,
+     * modal close logic) survived the WebAssetManager migration unchanged.
+     *
+     * @return void
+     */
+    public function testScriptContentIsUnchanged(): void
+    {
+        $reflection = new \ReflectionMethod(CustomField::class, 'registerJavaScript');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString("closest('.custom-code-btn')", $body);
+        $this->assertStringContainsString("closest('.custom-code-insert')", $body);
+        $this->assertStringContainsString('bootstrap.Modal.getInstance(modal)', $body);
+    }
+}


### PR DESCRIPTION
Part of #1484, part of #1463.

## Summary

Both fields returned raw \`<script>\`/\`<style>\` strings concatenated into \`getInput()\`'s HTML, bypassing \`WebAssetManager\` -- found during #1483's triage of the same audit.

## Fix

- \`CustomField::buildJavaScript()\` -> \`registerJavaScript()\`: static JS (no per-instance interpolation), same pattern as \`PopupCodeField\`/\`DescriptionFormatField\` (#1486) -- registered via \`addInlineScript()\`, manual \`static \$jsAdded\` guard removed since the asset manager's own content-hash naming dedupes repeated calls.
- \`ColorPickerField::buildStyles()\` -> \`registerStyles()\`: same pattern via \`addInlineStyle()\`.
- \`ColorPickerField::buildJavaScript()\` -> \`registerJavaScript()\`: unlike the above, this script interpolates \`\$id\` (function names are scoped per field instance), so each instance registers its own distinctly-named asset rather than being deduplicated -- the same behaviour as before, where each instance emitted its own \`<script>\` block inline.

All three JS/CSS bodies are byte-for-byte unchanged (diffed against the pre-fix heredocs/nowdocs during implementation).

Also removes \`CustomField::\$modalAdded\`, a static property declared but never read or written anywhere in the file -- dead code left over from before \`buildModalHtml()\` introduced its own local per-codeset static guard.

## Live test

Tested on \`j5-dev\` (Proclaim template's Media tab, which uses both field types side by side):
- Opened \`CustomField\`'s Insert Code modal, clicked a code button, confirmed insertion at cursor position and modal auto-close.
- Opened \`ColorPickerField\`'s dropdown, used the search filter, selected a swatch, confirmed the preview/display/hidden value all updated and the dropdown closed.
- Closed without saving to leave the dev site unchanged.

## Test plan

- [x] New \`CustomFieldTest.php\`, extended \`ColorPickerFieldTest.php\`: assert neither class concatenates a raw \`<script>\`/\`<style>\` tag and both call \`->addInlineScript(\`/\`->addInlineStyle(\`; assert the registered CSS/JS content (selectors, function names) is present unchanged.
- [x] Verified all new assertions fail against the pre-fix code (git stash) and pass against the fix.
- [x] \`composer test:unit\` -- 989 tests, all green.
- [x] \`php-cs-fixer\` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)