### PR TITLE
fix: changePlayerByMediaTypeXHR() reads mediatype correctly and matches real records

### DIFF
--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -34,6 +34,7 @@ use CWM\Component\Proclaim\Administrator\Lib\CwmpIconvert;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmrestore;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmssconvert;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
+use CWM\Component\Proclaim\Site\Helper\Cwmmedia;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
@@ -2096,10 +2097,32 @@ class CwmadminController extends FormController
     /**
      * Change Player by Media Type XHR - AJAX version with optimized batch update
      *
-     * Deliberately left as-is (not extracted to the Model) as part of #1443:
-     * its WHERE clause queries 'media_image' as a table column, but that key
-     * only exists inside the JSON params blob -- every call throws a DB error.
-     * Moving broken SQL into the Model doesn't fix it; see #1492.
+     * 'mediatype' is a MIME type string (e.g. "video/mp4") -- the value of the
+     * `mtFrom` MimeType field (see admin/forms/admin.xml), exactly what the
+     * non-AJAX CwmadminModel::playerByMediaType() also matches against. The
+     * previous version read it via getInt(), which strips non-digit
+     * characters (Joomla's INT filter), silently turning "video/mp4" into 4
+     * and "video/x-ms-wmv" into 0 -- neither is a usable value. It then
+     * compared that against 'media_image', a key that only exists inside the
+     * JSON params blob, not a real column on #__bsms_mediafiles, so every
+     * request that got past the mangled-value check still threw a DB error.
+     * See #1492.
+     *
+     * Deliberately left in the controller (not extracted to the Model) as
+     * part of #1443 -- the query itself was broken independent of where it
+     * lived, so moving it first would have just relocated the bug.
+     *
+     * Matching mirrors playerByMediaType()'s working logic (mime_type match,
+     * falling back to filename extension) without its dead-code bug (that
+     * method resets $from = '' at the top of every loop iteration, so its
+     * 'http'/'mediacode' branches can never fire). This version does not
+     * support the 'http'/'mediacode' sentinel values either -- that behavior
+     * was already non-functional in the method it mirrors, and reproducing
+     * it correctly is out of scope for this fix.
+     *
+     * Unlike playerByMediaType(), this does not filter to published = 1 --
+     * the point of a bulk "fix the player on files still using the wrong
+     * one" tool is to catch everything, not just currently-published rows.
      *
      * @return void
      *
@@ -2108,8 +2131,8 @@ class CwmadminController extends FormController
      */
     public function changePlayerByMediaTypeXHR(): void
     {
-        $app      = Factory::getApplication();
-        $input    = $app->getInput();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         header('Content-Type: application/json; charset=utf-8');
 
@@ -2124,10 +2147,18 @@ class CwmadminController extends FormController
             return;
         }
 
-        $mediaType = $input->getInt('mediatype', 0);
+        $mediaType = $input->getString('mediatype', 'x');
         $player    = $input->getCmd('player', 'x');
 
-        if ($mediaType === 0 || $player === 'x') {
+        // Not validated against Cwmmedia::getMimetypes()'s current value list --
+        // that list dropped the legacy 'audio/mp3' string in favor of the
+        // IANA-registered 'audio/mpeg' (#1397), but existing rows can still
+        // have 'audio/mp3' stored, and MimeTypeField deliberately keeps a
+        // stored-but-no-longer-offered value selectable in the mtFrom dropdown
+        // (see MimeTypeField::getOptions()). Rejecting it here would silently
+        // break matching for exactly the records #1397 was written to keep
+        // working. An unrecognized value just matches zero rows below.
+        if ($mediaType === 'x' || $mediaType === '' || $player === 'x') {
             echo json_encode([
                 'success' => false,
                 'message' => Text::_('JBS_ADM_ERROR_OCCURED') . ': ' . Text::_('JBS_ADM_SELECT_MEDIATYPE_PLAYER'),
@@ -2138,13 +2169,15 @@ class CwmadminController extends FormController
         }
 
         try {
-            $db = Factory::getContainer()->get(DatabaseInterface::class);
+            $db         = Factory::getContainer()->get(DatabaseInterface::class);
+            $mimetypes  = (new Cwmmedia())->getMimetypes();
+            $extensions = explode('|', (string) array_search($mediaType, $mimetypes, true));
 
-            // Get all media files with matching media type
+            // Match happens in PHP against the decoded params blob, not in SQL --
+            // mime_type / filename are JSON keys, not columns.
             $query = $db->createQuery()
                 ->select([$db->quoteName('id'), $db->quoteName('params')])
-                ->from($db->quoteName('#__bsms_mediafiles'))
-                ->where($db->quoteName('media_image') . ' = ' . $mediaType);
+                ->from($db->quoteName('#__bsms_mediafiles'));
 
             $db->setQuery($query);
             $mediaFiles = $db->loadObjectList();
@@ -2154,6 +2187,17 @@ class CwmadminController extends FormController
             foreach ($mediaFiles as $media) {
                 $reg = new Registry();
                 $reg->loadString($media->params);
+
+                $filename  = $reg->get('filename', '');
+                $extension = strtolower((string) substr($filename, strrpos($filename, '.') ?: 0));
+
+                $matches = $reg->get('mime_type', '') === $mediaType
+                    || ($extension !== '' && \in_array(ltrim($extension, '.'), $extensions, true));
+
+                if (!$matches) {
+                    continue;
+                }
+
                 $reg->set('player', $player);
 
                 $updateQuery = $db->createQuery()

--- a/tests/unit/Admin/Controller/CwmadminControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmadminControllerTest.php
@@ -21,9 +21,12 @@ use CWM\Component\Proclaim\Tests\ProclaimTestCase;
  * changePopupXHR() duplicated the same job with a more efficient batch
  * query. All five now delegate to CwmadminModel — see CwmadminModelTest.
  *
- * changePlayerByMediaTypeXHR() is deliberately left untouched: its query
- * is independently broken (queries a table column that doesn't exist —
- * see #1492) and moving broken SQL into the Model would not fix it.
+ * changePlayerByMediaTypeXHR() is deliberately left in the controller
+ * (not extracted to the Model): its query was independently broken —
+ * queried 'media_image' as a table column when that key only exists in
+ * the JSON params blob, and read the MIME-type 'mediatype' param via
+ * getInt(), which mangled it into a meaningless digit extraction. Fixed
+ * in place — see #1492 and CwmadminControllerTest's dedicated tests below.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -107,18 +110,70 @@ class CwmadminControllerTest extends ProclaimTestCase
     }
 
     /**
-     * changePlayerByMediaTypeXHR() is intentionally NOT refactored here —
-     * its query is independently broken (see #1492) and this asserts the
-     * scoping decision is visible in the method body via the doc comment,
-     * not silently dropped.
+     * Regression test for #1492: changePlayerByMediaTypeXHR() read the
+     * 'mediatype' request param (a MIME type string like "video/mp4", the
+     * value of the mtFrom MimeType field) via getInt(), which strips
+     * non-digit characters and silently turns it into a meaningless number
+     * ("video/mp4" -> 4, "video/x-ms-wmv" -> 0) instead of rejecting or
+     * preserving it. It then compared that against 'media_image', a key
+     * that only exists inside the JSON params blob, never a real column on
+     * #__bsms_mediafiles — so any request whose mangled value got past the
+     * "=== 0" guard still threw a DB error ("Unknown column 'media_image'").
      */
-    public function testChangePlayerByMediaTypeXHRDocumentsWhyItWasSkipped(): void
+    public function testChangePlayerByMediaTypeXHRReadsMediatypeAsAString(): void
     {
-        $reflection = new \ReflectionMethod(CwmadminController::class, 'changePlayerByMediaTypeXHR');
-        $lines      = file($reflection->getFileName());
-        $docStart   = $reflection->getStartLine() - 10;
-        $docBlock   = implode('', \array_slice($lines, max(0, $docStart - 1), 10));
+        $body = self::methodBody('changePlayerByMediaTypeXHR');
 
-        $this->assertStringContainsString('#1492', $docBlock, 'changePlayerByMediaTypeXHR() must document why it was left out of the #1443 refactor');
+        $this->assertDoesNotMatchRegularExpression(
+            '/getInt\(\s*[\'"]mediatype[\'"]/',
+            $body,
+            "getInt('mediatype', ...) mangles a MIME type string like \"video/mp4\" into a meaningless digit " .
+                'extraction (4) — see #1492'
+        );
+        $this->assertMatchesRegularExpression(
+            '/getString\(\s*[\'"]mediatype[\'"]/',
+            $body,
+            "changePlayerByMediaTypeXHR() must read 'mediatype' via getString() to preserve the MIME type " .
+                'string intact (getCmd() would strip the "/") — see #1492'
+        );
+    }
+
+    public function testChangePlayerByMediaTypeXHRDoesNotQueryMediaImageAsAColumn(): void
+    {
+        $body = self::methodBody('changePlayerByMediaTypeXHR');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/quoteName\(\s*[\'"]media_image[\'"]\s*\)/',
+            $body,
+            "'media_image' is a key inside the JSON params blob, not a column on #__bsms_mediafiles — every " .
+                'query using it as a column throws "Unknown column" — see #1492'
+        );
+    }
+
+    /**
+     * Deliberately NOT validated against Cwmmedia::getMimetypes()'s value
+     * list -- live-testing on j5-dev caught that the list dropped the legacy
+     * 'audio/mp3' string in favor of 'audio/mpeg' (#1397), but existing rows
+     * can still have 'audio/mp3' stored, and MimeTypeField keeps a
+     * stored-but-no-longer-offered value selectable. A whitelist check would
+     * have silently broken matching for exactly those records.
+     */
+    public function testChangePlayerByMediaTypeXHRDoesNotRejectUnrecognizedMimetypes(): void
+    {
+        $body = self::methodBody('changePlayerByMediaTypeXHR');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/!\s*\\\\?in_array\(\s*\$mediaType\s*,\s*\$mimetypes/',
+            $body,
+            'changePlayerByMediaTypeXHR() must not reject a mediatype value just because it is missing from ' .
+                "Cwmmedia::getMimetypes()'s current list — legacy stored values (e.g. 'audio/mp3', see #1397) " .
+                'must still be matchable — see #1492'
+        );
+        $this->assertStringContainsString(
+            'getMimetypes()',
+            $body,
+            'changePlayerByMediaTypeXHR() must still call Cwmmedia::getMimetypes() to resolve the ' .
+                'extension-based fallback match — see #1492'
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two independent bugs, not one (the issue only knew about the first):

1. The WHERE clause queried `media_image` as a table column on `#__bsms_mediafiles`, but that key only exists inside the JSON `params` blob — every request that reached the query threw "Unknown column 'media_image'".
2. `mediatype` (a MIME type string like `video/mp4`, the `mtFrom` MimeType field's value) was read via `getInt()`, which strips non-digit characters — `video/mp4` became `4`, `video/x-ms-wmv` became `0`. Most selections never even reached the broken query; they were silently rejected by the `=== 0` guard first.

## Fix

- Read `mediatype` via `getString()` to preserve it intact.
- Match in PHP against each row's decoded `params` (`mime_type`, falling back to filename extension) instead of a raw SQL WHERE on a JSON key — mirroring `CwmadminModel::playerByMediaType()`'s working approach, without its dead-code bug (that method resets `$from = ''` on every loop iteration, so its `http`/`mediacode` branches can never fire — not reproduced here; those sentinel values are out of scope for this fix, same as they already were in the method being mirrored).
- Deliberately **not** validated against `Cwmmedia::getMimetypes()`'s current value list — caught via live-testing that the list dropped the legacy `audio/mp3` string (superseded by `audio/mpeg`, #1397), but existing rows still have `audio/mp3` stored and `MimeTypeField` deliberately keeps such stored-but-no-longer-offered values selectable. A whitelist would have silently broken matching for exactly the records #1397 was written to keep working.
- Does not filter to `published = 1` (unlike `playerByMediaType()`) — a bulk "fix the player on files still using the wrong one" tool should catch everything, not just currently-published rows.

## Test plan
- [x] New regression tests confirm: no `getInt('mediatype'` call remains, `getString('mediatype'` is used instead, no `media_image` column reference, `getMimetypes()` is still called (for extension fallback) but not used as a rejection whitelist — verified failing before the fix, passing after
- [x] Full unit suite passes (1124 tests)
- [x] `composer lint:fix` clean (only pre-existing unrelated submodule drift, reverted)
- [x] **Live-tested on j5-dev against real seed data**: `mediatype=audio/mp3` (has an embedded digit — previously reached the broken SQL) correctly matched and updated 500 rows via exact `mime_type` match; `mediatype=audio/x-ms-wmv` (no embedded digit — previously silently rejected at the `=== 0` guard) correctly matched and updated 15 rows. Verified `params.player` actually changed on exactly the matched rows via direct DB query, then reverted the mutation precisely using the MySQL binlog (ROW format, full row images) to restore each row's exact prior `params` value.

Fixes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe