### PR TITLE
fix: cwmseriesdisplays.paginateAjax always 500'd — two distinct root causes

### DIFF
--- a/site/src/Controller/CwmseriesdisplaysController.php
+++ b/site/src/Controller/CwmseriesdisplaysController.php
@@ -33,15 +33,23 @@ class CwmseriesdisplaysController extends BaseController
     /**
      * Proxy for getModel
      *
+     * Unlike the single-item site controllers this codebase otherwise
+     * follows (CwmsermonController, CwmteachersController), this wraps a
+     * ListModel — ignore_request => true here would set __state_set in
+     * BaseModel::__construct(), permanently skipping populateState() and
+     * leaving list/filter/template state empty for any caller (like
+     * paginateAjax()) that fetches the model with fewer than 3 args. See
+     * #1502.
+     *
      * @param   string  $name    The name of the model
      * @param   string  $prefix  The prefix for the PHP class name
-     * @param   array   $config  Set ignore request
+     * @param   array   $config  Configuration array for the model
      *
      * @return  BaseDatabaseModel
      *
      * @since 7.0
      */
-    public function getModel($name = 'Cwmseriesdisplays', $prefix = 'Model', $config = ['ignore_request' => true]): BaseDatabaseModel
+    public function getModel($name = 'Cwmseriesdisplays', $prefix = 'Model', $config = []): BaseDatabaseModel
     {
         return parent::getModel($name, $prefix, $config);
     }
@@ -98,7 +106,10 @@ class CwmseriesdisplaysController extends BaseController
                 'total'      => $pagination->total,
                 'pagesTotal' => $pagination->pagesTotal,
             ], JSON_THROW_ON_ERROR);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // \Throwable (not \Exception): a graceful {success:false} beats an
+            // unhandled fatal HTML page for an endpoint whose only consumer is
+            // fetch()-based JS expecting JSON. See #1502.
             echo json_encode([
                 'success' => false,
                 'message' => 'Failed to load results',

--- a/site/src/Model/CwmseriesdisplaysModel.php
+++ b/site/src/Model/CwmseriesdisplaysModel.php
@@ -107,14 +107,18 @@ class CwmseriesdisplaysModel extends ListModel
         }
 
         // Load the parameters.
-        $params = $app->getParams();
-        $this->setState('params', $params);
+        $params   = $app->getParams();
         $template = Cwmparams::getTemplateparams();
         $admin    = Cwmparams::getAdmin();
 
         $template->params->merge($params);
         $template->params->merge($admin->params);
         $params = $template->params;
+        // Re-persist after the merge — 'params' must hold the template-merged
+        // Registry (with the per-field row/column layout settings the
+        // listing helper needs), not the raw application params captured
+        // above. Matches the equivalent line in CwmsermonsModel. See #1502.
+        $this->setState('params', $params);
 
         $t = (int)$params->get('seriesid');
 

--- a/tests/unit/Site/Controller/CwmseriesdisplaysControllerTest.php
+++ b/tests/unit/Site/Controller/CwmseriesdisplaysControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Site\Controller;
+
+use CWM\Component\Proclaim\Site\Controller\CwmseriesdisplaysController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1502: cwmseriesdisplays.paginateAjax always 500'd.
+ *
+ * Root causes (both fixed):
+ * 1. getModel()'s default config passed ignore_request => true, which sets
+ *    __state_set = true in BaseModel::__construct() (see
+ *    joomla-cms/libraries/src/MVC/Model/BaseModel.php), permanently
+ *    skipping populateState() for any caller — like paginateAjax() — that
+ *    fetches the model with fewer than 3 args. Fixed by dropping
+ *    ignore_request from the default (see CwmseriesdisplaysModelTest for
+ *    the companion populateState() fix).
+ * 2. paginateAjax()'s catch was \Exception, which doesn't catch \TypeError
+ *    (extends \Error, not \Exception) — so the null-params/template fallout
+ *    from bug #1 produced an unhandled fatal instead of a JSON error
+ *    response. Broadened to \Throwable regardless, since the endpoint's
+ *    only consumer is fetch()-based JS expecting JSON either way.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmseriesdisplaysControllerTest extends ProclaimTestCase
+{
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmseriesdisplaysController::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testGetModelDefaultConfigDoesNotIgnoreRequest(): void
+    {
+        $reflection  = new \ReflectionMethod(CwmseriesdisplaysController::class, 'getModel');
+        $configParam = $reflection->getParameters()[2];
+
+        $this->assertTrue($configParam->isDefaultValueAvailable());
+        $this->assertSame(
+            [],
+            $configParam->getDefaultValue(),
+            'getModel()\'s default $config must not set ignore_request — it silently skips populateState() ' .
+                'for any caller (like paginateAjax()) using fewer than 3 args — see #1502'
+        );
+    }
+
+    public function testPaginateAjaxCatchesThrowableNotJustException(): void
+    {
+        $body = self::methodBody('paginateAjax');
+
+        $this->assertStringContainsString(
+            'catch (\Throwable $e)',
+            $body,
+            'paginateAjax() must catch \Throwable — \TypeError (from the null-params bug this regression test ' .
+                'guards) extends \Error, not \Exception, and previously escaped as an unhandled fatal — see #1502'
+        );
+    }
+}

--- a/tests/unit/Site/Model/CwmseriesdisplaysModelTest.php
+++ b/tests/unit/Site/Model/CwmseriesdisplaysModelTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Site\Model;
+
+use CWM\Component\Proclaim\Site\Model\CwmseriesdisplaysModel;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1502: populateState() called
+ * $this->setState('params', $params) once using the raw application params,
+ * then reassigned its local $params to the template-merged Registry (with
+ * the per-field row/column layout settings Cwmlisting::getFluidListing()
+ * needs) — but never re-persisted that reassignment to state. Any caller
+ * reading $state->get('params') (paginateAjax()'s controller code, matching
+ * the pattern already correct in CwmsermonsController::filterAjax()) got
+ * the stale, unmerged params, producing "success" responses with
+ * correctly-counted but visually empty list items (no fields configured to
+ * render). Cwmseriesdisplays/HtmlView was unaffected — it reads
+ * $state->get('template')->params instead, which the merge always mutated
+ * correctly in place.
+ *
+ * Fixed by moving setState('params', $params) to fire after the
+ * reassignment, matching the equivalent, already-correct line in
+ * CwmsermonsModel::populateState().
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmseriesdisplaysModelTest extends ProclaimTestCase
+{
+    private static function methodBody(): string
+    {
+        $reflection = new \ReflectionMethod(CwmseriesdisplaysModel::class, 'populateState');
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testSetStateParamsFiresAfterTheTemplateMergeReassignment(): void
+    {
+        $body = self::methodBody();
+
+        $reassignPos = strpos($body, '$params = $template->params;');
+        $setStatePos = strpos($body, "\$this->setState('params', \$params);");
+
+        $this->assertNotFalse($reassignPos, 'Expected the $params = $template->params; reassignment line — see #1502');
+        $this->assertNotFalse($setStatePos, "Expected \$this->setState('params', \$params); — see #1502");
+        $this->assertGreaterThan(
+            $reassignPos,
+            $setStatePos,
+            "setState('params', ...) must fire AFTER the template-merge reassignment, not before it, or " .
+                "\$state->get('params') returns the raw pre-merge Registry — see #1502"
+        );
+    }
+
+    public function testSetStateParamsIsNotAlsoCalledBeforeTheMerge(): void
+    {
+        $body = self::methodBody();
+
+        // Only one setState('params', ...) call should exist now — the
+        // pre-fix code additionally had one right after `$params =
+        // $app->getParams();`, before the merge, whose value was always
+        // immediately superseded (and never re-persisted) by the
+        // reassignment below it.
+        $count = substr_count($body, "setState('params'");
+
+        $this->assertSame(1, $count, "setState('params', ...) should be called exactly once, after the merge — see #1502");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1502. Two independent, stacked bugs — fixing only one wasn't enough to make the endpoint actually work correctly.

**Bug 1 — the 500 itself:** `CwmseriesdisplaysController::getModel()`'s default `\$config` was `['ignore_request' => true]`. `BaseModel::__construct()` treats that as "the caller manages state manually" and sets `__state_set = true` immediately, permanently skipping `populateState()` on `getState()`. The normal `display()` flow never hits this — `BaseController::prepareViewModel()` always calls `getModel()` with an explicit 3-arg config, bypassing the controller's own default — but `paginateAjax()` calls `\$this->getModel('Cwmseriesdisplays', 'Site')` with only 2 args, silently getting a model whose `template`/`params`/list state were never populated → downstream `TypeError` → unhandled fatal. Fixed by dropping `ignore_request` from the default. This codebase's other site controllers with the same default (`CwmsermonController`, `CwmteachersController`) are unaffected — `ignore_request` is correct for a controller wrapping a single-item `FormModel`, just not a `ListModel`.

**Bug 2 — found only after fixing bug 1:** `CwmseriesdisplaysModel::populateState()` calls `\$this->setState('params', \$params)` once using the raw application params, then reassigns its local `\$params` to the template-merged `Registry` (containing the per-field row/column layout settings `Cwmlisting::getFluidListing()` needs to render *anything*) — but never re-persists that reassignment to state. `paginateAjax()` reads `\$state->get('params')` (matching the pattern already correct in `CwmsermonsController::filterAjax()`), so with only bug 1 fixed it got the stale, unmerged params: the endpoint returned `success:true` with the correct item count/pagination, but every rendered item was an empty `<div>`. `Cwmseriesdisplays/HtmlView` was never affected — it reads `\$state->get('template')->params` instead, which the merge always mutated in place correctly. Fixed by moving the `setState('params', ...)` call to after the reassignment, matching the equivalent, already-correct line in the sibling `CwmsermonsModel`.

Also broadened `paginateAjax()`'s `catch` from `\Exception` to `\Throwable` — `\TypeError` (what bug 1's null params/template actually threw) extends `\Error`, not `\Exception`, so it escaped the try/catch as an unhandled fatal instead of the intended JSON error response.

## How this was actually found

Both root causes were tracked down via temporary live instrumentation on j5-dev (file-log writes inside `populateState()`, debug JSON responses dumping state contents) — removed before this commit, not left behind. Stepped through in order: confirmed `populateState()` was never entered at all (bug 1) → fixed it, confirmed it now runs but the endpoint still returned empty item HTML despite `success:true` (bug 2) → traced the params/`\$template->params` divergence by diffing against the working `CwmsermonsModel::populateState()` → fixed → confirmed full, correct item content (images, links, column headers) matching the normal page's rendering byte-for-byte in structure.

## Test plan

- [x] Structural regression tests (4): `getModel()`'s default config no longer sets `ignore_request`; `paginateAjax()` catches `\Throwable`; `populateState()`'s `setState('params', ...)` fires after (not before) the template-merge reassignment; exactly one such call exists (guards against reintroducing the stale pre-merge call) — verified fail-before/pass-after via `git stash`
- [x] Full suite green: 1113 unit + 160 integration tests; lint clean (after reverting unrelated pre-existing submodule drift)
- [x] Live-tested on j5-dev: `cwmseriesdisplays.paginateAjax` with a valid token now returns `success:true` with correctly-rendered HTML (16KB, real images/links/column headers — up from a 500 before, and up from a hollow 768-byte all-empty-divs response after only bug 1 was fixed)
- [x] Re-verified the normal `view=cwmseriesdisplays` page load is unaffected by the shared-model fix (21 images, no PHP warnings, matching the pre-fix baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)