### PR TITLE
fix: CwmpIconvert validates PreachIT access codes against #__viewlevels

### DIFF
--- a/admin/src/Lib/CwmpIconvert.php
+++ b/admin/src/Lib/CwmpIconvert.php
@@ -199,6 +199,9 @@ class CwmpIconvert
     /** @var int|null YouTube server ID @since 10.1.0 */
     public ?int $youtube = null;
 
+    /** @var int[]|null Cached #__viewlevels ids, populated on first use @since __DEPLOY_VERSION__ */
+    private ?array $validAccessLevels = null;
+
     /**
      * Convert PreachIT
      *
@@ -348,7 +351,7 @@ class CwmpIconvert
                 $locations->id            = null;
                 $locations->published     = $pi->published;
                 $locations->location_text = $pi->name;
-                $locations->access        = $pi->access;
+                $locations->access        = $this->resolveAccessLevel($pi->access);
                 $locations->ordering      = $pi->ordering;
                 $locations->misc          = $pi->description;
                 $locations->image         = $pi->image_folderlrg . $pi->ministry_image_lrg;
@@ -545,7 +548,7 @@ class CwmpIconvert
 
                 $published = $pi->published;
                 $params    = '{"metakey":"' . $pi->metakey . '","metadesc":""}';
-                $access    = $pi->saccess;
+                $access    = $this->resolveAccessLevel($pi->saccess);
 
                 // Create the study then get the id to create the media file and comments
                 $datastudies                 = new \stdClass();
@@ -724,6 +727,36 @@ class CwmpIconvert
     }
 
     /**
+     * Validate a PreachIT-supplied access/view-level value against this site's
+     * `#__viewlevels` table, falling back to Public (id 1 — a protected system
+     * level guaranteed to exist on every Joomla install) when the value doesn't
+     * correspond to a real view level here. PreachIT's own access-code numbering
+     * has no guaranteed relationship to the target site's view level ids, which
+     * aren't even guaranteed contiguous (e.g. 1,2,3,5,6,7) — writing it through
+     * unvalidated can silently assign an imported record to a view level no
+     * user holds, making it permanently invisible with no error at import time.
+     *
+     * @param mixed $value  Raw PreachIT access/accesscode value
+     *
+     * @return int
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function resolveAccessLevel(mixed $value): int
+    {
+        $value = (int) $value;
+
+        if ($this->validAccessLevels === null) {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->createQuery()->select($db->quoteName('id'))->from($db->quoteName('#__viewlevels'));
+            $db->setQuery($query);
+            $this->validAccessLevels = array_map('intval', $db->loadColumn());
+        }
+
+        return \in_array($value, $this->validAccessLevels, true) ? $value : 1;
+    }
+
+    /**
      * Insert Media into Proclaim
      *
      * @param object $pi     PreachIT study row being converted
@@ -791,7 +824,7 @@ class CwmpIconvert
                     $media->podcast_id = $this->insertPodcast($pi);
                     $media->createdate = $pi->date;
                     $media->hits       = $pi->hits;
-                    $media->access     = $pi->accesscode;
+                    $media->access     = $this->resolveAccessLevel($pi->accesscode);
                     $media->language   = '*';
                     $media->created_by = $pi->user;
                     if (!$this->insertMediaRecord($media)) {
@@ -832,7 +865,7 @@ class CwmpIconvert
                     $media->podcast_id = $this->insertPodcast($pi);
                     $media->createdate = $pi->date;
                     $media->hits       = $pi->hits;
-                    $media->access     = $pi->accesscode;
+                    $media->access     = $this->resolveAccessLevel($pi->accesscode);
                     $media->language   = '*';
                     $media->created_by = $pi->user;
                     if (!$this->insertMediaRecord($media)) {
@@ -871,7 +904,7 @@ class CwmpIconvert
                     $media->podcast_id = $this->insertPodcast($pi);
                     $media->createdate = $pi->date;
                     $media->hits       = $pi->hits;
-                    $media->access     = $pi->accesscode;
+                    $media->access     = $this->resolveAccessLevel($pi->accesscode);
                     $media->language   = '*';
                     $media->created_by = $pi->user;
                     if (!$this->insertMediaRecord($media)) {

--- a/tests/unit/Admin/Lib/CwmpIconvertTest.php
+++ b/tests/unit/Admin/Lib/CwmpIconvertTest.php
@@ -13,6 +13,8 @@ namespace CWM\Component\Proclaim\Tests\Admin\Lib;
 
 use CWM\Component\Proclaim\Administrator\Lib\CwmpIconvert;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Regression tests for #1513.
@@ -170,6 +172,63 @@ class CwmpIconvertTest extends ProclaimTestCase
             '/return\s+null;\s*\}\s*$/',
             rtrim($body),
             'checkMedia() must explicitly return null on fall-through, not rely on implicit null — see #1513'
+        );
+    }
+
+    /**
+     * Regression tests for the access-level validation gap found while investigating #1515:
+     * $pi->saccess / $pi->access / $pi->accesscode (PreachIT's own access-code values) were
+     * written straight into Proclaim's `access` column with no check against this site's
+     * `#__viewlevels` table. That table's ids aren't even guaranteed contiguous, so an
+     * unmapped PreachIT code silently assigns an imported record to a view level no user
+     * holds -- the record exists but is invisible to everyone, with no error at import time.
+     *
+     * resolveAccessLevel() is exercised directly against the real `#__viewlevels` table
+     * (read-only) rather than a fabricated schema -- unlike PreachIT's own tables, this one
+     * genuinely exists on every Joomla install, so this is real behavior, not a guess.
+     */
+    public function testResolveAccessLevelAcceptsAnExistingViewLevel(): void
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()->select($db->quoteName('id'))->from($db->quoteName('#__viewlevels'));
+        $db->setQuery($query, 0, 1);
+        $validId = (int) $db->loadResult();
+
+        $this->assertGreaterThan(0, $validId, 'test precondition: #__viewlevels must have at least one row');
+
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'resolveAccessLevel');
+        $result     = $reflection->invoke(new CwmpIconvert(), $validId);
+
+        $this->assertSame($validId, $result);
+    }
+
+    public function testResolveAccessLevelFallsBackToPublicForAnUnmappedId(): void
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()->select('MAX(' . $db->quoteName('id') . ')')->from($db->quoteName('#__viewlevels'));
+        $db->setQuery($query);
+        $unmappedId = (int) $db->loadResult() + 1000;
+
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'resolveAccessLevel');
+        $result     = $reflection->invoke(new CwmpIconvert(), $unmappedId);
+
+        $this->assertSame(1, $result, 'an unmapped access value must fall back to Public (id 1) — see #1515');
+    }
+
+    public function testAllAccessSitesGoThroughResolveAccessLevel(): void
+    {
+        $bodies = self::methodBody('convertPI') . self::methodBody('insertMedia');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/->access\s*=\s*\$pi->(saccess|access|accesscode)\s*;/',
+            $bodies,
+            'every ->access assignment sourced from PreachIT data must go through ' .
+                'resolveAccessLevel() rather than being written unvalidated — see #1515'
+        );
+        $this->assertSame(
+            5,
+            preg_match_all('/resolveAccessLevel\(/', $bodies),
+            'expected 5 call sites (studies, locations, and 3x media video branches) — see #1515'
         );
     }
 


### PR DESCRIPTION
## Summary
- `$pi->saccess` / `$pi->access` / `$pi->accesscode` (PreachIT's own access-code values) were written straight into Proclaim's `access` column with no validation against the target site's `#__viewlevels` table. That table's ids aren't guaranteed contiguous (j5-dev has 1,2,3,5,6,7 — no 4), so an unmapped PreachIT code silently assigns an imported record to a view level no user holds — the record exists but is invisible everywhere, with no error at import time.
- Adds `CwmpIconvert::resolveAccessLevel(mixed $value): int` — validates against `#__viewlevels` (cached per `convertPI()` run to avoid N+1 queries across potentially hundreds of studies), falling back to Public (id 1, a protected system level guaranteed on every Joomla install).
- Applied at all 5 sites writing a PreachIT-sourced access value: studies, locations, and the 3 media video branches (JWPlayer/Vimeo/YouTube) in `insertMedia()`.
- `show_level` (separate column, also populated from `$pi->access` for studies) is left untouched — it's a legacy field with no read call site anywhere else in the codebase, not ACL-driving, out of scope here.

## Related
Found while investigating and closing #1515 (that issue's premise — missing `#__assets` rows cause 404s — turned out to be wrong; `asset_id=0` is the normal post-10.3.0 state). Filed as #1519.

## Test plan
Unlike #1515's scope, this is fully verifiable without a real PreachIT install: `resolveAccessLevel()` only depends on `#__viewlevels`, which genuinely exists on every Joomla site.

- [x] New tests exercise `resolveAccessLevel()` directly against the real (read-only) `#__viewlevels` table — valid id round-trips, unmapped id falls back to 1
- [x] Structural tests confirm all 5 write sites go through `resolveAccessLevel()`
- [x] Verified red-before/green-after via `git stash` on the source alone (3 failures pre-fix, 0 post-fix)
- [x] Full unit suite: 1136 tests, 0 failures
- [x] `php -l` clean, `php-cs-fixer` clean on changed files

Fixes #1519