### PR TITLE
fix: checkDeleteFiles() 500s on every call; dedupe with CwmmediafilesHelper

### DIFF
--- a/admin/src/Controller/CwmmediafilesController.php
+++ b/admin/src/Controller/CwmmediafilesController.php
@@ -18,11 +18,12 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmActionlogListTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediafilesHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Session\Session;
-use Joomla\Registry\Registry;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -106,54 +107,8 @@ class CwmmediafilesController extends AdminController
         ArrayHelper::toInteger($ids);
         $ids = array_filter($ids);
 
-        if (empty($ids)) {
-            header('Content-Type: application/json; charset=utf-8');
-            echo json_encode(['success' => true, 'hasFiles' => false, 'files' => []]);
-            $app->close();
-
-            return;
-        }
-
-        $db    = $this->getModel()->getDatabase();
-        $query = $db->createQuery()
-            ->select([
-                $db->quoteName('mf.id'),
-                $db->quoteName('mf.params', 'mf_params'),
-                $db->quoteName('sv.server_name'),
-                $db->quoteName('sv.params', 'sv_params'),
-                $db->quoteName('st.studytitle'),
-            ])
-            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->join('INNER', $db->quoteName('#__bsms_servers', 'sv') . ' ON ' . $db->quoteName('sv.id') . ' = ' . $db->quoteName('mf.server_id'))
-            ->join('LEFT', $db->quoteName('#__bsms_studies', 'st') . ' ON ' . $db->quoteName('st.id') . ' = ' . $db->quoteName('mf.study_id'))
-            ->whereIn($db->quoteName('mf.id'), $ids)
-            ->where($db->quoteName('mf.server_id') . ' > 0');
-        $db->setQuery($query);
-        $rows = $db->loadObjectList();
-
-        $files = [];
-
-        foreach ($rows as $row) {
-            $svParams = new Registry($row->sv_params ?: '{}');
-
-            if (!(int) $svParams->get('delete_files', 0)) {
-                continue;
-            }
-
-            $mfParams = new Registry($row->mf_params ?: '{}');
-            $filename = $mfParams->get('filename', '');
-
-            if ($filename === '') {
-                continue;
-            }
-
-            $files[] = [
-                'id'       => (int) $row->id,
-                'filename' => $filename,
-                'message'  => $row->studytitle ?: '',
-                'server'   => $row->server_name ?: '',
-            ];
-        }
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $files = CwmmediafilesHelper::findFilesForDelete($db, $ids, 'id');
 
         header('Content-Type: application/json; charset=utf-8');
         echo json_encode([

--- a/admin/src/Controller/CwmmessagesController.php
+++ b/admin/src/Controller/CwmmessagesController.php
@@ -18,11 +18,12 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmActionlogListTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediafilesHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Session\Session;
-use Joomla\Registry\Registry;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -106,54 +107,8 @@ class CwmmessagesController extends AdminController
         ArrayHelper::toInteger($ids);
         $ids = array_filter($ids);
 
-        if (empty($ids)) {
-            header('Content-Type: application/json; charset=utf-8');
-            echo json_encode(['success' => true, 'hasFiles' => false, 'files' => []]);
-            $app->close();
-
-            return;
-        }
-
-        $db    = $this->getModel()->getDatabase();
-        $query = $db->createQuery()
-            ->select([
-                $db->quoteName('mf.id'),
-                $db->quoteName('mf.params', 'mf_params'),
-                $db->quoteName('sv.server_name'),
-                $db->quoteName('sv.params', 'sv_params'),
-                $db->quoteName('st.studytitle'),
-            ])
-            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
-            ->join('INNER', $db->quoteName('#__bsms_servers', 'sv') . ' ON ' . $db->quoteName('sv.id') . ' = ' . $db->quoteName('mf.server_id'))
-            ->join('LEFT', $db->quoteName('#__bsms_studies', 'st') . ' ON ' . $db->quoteName('st.id') . ' = ' . $db->quoteName('mf.study_id'))
-            ->whereIn($db->quoteName('mf.study_id'), $ids)
-            ->where($db->quoteName('mf.server_id') . ' > 0');
-        $db->setQuery($query);
-        $rows = $db->loadObjectList();
-
-        $files = [];
-
-        foreach ($rows as $row) {
-            $svParams = new Registry($row->sv_params ?: '{}');
-
-            if (!(int) $svParams->get('delete_files', 0)) {
-                continue;
-            }
-
-            $mfParams = new Registry($row->mf_params ?: '{}');
-            $filename = $mfParams->get('filename', '');
-
-            if ($filename === '') {
-                continue;
-            }
-
-            $files[] = [
-                'id'       => (int) $row->id,
-                'filename' => $filename,
-                'message'  => $row->studytitle ?: '',
-                'server'   => $row->server_name ?: '',
-            ];
-        }
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $files = CwmmediafilesHelper::findFilesForDelete($db, $ids, 'study_id');
 
         header('Content-Type: application/json; charset=utf-8');
         echo json_encode([

--- a/admin/src/Helper/CwmmediafilesHelper.php
+++ b/admin/src/Helper/CwmmediafilesHelper.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\Database\DatabaseInterface;
+use Joomla\Registry\Registry;
+
+/**
+ * Shared query logic for the "check delete files" AJAX guard used before
+ * deleting media files (directly, by id) or messages (cascading, by
+ * study_id) — both need to warn the admin when the delete would also remove
+ * physical files on a delete-enabled server.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmediafilesHelper
+{
+    /**
+     * Find media files, among the given ids, that have a physical file on a
+     * delete-enabled server — the set a delete confirmation must warn about.
+     *
+     * @param   DatabaseInterface  $db        Database driver
+     * @param   int[]              $ids       Record ids to check
+     * @param   string             $idColumn  Which id the caller's $ids are: 'id' (media
+     *                                        file ids, CwmmediafilesController) or
+     *                                        'study_id' (message/study ids, CwmmessagesController)
+     *
+     * @return  array<int, array{id: int, filename: string, message: string, server: string}>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function findFilesForDelete(DatabaseInterface $db, array $ids, string $idColumn): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $column = match ($idColumn) {
+            'id', 'study_id' => $db->quoteName('mf.' . $idColumn),
+            default          => throw new \InvalidArgumentException('Invalid id column: ' . $idColumn),
+        };
+
+        $query = $db->createQuery()
+            ->select([
+                $db->quoteName('mf.id'),
+                $db->quoteName('mf.params', 'mf_params'),
+                $db->quoteName('sv.server_name'),
+                $db->quoteName('sv.params', 'sv_params'),
+                $db->quoteName('st.studytitle'),
+            ])
+            ->from($db->quoteName('#__bsms_mediafiles', 'mf'))
+            ->join('INNER', $db->quoteName('#__bsms_servers', 'sv') . ' ON ' . $db->quoteName('sv.id') . ' = ' . $db->quoteName('mf.server_id'))
+            ->join('LEFT', $db->quoteName('#__bsms_studies', 'st') . ' ON ' . $db->quoteName('st.id') . ' = ' . $db->quoteName('mf.study_id'))
+            ->whereIn($column, $ids)
+            ->where($db->quoteName('mf.server_id') . ' > 0');
+        $db->setQuery($query);
+        $rows = $db->loadObjectList();
+
+        $files = [];
+
+        foreach ($rows as $row) {
+            $svParams = new Registry($row->sv_params ?: '{}');
+
+            if (!(int) $svParams->get('delete_files', 0)) {
+                continue;
+            }
+
+            $mfParams = new Registry($row->mf_params ?: '{}');
+            $filename = $mfParams->get('filename', '');
+
+            if ($filename === '') {
+                continue;
+            }
+
+            $files[] = [
+                'id'       => (int) $row->id,
+                'filename' => $filename,
+                'message'  => $row->studytitle ?: '',
+                'server'   => $row->server_name ?: '',
+            ];
+        }
+
+        return $files;
+    }
+}

--- a/tests/unit/Admin/Controller/CwmmediafilesControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmmediafilesControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmmediafilesController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1448: checkDeleteFiles() built its own join query and
+ * Registry-parsing loop directly in the controller — duplicated verbatim in
+ * CwmmessagesController. Moved into CwmmediafilesHelper::findFilesForDelete();
+ * see CwmmediafilesHelperTest.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmediafilesControllerTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmmediafilesController method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmmediafilesController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testCheckDeleteFilesHasNoInlineQueryOrRegistryLoop(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertDoesNotMatchRegularExpression('/createQuery\(\)/', $body, 'checkDeleteFiles() must not build the query directly — see #1448');
+        $this->assertDoesNotMatchRegularExpression('/new Registry\(/', $body, 'checkDeleteFiles() must not parse server/media params directly — see #1448');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'checkDeleteFiles() must not contain the old row-processing loop — see #1448');
+    }
+
+    public function testCheckDeleteFilesDelegatesToSharedHelperById(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertStringContainsString(
+            "CwmmediafilesHelper::findFilesForDelete(\$db, \$ids, 'id')",
+            $body,
+            'CwmmediafilesController must check by media file id, not study_id — see #1448'
+        );
+    }
+
+    /**
+     * Pre-existing bug, caught live during the #1448 extraction: BaseDatabaseModel::getDatabase()
+     * is protected, so $this->getModel()->getDatabase() — present in this method since before
+     * this refactor — always 500'd. Fixed alongside the dedup by fetching DatabaseInterface from
+     * the container instead, matching the convention used everywhere else in this codebase.
+     */
+    public function testCheckDeleteFilesUsesContainerDatabaseNotProtectedModelMethod(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertStringNotContainsString(
+            'getModel()->getDatabase()',
+            $body,
+            'getModel()->getDatabase() calls a protected method and always 500s — see #1448'
+        );
+        $this->assertStringContainsString('Factory::getContainer()->get(DatabaseInterface::class)', $body);
+    }
+}

--- a/tests/unit/Admin/Controller/CwmmessagesControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmmessagesControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmmessagesController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1448: checkDeleteFiles() built its own join query and
+ * Registry-parsing loop directly in the controller — duplicated verbatim in
+ * CwmmediafilesController, differing only in matching mf.study_id instead of
+ * mf.id. Moved into CwmmediafilesHelper::findFilesForDelete(); see
+ * CwmmediafilesHelperTest.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmessagesControllerTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmmessagesController method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmmessagesController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testCheckDeleteFilesHasNoInlineQueryOrRegistryLoop(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertDoesNotMatchRegularExpression('/createQuery\(\)/', $body, 'checkDeleteFiles() must not build the query directly — see #1448');
+        $this->assertDoesNotMatchRegularExpression('/new Registry\(/', $body, 'checkDeleteFiles() must not parse server/media params directly — see #1448');
+        $this->assertDoesNotMatchRegularExpression('/\bforeach\b/', $body, 'checkDeleteFiles() must not contain the old row-processing loop — see #1448');
+    }
+
+    public function testCheckDeleteFilesDelegatesToSharedHelperByStudyId(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertStringContainsString(
+            "CwmmediafilesHelper::findFilesForDelete(\$db, \$ids, 'study_id')",
+            $body,
+            'CwmmessagesController must check by study_id (cascading message delete), not media file id — see #1448'
+        );
+    }
+
+    /**
+     * Pre-existing bug, caught live during the #1448 extraction: BaseDatabaseModel::getDatabase()
+     * is protected, so $this->getModel()->getDatabase() — present in this method since before
+     * this refactor — always 500'd. Fixed alongside the dedup by fetching DatabaseInterface from
+     * the container instead, matching the convention used everywhere else in this codebase.
+     */
+    public function testCheckDeleteFilesUsesContainerDatabaseNotProtectedModelMethod(): void
+    {
+        $body = self::methodBody('checkDeleteFiles');
+
+        $this->assertStringNotContainsString(
+            'getModel()->getDatabase()',
+            $body,
+            'getModel()->getDatabase() calls a protected method and always 500s — see #1448'
+        );
+        $this->assertStringContainsString('Factory::getContainer()->get(DatabaseInterface::class)', $body);
+    }
+}

--- a/tests/unit/Admin/Helper/CwmmediafilesHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmmediafilesHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediafilesHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Regression test for #1448: CwmmediafilesController and CwmmessagesController
+ * each implemented checkDeleteFiles() as a ~70-line near-verbatim duplicate
+ * (same join query + Registry parsing loop), differing only in whether the
+ * incoming ids are matched against mf.id or mf.study_id. Consolidated into
+ * CwmmediafilesHelper::findFilesForDelete(), taking the differing column as
+ * a parameter; confirmed byte-for-byte identical before extraction (`diff`
+ * on the two original method bodies showed exactly one line differed).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmediafilesHelperTest extends ProclaimTestCase
+{
+    public function testFindFilesForDeleteReturnsEmptyArrayForEmptyIds(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $this->assertSame([], CwmmediafilesHelper::findFilesForDelete($db, [], 'id'));
+    }
+
+    public function testFindFilesForDeleteRejectsUnknownColumn(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        CwmmediafilesHelper::findFilesForDelete($db, [1], 'not_a_real_column');
+    }
+
+    /**
+     * Real DB round-trip (not mocked) against the live query — no seeded
+     * media file on this dev site has server params.delete_files set, so
+     * this exercises the "no matching files" branch, but it does prove the
+     * query itself is syntactically valid against the real schema (a typo'd
+     * column/table name would fail here even though a mock could never
+     * catch it).
+     *
+     * @return void
+     */
+    public function testFindFilesForDeleteRunsRealQueryById(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $result = CwmmediafilesHelper::findFilesForDelete($db, [-1], 'id');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindFilesForDeleteRunsRealQueryByStudyId(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $result = CwmmediafilesHelper::findFilesForDelete($db, [-1], 'study_id');
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug fix**: `CwmmediafilesController::checkDeleteFiles()` and `CwmmessagesController::checkDeleteFiles()` both called `$this->getModel()->getDatabase()` — but `BaseDatabaseModel::getDatabase()` is `protected`, so calling it from a controller is a scope violation. This is not new to this PR: it predates the refactor (confirmed via `git show` on the pre-refactor commit) and means both AJAX endpoints have been returning HTTP 500 on every real invocation. Confirmed live: `cwmmediafiles.checkDeleteFiles?cid[]=<id>` and `cwmmessages.checkDeleteFiles?cid[]=<id>` both 500'd with `Call to protected method ...getDatabase() from scope ...Controller` before this fix, and return 200 with the expected JSON shape after.
- **Dedup** (#1448): the two controllers' `checkDeleteFiles()` bodies were a ~70-line near-verbatim duplicate (same join query + `Registry` parsing loop), differing only in matching `mf.id` vs `mf.study_id`. Extracted into `CwmmediafilesHelper::findFilesForDelete(DatabaseInterface $db, array $ids, string $idColumn)`.

**User-facing impact of the bug fix**: this endpoint backs the "physical files will be affected" warning modal in `media/js/delete-confirm.js` on the Media Files and Messages list views. When the endpoint fails, the JS `.catch()` deliberately falls through to the normal delete (`origSubmitbutton(task)`, "never block deletion on AJAX failure") — so delete itself was never broken, but the warning modal that tells an admin their action will also delete files off disk has not been firing.

**Not fixed here — filing separately**: while confirming this fix, I found the JS's own CSRF-token lookup (`form.querySelector('input[type="hidden"][value="1"]')`) matches the `delete_physical_files` hidden field before the actual token field in both list templates (same order in both `admin/tmpl/cwmmediafiles/default.php` and `admin/tmpl/cwmmessages/default.php` — `delete_physical_files` renders immediately before `HTMLHelper::_('form.token')`). That sends the wrong param to the endpoint, `Session::checkToken('get')` fails, and the modal is skipped for that reason too — independent of the bug fixed here. That's a JS-only fix with different blast radius, so it's out of scope for this PR; will file as a follow-up issue.

## Test plan

- [x] New/updated tests: `CwmmediafilesHelperTest` (4, including 2 real DB round-trips against `Factory::getContainer()->get(DatabaseInterface::class)`), `CwmmediafilesControllerTest` / `CwmmessagesControllerTest` (3 each, including a dedicated regression test pinning the `getDatabase()` fix)
- [x] Verified fail-before/pass-after via `git stash` (7 failures + 3 errors of 10 pre-fix; all 10 pass post-fix)
- [x] Full unit suite green, lint clean
- [x] Live-tested both endpoints in-browser with a valid CSRF token: `cwmmediafiles.checkDeleteFiles?cid[]=2470` → `{"success":true,"hasFiles":false,"files":[]}`; `cwmmessages.checkDeleteFiles?cid[]=829` → same shape
- [ ] Not exercised: the `hasFiles: true` branch / full delete-confirm modal flow — no server on this dev site has `delete_files=1` set, and triggering a real delete to test the modal path risked destructive side effects on dev data. That branch has no live or automated coverage beyond the helper's query-validity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)