### PR TITLE
fix: move CwmadminController's legacy AJAX SQL into CwmadminModel

### DIFF
--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -143,41 +143,26 @@ class CwmadminController extends FormController
             return;
         }
 
-        $db   = Factory::getContainer()->get(DatabaseInterface::class);
-        $msg  = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
         $post = $this->input->post->get('jform', [], 'array');
         $reg  = new Registry();
         $reg->loadArray($post['params']);
         $from = $reg->get('from', 'x');
         $to   = $reg->get('to', 'x');
 
-        if ($from !== 'x' && $to !== 'x') {
-            $query = $db->createQuery();
-            $query->select($db->quoteName(['id', 'params']))
-                ->from($db->quoteName('#__bsms_mediafiles'));
-            $db->setQuery($query);
+        if ($from === 'x' || $to === 'x') {
+            $this->setRedirect(
+                'index.php?option=com_proclaim&view=cwmadmin',
+                Text::_('JBS_ADM_ERROR_OCCURED') . ': Missed setting the From or To'
+            );
 
-            foreach ($db->loadObjectList() as $media) {
-                $reg = new Registry();
-                $reg->loadString($media->params);
+            return;
+        }
 
-                if ($reg->get('player', 0) == $from) {
-                    $reg->set('player', $to);
-
-                    $query = $db->createQuery();
-                    $query->update($db->quoteName('#__bsms_mediafiles'))
-                        ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                        ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                    $db->setQuery($query);
-
-                    if (!$db->execute()) {
-                        $msg = Text::_('JBS_ADM_ERROR_OCCURED');
-                        $this->setRedirect('index.php?option=com_proclaim&view=cwmadmin', $msg);
-                    }
-                }
-            }
-        } else {
-            $msg = Text::_('JBS_ADM_ERROR_OCCURED') . ': Missed setting the From or To';
+        try {
+            $this->getModel()->changePlayer($from, $to);
+            $msg = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
+        } catch (\Exception) {
+            $msg = Text::_('JBS_ADM_ERROR_OCCURED');
         }
 
         $this->setRedirect('index.php?option=com_proclaim&view=cwmadmin', $msg);
@@ -200,44 +185,17 @@ class CwmadminController extends FormController
             return;
         }
 
-        $db   = Factory::getContainer()->get(DatabaseInterface::class);
         $post = $this->input->post->get('jform', [], 'array');
         $reg  = new Registry();
         $reg->loadArray($post['params']);
-        $from  = $reg->get('pFrom', 'x');
-        $form2 = '';
-        $to    = $reg->get('pTo', 'x');
-        $msg   = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
-        $query = $db->createQuery();
-        $query->select($db->quoteName(['id', 'params']))
-            ->from($db->quoteName('#__bsms_mediafiles'));
-        $db->setQuery($query);
+        $from = $reg->get('pFrom', 'x');
+        $to   = $reg->get('pTo', 'x');
 
-        foreach ($db->loadObjectList() as $media) {
-            $reg = new Registry();
-            $reg->loadString($media->params);
-
-            if ($from == '100') {
-                $from  = '0';
-                $form2 = '100';
-            } elseif ($to == '100') {
-                $to = '';
-            }
-
-            if ($reg->get('popup', 0) == $from || $reg->get('popup', 0) == $form2) {
-                $reg->set('popup', $to);
-
-                $query = $db->createQuery();
-                $query->update($db->quoteName('#__bsms_mediafiles'))
-                    ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                    ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                $db->setQuery($query);
-
-                if (!$db->execute()) {
-                    $msg = Text::_('JBS_ADM_ERROR_OCCURED');
-                    $this->setRedirect('index.php?option=com_proclaim&view=cwmadmin', $msg);
-                }
-            }
+        try {
+            $this->getModel()->changePopup($from, $to);
+            $msg = Text::_('JBS_CMN_OPERATION_SUCCESSFUL');
+        } catch (\Exception) {
+            $msg = Text::_('JBS_ADM_ERROR_OCCURED');
         }
 
         $this->setRedirect('index.php?option=com_proclaim&view=cwmadmin', $msg);
@@ -260,196 +218,20 @@ class CwmadminController extends FormController
             return;
         }
 
-        $post    = $this->input->post->get('jform', [], 'raw');
-        $decoded = json_decode($post['mediaimage'], true, 512, JSON_THROW_ON_ERROR);
-        $db      = Factory::getContainer()->get(DatabaseInterface::class);
-        $query   = $db->createQuery();
-        $query->select($db->quoteName(['id', 'params']))
-            ->from($db->quoteName('#__bsms_mediafiles'));
-        $db->setQuery($query);
-        $images    = $db->loadObjectList();
-        $error     = 0;
-        $added     = 0;
-        $errortext = '';
-        $msg       = Text::_('JBS_RESULTS') . ': ';
+        $post = $this->input->post->get('jform', [], 'raw');
+        // Decoded as an object (not an associative array) -- the matcher below
+        // uses `->` property access throughout, matching how this payload has
+        // always been consumed here.
+        $decoded = json_decode($post['mediaimage'], false, 512, JSON_THROW_ON_ERROR);
 
-        switch ($decoded->media_use_button_icon) {
-            case 1:
-                // Button only
-                $buttontype = $decoded->media_button_type;
-                $buttontext = $decoded->media_button_text;
+        $result = $this->getModel()->changeMediaImages($decoded, $post);
 
-                if (!isset($post['media_icon_type'])) {
-                    $post['media_icon_type'] = 0;
-                }
-
-                foreach ($images as $media) {
-                    $reg = new Registry();
-                    $reg->loadString($media->params);
-
-                    if (
-                        $reg->get('media_button_type') == $buttontype && $reg->get(
-                            'media_button_text'
-                        ) == $buttontext
-                    ) {
-                        $query = $db->createQuery();
-                        $reg->set('media_button_color', $post['media_button_color']);
-                        $reg->set('media_button_text', $post['media_button_text']);
-                        $reg->set('media_button_type', $post['media_button_type']);
-                        $reg->set('media_custom_icon', $post['media_custom_icon']);
-                        $reg->set('media_icon_type', $post['media_icon_type']);
-                        $reg->set('media_image', $post['media_image']);
-                        $reg->set('media_use_button_icon', $post['media_use_button_icon']);
-                        $db->setQuery($query);
-
-                        try {
-                            $query->update($db->quoteName('#__bsms_mediafiles'))
-                                ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                                ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                            $db->execute();
-                            $rows  = $db->getAffectedRows();
-                            $added = $added + $rows;
-                        } catch (\RuntimeException $e) {
-                            $errortext .= $e->getMessage() . '<br />';
-                            $error++;
-                        }
-                    }
-                }
-
-                $msg .= Text::_('JBS_ERROR') . ': ' . $error . '<br />' . $errortext . '<br />' . Text::_(
-                    'JBS_RESULTS'
-                ) .
-                    ': ' . $added . ' ' . Text::_('JBS_SUCCESS');
-                break;
-            case 2:
-                $buttontype = $decoded->media_button_type;
-                $icontype   = $decoded->media_icon_type;
-
-                foreach ($images as $media) {
-                    $reg = new Registry();
-                    $reg->loadString($media->params);
-
-                    if ($reg->get('media_button_type') == $buttontype && $reg->get('media_icon_type') == $icontype) {
-                        $query = $db->createQuery();
-                        $reg->set('media_button_color', $post['media_button_color']);
-                        $reg->set('media_button_text', $post['media_button_text']);
-                        $reg->set('media_button_type', $post['media_button_type']);
-                        $reg->set('media_custom_icon', $post['media_custom_icon']);
-                        $reg->set('media_icon_type', $post['media_icon_type']);
-                        $reg->set('media_image', $post['media_image']);
-                        $reg->set('media_use_button_icon', $post['media_use_button_icon']);
-                        $db->setQuery($query);
-
-                        try {
-                            $query->update($db->quoteName('#__bsms_mediafiles'))
-                                ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                                ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                            $db->execute();
-                            $rows  = $db->getAffectedRows();
-                            $added = $added + $rows;
-                        } catch (\RuntimeException $e) {
-                            $errortext .= $e->getMessage() . '<br />';
-                            $error++;
-                        }
-                    }
-                }
-
-                $msg .= Text::_('JBS_ERROR') . ': ' . $error . '<br />' . $errortext . '<br />' . Text::_(
-                    'JBS_RESULTS'
-                ) .
-                    ': ' . $added . ' ' . Text::_('JBS_SUCCESS');
-                break;
-            case 3:
-                // Icon only
-                $icontype = $decoded->media_icon_type;
-
-                if (!isset($post['media_button_type'])) {
-                    $post['media_button_type'] = 0;
-                }
-
-                foreach ($images as $media) {
-                    $reg = new Registry();
-                    $reg->loadString($media->params);
-
-                    if ($reg->get('media_icon_type') == $icontype) {
-                        $query = $db->createQuery();
-                        $reg->set('media_button_color', $post['media_button_color']);
-                        $reg->set('media_button_text', $post['media_button_text']);
-                        $reg->set('media_button_type', $post['media_button_type']);
-                        $reg->set('media_custom_icon', $post['media_custom_icon']);
-                        $reg->set('media_icon_type', $post['media_icon_type']);
-                        $reg->set('media_image', $post['media_image']);
-                        $reg->set('media_use_button_icon', $post['media_use_button_icon']);
-                        $db->setQuery($query);
-
-                        try {
-                            $query->update($db->quoteName('#__bsms_mediafiles'))
-                                ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                                ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                            $db->execute();
-                            $rows  = $db->getAffectedRows();
-                            $added = $added + $rows;
-                        } catch (\RuntimeException $e) {
-                            $errortext .= $e->getMessage() . '<br />';
-                            $error++;
-                        }
-                    }
-                }
-
-                $msg .= Text::_('JBS_ERROR') . ': ' . $error . '<br />' . $errortext . '<br />' . Text::_(
-                    'JBS_RESULTS'
-                ) .
-                    ': ' . $added . ' ' . Text::_('JBS_SUCCESS');
-                break;
-            case 0:
-                // It's an image
-                $mediaimage = $decoded->media_image;
-
-                if (!isset($post['media_icon_type'])) {
-                    $post['media_icon_type'] = 0;
-                }
-
-                if (!isset($post['media_button_type'])) {
-                    $post['media_button_type'] = 0;
-                }
-
-                foreach ($images as $media) {
-                    $reg = new Registry();
-                    $reg->loadString($media->params);
-
-                    if ($reg->get('media_image') == $mediaimage) {
-                        $query = $db->createQuery();
-                        $reg->set('media_button_color', $post['media_button_color']);
-                        $reg->set('media_button_text', $post['media_button_text']);
-                        $reg->set('media_button_type', $post['media_button_type']);
-                        $reg->set('media_custom_icon', $post['media_custom_icon']);
-                        $reg->set('media_icon_type', $post['media_icon_type']);
-                        $reg->set('media_image', $post['media_image']);
-                        $reg->set('media_use_button_icon', $post['media_use_button_icon']);
-
-                        try {
-                            $db->setQuery($query);
-                            $query->update($db->quoteName('#__bsms_mediafiles'))
-                                ->set($db->quoteName('params') . ' = ' . $db->q($reg->toString()))
-                                ->where($db->quoteName('id') . ' = ' . (int)$media->id);
-                            $db->execute();
-                            $rows  = $db->getAffectedRows();
-                            $added += $rows;
-                        } catch (\RuntimeException $e) {
-                            $errortext .= $e->getMessage() . '<br />';
-                            $error++;
-                        }
-                    }
-                }
-
-                $msg .= Text::_('JBS_ERROR') . ': ' . $error . '<br />' . $errortext . '<br />' . Text::_(
-                    'JBS_RESULTS'
-                ) .
-                    ': ' . $added . ' ' . Text::_('JBS_SUCCESS');
-                break;
-            default:
-                $msg = Text::_('JBS_NOTHING_MATCHED');
-                break;
+        if (!$result['matched']) {
+            $msg = Text::_('JBS_NOTHING_MATCHED');
+        } else {
+            $msg = Text::_('JBS_RESULTS') . ': ' . Text::_('JBS_ERROR') . ': ' . $result['error'] . '<br />'
+                . $result['errortext'] . '<br />' . Text::_('JBS_RESULTS') . ': ' . $result['added'] . ' '
+                . Text::_('JBS_SUCCESS');
         }
 
         $this->setRedirect('index.php?option=com_proclaim&view=cwmadmin', $msg);
@@ -2237,20 +2019,7 @@ class CwmadminController extends FormController
         }
 
         try {
-            $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-            // Use optimized batch update with JSON functions
-            // This replaces the N+1 query pattern with a single UPDATE
-            $query = $db->createQuery()
-                ->update($db->quoteName('#__bsms_mediafiles'))
-                ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
-                    . $db->quote('"player":"' . $from . '"') . ', '
-                    . $db->quote('"player":"' . $to . '"') . ')')
-                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"player":"' . $from . '"%'));
-
-            $db->setQuery($query);
-            $db->execute();
-            $count = $db->getAffectedRows();
+            $count = $this->getModel()->changePlayer($from, $to);
 
             echo json_encode([
                 'success' => true,
@@ -2307,44 +2076,7 @@ class CwmadminController extends FormController
         }
 
         try {
-            $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-            // Handle legacy value mapping (100 = 0, etc.)
-            $searchFrom  = $from;
-            $searchFrom2 = null;
-
-            if ($from === '100') {
-                $searchFrom  = '0';
-                $searchFrom2 = '100';
-            }
-
-            $replaceTo = $to === '100' ? '' : $to;
-
-            // Use optimized batch update
-            $query = $db->createQuery()
-                ->update($db->quoteName('#__bsms_mediafiles'))
-                ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
-                    . $db->quote('"popup":"' . $searchFrom . '"') . ', '
-                    . $db->quote('"popup":"' . $replaceTo . '"') . ')')
-                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"popup":"' . $searchFrom . '"%'));
-
-            $db->setQuery($query);
-            $db->execute();
-            $count = $db->getAffectedRows();
-
-            // If there's a secondary search pattern (for legacy 100 value)
-            if ($searchFrom2 !== null) {
-                $query = $db->createQuery()
-                    ->update($db->quoteName('#__bsms_mediafiles'))
-                    ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
-                        . $db->quote('"popup":"' . $searchFrom2 . '"') . ', '
-                        . $db->quote('"popup":"' . $replaceTo . '"') . ')')
-                    ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"popup":"' . $searchFrom2 . '"%'));
-
-                $db->setQuery($query);
-                $db->execute();
-                $count += $db->getAffectedRows();
-            }
+            $count = $this->getModel()->changePopup($from, $to);
 
             echo json_encode([
                 'success' => true,
@@ -2363,6 +2095,11 @@ class CwmadminController extends FormController
 
     /**
      * Change Player by Media Type XHR - AJAX version with optimized batch update
+     *
+     * Deliberately left as-is (not extracted to the Model) as part of #1443:
+     * its WHERE clause queries 'media_image' as a table column, but that key
+     * only exists inside the JSON params blob -- every call throws a DB error.
+     * Moving broken SQL into the Model doesn't fix it; see #1492.
      *
      * @return void
      *

--- a/admin/src/Model/CwmadminModel.php
+++ b/admin/src/Model/CwmadminModel.php
@@ -630,6 +630,198 @@ class CwmadminModel extends AdminModel
     }
 
     /**
+     * Bulk-change the player used by all media files currently set to $from.
+     *
+     * Uses a single batch UPDATE ... REPLACE() rather than a per-row PHP loop.
+     * Live params data always stores 'player' as a quoted JSON string value
+     * (verified against j5-dev: all Server addons write it via Registry::set()
+     * with a string), so the LIKE/REPLACE substring match is equivalent to the
+     * legacy loose-compare ($reg->get('player', 0) == $from) it replaces.
+     *
+     * @param   string  $from  The player value to match.
+     * @param   string  $to    The player value to change matching rows to.
+     *
+     * @return  int  Number of rows updated.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public function changePlayer(string $from, string $to): int
+    {
+        $db = $this->getDatabase();
+
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__bsms_mediafiles'))
+            ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
+                . $db->quote('"player":"' . $from . '"') . ', '
+                . $db->quote('"player":"' . $to . '"') . ')')
+            ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"player":"' . $from . '"%'));
+
+        $db->setQuery($query);
+        $db->execute();
+
+        return $db->getAffectedRows();
+    }
+
+    /**
+     * Bulk-change the popup setting used by all media files currently set to $from.
+     *
+     * Value '100' is a legacy alias: as a "from" it also matches rows still
+     * storing the old '0' popup value, and as a "to" it maps to an empty
+     * string. The from/to normalization is resolved once up front (matching
+     * the batch pattern), not re-evaluated per row.
+     *
+     * @param   string  $from  The popup value to match ('100' also matches '0').
+     * @param   string  $to    The popup value to change matching rows to ('100' maps to '').
+     *
+     * @return  int  Number of rows updated.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public function changePopup(string $from, string $to): int
+    {
+        $db = $this->getDatabase();
+
+        $searchFrom  = $from;
+        $searchFrom2 = null;
+
+        if ($from === '100') {
+            $searchFrom  = '0';
+            $searchFrom2 = '100';
+        }
+
+        $replaceTo = $to === '100' ? '' : $to;
+
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__bsms_mediafiles'))
+            ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
+                . $db->quote('"popup":"' . $searchFrom . '"') . ', '
+                . $db->quote('"popup":"' . $replaceTo . '"') . ')')
+            ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"popup":"' . $searchFrom . '"%'));
+
+        $db->setQuery($query);
+        $db->execute();
+        $count = $db->getAffectedRows();
+
+        if ($searchFrom2 !== null) {
+            $query = $db->createQuery()
+                ->update($db->quoteName('#__bsms_mediafiles'))
+                ->set($db->quoteName('params') . ' = REPLACE(' . $db->quoteName('params') . ', '
+                    . $db->quote('"popup":"' . $searchFrom2 . '"') . ', '
+                    . $db->quote('"popup":"' . $replaceTo . '"') . ')')
+                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"popup":"' . $searchFrom2 . '"%'));
+
+            $db->setQuery($query);
+            $db->execute();
+            $count += $db->getAffectedRows();
+        }
+
+        return $count;
+    }
+
+    /**
+     * Determine which media_* params key(s) identify the matching rows for a
+     * mediaimages() bulk update, based on $decoded->media_use_button_icon.
+     *
+     * Pure decision logic (no DB access), split out so it can be unit tested
+     * without a database. Returns null for an unrecognized mode.
+     *
+     * @param   object  $decoded  Decoded 'mediaimage' JSON payload from the request.
+     *
+     * @return  array{keys: string[], values: array<int, mixed>}|null
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function resolveMediaImageMatcher(object $decoded): ?array
+    {
+        return match ((int) $decoded->media_use_button_icon) {
+            1       => ['keys' => ['media_button_type', 'media_button_text'], 'values' => [$decoded->media_button_type, $decoded->media_button_text]],
+            2       => ['keys' => ['media_button_type', 'media_icon_type'], 'values' => [$decoded->media_button_type, $decoded->media_icon_type]],
+            3       => ['keys' => ['media_icon_type'], 'values' => [$decoded->media_icon_type]],
+            0       => ['keys' => ['media_image'], 'values' => [$decoded->media_image]],
+            default => null,
+        };
+    }
+
+    /**
+     * Bulk-update the button/icon/image display params of all media files
+     * matching the mode described by $decoded (see resolveMediaImageMatcher()).
+     *
+     * Replaces mediaimages()'s four near-identical switch-case blocks (one
+     * per media_use_button_icon mode) with a single parameterized loop.
+     *
+     * @param   object  $decoded  Decoded 'mediaimage' JSON payload from the request.
+     * @param   array   $post     The raw 'jform' POST array with the new display values.
+     *
+     * @return  array{added: int, error: int, errortext: string, matched: bool}
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public function changeMediaImages(object $decoded, array $post): array
+    {
+        $matcher = self::resolveMediaImageMatcher($decoded);
+
+        if ($matcher === null) {
+            return ['added' => 0, 'error' => 0, 'errortext' => '', 'matched' => false];
+        }
+
+        $post['media_icon_type']   = $post['media_icon_type'] ?? 0;
+        $post['media_button_type'] = $post['media_button_type'] ?? 0;
+
+        $db    = $this->getDatabase();
+        $query = $db->createQuery();
+        $query->select($db->quoteName(['id', 'params']))
+            ->from($db->quoteName('#__bsms_mediafiles'));
+        $db->setQuery($query);
+        $images = $db->loadObjectList();
+
+        $added     = 0;
+        $error     = 0;
+        $errortext = '';
+
+        foreach ($images as $media) {
+            $reg = new Registry();
+            $reg->loadString($media->params);
+
+            $matches = true;
+
+            foreach ($matcher['keys'] as $i => $key) {
+                if ($reg->get($key) != $matcher['values'][$i]) {
+                    $matches = false;
+
+                    break;
+                }
+            }
+
+            if (!$matches) {
+                continue;
+            }
+
+            $reg->set('media_button_color', $post['media_button_color']);
+            $reg->set('media_button_text', $post['media_button_text']);
+            $reg->set('media_button_type', $post['media_button_type']);
+            $reg->set('media_custom_icon', $post['media_custom_icon']);
+            $reg->set('media_icon_type', $post['media_icon_type']);
+            $reg->set('media_image', $post['media_image']);
+            $reg->set('media_use_button_icon', $post['media_use_button_icon']);
+
+            try {
+                $updateQuery = $db->createQuery();
+                $updateQuery->update($db->quoteName('#__bsms_mediafiles'))
+                    ->set($db->quoteName('params') . ' = ' . $db->quote($reg->toString()))
+                    ->where($db->quoteName('id') . ' = ' . (int) $media->id);
+                $db->setQuery($updateQuery);
+                $db->execute();
+                $added += $db->getAffectedRows();
+            } catch (\RuntimeException $e) {
+                $errortext .= $e->getMessage() . '<br />';
+                $error++;
+            }
+        }
+
+        return ['added' => $added, 'error' => $error, 'errortext' => $errortext, 'matched' => true];
+    }
+
+    /**
      * Method to test whether a record can be deleted.
      *
      * @param   object  $record  A record object.

--- a/tests/unit/Admin/Controller/CwmadminControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmadminControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Unit tests for CwmadminController
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmadminController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1443: changePlayers(), changePopup(), and
+ * mediaimages() built and executed raw SQL directly in the controller
+ * (each with its own per-row N+1 loop), while changePlayersXHR() and
+ * changePopupXHR() duplicated the same job with a more efficient batch
+ * query. All five now delegate to CwmadminModel — see CwmadminModelTest.
+ *
+ * changePlayerByMediaTypeXHR() is deliberately left untouched: its query
+ * is independently broken (queries a table column that doesn't exist —
+ * see #1492) and moving broken SQL into the Model would not fix it.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmadminControllerTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmadminController method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmadminController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testChangePlayersDelegatesToModelAndHasNoRawSql(): void
+    {
+        $body = self::methodBody('changePlayers');
+
+        $this->assertMatchesRegularExpression('/getModel\(\)->changePlayer\(/', $body, 'changePlayers() must delegate to CwmadminModel::changePlayer() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/createQuery\(\)/', $body, 'changePlayers() must not build SQL directly — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'changePlayers() must not contain the old per-row loop — see #1443');
+    }
+
+    public function testChangePopupDelegatesToModelAndHasNoRawSql(): void
+    {
+        $body = self::methodBody('changePopup');
+
+        $this->assertMatchesRegularExpression('/getModel\(\)->changePopup\(/', $body, 'changePopup() must delegate to CwmadminModel::changePopup() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/createQuery\(\)/', $body, 'changePopup() must not build SQL directly — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'changePopup() must not contain the old per-row loop — see #1443');
+    }
+
+    public function testMediaimagesDelegatesToModelAndHasNoSwitchStatement(): void
+    {
+        $body = self::methodBody('mediaimages');
+
+        $this->assertMatchesRegularExpression('/getModel\(\)->changeMediaImages\(/', $body, 'mediaimages() must delegate to CwmadminModel::changeMediaImages() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bswitch\b/', $body, 'mediaimages() must not contain the old four-case switch — see #1443');
+    }
+
+    /**
+     * Regression test for the decode-mode bug bundled into #1443: the
+     * payload was decoded with json_decode(..., true, ...) (associative
+     * array) while every switch branch read it via `->` property access.
+     * See CwmadminModelTest::testResolveMatcherWorksAgainstRealJsonDecodedObject().
+     */
+    public function testMediaimagesDecodesPayloadAsObjectNotArray(): void
+    {
+        $body = self::methodBody('mediaimages');
+
+        $this->assertMatchesRegularExpression(
+            '/json_decode\(\s*\$post\[.mediaimage.\]\s*,\s*false\s*,/',
+            $body,
+            'mediaimages() must decode the payload as an object (associative=false) to match the `->` access used throughout — see #1443'
+        );
+    }
+
+    public function testChangePlayersXHRDelegatesToModelAndHasNoDuplicateSql(): void
+    {
+        $body = self::methodBody('changePlayersXHR');
+
+        $this->assertMatchesRegularExpression('/getModel\(\)->changePlayer\(/', $body, 'changePlayersXHR() must delegate to CwmadminModel::changePlayer() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/REPLACE\(/', $body, 'changePlayersXHR() must not duplicate the batch SQL now owned by the Model — see #1443');
+    }
+
+    public function testChangePopupXHRDelegatesToModelAndHasNoDuplicateSql(): void
+    {
+        $body = self::methodBody('changePopupXHR');
+
+        $this->assertMatchesRegularExpression('/getModel\(\)->changePopup\(/', $body, 'changePopupXHR() must delegate to CwmadminModel::changePopup() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/REPLACE\(/', $body, 'changePopupXHR() must not duplicate the batch SQL now owned by the Model — see #1443');
+    }
+
+    /**
+     * changePlayerByMediaTypeXHR() is intentionally NOT refactored here —
+     * its query is independently broken (see #1492) and this asserts the
+     * scoping decision is visible in the method body via the doc comment,
+     * not silently dropped.
+     */
+    public function testChangePlayerByMediaTypeXHRDocumentsWhyItWasSkipped(): void
+    {
+        $reflection = new \ReflectionMethod(CwmadminController::class, 'changePlayerByMediaTypeXHR');
+        $lines      = file($reflection->getFileName());
+        $docStart   = $reflection->getStartLine() - 10;
+        $docBlock   = implode('', \array_slice($lines, max(0, $docStart - 1), 10));
+
+        $this->assertStringContainsString('#1492', $docBlock, 'changePlayerByMediaTypeXHR() must document why it was left out of the #1443 refactor');
+    }
+}

--- a/tests/unit/Admin/Model/CwmadminModelTest.php
+++ b/tests/unit/Admin/Model/CwmadminModelTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Unit tests for CwmadminModel
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmadminModel;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1443: CwmadminController's legacy AJAX tools
+ * (changePlayers(), changePopup(), mediaimages()) built and executed raw SQL
+ * directly in the controller, each with its own per-row N+1 loop. That work
+ * moved into CwmadminModel::changePlayer()/changePopup()/changeMediaImages(),
+ * using the single-query batch REPLACE() pattern the newer XHR siblings
+ * (changePlayersXHR(), changePopupXHR()) already proved out, and both the
+ * legacy and XHR controller methods now delegate to the same model methods.
+ *
+ * mediaimages()'s four near-identical switch-case blocks collapsed into
+ * changeMediaImages(), backed by the pure resolveMediaImageMatcher() decision
+ * function tested directly here (no DB needed).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmadminModelTest extends ProclaimTestCase
+{
+    /**
+     * Invoke the private static resolveMediaImageMatcher() via reflection.
+     *
+     * @param   object  $decoded
+     *
+     * @return  array{keys: string[], values: array<int, mixed>}|null
+     */
+    private static function resolveMatcher(object $decoded): ?array
+    {
+        $method = new \ReflectionMethod(CwmadminModel::class, 'resolveMediaImageMatcher');
+
+        return $method->invoke(null, $decoded);
+    }
+
+    /**
+     * Get the source body of a CwmadminModel method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmadminModel::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testResolveMatcherButtonOnlyMode(): void
+    {
+        $decoded = (object) [
+            'media_use_button_icon' => 1,
+            'media_button_type'     => 'primary',
+            'media_button_text'     => 'Watch',
+        ];
+
+        $this->assertSame(
+            ['keys' => ['media_button_type', 'media_button_text'], 'values' => ['primary', 'Watch']],
+            self::resolveMatcher($decoded)
+        );
+    }
+
+    public function testResolveMatcherButtonAndIconMode(): void
+    {
+        $decoded = (object) [
+            'media_use_button_icon' => 2,
+            'media_button_type'     => 'primary',
+            'media_icon_type'       => 'fa-play',
+        ];
+
+        $this->assertSame(
+            ['keys' => ['media_button_type', 'media_icon_type'], 'values' => ['primary', 'fa-play']],
+            self::resolveMatcher($decoded)
+        );
+    }
+
+    public function testResolveMatcherIconOnlyMode(): void
+    {
+        $decoded = (object) [
+            'media_use_button_icon' => 3,
+            'media_icon_type'       => 'fa-play',
+        ];
+
+        $this->assertSame(
+            ['keys' => ['media_icon_type'], 'values' => ['fa-play']],
+            self::resolveMatcher($decoded)
+        );
+    }
+
+    public function testResolveMatcherImageMode(): void
+    {
+        $decoded = (object) [
+            'media_use_button_icon' => 0,
+            'media_image'           => 'images/biblestudy/streamingvideo24.png',
+        ];
+
+        $this->assertSame(
+            ['keys' => ['media_image'], 'values' => ['images/biblestudy/streamingvideo24.png']],
+            self::resolveMatcher($decoded)
+        );
+    }
+
+    public function testResolveMatcherUnknownModeReturnsNull(): void
+    {
+        $decoded = (object) ['media_use_button_icon' => 99];
+
+        $this->assertNull(self::resolveMatcher($decoded));
+    }
+
+    /**
+     * Regression test for the decode-mode bug bundled into #1443:
+     * mediaimages() used to json_decode() the payload as an associative
+     * array (2nd arg `true`) while every branch read it with `->` property
+     * access. PHP's loose `==` makes `null == 0` true, so the switch always
+     * silently fell into case 0 regardless of what was actually selected.
+     * Passing a genuine object (as the fixed controller now decodes it)
+     * through the real json_decode() path proves the matcher works against
+     * real request payloads, not just hand-built stdClass fixtures.
+     */
+    public function testResolveMatcherWorksAgainstRealJsonDecodedObject(): void
+    {
+        $json    = '{"media_use_button_icon":2,"media_button_type":"primary","media_icon_type":"fa-play"}';
+        $decoded = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(
+            ['keys' => ['media_button_type', 'media_icon_type'], 'values' => ['primary', 'fa-play']],
+            self::resolveMatcher($decoded)
+        );
+    }
+
+    public function testChangePlayerUsesSingleBatchUpdateNotPerRowLoop(): void
+    {
+        $body = self::methodBody('changePlayer');
+
+        $this->assertStringContainsString('REPLACE(', $body, 'changePlayer() must use a batch UPDATE ... REPLACE() — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'changePlayer() must not re-introduce a per-row N+1 loop — see #1443');
+    }
+
+    public function testChangePopupUsesBatchUpdatesNotPerRowLoop(): void
+    {
+        $body = self::methodBody('changePopup');
+
+        $this->assertSame(2, substr_count($body, 'REPLACE('), 'changePopup() must issue at most two batch REPLACE() updates (plain value + legacy "100" alias) — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'changePopup() must not re-introduce a per-row N+1 loop — see #1443');
+    }
+
+    public function testChangeMediaImagesHasOneLoopNotFourSwitchCases(): void
+    {
+        $body = self::methodBody('changeMediaImages');
+
+        $this->assertSame(1, substr_count($body, 'foreach ($images'), 'changeMediaImages() must collapse the four per-mode loops over $images into one — see #1443');
+        $this->assertDoesNotMatchRegularExpression('/\bswitch\b/', $body, 'changeMediaImages() must not re-introduce the mediaimages() switch statement — see #1443');
+    }
+}


### PR DESCRIPTION
## Summary

- `changePlayers()`, `changePopup()`, and `mediaimages()` built and executed raw SQL directly in the controller, each with its own per-row N+1 PHP loop. `changePlayersXHR()`/`changePopupXHR()` already proved out a more efficient single-query batch `REPLACE()` pattern, but that SQL also lived directly in the controller, duplicated across the legacy/XHR pairs.
- Moved the work into `CwmadminModel::changePlayer()`/`changePopup()`/`changeMediaImages()`, using the batch `REPLACE()` pattern throughout. All five controller methods now delegate to the same three model methods.
- `mediaimages()`'s four near-identical switch-case blocks collapsed into one loop backed by a pure `resolveMediaImageMatcher()` decision function (unit tested directly, including against real `json_decode()` output).
- Bonus fix found while touching this code: `mediaimages()` decoded its JSON payload as an associative array (`json_decode($json, true, ...)`) while every branch read it via `->` property access. PHP's loose `==` makes `null == 0` true, so the switch always silently fell into case 0 regardless of what was actually selected in the UI.
- `changePlayerByMediaTypeXHR()` is deliberately **not** touched here: its query references `media_image` as a table column, but that key only exists inside the JSON `params` blob — every call has been throwing a DB error independent of where the code lives. Filed separately as #1492 since fixing it requires a real semantic decision, not just a move.

## Verification

- 16 new regression tests (structural + pure-logic), all verified red against the pre-fix code (`git stash`) and green after — see `CwmadminModelTest` and `CwmadminControllerTest`.
- Full unit suite: 1018 tests / 2103 assertions, all passing.
- `composer lint:fix` clean on all changed files.
- Live-tested `changePlayers()` and `changePopup()` against j5-dev's real data (112-row and 1194-row bulk updates, both correct) — DB backed up beforehand and restored to its exact prior state afterward.
- `mediaimages()` has no live UI entry point in the current admin templates/JS (grepped — no template submits `jform[mediaimage]`), so it's covered by unit tests against real `json_decode()` output rather than a live click-test.

## Test plan

- [x] Unit tests pass (`composer test:unit`)
- [x] Lint clean (`composer lint:fix`)
- [x] Live-verified on j5-dev, DB restored afterward
- [x] CI green

Fixes #1443