### PR TITLE
Correct CwmcpanelController's base class to BaseController

### DIFF
--- a/admin/src/Controller/CwmcpanelController.php
+++ b/admin/src/Controller/CwmcpanelController.php
@@ -16,14 +16,19 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\MVC\Controller\FormController;
+use Joomla\CMS\MVC\Controller\BaseController;
 
 /**
  * Controller for the cPanel
  *
+ * Pure display controller -- CwmcpanelModel extends BaseModel, not
+ * FormModel, and no task=cwmcpanel.* routing exists (only view=cwmcpanel
+ * display links). Matches DisplayController's pattern for display-only
+ * controllers. See #1449.
+ *
  * @package  Proclaim.Admin
  * @since    7.0.0
  */
-class CwmcpanelController extends FormController
+class CwmcpanelController extends BaseController
 {
 }

--- a/tests/unit/Admin/Controller/CwmcpanelControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmcpanelControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Unit tests for CwmcpanelController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmcpanelController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\MVC\Controller\FormController;
+
+/**
+ * Regression test for #1449: CwmcpanelController extended FormController,
+ * but CwmcpanelModel extends BaseModel, not FormModel -- and no
+ * task=cwmcpanel.* routing exists anywhere (only view=cwmcpanel display
+ * links/redirects). Now extends BaseController, matching DisplayController's
+ * pattern for display-only controllers.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmcpanelControllerTest extends ProclaimTestCase
+{
+    public function testExtendsBaseControllerNotFormController(): void
+    {
+        $this->assertTrue(
+            is_subclass_of(CwmcpanelController::class, BaseController::class),
+            'CwmcpanelController must extend Joomla BaseController — see #1449'
+        );
+
+        $this->assertFalse(
+            is_subclass_of(CwmcpanelController::class, FormController::class),
+            'CwmcpanelController must not extend FormController — its model (CwmcpanelModel) extends BaseModel, not FormModel — see #1449'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1449. Part of #1442.

## Summary

\`CwmcpanelController\` (empty body) extended \`FormController\`, but \`CwmcpanelModel\` extends \`BaseModel\`, not \`FormModel\`. Confirmed via repo-wide grep that no \`task=cwmcpanel.*\` routing exists anywhere -- every reference is \`view=cwmcpanel\` (display links/redirects) -- so this was harmless in practice, but the base class didn't match reality.

## Fix

Now extends \`BaseController\`, matching \`DisplayController\`'s (and \`CwmanalyticsController\`'s, \`CwmlicenseController\`'s) established pattern for display-only controllers in this codebase -- confirmed these are the existing precedent via grep before making the change.

## Test plan

- [x] New \`CwmcpanelControllerTest.php\`: asserts the controller extends \`BaseController\` and does NOT extend \`FormController\`.
- [x] Verified the test fails against the pre-fix code (git stash) and passes against the fix.
- [x] Live-verified on \`j5-dev\`: the Control Panel view (\`view=cwmcpanel\`) still renders correctly -- version info, post-install messages, dashboard cards all display as before.
- [x] \`composer test:unit\` -- 1002 tests, all green.
- [x] \`php-cs-fixer\` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)