### PR TITLE
fix: regenerate podcast RSS feeds when podcast settings are saved

### DIFF
--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -18,10 +18,12 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use CWM\Component\Proclaim\Administrator\Table\CwmpodcastTable;
+use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
@@ -111,6 +113,32 @@ class CwmpodcastModel extends AdminModel
         }
 
         return $data;
+    }
+
+    /**
+     * Save the podcast, then regenerate its RSS feed so settings changes
+     * (image, category, explicit flag, etc.) take effect immediately instead
+     * of waiting for the next manual "Generate Feeds" click or scheduled task run.
+     *
+     * @param   array  $data  The form data.
+     *
+     * @return  bool  True on success.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function save($data): bool
+    {
+        if (!parent::save($data)) {
+            return false;
+        }
+
+        try {
+            (new Cwmpodcast())->makePodcasts();
+        } catch (\Exception $e) {
+            Log::add('Podcast feed regeneration after save failed: ' . $e->getMessage(), Log::WARNING, 'com_proclaim');
+        }
+
+        return true;
     }
 
     /**

--- a/tests/unit/Admin/Model/CwmpodcastModelTest.php
+++ b/tests/unit/Admin/Model/CwmpodcastModelTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmpodcastModel;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1509: podcast RSS feeds are static XML files written
+ * by Cwmpodcast::makePodcasts(), which only ran from the admin "Write XML"
+ * button or the scheduled task — never from saving the podcast settings
+ * form. Confirmed live on nfsda.org: changing the "Podcast Image" field and
+ * saving did not update <itunes:image>/<podcast:image> in the feed until
+ * "Write XML" was run manually afterward.
+ *
+ * Fixed by having CwmpodcastModel::save() regenerate the feeds after a
+ * successful save, matching the existing manual-button behavior.
+ * Regeneration failures are logged, never allowed to fail the settings save
+ * itself — a broken feed write shouldn't block an admin from saving
+ * unrelated changes.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmpodcastModelTest extends ProclaimTestCase
+{
+    private static function methodBody(): string
+    {
+        $reflection = new \ReflectionMethod(CwmpodcastModel::class, 'save');
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testSaveReturnsFalseImmediatelyWhenParentSaveFails(): void
+    {
+        $body = self::methodBody();
+
+        $this->assertMatchesRegularExpression(
+            '/if\s*\(\s*!\s*parent::save\(\$data\)\s*\)\s*\{\s*return\s+false;/s',
+            $body,
+            'save() must bail out before attempting feed regeneration when the underlying save fails — see #1509'
+        );
+    }
+
+    public function testSaveTriggersFeedRegenerationOnSuccess(): void
+    {
+        $body = self::methodBody();
+
+        $this->assertStringContainsString(
+            'makePodcasts()',
+            $body,
+            'save() must call Cwmpodcast::makePodcasts() so settings changes (image, category, etc.) take ' .
+                'effect immediately instead of waiting for a manual "Write XML" click or the scheduled task — see #1509'
+        );
+    }
+
+    public function testFeedRegenerationFailureIsCaughtAndLoggedNotThrown(): void
+    {
+        $body = self::methodBody();
+
+        $this->assertMatchesRegularExpression(
+            '/catch\s*\(\s*\\\\Exception\s+\$e\s*\)\s*\{\s*Log::add/s',
+            $body,
+            'A feed regeneration failure must be caught and logged, not allowed to propagate and fail the ' .
+                'settings save — see #1509'
+        );
+    }
+
+    public function testSaveAlwaysReturnsTrueAfterASuccessfulParentSaveRegardlessOfRegenerationOutcome(): void
+    {
+        $body = self::methodBody();
+
+        // The final statement must be `return true;`, not `return $filewritten;`
+        // or similar — regeneration failing must not make the settings save
+        // itself look like it failed.
+        $this->assertMatchesRegularExpression(
+            '/return\s+true;\s*\}\s*$/',
+            $body,
+            'save() must unconditionally return true once parent::save() succeeded, regardless of whether ' .
+                'feed regeneration succeeded — see #1509'
+        );
+    }
+
+    public function testCwmpodcastImportedFromSiteHelperNamespace(): void
+    {
+        $reflection = new \ReflectionClass(CwmpodcastModel::class);
+        $contents   = file_get_contents($reflection->getFileName());
+
+        $this->assertStringContainsString(
+            'use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;',
+            $contents,
+            'CwmpodcastModel must import the site-side Cwmpodcast helper (the same class the admin ' .
+                '"Write XML" controller and the scheduled task both call) to regenerate feeds — see #1509'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `Cwmpodcast::makePodcasts()` (which writes the static feed XML files) was only ever invoked from the admin "Write XML" button or the scheduled task — never when the podcast settings form itself was saved.
- `CwmpodcastModel::save()` now regenerates all feeds after a successful save, matching the existing manual-button behavior, so settings changes (image, category, explicit flag, etc.) take effect immediately.
- Regeneration failures are caught and logged (`Log::WARNING`, `com_proclaim` category) — never allowed to fail the settings save itself.

Confirmed live on nfsda.org: changing the "Podcast Image" field and saving did not update `<itunes:image>`/`<podcast:image>` in the feed until "Write XML" was run manually afterward.

Fixes #1509

## Test plan
- [x] New regression test (`CwmpodcastModelTest`) verifies via reflection: bail-out on failed parent save, `makePodcasts()` call on success, catch+log around it, unconditional `return true`, and the `Cwmpodcast` import — verified failing before the fix (4/5) and passing after (5/5)
- [x] Full unit suite passes (1118 tests)
- [x] `composer lint:fix` clean (only pre-existing unrelated submodule drift, reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe