### PR TITLE
refactor: extract CwmscriptureController's provider-fallback chain into a helper

### DIFF
--- a/site/src/Controller/CwmscriptureController.php
+++ b/site/src/Controller/CwmscriptureController.php
@@ -11,8 +11,7 @@
 
 namespace CWM\Component\Proclaim\Site\Controller;
 
-use CWM\Library\Scripture\Bible\AbstractBibleProvider;
-use CWM\Library\Scripture\Bible\BibleProviderFactory;
+use CWM\Component\Proclaim\Site\Helper\CwmscriptureLookupHelper;
 use CWM\Library\Scripture\Helper\ScriptureParamsHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Factory;
@@ -93,103 +92,7 @@ class CwmscriptureController extends BaseController
             $scriptureParams = new Registry();
         }
 
-        try {
-            AbstractBibleProvider::registerLogger();
-            $provider  = BibleProviderFactory::getProviderForTranslation($version, $scriptureParams);
-            $cacheDays = (int) $scriptureParams->get('cache_days', 30);
-
-            if ($cacheDays > 0 && method_exists($provider, 'setCacheTtl')) {
-                $provider->setCacheTtl($cacheDays * 86400);
-            }
-
-            $result      = $provider->getPassage($reference, $version);
-            $transient   = ($provider instanceof AbstractBibleProvider) && $provider->isLastErrorTransient();
-            $usedVersion = $version;
-
-            // Fallback 1: try same version via Local provider
-            if (!$result->hasText() && $provider->getName() !== 'local') {
-                try {
-                    $localProvider = BibleProviderFactory::getProvider('local');
-                    $localResult   = $localProvider->getPassage($reference, $version);
-
-                    if ($localResult->hasText()) {
-                        $result    = $localResult;
-                        $transient = false;
-                    }
-                } catch (\Throwable $e) {
-                    // Continue to next fallback
-                }
-            }
-
-            // Fallback 2: try admin default version locally
-            if (!$result->hasText()) {
-                $defaultVersion = (string) $scriptureParams->get('default_version', 'kjv');
-
-                if ($defaultVersion === '') {
-                    $defaultVersion = 'kjv';
-                }
-
-                if ($defaultVersion !== $version) {
-                    try {
-                        $localProvider = BibleProviderFactory::getProvider('local');
-                        $defaultResult = $localProvider->getPassage($reference, $defaultVersion);
-
-                        if ($defaultResult->hasText()) {
-                            $result      = $defaultResult;
-                            $usedVersion = $defaultVersion;
-                            $transient   = false;
-                        }
-                    } catch (\Throwable $e) {
-                        // Continue to hard fallback
-                    }
-                }
-            }
-
-            // Fallback 3: hard fallback to KJV (bundled, always auto-downloaded)
-            if ($usedVersion !== 'kjv' && !$result->hasText()) {
-                try {
-                    $localProvider = BibleProviderFactory::getProvider('local');
-                    $kjvResult     = $localProvider->getPassage($reference, 'kjv');
-
-                    if ($kjvResult->hasText()) {
-                        $result      = $kjvResult;
-                        $usedVersion = 'kjv';
-                        $transient   = false;
-                    }
-                } catch (\Throwable $e) {
-                    // Even KJV failed
-                }
-            }
-
-            $providerName = ($provider instanceof AbstractBibleProvider) ? $provider->getName() : 'unknown';
-
-            if ($result->hasText()) {
-                $this->sendJson($app, [
-                    'success'     => true,
-                    'text'        => $result->text,
-                    'copyright'   => $result->copyright,
-                    'translation' => $usedVersion,
-                    'fallback'    => $usedVersion !== $version,
-                    'provider'    => $providerName,
-                    'requested'   => $version,
-                ]);
-            } else {
-                $this->sendJson($app, [
-                    'success'   => false,
-                    'retryable' => $transient,
-                    'message'   => Text::_('COM_PROCLAIM_SCRIPTURE_AJAX_NO_PASSAGE_TEXT'),
-                    'provider'  => $providerName,
-                    'requested' => $version,
-                ]);
-            }
-        } catch (\Throwable $e) {
-            $this->sendJson($app, [
-                'success'   => false,
-                'retryable' => false,
-                'message'   => Text::sprintf('COM_PROCLAIM_SCRIPTURE_AJAX_PROVIDER_ERROR', $e->getMessage()),
-                'requested' => $version,
-            ]);
-        }
+        $this->sendJson($app, CwmscriptureLookupHelper::lookupPassage($reference, $version, $scriptureParams));
     }
 
     /**

--- a/site/src/Helper/CwmscriptureLookupHelper.php
+++ b/site/src/Helper/CwmscriptureLookupHelper.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Site\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Library\Scripture\Bible\AbstractBibleProvider;
+use CWM\Library\Scripture\Bible\BibleProviderFactory;
+use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
+
+/**
+ * Passage lookup with provider fallback for the scripture AJAX endpoint.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmscriptureLookupHelper
+{
+    /**
+     * Fetch a passage, falling back through local providers when the
+     * configured provider has no text for the requested translation.
+     *
+     * Fallback order: configured provider → local provider (same version)
+     * → local provider (admin default version) → local provider (KJV,
+     * bundled and always available).
+     *
+     * @param   string    $reference        Scripture reference (e.g. "John 3:16")
+     * @param   string    $version          Requested translation code
+     * @param   Registry  $scriptureParams  Scripture library params (cache_days, default_version)
+     *
+     * @return  array  Response payload, ready to serialize as the AJAX response
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function lookupPassage(string $reference, string $version, Registry $scriptureParams): array
+    {
+        try {
+            AbstractBibleProvider::registerLogger();
+            $provider  = BibleProviderFactory::getProviderForTranslation($version, $scriptureParams);
+            $cacheDays = (int) $scriptureParams->get('cache_days', 30);
+
+            if ($cacheDays > 0 && method_exists($provider, 'setCacheTtl')) {
+                $provider->setCacheTtl($cacheDays * 86400);
+            }
+
+            $result      = $provider->getPassage($reference, $version);
+            $transient   = ($provider instanceof AbstractBibleProvider) && $provider->isLastErrorTransient();
+            $usedVersion = $version;
+
+            // Fallback 1: try same version via Local provider
+            if (!$result->hasText() && $provider->getName() !== 'local') {
+                try {
+                    $localProvider = BibleProviderFactory::getProvider('local');
+                    $localResult   = $localProvider->getPassage($reference, $version);
+
+                    if ($localResult->hasText()) {
+                        $result    = $localResult;
+                        $transient = false;
+                    }
+                } catch (\Throwable $e) {
+                    // Continue to next fallback
+                }
+            }
+
+            // Fallback 2: try admin default version locally
+            if (!$result->hasText()) {
+                $defaultVersion = (string) $scriptureParams->get('default_version', 'kjv');
+
+                if ($defaultVersion === '') {
+                    $defaultVersion = 'kjv';
+                }
+
+                if ($defaultVersion !== $version) {
+                    try {
+                        $localProvider = BibleProviderFactory::getProvider('local');
+                        $defaultResult = $localProvider->getPassage($reference, $defaultVersion);
+
+                        if ($defaultResult->hasText()) {
+                            $result      = $defaultResult;
+                            $usedVersion = $defaultVersion;
+                            $transient   = false;
+                        }
+                    } catch (\Throwable $e) {
+                        // Continue to hard fallback
+                    }
+                }
+            }
+
+            // Fallback 3: hard fallback to KJV (bundled, always auto-downloaded)
+            if ($usedVersion !== 'kjv' && !$result->hasText()) {
+                try {
+                    $localProvider = BibleProviderFactory::getProvider('local');
+                    $kjvResult     = $localProvider->getPassage($reference, 'kjv');
+
+                    if ($kjvResult->hasText()) {
+                        $result      = $kjvResult;
+                        $usedVersion = 'kjv';
+                        $transient   = false;
+                    }
+                } catch (\Throwable $e) {
+                    // Even KJV failed
+                }
+            }
+
+            $providerName = ($provider instanceof AbstractBibleProvider) ? $provider->getName() : 'unknown';
+
+            if ($result->hasText()) {
+                return [
+                    'success'     => true,
+                    'text'        => $result->text,
+                    'copyright'   => $result->copyright,
+                    'translation' => $usedVersion,
+                    'fallback'    => $usedVersion !== $version,
+                    'provider'    => $providerName,
+                    'requested'   => $version,
+                ];
+            }
+
+            return [
+                'success'   => false,
+                'retryable' => $transient,
+                'message'   => Text::_('COM_PROCLAIM_SCRIPTURE_AJAX_NO_PASSAGE_TEXT'),
+                'provider'  => $providerName,
+                'requested' => $version,
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'success'   => false,
+                'retryable' => false,
+                'message'   => Text::sprintf('COM_PROCLAIM_SCRIPTURE_AJAX_PROVIDER_ERROR', $e->getMessage()),
+                'requested' => $version,
+            ];
+        }
+    }
+}

--- a/tests/unit/Site/Controller/CwmscriptureControllerTest.php
+++ b/tests/unit/Site/Controller/CwmscriptureControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Unit tests for CwmscriptureController
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Controller;
+
+use CWM\Component\Proclaim\Site\Controller\CwmscriptureController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1445: getPassageXHR() built a ~100-line, three-tier
+ * provider fallback chain (remote → local same version → local default
+ * version → hardcoded KJV) directly in the controller action. That logic
+ * moved into CwmscriptureLookupHelper::lookupPassage() — see
+ * CwmscriptureLookupHelperTest. getPassageXHR() now only handles the
+ * CSRF/reference-presence checks and serializes the helper's result.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmscriptureControllerTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmscriptureController method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmscriptureController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testGetPassageXHRHasNoProviderFallbackChain(): void
+    {
+        $body = self::methodBody('getPassageXHR');
+
+        $this->assertDoesNotMatchRegularExpression('/BibleProviderFactory::/', $body, 'getPassageXHR() must not call the provider factory directly — see #1445');
+        $this->assertDoesNotMatchRegularExpression('/Fallback \d:/', $body, 'getPassageXHR() must not contain the old fallback-chain comments/logic — see #1445');
+        $this->assertDoesNotMatchRegularExpression('/hasText\(\)/', $body, 'getPassageXHR() must not inspect provider results directly — see #1445');
+    }
+
+    public function testGetPassageXHRDelegatesToLookupHelper(): void
+    {
+        $body = self::methodBody('getPassageXHR');
+
+        $this->assertStringContainsString(
+            'CwmscriptureLookupHelper::lookupPassage(',
+            $body,
+            'getPassageXHR() must delegate the passage lookup to CwmscriptureLookupHelper — see #1445'
+        );
+    }
+
+    public function testGetPassageXHRStillChecksTokenAndReference(): void
+    {
+        $body = self::methodBody('getPassageXHR');
+
+        $this->assertStringContainsString('Session::checkToken(', $body, 'getPassageXHR() must still guard against CSRF — see #1445');
+        $this->assertStringContainsString('empty($reference)', $body, 'getPassageXHR() must still reject an empty reference — see #1445');
+    }
+}

--- a/tests/unit/Site/Helper/CwmscriptureLookupHelperTest.php
+++ b/tests/unit/Site/Helper/CwmscriptureLookupHelperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Unit tests for CwmscriptureLookupHelper
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\CwmscriptureLookupHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\Registry\Registry;
+
+/**
+ * Tests for the CwmscriptureLookupHelper class, extracted from
+ * CwmscriptureController::getPassageXHR() as part of #1445.
+ *
+ * lookupPassage() drives real Bible provider I/O (remote APIs, DB-backed
+ * local lookups whose seed data varies by environment), so full behavioral
+ * coverage lives in the live dispatch test performed against j5-dev during
+ * the #1445 investigation rather than here. These tests cover structure.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmscriptureLookupHelperTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmscriptureLookupHelper method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmscriptureLookupHelper::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testLookupPassageSignature(): void
+    {
+        $method = new \ReflectionMethod(CwmscriptureLookupHelper::class, 'lookupPassage');
+        $this->assertTrue($method->isStatic());
+        $this->assertReturnTypeName('array', $method);
+
+        $params = $method->getParameters();
+        $this->assertParamTypeName('string', $params[0]);
+        $this->assertParamTypeName('string', $params[1]);
+        $this->assertParamTypeName(Registry::class, $params[2]);
+    }
+
+    public function testLookupPassagePreservesThreeTierFallbackChain(): void
+    {
+        $body = self::methodBody('lookupPassage');
+
+        $this->assertStringContainsString('Fallback 1', $body, 'see #1445 — same version via local provider');
+        $this->assertStringContainsString('Fallback 2', $body, 'see #1445 — admin default version via local provider');
+        $this->assertStringContainsString('Fallback 3', $body, 'see #1445 — hard fallback to KJV');
+    }
+
+    public function testLookupPassageCatchesProviderExceptions(): void
+    {
+        $body = self::methodBody('lookupPassage');
+
+        $this->assertStringContainsString('catch (\Throwable $e)', $body);
+        $this->assertStringContainsString('COM_PROCLAIM_SCRIPTURE_AJAX_PROVIDER_ERROR', $body);
+    }
+
+    public function testLookupPassageReturnsArrayContractForBothOutcomes(): void
+    {
+        $body = self::methodBody('lookupPassage');
+
+        // Success branch
+        $this->assertStringContainsString("'success'     => true,", $body);
+        $this->assertStringContainsString("'translation' => \$usedVersion,", $body);
+
+        // Failure branches (no-text and provider-exception) both report retryable
+        $this->assertSame(2, substr_count($body, "'retryable' =>"), 'Both failure branches must report whether the failure is retryable — see #1445');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1445 — part of epic #1442 (move business logic out of controllers into Models/Helpers).

`CwmscriptureController::getPassageXHR()` (site AJAX endpoint for Bible version switching) built a ~100-line, three-tier provider fallback chain directly in the controller action: remote/configured provider → local provider (same version) → local provider (admin default version) → hardcoded KJV.

Extracted to `CwmscriptureLookupHelper::lookupPassage()` — a line-for-line move, not a rewrite, returning the exact same response array shape the controller previously built inline. The controller now only handles CSRF-token/reference validation and serializes the helper's result (223 lines → 127).

## Test plan

- [x] New `CwmscriptureControllerTest` + `CwmscriptureLookupHelperTest`: structural regression tests confirming the extraction (no provider-factory calls or fallback logic left in the controller, delegation to the helper, the three-tier fallback structure and array-contract shape preserved in the helper).
- [x] Verified new tests fail against pre-fix code (`git stash -u` the fix, confirm errors/failures; pop, confirm pass)
- [x] Full unit suite: 1065 tests, 0 regressions
- [x] `composer lint:fix` clean
- [x] **Live-tested** on j5-dev through the real frontend dispatch path: opened message #829 ("The Tossing of the Waves", has an `Ephesians 4:14-16` reference with a version switcher), switched from King James Version to American Standard Version — network request returned HTTP 200 and the passage text/copyright/version label updated correctly, confirming `getPassageXHR()` → `CwmscriptureLookupHelper::lookupPassage()` works end-to-end.

**Test depth note:** the structural tests confirm the extraction happened, not the fallback *behavior* — `lookupPassage()` drives real provider I/O (remote APIs, DB-backed local lookups whose seed data varies by environment), so it isn't practical to unit-test the fallback chain itself without mocking infrastructure this suite doesn't have yet. Behavioral confidence comes from (a) the extraction being a straight move with no logic changes, verified by diff review, and (b) the live dispatch test above exercising the real success path end-to-end.