### PR TITLE
fix: delete-confirm.js sends the wrong CSRF token, silently disabling the warning modal

### DIFF
--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -247,6 +248,9 @@ class HtmlView extends BaseHtmlView
             // Delete confirmation dialog for physical files
             $wa = $this->getDocument()->getWebAssetManager();
             $wa->useScript('com_proclaim.delete-confirm');
+            $this->getDocument()->addScriptOptions('com_proclaim.deleteConfirm', [
+                'csrfToken' => Session::getFormToken(),
+            ]);
 
             Text::script('JBS_DEL_PHYSICAL_FILES_TITLE');
             Text::script('JBS_DEL_PHYSICAL_FILES_WARNING');

--- a/admin/src/View/Cwmmessages/HtmlView.php
+++ b/admin/src/View/Cwmmessages/HtmlView.php
@@ -28,6 +28,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
@@ -253,6 +254,9 @@ class HtmlView extends BaseHtmlView
             // Delete confirmation dialog for physical files
             $wa = $this->getDocument()->getWebAssetManager();
             $wa->useScript('com_proclaim.delete-confirm');
+            $this->getDocument()->addScriptOptions('com_proclaim.deleteConfirm', [
+                'csrfToken' => Session::getFormToken(),
+            ]);
 
             Text::script('JBS_DEL_PHYSICAL_FILES_TITLE');
             Text::script('JBS_DEL_PHYSICAL_FILES_WARNING');

--- a/build/media_source/js/delete-confirm.es6.js
+++ b/build/media_source/js/delete-confirm.es6.js
@@ -83,12 +83,13 @@
 
         const ids = Array.from(checkboxes).map((cb) => cb.value);
 
-        // Find the CSRF token input in the form
-        const tokenInput = form.querySelector('input[type="hidden"][value="1"]');
-        let tokenParam = '';
-        if (tokenInput) {
-            tokenParam = `&${encodeURIComponent(tokenInput.name)}=1`;
-        }
+        // CSRF token name — passed explicitly by the PHP view (see
+        // addScriptOptions('com_proclaim.deleteConfirm', ...)) rather than
+        // guessed by scanning the DOM. Joomla renders more than one hidden
+        // input with value="1" on this form (e.g. delete_physical_files),
+        // so a `value="1"` selector can't reliably tell them apart — see #1501.
+        const { csrfToken } = Joomla.getOptions('com_proclaim.deleteConfirm') || {};
+        const tokenParam = csrfToken ? `&${encodeURIComponent(csrfToken)}=1` : '';
 
         const url = `index.php?option=com_proclaim&task=${context}.checkDeleteFiles`
       + `&cid[]=${ids.join('&cid[]=')

--- a/tests/js/delete-confirm.test.js
+++ b/tests/js/delete-confirm.test.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Regression test for #1501: delete-confirm.js located the CSRF token by
+ * scanning the form for `input[type="hidden"][value="1"]`. Both the
+ * cwmmediafiles and cwmmessages list templates render a
+ * `delete_physical_files` hidden field with value="1" immediately before
+ * the real token field, so the DOM-scan always matched the wrong field —
+ * the AJAX call was sent with `&delete_physical_files=1` instead of the
+ * real token, `Session::checkToken('get')` failed server-side, and the
+ * "physical files will be affected" warning modal never fired.
+ *
+ * Fixed by having the PHP view pass the token explicitly via
+ * addScriptOptions('com_proclaim.deleteConfirm', {csrfToken}) instead of
+ * guessing from the DOM.
+ *
+ * Note: innerHTML usage in setupModule() is safe — it builds DOM for unit
+ * tests from static strings, not from external input.
+ */
+
+function setupModule(fetchJsonMock) {
+    document.body.innerHTML =
+        '<form id="adminForm" action="index.php?option=com_proclaim&view=cwmmediafiles">' +
+            '<input type="checkbox" name="cid[]" value="42" checked />' +
+            '<input type="hidden" name="task" value="" />' +
+            '<input type="hidden" name="boxchecked" value="0" />' +
+            '<input type="hidden" name="delete_physical_files" value="1" />' +
+            '<input type="hidden" name="abc123realtoken" value="1" />' +
+        '</form>';
+
+    global.Joomla = {
+        getOptions: jest.fn((key) => {
+            if (key === 'com_proclaim.deleteConfirm') {
+                return { csrfToken: 'abc123realtoken' };
+            }
+
+            return {};
+        }),
+        Text: { _: jest.fn((key) => key) },
+        submitbutton: jest.fn(),
+    };
+
+    global.window.ProclaimFetch = { fetchJson: fetchJsonMock };
+    global.bootstrap = { Modal: jest.fn() };
+
+    jest.isolateModules(() => {
+        require('../../build/media_source/js/delete-confirm.es6.js');
+    });
+}
+
+describe('delete-confirm.js token selection', () => {
+    afterEach(() => {
+        delete global.Joomla;
+        delete global.window.ProclaimFetch;
+        delete global.bootstrap;
+        jest.clearAllMocks();
+    });
+
+    it('sends the real CSRF token, not the delete_physical_files hidden field, in the checkDeleteFiles request', () => {
+        const fetchJsonMock = jest.fn().mockReturnValue(new Promise(() => {}));
+        setupModule(fetchJsonMock);
+
+        global.Joomla.submitbutton('cwmmediafiles.delete');
+
+        expect(fetchJsonMock).toHaveBeenCalledTimes(1);
+        const requestedUrl = fetchJsonMock.mock.calls[0][0];
+
+        expect(requestedUrl).toContain('abc123realtoken=1');
+        expect(requestedUrl).not.toContain('delete_physical_files=1');
+    });
+
+    it('omits the token param entirely when no csrfToken option is provided, rather than falling back to a DOM scan', () => {
+        const fetchJsonMock = jest.fn().mockReturnValue(new Promise(() => {}));
+        setupModule(fetchJsonMock);
+        global.Joomla.getOptions = jest.fn(() => ({}));
+
+        global.Joomla.submitbutton('cwmmediafiles.delete');
+
+        const requestedUrl = fetchJsonMock.mock.calls[0][0];
+        expect(requestedUrl).not.toContain('delete_physical_files=1');
+        expect(requestedUrl).not.toContain('abc123realtoken=1');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1501. \`delete-confirm.js\` located the CSRF token via \`form.querySelector('input[type="hidden"][value="1"]')\`. Both the Media Files and Messages list templates render a \`delete_physical_files\` hidden field with \`value="1"\` immediately before the real token field, so the selector's first-match semantics always picked the wrong one — confirmed live on j5-dev, the old selector matched \`delete_physical_files\` by name exactly as the issue predicted.

The request went out as \`&delete_physical_files=1\` instead of the real token param, \`Session::checkToken('get')\` failed server-side, and \`checkDeleteFiles()\` returned an "Invalid token" error. Because the JS's own failure handling deliberately falls through to a normal delete on any AJAX failure ("never block deletion on AJAX failure"), this never broke delete itself — it just meant the "Physical Files Will Be Affected" warning modal, the entire point of the feature, has not been firing on either list view.

Fixed per the issue's second suggested option: the PHP view now passes the token explicitly via \`addScriptOptions('com_proclaim.deleteConfirm', ['csrfToken' => Session::getFormToken()])\` (matching the existing pattern already used for \`sermon-filters.es6.js\`), and the JS reads it via \`Joomla.getOptions()\` instead of scanning form fields.

## Test plan

- [x] New Jest regression test (2 cases): the real token is sent (not \`delete_physical_files\`) when the option is present; the token param is omitted entirely (not guessed from the DOM) when the option is absent — verified fail-before/pass-after via \`git stash\`, both failing tests reproduced the exact bug (\`delete_physical_files=1\` in the captured URL) against the pre-fix source
- [x] Full suites green: 232 JS tests (\`npm test\`), 1113 PHP unit tests; lint clean (after reverting unrelated pre-existing submodule drift)
- [x] Live-tested on j5-dev: navigated both list views' Trash filter (where the script/options actually load — gated on \`filter.published === CONDITION_TRASHED\`), confirmed \`Joomla.getOptions('com_proclaim.deleteConfirm').csrfToken\` is now populated with a real 32-char token, and replicated the exact URL-building logic \`delete-confirm.js\` now uses against both \`cwmmediafiles.checkDeleteFiles\` and \`cwmmessages.checkDeleteFiles\` — both returned \`success:true\` (previously would have failed with \`Invalid token\`)
- [ ] Not exercised: the full end-to-end click-through-to-modal flow (select rows → Delete → modal appears) — per the issue's own test plan note, this remains untestable on j5-dev since no seeded server has \`delete_files=1\`, and triggering a real delete to test it risks destructive side effects on dev data

🤖 Generated with [Claude Code](https://claude.com/claude-code)