### PR TITLE
fix: controller cleanup nits — legacy by-ref getModel(), duplicated shutdown handler, dead code

### DIFF
--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -28,7 +28,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\InstallerHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\MVC\Controller\FormController;
+use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Installer\Administrator\Model\DatabaseModel;
@@ -43,7 +43,7 @@ use Joomla\Filesystem\Path;
  * @package  Proclaim.Admin
  * @since    7.0.0
  */
-class CwmbackupController extends FormController
+class CwmbackupController extends BaseController
 {
     // =========================================================================
     // AJAX Export Methods
@@ -186,22 +186,7 @@ class CwmbackupController extends FormController
      */
     public function finalizeExportXHR(): void
     {
-        // Register a shutdown handler to catch fatal errors
-        register_shutdown_function(function () {
-            $error = error_get_last();
-
-            if ($error !== null && \in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
-                while (ob_get_level()) {
-                    ob_end_clean();
-                }
-                header('Content-Type: application/json; charset=utf-8');
-                echo json_encode([
-                    'success' => false,
-                    'message' => 'PHP Fatal: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'],
-                    'data'    => [],
-                ], JSON_THROW_ON_ERROR);
-            }
-        });
+        $this->registerFatalErrorShutdownHandler();
 
         try {
             // Check for request forgeries
@@ -581,22 +566,7 @@ class CwmbackupController extends FormController
      */
     public function postRestoreStepXHR(): void
     {
-        // Register a shutdown handler to catch fatal errors
-        register_shutdown_function(function () {
-            $error = error_get_last();
-
-            if ($error !== null && \in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
-                while (ob_get_level()) {
-                    ob_end_clean();
-                }
-                header('Content-Type: application/json; charset=utf-8');
-                echo json_encode([
-                    'success' => false,
-                    'message' => 'PHP Fatal: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'],
-                    'data'    => [],
-                ], JSON_THROW_ON_ERROR);
-            }
-        });
+        $this->registerFatalErrorShutdownHandler();
 
         try {
             if (!Session::checkToken('get') && !Session::checkToken()) {
@@ -674,22 +644,7 @@ class CwmbackupController extends FormController
         ini_set('display_errors', '0');
         ob_start();
 
-        // Register a shutdown handler to catch fatal errors
-        register_shutdown_function(function () {
-            $error = error_get_last();
-
-            if ($error !== null && \in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
-                while (ob_get_level()) {
-                    ob_end_clean();
-                }
-                header('Content-Type: application/json; charset=utf-8');
-                echo json_encode([
-                    'success' => false,
-                    'message' => 'PHP Fatal: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'],
-                    'data'    => [],
-                ], JSON_THROW_ON_ERROR);
-            }
-        });
+        $this->registerFatalErrorShutdownHandler();
 
         try {
             // Check for request forgeries
@@ -1116,5 +1071,32 @@ class CwmbackupController extends FormController
 
         // Use exit instead of $app->close() to avoid any shutdown processing issues
         exit(0);
+    }
+
+    /**
+     * Register a shutdown handler that reports a PHP fatal error as JSON
+     * instead of letting it surface as a blank/HTML response to an XHR caller.
+     *
+     * @return void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function registerFatalErrorShutdownHandler(): void
+    {
+        register_shutdown_function(function () {
+            $error = error_get_last();
+
+            if ($error !== null && \in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+                while (ob_get_level()) {
+                    ob_end_clean();
+                }
+                header('Content-Type: application/json; charset=utf-8');
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'PHP Fatal: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line'],
+                    'data'    => [],
+                ], JSON_THROW_ON_ERROR);
+            }
+        });
     }
 }

--- a/api/src/Controller/SermonsController.php
+++ b/api/src/Controller/SermonsController.php
@@ -33,6 +33,26 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 class SermonsController extends AbstractWritableController
 {
     /**
+     * The content type for serialization.
+     *
+     * @var    string
+     * @since  10.3.0
+     */
+    protected $contentType = 'sermons';
+
+    /**
+     * The default view for the display method.
+     *
+     * @var    string
+     * @since  10.3.0
+     */
+    protected $default_view = 'sermons';
+
+    protected $logType = 'message';
+
+    protected $logTitleField = 'studytitle';
+
+    /**
      * List sermons — published and archived only.
      *
      * Supports query filters: ?filter[teacher]=5&filter[series]=3&filter[search]=keyword
@@ -78,26 +98,6 @@ class SermonsController extends AbstractWritableController
 
         return parent::displayList();
     }
-
-    /**
-     * The content type for serialization.
-     *
-     * @var    string
-     * @since  10.3.0
-     */
-    protected $contentType = 'sermons';
-
-    /**
-     * The default view for the display method.
-     *
-     * @var    string
-     * @since  10.3.0
-     */
-    protected $default_view = 'sermons';
-
-    protected $logType = 'message';
-
-    protected $logTitleField = 'studytitle';
 
     /**
      * Get the model, mapping API names to Cwm-prefixed model classes.

--- a/site/src/Controller/CwmseriesdisplayController.php
+++ b/site/src/Controller/CwmseriesdisplayController.php
@@ -49,6 +49,6 @@ class CwmseriesdisplayController extends BaseController
      */
     public function display($cachable = false, $urlparams = []): static
     {
-        return parent::display();
+        return parent::display($cachable, $urlparams);
     }
 }

--- a/site/src/Controller/CwmseriesdisplaysController.php
+++ b/site/src/Controller/CwmseriesdisplaysController.php
@@ -11,13 +11,11 @@
 
 namespace CWM\Component\Proclaim\Site\Controller;
 
-use CWM\Component\Proclaim\Site\Helper\Cwmimages;
 use CWM\Component\Proclaim\Site\Helper\Cwmlisting;
-use CWM\Component\Proclaim\Site\Helper\Cwmpagebuilder;
+use CWM\Component\Proclaim\Site\Helper\CwmseriesdisplaysHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -39,15 +37,13 @@ class CwmseriesdisplaysController extends BaseController
      * @param   string  $prefix  The prefix for the PHP class name
      * @param   array   $config  Set ignore request
      *
-     * @return BaseDatabaseModel|bool
+     * @return  BaseDatabaseModel
      *
      * @since 7.0
      */
-    public function &getModel($name = 'Cwmseriesdisplays', $prefix = 'Model', $config = ['ignore_request' => true]): BaseDatabaseModel|bool
+    public function getModel($name = 'Cwmseriesdisplays', $prefix = 'Model', $config = ['ignore_request' => true]): BaseDatabaseModel
     {
-        $model = parent::getModel($name, $prefix, $config);
-
-        return $model;
+        return parent::getModel($name, $prefix, $config);
     }
 
     /**
@@ -82,35 +78,11 @@ class CwmseriesdisplaysController extends BaseController
             $template = $state->get('template');
             $params   = $state->get('params');
 
-            $items       = $model->getItems();
-            $pagination  = $model->getPagination();
-            $pagebuilder = new Cwmpagebuilder();
+            $items      = $model->getItems();
+            $pagination = $model->getPagination();
 
             // Prepare items the same way the HtmlView does
-            foreach ($items as $item) {
-                $item->slug  = $item->alias ? ($item->id . ':' . $item->alias) : $item->id . ':'
-                    . str_replace(' ', '-', htmlspecialchars_decode($item->series_text, ENT_QUOTES));
-                $seriesimage = Cwmimages::getSeriesThumbnail($item->series_thumbnail);
-
-                if ($seriesimage->path) {
-                    $item->image = Cwmimages::renderPicture($seriesimage, $item->series_text ?? '');
-                }
-
-                $item->serieslink = Route::_(
-                    'index.php?option=com_proclaim&view=cwmseriesdisplay&id=' . $item->slug . '&t=' . $template->id
-                );
-                $teacherimage     = Cwmimages::getTeacherImage($item->thumb ?? '');
-
-                if ($teacherimage->path) {
-                    $item->teacherimage = Cwmimages::renderPicture($teacherimage, $item->teachername ?? '');
-                }
-
-                if (isset($item->description)) {
-                    $item->text        = $item->description;
-                    $description       = $pagebuilder->runContentPlugins($item, $params);
-                    $item->description = $description->text;
-                }
-            }
+            $items = CwmseriesdisplaysHelper::prepareItems($items, $params, $template);
 
             // Render using the same listing helper
             $listing = new Cwmlisting();

--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -369,14 +369,8 @@ class CwmsermonController extends FormController
      */
     protected function allowAdd($data = []): bool
     {
-        $allow = null;
-
-        if ($allow === null) {
-            // In the absence of better information, revert to the component permissions.
-            return parent::allowAdd();
-        }
-
-        return $allow;
+        // In the absence of better information, revert to the component permissions.
+        return parent::allowAdd();
     }
 
     /**

--- a/site/src/Controller/CwmsermonsController.php
+++ b/site/src/Controller/CwmsermonsController.php
@@ -19,6 +19,7 @@ use CWM\Component\Proclaim\Site\Helper\Cwmmedia;
 use CWM\Component\Proclaim\Site\Model\CwmsermonsModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -121,6 +122,13 @@ class CwmsermonsController extends BaseController
     {
         $app = Factory::getApplication();
         header('Content-Type: application/json; charset=utf-8');
+
+        if (!Session::checkToken('get')) {
+            echo json_encode(['success' => false, 'message' => 'Invalid token'], JSON_THROW_ON_ERROR);
+            $app->close();
+
+            return;
+        }
 
         CwmDebug::startTimer('filterAjax');
 

--- a/site/src/Controller/CwmteachersController.php
+++ b/site/src/Controller/CwmteachersController.php
@@ -13,7 +13,6 @@ namespace CWM\Component\Proclaim\Site\Controller;
 
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\CMS\User\CurrentUserInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -34,14 +33,12 @@ class CwmteachersController extends BaseController
      * @param   string  $prefix  The prefix for the PHP class name
      * @param   array   $config  Set ignore request
      *
-     * @return bool|BaseDatabaseModel|CurrentUserInterface $model
+     * @return  BaseDatabaseModel
      *
      * @since 7.0
      */
-    public function &getModel($name = 'Cwmteacher', $prefix = '', $config = ['ignore_request' => true]): CurrentUserInterface|BaseDatabaseModel|bool
+    public function getModel($name = 'Cwmteachers', $prefix = '', $config = ['ignore_request' => true]): BaseDatabaseModel
     {
-        $model = parent::getModel($name, $prefix, $config);
-
-        return $model;
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/site/src/Controller/DisplayController.php
+++ b/site/src/Controller/DisplayController.php
@@ -42,10 +42,9 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
     {
         // Get input early to check view before parent construction.
         $appInput = $input ?? Factory::getApplication()->getInput();
+        $view     = $appInput->get('view');
 
-        if ($appInput->get('view') === 'cwmlandingpage' && $appInput->get('layout') === 'modal') {
-            $config['base_path'] = JPATH_ADMINISTRATOR . '/components';
-        } elseif ($appInput->get('view') === 'cwmsermons' && $appInput->get('layout') === 'modal') {
+        if (($view === 'cwmlandingpage' || $view === 'cwmsermons') && $appInput->get('layout') === 'modal') {
             $config['base_path'] = JPATH_ADMINISTRATOR . '/components';
         }
 

--- a/site/src/Helper/CwmseriesdisplaysHelper.php
+++ b/site/src/Helper/CwmseriesdisplaysHelper.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Site\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Router\Route;
+use Joomla\Registry\Registry;
+
+/**
+ * Shared item-prep logic for series-display listings.
+ *
+ * @package  Proclaim.Site
+ * @since    __DEPLOY_VERSION__
+ */
+class CwmseriesdisplaysHelper
+{
+    /**
+     * Prepare raw series rows for rendering: slug/link generation, thumbnail
+     * and teacher-image resolution, and content-plugin processing on the
+     * description. Shared by CwmseriesdisplaysController::paginateAjax() and
+     * Cwmseriesdisplays HtmlView::display() so both entry points render
+     * identically.
+     *
+     * @param   array          $items     Raw series rows from CwmseriesdisplaysModel::getItems()
+     * @param   Registry|null  $params    Template params (passed to content plugins); may be
+     *                                    absent when called outside the normal display() flow
+     * @param   object|null    $template  Active template row (only ->id is used)
+     *
+     * @return  array  The same $items, mutated in place
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function prepareItems(array $items, ?Registry $params, ?object $template): array
+    {
+        $pagebuilder = new Cwmpagebuilder();
+
+        foreach ($items as $item) {
+            $item->slug  = $item->alias ? ($item->id . ':' . $item->alias) : $item->id . ':'
+                . str_replace(' ', '-', htmlspecialchars_decode($item->series_text, ENT_QUOTES));
+            $seriesimage = Cwmimages::getSeriesThumbnail($item->series_thumbnail);
+
+            if ($seriesimage->path) {
+                $item->image = Cwmimages::renderPicture($seriesimage, $item->series_text ?? '');
+            }
+
+            $item->serieslink = Route::_(
+                'index.php?option=com_proclaim&view=cwmseriesdisplay&id=' . $item->slug . '&t=' . ($template?->id ?? '')
+            );
+            $teacherimage     = Cwmimages::getTeacherImage($item->thumb ?? '');
+
+            if ($teacherimage->path) {
+                $item->teacherimage = Cwmimages::renderPicture($teacherimage, $item->teachername ?? '');
+            }
+
+            if (isset($item->description)) {
+                $item->text        = $item->description;
+                $description       = $pagebuilder->runContentPlugins($item, $params);
+                $item->description = $description->text;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/site/src/View/Cwmseriesdisplays/HtmlView.php
+++ b/site/src/View/Cwmseriesdisplays/HtmlView.php
@@ -19,7 +19,7 @@ namespace CWM\Component\Proclaim\Site\View\Cwmseriesdisplays;
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmimages;
 use CWM\Component\Proclaim\Site\Helper\Cwmlisting;
-use CWM\Component\Proclaim\Site\Helper\Cwmpagebuilder;
+use CWM\Component\Proclaim\Site\Helper\CwmseriesdisplaysHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmserieslist;
 use CWM\Component\Proclaim\Site\Helper\UpdateFiltersTrait;
 use Joomla\CMS\Factory;
@@ -27,7 +27,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
@@ -160,37 +159,16 @@ class HtmlView extends BaseHtmlView
         $this->template = $this->state->get('template');
 
         $uri                   = new Uri();
-        $pagebuilder           = new Cwmpagebuilder();
         $items                 = $this->get('Items');
         $this->activeFilters   = $this->get('ActiveFilters');
 
         // Get a filter form.
         $this->filterForm = $this->get('FilterForm');
-        // Adjust the slug if there is no alias in the row
-        foreach ($items as $item) {
-            $item->slug  = $item->alias ? ($item->id . ':' . $item->alias) : $item->id . ':'
-                . str_replace(' ', '-', htmlspecialchars_decode($item->series_text, ENT_QUOTES));
-            $seriesimage = Cwmimages::getSeriesThumbnail($item->series_thumbnail);
 
-            if ($seriesimage->path) {
-                $item->image = Cwmimages::renderPicture($seriesimage, $item->series_text ?? '');
-            }
-
-            $item->serieslink = Route::_(
-                'index.php?option=com_proclaim&view=cwmseriesdisplay&id=' . $item->slug . '&t=' . $this->template->id
-            );
-            $teacherimage     = Cwmimages::getTeacherImage($item->thumb ?? '');
-
-            if ($teacherimage->path) {
-                $item->teacherimage = Cwmimages::renderPicture($teacherimage, $item->teachername ?? '');
-            }
-
-            if (isset($item->description)) {
-                $item->text        = $item->description;
-                $description       = $pagebuilder->runContentPlugins($item, $params);
-                $item->description = $description->text;
-            }
-        }
+        // Adjust the slug if there is no alias in the row; the same prep
+        // runs in CwmseriesdisplaysController::paginateAjax() so both entry
+        // points render identically.
+        $items = CwmseriesdisplaysHelper::prepareItems($items, $params, $this->template);
 
         $this->items           = $items;
         $pagination            = $this->get('Pagination');

--- a/tests/unit/Admin/Controller/CwmbackupControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmbackupControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmbackupController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression test for #1450: finalizeExportXHR(), postRestoreStepXHR(), and
+ * finalizeImportXHR() each inlined an identical register_shutdown_function()
+ * fatal-error-catching block. Extracted into a single private
+ * registerFatalErrorShutdownHandler(), called from all three. Also pins the
+ * FormController → BaseController base-class change (this controller is a
+ * pure AJAX method bag; it never calls save/edit/cancel/getForm()).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmbackupControllerTest extends ProclaimTestCase
+{
+    private static function fileSource(): string
+    {
+        $reflection = new \ReflectionClass(CwmbackupController::class);
+
+        return file_get_contents($reflection->getFileName());
+    }
+
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmbackupController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testExtendsBaseControllerNotFormController(): void
+    {
+        $reflection = new \ReflectionClass(CwmbackupController::class);
+
+        $this->assertSame(
+            \Joomla\CMS\MVC\Controller\BaseController::class,
+            $reflection->getParentClass()->getName(),
+            'CwmbackupController is a pure AJAX method bag (no save/edit/cancel/getForm) — see #1450'
+        );
+    }
+
+    public function testRegisterShutdownFunctionAppearsExactlyOnce(): void
+    {
+        $count = substr_count(self::fileSource(), 'register_shutdown_function(');
+
+        $this->assertSame(
+            1,
+            $count,
+            'register_shutdown_function() must be called from a single shared helper, not duplicated per XHR method — see #1450'
+        );
+    }
+
+    #[DataProvider('xhrMethodsProvider')]
+    public function testXhrMethodDelegatesToSharedShutdownHandler(string $method): void
+    {
+        $body = self::methodBody($method);
+
+        $this->assertStringContainsString(
+            '$this->registerFatalErrorShutdownHandler();',
+            $body,
+            $method . '() must register the fatal-error handler via the shared helper — see #1450'
+        );
+        $this->assertStringNotContainsString('register_shutdown_function(', $body);
+    }
+
+    public static function xhrMethodsProvider(): array
+    {
+        return [
+            'finalizeExportXHR'  => ['finalizeExportXHR'],
+            'postRestoreStepXHR' => ['postRestoreStepXHR'],
+            'finalizeImportXHR'  => ['finalizeImportXHR'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Bundle of low-impact controller cleanups from the #1442 MVC audit (#1450). Each item independently verified against the current code before fixing — a few of the issue's original claims didn't quite match what's actually in the codebase; noted below.

- **Legacy by-ref `&getModel()`**: dropped in `CwmteachersController` and `CwmseriesdisplaysController` (J3-era pattern; J5/J6 `BaseController::getModel()` isn't by-reference — confirmed against the current `joomla-cms` source). Narrowed return types to `BaseDatabaseModel` to match every other `getModel()` override in this codebase. Fixed `CwmteachersController`'s default model name (was singular `'Cwmteacher'` on a plural list controller) and dropped its nonsensical `CurrentUserInterface|BaseDatabaseModel|bool` union type.
- **`CwmbackupController` shutdown-handler triplication**: the identical `register_shutdown_function` fatal-error-catching block was copy-pasted verbatim 3x (confirmed byte-identical via diff). Extracted into one private `registerFatalErrorShutdownHandler()`. Also switched the base class from `FormController` to `BaseController` — verified via grep that it never calls `save()`/`edit()`/`cancel()`/`add()`/`getForm()`, is dispatched only via `task=cwmbackup.*XHR`, and confirmed via `joomla-cms` source that `MVCFactory::createController()` gracefully skips `setFormFactoryOnObject()` when the class doesn't implement `FormFactoryAwareInterface` (no crash). Live-tested `cwmbackup.getExportTablesXHR` post-swap on j5-dev: 200, correct JSON.
- **`CwmseriesdisplayController::display()`** declared `$cachable`/`$urlparams` but called `parent::display()` with no args. Passed them through. Confirmed this is a no-op today — Joomla's own dispatch (`BaseController::execute()`) always calls `display()` with zero args, so both params are always at their declared defaults — but the override should forward what it declares.
- **Dead code in `CwmsermonController::allowAdd()`**: `$allow = null; if ($allow === null) { return parent::allowAdd(); } return $allow;` — the second branch is unreachable. Collapsed to a bare `return parent::allowAdd();`.
- **CSRF check added to `CwmsermonsController::filterAjax()`**. Note: the issue text said filterAjax's "sibling paginateAjax()" has this check — `CwmsermonsController` has no `paginateAjax()` method at all; the sibling with the check is actually `CwmseriesdisplaysController::paginateAjax()` (different class). The underlying claim (filterAjax lacked a check) was correct regardless. Before adding it, confirmed the JS caller (`sermon-filters.es6.js`'s `buildQueryString()`) already appends the CSRF token unconditionally via `opts.csrfToken`, so no caller-side change needed. Live-tested both paths on j5-dev: valid token → 200/success; no token → 200/`{"success":false,"message":"Invalid token"}`.
- **Item-prep dedup**: the issue described this as `filterAjax()`/`paginateAjax()` duplicating `HtmlView` logic within `CwmsermonsController` — that combination doesn't exist there either. The real ~40-line verbatim duplicate is between `CwmseriesdisplaysController::paginateAjax()` and `Cwmseriesdisplays/HtmlView::display()` (confirmed byte-identical via diff). Extracted into `CwmseriesdisplaysHelper::prepareItems()`, used by both.
  - **Pre-existing bug found via live testing** (not introduced by this PR — confirmed via `git stash` against unmodified `development`, same failure before and after): `cwmseriesdisplays.paginateAjax` always 500s because `$state->get('params')`/`$state->get('template')` are null when the model is fetched directly (`$this->getModel(...)`) outside the normal `display()` flow, and that null then hits strictly-typed downstream calls (`Cwmpagebuilder::runContentPlugins()`, `Cwmlisting::getFluidListing()`). Loosened the new helper's params to nullable to match what the call site actually passes (matching the original's implicit tolerance), but did **not** fix the root state-population bug — filed separately as **#1502** since it's a deeper, unrelated issue. The normal `view=cwmseriesdisplays` page load is unaffected (uses the `display()` flow, not this AJAX path) — live-verified on j5-dev, renders correctly with images/links.
- **`DisplayController`**: collapsed two identical `elseif` bodies (`cwmlandingpage` vs `cwmsermons` modal-layout check) into one condition.
- **`api/src/Controller/SermonsController.php`**: reordered properties before methods, matching every sibling API controller (style-only).

**Deferred to a follow-up** (#1503): the JSON-response mechanism sprawl (5 duplicated `sendJsonResponse()` implementations, plus `JsonResponse`, hand-rolled `json_encode`, and `CWMAddon::outputJson()` — actually more duplication than the issue's original "3x" estimate). This is a real multi-file refactor with its own blast radius; the issue text itself called it "not urgent," so bundling it here would make this PR unreviewable.

## Test plan

- [x] New regression test `CwmbackupControllerTest` (5 tests: base-class assertion, single `register_shutdown_function` call site, all 3 XHR methods delegate to the shared helper) — verified fail-before/pass-after via `git stash`
- [x] Full unit suite green (1101 tests, 2242 assertions), lint clean (after reverting unrelated pre-existing submodule drift)
- [x] Live-tested on j5-dev: `cwmbackup.getExportTablesXHR` (base-class swap), `cwmsermons.filterAjax` with and without CSRF token, `cwmseriesdisplays.paginateAjax` (pre-existing 500 confirmed unchanged), `view=cwmseriesdisplays` list page, `view=cwmteachers` list page, `view=cwmsermons` (exercises the collapsed `DisplayController` branch), and the individual series-display detail page (`CwmseriesdisplayController::display()` arg-forwarding fix) — all render correctly, no PHP warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)