### PR TITLE
refactor: consolidate 5 duplicate sendJsonResponse() implementations into a shared trait

### DIFF
--- a/admin/src/Controller/CwmanalyticsController.php
+++ b/admin/src/Controller/CwmanalyticsController.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
 use CWM\Component\Proclaim\Administrator\Model\CwmanalyticsModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -32,6 +33,8 @@ use Joomla\Registry\Registry;
  */
 class CwmanalyticsController extends BaseController
 {
+    use CwmJsonResponseTrait;
+
     /**
      * Seed the monthly aggregates table with legacy hit/play/download counts
      * from existing study and media-file records.
@@ -206,35 +209,5 @@ class CwmanalyticsController extends BaseController
             'periodStart'   => $start,
             'periodEnd'     => $end,
         ]);
-    }
-
-    /**
-     * Send a JSON response and terminate execution.
-     *
-     * @param   bool    $success  Whether the request succeeded.
-     * @param   string  $message  Optional message.
-     * @param   array   $data     Optional data payload.
-     *
-     * @return  never
-     *
-     * @since   10.1.0
-     */
-    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
-    {
-        while (ob_get_level()) {
-            ob_end_clean();
-        }
-
-        $response = json_encode([
-            'success' => $success,
-            'message' => $message,
-            'data'    => $data,
-        ], JSON_THROW_ON_ERROR);
-
-        header('Content-Type: application/json; charset=utf-8');
-        header('Cache-Control: no-store');
-        echo $response;
-
-        Factory::getApplication()->close();
     }
 }

--- a/admin/src/Controller/CwmassetsController.php
+++ b/admin/src/Controller/CwmassetsController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use Joomla\CMS\Factory;
@@ -34,6 +35,8 @@ use Joomla\Database\DatabaseInterface;
  */
 class CwmassetsController extends BaseController
 {
+    use CwmJsonResponseTrait;
+
     /**
      * Prevents Joomla's pluralization mechanism from altering the view name.
      *
@@ -322,33 +325,5 @@ class CwmassetsController extends BaseController
         } catch (\Exception $e) {
             $this->sendJsonResponse(false, 'Failed to rebuild asset tree: ' . $e->getMessage());
         }
-    }
-
-    /**
-     * Send JSON response and close the application.
-     *
-     * @param   bool    $success  Success status
-     * @param   string  $message  Message
-     * @param   array   $data     Additional data
-     *
-     * @return never
-     *
-     * @throws \Exception
-     * @since 10.1.0
-     */
-    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
-    {
-        $app = Factory::getApplication();
-        header('Content-Type: application/json; charset=utf-8');
-        $app->setHeader('Cache-Control', 'no-cache, must-revalidate');
-
-        $response = [
-            'success' => $success,
-            'message' => $message,
-            'data'    => $data,
-        ];
-
-        echo json_encode($response, JSON_THROW_ON_ERROR);
-        $app->close();
     }
 }

--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
@@ -45,6 +46,8 @@ use Joomla\Filesystem\Path;
  */
 class CwmbackupController extends BaseController
 {
+    use CwmJsonResponseTrait;
+
     // =========================================================================
     // AJAX Export Methods
     // =========================================================================
@@ -1026,51 +1029,6 @@ class CwmbackupController extends BaseController
         Log::add('Compressed backup file: ' . basename($zipPath), Log::INFO, 'com_proclaim');
 
         return $zipPath;
-    }
-
-    /**
-     * Send JSON response and terminate.
-     *
-     * @param   bool    $success  Success status
-     * @param   string  $message  Message
-     * @param   array   $data     Additional data
-     *
-     * @return never
-     *
-     * @throws \Exception
-     * @since 10.1.0
-     */
-    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
-    {
-        $app = Factory::getApplication();
-
-        // Capture and log any stray output (PHP errors, warnings, etc.)
-        $strayOutput = '';
-
-        while (ob_get_level()) {
-            $strayOutput .= ob_get_clean();
-        }
-
-        if (!empty($strayOutput)) {
-            Log::add('Stray output captured: ' . substr($strayOutput, 0, 500), Log::WARNING, 'com_proclaim');
-        }
-
-        // Set JSON headers directly (only if headers not already sent)
-        if (!headers_sent()) {
-            header('Content-Type: application/json; charset=utf-8');
-            header('Cache-Control: no-cache, must-revalidate');
-        }
-
-        $response = [
-            'success' => $success,
-            'message' => $message,
-            'data'    => $data,
-        ];
-
-        echo json_encode($response, JSON_THROW_ON_ERROR);
-
-        // Use exit instead of $app->close() to avoid any shutdown processing issues
-        exit(0);
     }
 
     /**

--- a/admin/src/Controller/CwmlocationwizardController.php
+++ b/admin/src/Controller/CwmlocationwizardController.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
@@ -32,6 +33,8 @@ use Joomla\CMS\Session\Session;
  */
 class CwmlocationwizardController extends BaseController
 {
+    use CwmJsonResponseTrait;
+
     /**
      * Prevents Joomla's pluralization mechanism from altering the view name.
      *
@@ -254,36 +257,5 @@ class CwmlocationwizardController extends BaseController
         }
 
         $this->sendJsonResponse(true, '', $data);
-    }
-
-    /**
-     * Send a JSON response and terminate execution.
-     *
-     * @param   bool    $success  Whether the operation succeeded.
-     * @param   string  $message  Human-readable message.
-     * @param   array   $data     Extra data payload.
-     *
-     * @return  never
-     *
-     * @since   10.1.0
-     */
-    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
-    {
-        // Clean any stray output
-        while (ob_get_level()) {
-            ob_end_clean();
-        }
-
-        $response = json_encode([
-            'success' => $success,
-            'message' => $message,
-            'data'    => $data,
-        ], JSON_THROW_ON_ERROR);
-
-        header('Content-Type: application/json; charset=utf-8');
-        header('Cache-Control: no-store');
-        echo $response;
-
-        Factory::getApplication()->close();
     }
 }

--- a/admin/src/Controller/CwmsetupwizardController.php
+++ b/admin/src/Controller/CwmsetupwizardController.php
@@ -13,6 +13,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
@@ -27,6 +28,8 @@ use Joomla\CMS\Session\Session;
  */
 class CwmsetupwizardController extends BaseController
 {
+    use CwmJsonResponseTrait;
+
     /**
      * @var    string
      * @since  10.3.0
@@ -257,35 +260,5 @@ class CwmsetupwizardController extends BaseController
         $data  = $model->getCurrentState();
 
         $this->sendJsonResponse(true, '', $data);
-    }
-
-    /**
-     * Send a JSON response and terminate execution.
-     *
-     * @param   bool    $success  Whether the operation succeeded.
-     * @param   string  $message  Human-readable message.
-     * @param   array   $data     Extra data payload.
-     *
-     * @return  never
-     *
-     * @since   10.3.0
-     */
-    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
-    {
-        while (ob_get_level()) {
-            ob_end_clean();
-        }
-
-        $response = json_encode([
-            'success' => $success,
-            'message' => $message,
-            'data'    => $data,
-        ], JSON_THROW_ON_ERROR);
-
-        header('Content-Type: application/json; charset=utf-8');
-        header('Cache-Control: no-store');
-        echo $response;
-
-        Factory::getApplication()->close();
     }
 }

--- a/admin/src/Controller/Trait/CwmJsonResponseTrait.php
+++ b/admin/src/Controller/Trait/CwmJsonResponseTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Administrator\Controller\Trait;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Log\Log;
+
+/**
+ * Send a uniform {success, message, data} JSON response and terminate.
+ *
+ * Consolidates 5 previously byte-identical-envelope, independently
+ * maintained sendJsonResponse() implementations (CwmassetsController,
+ * CwmlocationwizardController, CwmsetupwizardController,
+ * CwmanalyticsController, CwmbackupController) into one. This is the
+ * CwmbackupController implementation, which was the most complete of the
+ * five: it captures and logs stray output (PHP notices/warnings that would
+ * otherwise corrupt the JSON body), guards header calls with headers_sent(),
+ * and exits immediately rather than routing through Joomla's shutdown
+ * processing.
+ *
+ * Only the plumbing was unified — every consuming controller already
+ * produced this exact envelope shape, so no JS consumer is affected.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait CwmJsonResponseTrait
+{
+    /**
+     * Send JSON response and terminate.
+     *
+     * @param   bool    $success  Success status
+     * @param   string  $message  Message
+     * @param   array   $data     Additional data
+     *
+     * @return never
+     *
+     * @throws \Exception
+     * @since __DEPLOY_VERSION__
+     */
+    private function sendJsonResponse(bool $success, string $message = '', array $data = []): never
+    {
+        // Capture and log any stray output (PHP errors, warnings, etc.)
+        $strayOutput = '';
+
+        while (ob_get_level()) {
+            $strayOutput .= ob_get_clean();
+        }
+
+        if (!empty($strayOutput)) {
+            Log::add('Stray output captured: ' . substr($strayOutput, 0, 500), Log::WARNING, 'com_proclaim');
+        }
+
+        // Set JSON headers directly (only if headers not already sent)
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+            header('Cache-Control: no-cache, must-revalidate');
+        }
+
+        $response = [
+            'success' => $success,
+            'message' => $message,
+            'data'    => $data,
+        ];
+
+        echo json_encode($response, JSON_THROW_ON_ERROR);
+
+        // Use exit instead of $app->close() to avoid any shutdown processing issues
+        exit(0);
+    }
+}

--- a/tests/unit/Admin/Controller/CwmJsonResponseTraitTest.php
+++ b/tests/unit/Admin/Controller/CwmJsonResponseTraitTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Controller\CwmanalyticsController;
+use CWM\Component\Proclaim\Administrator\Controller\CwmassetsController;
+use CWM\Component\Proclaim\Administrator\Controller\CwmbackupController;
+use CWM\Component\Proclaim\Administrator\Controller\CwmlocationwizardController;
+use CWM\Component\Proclaim\Administrator\Controller\CwmsetupwizardController;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression test for #1503 (partial — scope narrowed after investigation):
+ * CwmassetsController, CwmlocationwizardController, CwmsetupwizardController,
+ * CwmanalyticsController, and CwmbackupController each carried their own
+ * private sendJsonResponse() implementation. All five already produced the
+ * identical {success, message, data} envelope — they differed only in
+ * plumbing (stray-output handling, header guards, termination method) — so
+ * consolidating them into one trait is a pure deduplication with no
+ * consumer-facing change.
+ *
+ * The trait body is CwmbackupController's prior implementation, the most
+ * complete of the five (stray-output capture + logging, headers_sent()
+ * guard, exit(0) rather than $app->close()). registerFatalErrorShutdownHandler()
+ * stays Backup-only — it exists for that controller's long-running
+ * import/export operations, not the other four's short AJAX actions.
+ *
+ * The other 3 JSON-response mechanisms in the codebase (Joomla\CMS\Response\JsonResponse,
+ * hand-rolled json_encode()+header(), and CWMAddon::outputJson()) were
+ * investigated and deliberately NOT touched — see the #1503 issue comment
+ * for the evidence: they have inconsistent, endpoint-specific envelope
+ * shapes with confirmed JS consumers depending on that specific shape
+ * (e.g. build/media_source/js/delete-confirm.es6.js reads flat
+ * `data.hasFiles`/`data.files`), so unifying them would be a breaking
+ * change with no functional benefit.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmJsonResponseTraitTest extends ProclaimTestCase
+{
+    private const CONSUMERS = [
+        CwmassetsController::class,
+        CwmlocationwizardController::class,
+        CwmsetupwizardController::class,
+        CwmanalyticsController::class,
+        CwmbackupController::class,
+    ];
+
+    public function testExactlyOneSendJsonResponseDeclarationExistsRepoWide(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $hits = [];
+
+        foreach (['admin', 'site'] as $subdir) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root . '/' . $subdir, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->getExtension() !== 'php' || str_contains($file->getPathname(), '/vendor/')) {
+                    continue;
+                }
+
+                if (str_contains(file_get_contents($file->getPathname()), 'function sendJsonResponse')) {
+                    $hits[] = str_replace($root . '/', '', $file->getPathname());
+                }
+            }
+        }
+
+        $this->assertSame(
+            ['admin/src/Controller/Trait/CwmJsonResponseTrait.php'],
+            $hits,
+            'sendJsonResponse() must be declared exactly once, in CwmJsonResponseTrait — found in: ' .
+                implode(', ', $hits) . ' — see #1503'
+        );
+    }
+
+    public function testAllFiveFormerlyDuplicatedControllersUseTheTrait(): void
+    {
+        foreach (self::CONSUMERS as $class) {
+            $this->assertContains(
+                CwmJsonResponseTrait::class,
+                class_uses($class),
+                $class . ' must use CwmJsonResponseTrait instead of declaring its own sendJsonResponse() — see #1503'
+            );
+        }
+    }
+
+    public function testTraitProducesTheEstablishedSuccessMessageDataEnvelope(): void
+    {
+        $reflection = new \ReflectionMethod(CwmJsonResponseTrait::class, 'sendJsonResponse');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        foreach (["'success' => \$success", "'message' => \$message", "'data'    => \$data"] as $key) {
+            $this->assertStringContainsString(
+                $key,
+                $body,
+                'The consolidated trait must preserve the exact envelope every prior implementation already ' .
+                    'produced, since JS consumers depend on this shape — see #1503'
+            );
+        }
+    }
+
+    public function testCwmbackupControllerRetainsItsOwnFatalErrorShutdownHandler(): void
+    {
+        $reflection = new \ReflectionClass(CwmbackupController::class);
+
+        $this->assertTrue(
+            $reflection->hasMethod('registerFatalErrorShutdownHandler'),
+            'registerFatalErrorShutdownHandler() is intentionally Backup-only (long-running import/export ' .
+                'operations) and must not have been removed while consolidating sendJsonResponse() — see #1503'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the 5 byte-identical-envelope `sendJsonResponse()` private methods (`CwmassetsController`, `CwmlocationwizardController`, `CwmsetupwizardController`, `CwmanalyticsController`, `CwmbackupController`) into a single `CwmJsonResponseTrait`.
- All 5 already produced the exact same `{success, message, data}` envelope — they differed only in plumbing. This is pure deduplication with **no change in HTTP response shape**.
- The trait body is `CwmbackupController`'s prior implementation (the most complete: stray-output capture + logging, `headers_sent()` guard, `exit(0)`). `registerFatalErrorShutdownHandler()` stays Backup-only — it exists for that controller's long-running import/export operations, not the other four's short AJAX actions.

## Scope note (narrowed from the original issue)
#1503 originally framed this as unifying all 4 competing JSON-response mechanisms in the codebase. Investigation (a dedicated audit of every mechanism and its JS consumers) found that only mechanism 1 (`sendJsonResponse()`) is safe to consolidate — see the issue comment for the full breakdown of why the other 3 (`Joomla\CMS\Response\JsonResponse`, hand-rolled `json_encode()+header()`, `CWMAddon::outputJson()`) have inconsistent, endpoint-specific envelope shapes with confirmed JS consumers depending on those exact shapes, and unifying them would be a breaking change with no functional benefit.

## Test plan
- [x] New regression test (`CwmJsonResponseTraitTest`): exactly one `sendJsonResponse()` declaration exists repo-wide, all 5 controllers use the trait, envelope shape preserved, `CwmbackupController` retains its fatal-error shutdown handler
- [x] Full unit suite passes (1117 tests)
- [x] `composer lint:fix` clean (only pre-existing unrelated submodule drift, reverted)
- [x] Live-tested on j5-dev: all 5 endpoints (`cwmbackup.getExportTablesXHR`, `cwmassets.checkAssetsXHR`, `cwmlocationwizard.getStepData`, `cwmsetupwizard.getStepData`, `cwmanalytics.getStudyAnalyticsXHR`) return the identical envelope through the shared trait, including the CSRF-failure `{success:false}` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe