### PR TITLE
fix: CwmpIconvert PreachIT converter — broken redirect message, malformed/mis-escaped JSON, untyped params

### DIFF
--- a/admin/src/Lib/CwmpIconvert.php
+++ b/admin/src/Lib/CwmpIconvert.php
@@ -15,14 +15,6 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-/**
- * Convert Class
- * PreachIT Converter system
- *
- * @package  Proclaim.Admin
- * @since    7.1.0
- */
-
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
@@ -30,6 +22,13 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
+/**
+ * Convert Class
+ * PreachIT Converter system
+ *
+ * @package  Proclaim.Admin
+ * @since    7.1.0
+ */
 class CwmpIconvert
 {
     /**
@@ -208,7 +207,7 @@ class CwmpIconvert
      * @throws \Exception
      * @since 7.1.0
      */
-    public function convertPI(): void
+    public function convertPI(): string
     {
         // Check for request forgeries.
         if (!Session::checkToken('get') && !Session::checkToken()) {
@@ -596,7 +595,7 @@ class CwmpIconvert
 
                 // Create the mediafiles
                 if ($pi->audio_link) {
-                    if (!$audio = $this->insertMedia($pi, $type = 'audio', $newid, $oldid)) {
+                    if (!$this->insertMedia($pi, 'audio', $newid)) {
                         $this->mnoadd++;
                     } else {
                         $this->madd++;
@@ -604,7 +603,7 @@ class CwmpIconvert
                 }
 
                 if ($pi->video_link) {
-                    if (!$video = $this->insertMedia($pi, $type = 'video', $newid, $oldid)) {
+                    if (!$this->insertMedia($pi, 'video', $newid)) {
                         $this->mnoadd++;
                     } else {
                         $this->madd++;
@@ -612,7 +611,7 @@ class CwmpIconvert
                 }
 
                 if ($pi->slides_link) {
-                    if (!$slides = $this->insertMedia($pi, $type = 'slides', $newid, $oldid)) {
+                    if (!$this->insertMedia($pi, 'slides', $newid)) {
                         $this->mnoadd++;
                     } else {
                         $this->madd++;
@@ -620,7 +619,7 @@ class CwmpIconvert
                 }
 
                 if ($pi->notes_link) {
-                    if (!$notes = $this->insertMedia($pi, $type = 'notes', $newid, $oldid)) {
+                    if (!$this->insertMedia($pi, 'notes', $newid)) {
                         $this->mnoadd++;
                     } else {
                         $this->madd++;
@@ -631,18 +630,16 @@ class CwmpIconvert
             }
             // Endforeach study
         }
-        /**$piconvertresults = '<table><tr><td><h3>' . Text::_('JBS_IBM_PREACHIT_RESULTS') . '</h3></td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_SERVERS') . '<strong>' . $this->svadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->svnoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_TEACHERS') . '<strong>' . $this->tadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->tnoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_SERIES') . '<strong>' . $$this->sradd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->srnoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_PODCAST') . '<strong>' . $this->padd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->pnoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_STUDIES') . '<strong>' . $this->sadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->snoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_MEDIA') . '<strong>' . $this->madd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->mnoadd . '</td></tr>'
-         * . '<tr><td>' . Text::_('JBS_IBM_PI_COMMENTS') . '<strong>' . $this->cadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED')
-         * . $this->cnoadd . '</td></tr>'
-         * . '</table>';
-         *
-         * Factory::getApplication()->enqueueMessage(Text::_($piconvertresults), 'message'); ;*/
+        $piconvertresults = '<table><tr><td><h3>' . Text::_('JBS_IBM_PREACHIT_RESULTS') . '</h3></td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_TEACHERS') . '<strong>' . $this->tadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->tnoadd . '</td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_SERIES') . '<strong>' . $this->sradd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->srnoadd . '</td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_PODCAST') . '<strong>' . $this->padd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->pnoadd . '</td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_STUDIES') . '<strong>' . $this->sadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->snoadd . '</td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_MEDIA') . '<strong>' . $this->madd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->mnoadd . '</td></tr>'
+            . '<tr><td>' . Text::_('JBS_IBM_PI_COMMENTS') . '<strong>' . $this->cadd . '</strong> - ' . Text::_('JBS_IBM_NOT_CONVERTED') . $this->cnoadd . '</td></tr>'
+            . '</table>';
+
+        return $piconvertresults;
     }
 
     /**
@@ -729,44 +726,24 @@ class CwmpIconvert
     /**
      * Insert Media into Proclaim
      *
-     * @param object $pi ?
-     * @param string $type Type of Media
-     * @param int $newid New ID
-     * @param int $oldid Old ID
+     * @param object $pi     PreachIT study row being converted
+     * @param string $type   Type of Media (audio|video|slides|notes)
+     * @param int    $newid  New Proclaim study ID
      *
      * @return bool
      *
+     * @throws \JsonException
      * @since 9.0.0
-     *
      */
-    public function insertMedia($pi, $type, $newid, $oldid): bool
+    public function insertMedia(object $pi, string $type, int $newid): bool
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery();
         $query->select('*')->from($db->quoteName('#__pifilepath'));
         $db->setQuery($query);
-        $folders     = $db->loadObjectList();
-        $podcast_id  = '0';
-        $media       = new \stdClass();
-        $study_id    = $newid;
-        $media_image = '';
-        $path        = '';
-        $filename    = '';
-        $size        = '';
-        $mime_type   = '';
-        $podcast_id  = '';
-        $filesize    = '';
-        $mediacode   = '';
-        $link_type   = '';
-        $player      = '';
-        $pod         = [];
-        $query       = $db->createQuery();
-        $query->select('*')->from($db->quoteName('#__pipodcast'))->where($db->quoteName('published') . ' = 1');
-        $db->setQuery($query);
-        $podcasts = $db->loadObjectList();
+        $folders = $db->loadObjectList();
 
         if ($type == 'video') {
-            $filesize = $pi->videofs;
             switch ($pi->video_type) {
                 case 4:
                     // Bliptv no longer exists
@@ -784,12 +761,31 @@ class CwmpIconvert
                     $query = $db->createQuery();
                     $query->select($db->quoteName('folder'))->from($db->quoteName('#__pifilepath'))->where($db->quoteName('id') . ' = ' . (int) $pi->video_link);
                     $db->setQuery($query);
-                    $object            = $db->loadObject();
-                    $path              = $object->folder;
-                    $filename          = $path . $pi->video_link;
-                    $filename          = $db->escape($filename);
+                    $object   = $db->loadObject();
+                    $filename = $object->folder . $pi->video_link;
+
                     $media             = new \stdClass();
-                    $media->params     = '{"size":"' . $filesize . ',"filename":"' . $filename . ',"link_type":"","player":"3","popup":"1","mediacode":"","media_image":"","media_use_button_icon":"3","media_button_text":"Video","media_button_type":"btn-link","media_button_color":"","media_icon_type":"fa-solid fa-video","media_custom_icon":"","media_icon_text_size":"24","mime_type":"image\/jpeg","autostart":"1"":"","media_hours":"' . $pi->dur_hrs . '","media_minutes":"' . $pi->dur_mins . '","media_seconds":"' . $pi->dur_secs . '"}';
+                    $media->params     = json_encode([
+                        'size'                  => $pi->videofs,
+                        'filename'              => $filename,
+                        'link_type'             => '',
+                        'player'                => '3',
+                        'popup'                 => '1',
+                        'mediacode'             => '',
+                        'media_image'           => '',
+                        'media_use_button_icon' => '3',
+                        'media_button_text'     => 'Video',
+                        'media_button_type'     => 'btn-link',
+                        'media_button_color'    => '',
+                        'media_icon_type'       => 'fa-solid fa-video',
+                        'media_custom_icon'     => '',
+                        'media_icon_text_size'  => '24',
+                        'mime_type'             => 'image/jpeg',
+                        'autostart'             => '1',
+                        'media_hours'           => $pi->dur_hrs,
+                        'media_minutes'         => $pi->dur_mins,
+                        'media_seconds'         => $pi->dur_secs,
+                    ], JSON_THROW_ON_ERROR);
                     $media->study_id   = $newid;
                     $media->server_id  = $this->legacyvideo;
                     $media->podcast_id = $this->insertPodcast($pi);
@@ -808,10 +804,29 @@ class CwmpIconvert
 
                 case 2:
                     // Vimeo
+                    $mediacode = '<iframe src="https://player.vimeo.com/video/' . $pi->video_link . '" width="500" height="500" frameborder="0" loading="lazy"></iframe> ';
+
                     $media             = new \stdClass();
-                    $mediacode         = '<iframe src="https://player.vimeo.com/video/' . $pi->video_link . '" width="500" height="500" frameborder="0" loading="lazy"></iframe> ';
-                    $mediacode         = $db->escape($mediacode);
-                    $media->params     = '{"filename":"' . $pi->video_link . '","link_type":"","player":"5","popup":"1","mediacode":"' . $mediacode . '","media_image":"","media_use_button_icon":"3","media_button_text":"Video","media_button_type":"btn-link","media_button_color":"","media_icon_type":"fa-solid fa-video","media_custom_icon":"","media_icon_text_size":"24","mime_type":"image\/jpeg","autostart":"1","media_hours":"' . $pi->dur_hrs . '","media_minutes":"' . $pi->dur_mins . '","media_seconds":"' . $pi->dur_secs . '"}';
+                    $media->params     = json_encode([
+                        'filename'              => $pi->video_link,
+                        'link_type'             => '',
+                        'player'                => '5',
+                        'popup'                 => '1',
+                        'mediacode'             => $mediacode,
+                        'media_image'           => '',
+                        'media_use_button_icon' => '3',
+                        'media_button_text'     => 'Video',
+                        'media_button_type'     => 'btn-link',
+                        'media_button_color'    => '',
+                        'media_icon_type'       => 'fa-solid fa-video',
+                        'media_custom_icon'     => '',
+                        'media_icon_text_size'  => '24',
+                        'mime_type'             => 'image/jpeg',
+                        'autostart'             => '1',
+                        'media_hours'           => $pi->dur_hrs,
+                        'media_minutes'         => $pi->dur_mins,
+                        'media_seconds'         => $pi->dur_secs,
+                    ], JSON_THROW_ON_ERROR);
                     $media->study_id   = $newid;
                     $media->server_id  = $this->legacyvideo;
                     $media->podcast_id = $this->insertPodcast($pi);
@@ -830,11 +845,27 @@ class CwmpIconvert
 
                 case 3:
                     // Youtube
-                    $mediacode = '<iframe width="500" height="500" src="https://www.youtube.com/embed/' . $pi->video_link
-                        . '" allowfullscreen loading="lazy"></iframe>';
                     $media             = new \stdClass();
-                    $mediacode         = $db->escape($mediacode);
-                    $media->params     = '{"filename":"https:\/\/youtu.be\/' . $pi->video_link . '","link_type":"","player":"1","popup":"3","mediacode":"","media_image":"","media_use_button_icon":"3","media_button_text":"Watch","media_button_type":"btn-link","media_button_color":"","media_icon_type":"fa-brands fa-youtube","media_custom_icon":"","media_icon_text_size":"24","mime_type":"image\/jpeg","autostart":"1","media_hours":"' . $pi->dur_hrs . '","media_minutes":"' . $pi->dur_mins . '","media_seconds":"' . $pi->dur_secs . '"}';
+                    $media->params     = json_encode([
+                        'filename'              => 'https://youtu.be/' . $pi->video_link,
+                        'link_type'             => '',
+                        'player'                => '1',
+                        'popup'                 => '3',
+                        'mediacode'             => '',
+                        'media_image'           => '',
+                        'media_use_button_icon' => '3',
+                        'media_button_text'     => 'Watch',
+                        'media_button_type'     => 'btn-link',
+                        'media_button_color'    => '',
+                        'media_icon_type'       => 'fa-brands fa-youtube',
+                        'media_custom_icon'     => '',
+                        'media_icon_text_size'  => '24',
+                        'mime_type'             => 'image/jpeg',
+                        'autostart'             => '1',
+                        'media_hours'           => $pi->dur_hrs,
+                        'media_minutes'         => $pi->dur_mins,
+                        'media_seconds'         => $pi->dur_secs,
+                    ], JSON_THROW_ON_ERROR);
                     $media->study_id   = $newid;
                     $media->server_id  = $this->youtube;
                     $media->podcast_id = $this->insertPodcast($pi);
@@ -854,19 +885,41 @@ class CwmpIconvert
         }
 
         if ($type == 'audio') {
+            $filename = '';
+
             foreach ($folders as $folder) {
                 if ($folder->id == $pi->audio_folder) {
                     $filename = $folder->folder . $pi->audio_link;
-                    $filename = $db->escape($filename);
                 }
             }
+
             $media         = new \stdClass();
-            $media->params = '{"filename":"' . $filename . '","mediacode":"","size":"' . $pi->audiofs .
-                '","special":"","player":"7","popup":"3","link_type":"1","media_hours":"' .
-                $pi->dur_hrs . '","media_minutes":"' . $pi->dur_mins . '","media_seconds":"' . $pi->dur_secs .
-                '","media_image":"images\/biblestudy\/speaker24.png","media_use_button_icon":"3","media_button_text":"Listen",' .
-                '"media_button_color":"","media_icon_type":"fa-solid fa-play","media_custom_icon":"","media_icon_text_size":"24","mime_type":"audio\/mp3",' .
-                '"playerwidth":"","playerheight":"","itempopuptitle":"","itempopupfooter":"","popupmargin":"50","autostart":"1"}';
+            $media->params = json_encode([
+                'filename'              => $filename,
+                'mediacode'             => '',
+                'size'                  => $pi->audiofs,
+                'special'               => '',
+                'player'                => '7',
+                'popup'                 => '3',
+                'link_type'             => '1',
+                'media_hours'           => $pi->dur_hrs,
+                'media_minutes'         => $pi->dur_mins,
+                'media_seconds'         => $pi->dur_secs,
+                'media_image'           => 'images/biblestudy/speaker24.png',
+                'media_use_button_icon' => '3',
+                'media_button_text'     => 'Listen',
+                'media_button_color'    => '',
+                'media_icon_type'       => 'fa-solid fa-play',
+                'media_custom_icon'     => '',
+                'media_icon_text_size'  => '24',
+                'mime_type'             => 'audio/mp3',
+                'playerwidth'           => '',
+                'playerheight'          => '',
+                'itempopuptitle'        => '',
+                'itempopupfooter'       => '',
+                'popupmargin'           => '50',
+                'autostart'             => '1',
+            ], JSON_THROW_ON_ERROR);
             $media->study_id   = $newid;
             $media->server_id  = 1;
             $media->podcast_id = $this->insertPodcast($pi);
@@ -875,9 +928,6 @@ class CwmpIconvert
             $media->downloads  = $pi->downloads;
             $media->language   = '*';
             $media->created_by = $pi->user;
-            if ($podcasts) {
-                $media->podcast_id = $this->insertPodcast($pi);
-            }
             if (!$this->insertMediaRecord($media)) {
                 $this->mnoadd++;
             } else {
@@ -887,22 +937,43 @@ class CwmpIconvert
 
 
         if ($type == 'notes') {
-            $filesize = $pi->notesfs;
-            $query    = $db->createQuery();
+            $query = $db->createQuery();
             $query->select($db->quoteName('folder'))->from($db->quoteName('#__pifilepath'))->where($db->quoteName('id') . ' = ' . (int) $pi->notes_folder);
             $db->setQuery($query);
-            $object           = $db->loadObject();
-            $path             = $object->folder;
-            $filename         = $path . $pi->notes_link;
-            $filename         = $db->escape($filename);
+            $object   = $db->loadObject();
+            $filename = $object->folder . $pi->notes_link;
+
             $media            = new \stdClass();
             $media->server_id = 3;
-            $media->params    = '{"filename":"' . $filename . '","mediacode":"","size":"' . $filesize .
-                '","special":"","player":"0","popup":"3","link_type":"0","media_hours":"","media_minutes":"","media_seconds":"",' .
-                '"docMan_id":"0","article_id":"","virtueMart_id":"0","media_image":"images\/biblestudy\/speaker24.png","media_use_button_icon":"3",' .
-                '"media_button_text":"Text","media_button_color":"","media_icon_type":"fa-solid fa-note-sticky","media_custom_icon":"",' .
-                '"media_icon_text_size":"24","mime_type":"audio\/mp3","playerwidth":"","playerheight":"","itempopuptitle":"","itempopupfooter":"",' .
-                '"popupmargin":"50","autostart":"false"}';
+            $media->params    = json_encode([
+                'filename'              => $filename,
+                'mediacode'             => '',
+                'size'                  => $pi->notesfs,
+                'special'               => '',
+                'player'                => '0',
+                'popup'                 => '3',
+                'link_type'             => '0',
+                'media_hours'           => '',
+                'media_minutes'         => '',
+                'media_seconds'         => '',
+                'docMan_id'             => '0',
+                'article_id'            => '',
+                'virtueMart_id'         => '0',
+                'media_image'           => 'images/biblestudy/speaker24.png',
+                'media_use_button_icon' => '3',
+                'media_button_text'     => 'Text',
+                'media_button_color'    => '',
+                'media_icon_type'       => 'fa-solid fa-note-sticky',
+                'media_custom_icon'     => '',
+                'media_icon_text_size'  => '24',
+                'mime_type'             => 'audio/mp3',
+                'playerwidth'           => '',
+                'playerheight'          => '',
+                'itempopuptitle'        => '',
+                'itempopupfooter'       => '',
+                'popupmargin'           => '50',
+                'autostart'             => 'false',
+            ], JSON_THROW_ON_ERROR);
             $media->study_id   = $newid;
             $media->podcast_id = $this->insertPodcast($pi);
             $media->createdate = $pi->date;
@@ -919,22 +990,42 @@ class CwmpIconvert
 
 
         if ($type == 'slides') {
-            $filesize = $pi->slidesfs;
-            $query    = $db->createQuery();
+            $query = $db->createQuery();
             $query->select($db->quoteName('folder'))->from($db->quoteName('#__pifilepath'))->where($db->quoteName('id') . ' = ' . (int) $pi->slides_folder);
             $db->setQuery($query);
-            $object        = $db->loadObject();
-            $path          = $object->folder;
-            $filename      = $path . $pi->slides_link;
-            $filename      = $db->escape($filename);
+            $object   = $db->loadObject();
+            $filename = $object->folder . $pi->slides_link;
+
             $media         = new \stdClass();
-            $media->params = '{"filename":"' . $filename . '","mediacode":"","size":"' . $filesize .
-                '","special":"","player":"0","popup":"3","link_type":"0","media_hours":"' . $pi->dur_hrs .
-                '","media_minutes":"' . $pi->dur_mins . '","media_seconds":"' . $pi->dur_secs .
-                '","docMan_id":"0","article_id":"","virtueMart_id":"0","media_image":"images\/biblestudy\/speaker24.png",' .
-                '"media_use_button_icon":"3","media_button_text":"Audio","media_button_color":"","media_icon_type":"fa-solid fa-file-powerpoint",' .
-                '"media_custom_icon":"","media_icon_text_size":"24","mime_type":"audio\/mp3","playerwidth":"","playerheight":"",' .
-                '"itempopuptitle":"","itempopupfooter":"","popupmargin":"50","autostart":"false"}';
+            $media->params = json_encode([
+                'filename'              => $filename,
+                'mediacode'             => '',
+                'size'                  => $pi->slidesfs,
+                'special'               => '',
+                'player'                => '0',
+                'popup'                 => '3',
+                'link_type'             => '0',
+                'media_hours'           => $pi->dur_hrs,
+                'media_minutes'         => $pi->dur_mins,
+                'media_seconds'         => $pi->dur_secs,
+                'docMan_id'             => '0',
+                'article_id'            => '',
+                'virtueMart_id'         => '0',
+                'media_image'           => 'images/biblestudy/speaker24.png',
+                'media_use_button_icon' => '3',
+                'media_button_text'     => 'Audio',
+                'media_button_color'    => '',
+                'media_icon_type'       => 'fa-solid fa-file-powerpoint',
+                'media_custom_icon'     => '',
+                'media_icon_text_size'  => '24',
+                'mime_type'             => 'audio/mp3',
+                'playerwidth'           => '',
+                'playerheight'          => '',
+                'itempopuptitle'        => '',
+                'itempopupfooter'       => '',
+                'popupmargin'           => '50',
+                'autostart'             => 'false',
+            ], JSON_THROW_ON_ERROR);
             $media->study_id   = $newid;
             $media->server_id  = 3;
             $media->podcast_id = $this->insertPodcast($pi);
@@ -943,9 +1034,6 @@ class CwmpIconvert
             $media->downloads  = $pi->downloads;
             $media->language   = '*';
             $media->created_by = $pi->user;
-            if ($podcasts) {
-                $podcast_id = $this->insertPodcast($pi);
-            }
             if (!$this->insertMediaRecord($media)) {
                 $this->mnoadd++;
             } else {
@@ -958,17 +1046,16 @@ class CwmpIconvert
     }
 
     /**
-     * @param $pi
+     * @param object $pi PreachIT study row being matched against podcast inclusion/exclusion rules
      *
-     * @return false|mixed|void
+     * @return int|null  Matching Proclaim podcast ID, or null if no podcast matches / exclusion applies
      *
      * @since 9.0.0
      */
-    private function insertPodcast($pi): mixed
+    private function insertPodcast(object $pi): ?int
     {
-        $podtest = 0;
-        $db      = Factory::getContainer()->get(DatabaseInterface::class);
-        $query   = $db->createQuery();
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery();
         $query->select('*')->from($db->quoteName('#__pipodcast'))->where($db->quoteName('published') . ' = 1');
         $db->setQuery($query);
         $podcasts        = $db->loadObjectList();
@@ -1101,18 +1188,20 @@ class CwmpIconvert
             }
             //Use include/exclude lists to determine if the media file is in which podcast
         } // end foreach podcast
+
+        return null;
     }
 
     /**
-     * @param $includemedia
-     * @param $pi
-     * @param $podcast
+     * @param array  $includemedia  Media types this podcast includes (or ['all'])
+     * @param object $pi            PreachIT study row being matched
+     * @param object $podcast       PreachIT podcast row being matched against
      *
-     * @return mixed|void
+     * @return int|null  Matching Proclaim podcast ID, or null if no media type matches
      *
      * @since 9.0.0
      */
-    private function checkMedia($includemedia, $pi, $podcast): mixed
+    private function checkMedia(array $includemedia, object $pi, object $podcast): ?int
     {
         //check for which media to include
         if ($includemedia == 'all') {
@@ -1152,16 +1241,18 @@ class CwmpIconvert
                 }
             }
         }
+
+        return null;
     }
 
     /**
-     * @param $mediafiles
+     * @param object $mediafiles  Media file row to insert
      *
      * @return bool
      *
      * @since 9.0.0
      */
-    private function insertMediaRecord($mediafiles): bool
+    private function insertMediaRecord(object $mediafiles): bool
     {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
         if (!$db->insertObject('#__bsms_mediafiles', $mediafiles, 'id')) {
@@ -1174,14 +1265,14 @@ class CwmpIconvert
     /**
      * Insert Comments
      *
-     * @param int $oldid ?
-     * @param int $newid ?
+     * @param int $oldid  PreachIT study ID the comments belonged to
+     * @param int $newid  Newly created Proclaim study ID
      *
      * @return bool
      *
      * @since 9.0.0
      */
-    private function insertComments($oldid, $newid): bool
+    private function insertComments(int $oldid, int $newid): bool
     {
         if (!$this->picomments) {
             return false;

--- a/tests/unit/Admin/Lib/CwmpIconvertTest.php
+++ b/tests/unit/Admin/Lib/CwmpIconvertTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * Unit tests for CwmpIconvert
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\CwmpIconvert;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1513.
+ *
+ * convertPI() is not exercised end-to-end here: it truncates
+ * #__bsms_studies/#__bsms_teachers/#__bsms_mediafiles/#__bsms_podcast/
+ * #__bsms_locations/#__bsms_series unconditionally and reads from PreachIT's
+ * own tables (#__pistudies, #__piteachers, ...), none of which exist outside
+ * a real PreachIT install. Running it against a real DB would destroy
+ * whatever Proclaim data is already there. These are structural/source
+ * assertions instead, matching the pattern used for other DB-touching
+ * converters in this test suite.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmpIconvertTest extends ProclaimTestCase
+{
+    /**
+     * Get the source body of a CwmpIconvert method for structural assertions.
+     *
+     * @param   string  $method
+     *
+     * @return  string
+     */
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    /**
+     * convertPI() returned void, so CwmadminController::convertPreachIt() passed null to
+     * setRedirect() as the flash message on every conversion — success or failure looked
+     * identical to the user. The sibling Cwmssconvert::convertSS() already returns a built
+     * results-summary string; convertPI() must do the same.
+     */
+    public function testConvertPIReturnsString(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'convertPI');
+
+        $this->assertSame('string', (string) $reflection->getReturnType(), 'convertPI() must return string — see #1513');
+    }
+
+    public function testConvertPIReturnsTheBuiltResultsTable(): void
+    {
+        $body = self::methodBody('convertPI');
+
+        $this->assertMatchesRegularExpression(
+            '/return\s+\$piconvertresults;/',
+            $body,
+            'convertPI() must return the results-summary table it builds, not a dangling local — see #1513'
+        );
+        // The pre-#1513 dead code referenced counters that were never tracked
+        // ($this->svadd/$this->svnoadd) and a `$$this->sradd` typo; neither must resurface.
+        $this->assertDoesNotMatchRegularExpression('/\$this->svadd|\$this->svnoadd/', $body);
+        $this->assertDoesNotMatchRegularExpression('/\$\$this->sradd/', $body);
+    }
+
+    public function testConvertPreachItControllerPassesResultToRedirect(): void
+    {
+        $reflection = new \ReflectionMethod(
+            \CWM\Component\Proclaim\Administrator\Controller\CwmadminController::class,
+            'convertPreachIt'
+        );
+        $lines = file($reflection->getFileName());
+        $body  = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/\$piconversion\s*=\s*\$convert->convertPI\(\)/',
+            $body
+        );
+        $this->assertMatchesRegularExpression(
+            '/setRedirect\([^;]*\$piconversion/',
+            $body,
+            'convertPreachIt() must pass convertPI()\'s return value to setRedirect() — see #1513'
+        );
+    }
+
+    /**
+     * insertMedia() hand-built its `params` JSON blob via string concatenation, mixing
+     * $db->escape() (SQL escaping) into JSON content — wrong escaping semantics, and one
+     * branch (JWPlayer) was outright malformed JSON (missing colon after "size", a stray
+     * '":""' token). All branches must build an array and encode it instead.
+     */
+    public function testInsertMediaBuildsParamsViaJsonEncode(): void
+    {
+        $body = self::methodBody('insertMedia');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\$media(->params)?\s*=\s*.\{"/',
+            $body,
+            'insertMedia() must not hand-build the params JSON string via concatenation — see #1513'
+        );
+        $this->assertSame(
+            6,
+            preg_match_all('/json_encode\(\s*\[/', $body),
+            'insertMedia() must build params via json_encode() in all 6 branches ' .
+                '(JWPlayer/Vimeo/YouTube video, audio, notes, slides) — see #1513'
+        );
+    }
+
+    public function testInsertMediaDoesNotSqlEscapeValuesBeforeJsonEncoding(): void
+    {
+        $body = self::methodBody('insertMedia');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\$db->escape\(\s*\$(filename|mediacode)\s*\)/',
+            $body,
+            'filename/mediacode must not be SQL-escaped before being embedded in JSON — json_encode() ' .
+                'handles its own escaping, and SQL-escaping first corrupts values containing backslashes or quotes — see #1513'
+        );
+    }
+
+    public function testInsertMediaHasTypedParameters(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'insertMedia');
+        $params     = $reflection->getParameters();
+
+        $this->assertSame('object', (string) $params[0]->getType());
+        $this->assertSame('string', (string) $params[1]->getType());
+        $this->assertSame('int', (string) $params[2]->getType());
+        $this->assertCount(3, $params, 'the unused $oldid parameter must stay removed — see #1513');
+    }
+
+    public function testInsertPodcastReturnsNullableIntWithExplicitFallthrough(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'insertPodcast');
+
+        $this->assertSame('?int', (string) $reflection->getReturnType());
+
+        $body = self::methodBody('insertPodcast');
+        $this->assertMatchesRegularExpression(
+            '/return\s+null;\s*\}\s*$/',
+            rtrim($body),
+            'insertPodcast() must explicitly return null on fall-through, not rely on implicit null — see #1513'
+        );
+    }
+
+    public function testCheckMediaReturnsNullableIntWithExplicitFallthrough(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'checkMedia');
+
+        $this->assertSame('?int', (string) $reflection->getReturnType());
+
+        $body = self::methodBody('checkMedia');
+        $this->assertMatchesRegularExpression(
+            '/return\s+null;\s*\}\s*$/',
+            rtrim($body),
+            'checkMedia() must explicitly return null on fall-through, not rely on implicit null — see #1513'
+        );
+    }
+
+    public function testClassDocblockIsAboveTheClassDeclaration(): void
+    {
+        $reflection = new \ReflectionClass(CwmpIconvert::class);
+        $lines      = file($reflection->getFileName());
+        $classLine  = $reflection->getStartLine();
+
+        // The line immediately above the class declaration must close a docblock (`*/`),
+        // not a `use` import statement — the class docblock was previously stranded above
+        // the use-import block instead of directly above the class.
+        $this->assertMatchesRegularExpression('/\*\/\s*$/', $lines[$classLine - 2]);
+    }
+}


### PR DESCRIPTION
## Summary
- `convertPI(): void` → `: string` — restores the (previously dead/commented-out) results-summary table and returns it, mirroring the sibling `Cwmssconvert::convertSS()` pattern. Fixes the actual reported bug: every conversion, success or failure, redirected with a null message.
- `insertMedia()`'s hand-built JSON `params` strings replaced with `json_encode()` across all 6 construction sites (JWPlayer/Vimeo/YouTube video, audio, notes, slides). One of those (JWPlayer) was already invalid JSON before this change — missing colon after `"size"`, a stray `":""` token. Also dropped `$db->escape()` calls on `$filename`/`$mediacode` before JSON embedding — SQL-escaping and JSON-escaping are different schemes, and mixing them corrupted values with backslashes/quotes.
- Type hints added: `insertMedia()`, `insertPodcast()`, `checkMedia()`, `insertMediaRecord()`, `insertComments()`.
- `insertPodcast()`/`checkMedia()` now explicitly `return null` on fall-through instead of relying on implicit null.
- Removed a dead `$podcast_id = $this->insertPodcast($pi);` write in the `slides` branch (value never read — `media->podcast_id` was already set unconditionally a few lines earlier) and the same dead pattern in `audio`. Removed the unused `$oldid` parameter from `insertMedia()`.
- Class docblock moved to directly above the class declaration (was stranded above the `use` import block).

## Deliberately deferred
The Table-layer bypass (raw `$db->insertObject()` instead of Joomla's Table classes → converted records get no `#__assets` rows → ACL-drift 404s) is filed separately as #1515. No `#__pi*` (PreachIT) tables exist on any dev/test site, so `convertPI()` can't be exercised end-to-end at all right now — rewriting the highest-risk part of it with zero ability to verify the result isn't worth the risk. Scope rationale posted on #1513.

## Test plan
- [x] `tests/unit/Admin/Lib/CwmpIconvertTest.php` (new, 9 tests) — structural/reflection-based, since `convertPI()` truncates live Proclaim tables unconditionally and can't safely be executed against any real DB. Verified red-before/green-after via `git stash` on the source file alone (8/9 fail on the pre-fix code).
- [x] Full unit suite: 1133 tests, 0 failures
- [x] `php -l` clean
- [x] `composer lint:fix` clean on changed files (submodule drift in `plugins/content/scripturelinks` reverted, pre-existing/unrelated)

Fixes #1513