### PR TITLE
fix: Cwmbackup validates table names against Proclaim's own tables

### DIFF
--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -21,6 +21,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\Version;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
@@ -57,6 +58,48 @@ class Cwmbackup
      * @since 9.0.0
      */
     protected string $saveAsName = '';
+
+    /**
+     * Cached list of this component's own table names (with `#__` prefix), as
+     * returned by CwmdbHelper::getObjects(). Populated on first use.
+     *
+     * @var string[]|null
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static ?array $knownTables = null;
+
+    /**
+     * Reject any table name that isn't one of this component's own tables.
+     *
+     * The table-export methods below take `$table` from AJAX request input
+     * (see CwmbackupController::exportTableXHR()) and interpolate it directly
+     * into `SHOW CREATE TABLE`/`SELECT *` queries. Without this check, a
+     * request for e.g. `#__users` would export Joomla's user table — including
+     * password hashes — through an endpoint meant only for this component's
+     * own `#__bsms_*` tables. Validating here (not just in the controller)
+     * keeps every export method safe regardless of caller.
+     *
+     * @param   string  $table  Full table name (with `#__` prefix) to check
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function isKnownProclaimTable(string $table): bool
+    {
+        if (self::$knownTables === null) {
+            self::$knownTables = array_column(CwmdbHelper::getObjects(), 'name');
+        }
+
+        if (\in_array($table, self::$knownTables, true)) {
+            return true;
+        }
+
+        Log::add('Rejected export/count request for non-Proclaim table: ' . $table, Log::WARNING, 'com_proclaim');
+
+        return false;
+    }
 
     /**
      * Generate a standardized backup filename
@@ -465,6 +508,10 @@ class Cwmbackup
             return $this->getProclaimAssetsExport();
         }
 
+        if (!self::isKnownProclaimTable($table)) {
+            return '';
+        }
+
         // Reset the execution time limit for long-running exports
         if (\function_exists('set_time_limit')) {
             set_time_limit(\ini_get('max_execution_time'));
@@ -537,6 +584,10 @@ class Cwmbackup
      */
     public function getTableRowCount(string $table): int
     {
+        if (!self::isKnownProclaimTable($table)) {
+            return 0;
+        }
+
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery()
             ->select('COUNT(*)')
@@ -557,6 +608,10 @@ class Cwmbackup
      */
     public function getExportTableStructure(string $table): string
     {
+        if (!self::isKnownProclaimTable($table)) {
+            return '';
+        }
+
         $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $prefix = $db->getPrefix();
         $export = '';
@@ -593,6 +648,10 @@ class Cwmbackup
      */
     public function getExportTableRows(string $table, int $offset, int $limit): string
     {
+        if (!self::isKnownProclaimTable($table)) {
+            return '';
+        }
+
         if (\function_exists('set_time_limit')) {
             set_time_limit(\ini_get('max_execution_time'));
         }

--- a/tests/unit/Admin/Lib/CwmbackupTest.php
+++ b/tests/unit/Admin/Lib/CwmbackupTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Administrator\Lib\Cwmbackup;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1521.
+ *
+ * getExportTableData()/getTableRowCount()/getExportTableStructure()/getExportTableRows()
+ * took `$table` straight from AJAX request input (CwmbackupController::exportTableXHR())
+ * and interpolated it into SHOW CREATE TABLE / SELECT * queries with no allow-list check.
+ * A request for e.g. `#__users` would export Joomla's user table -- including password
+ * hashes -- through an endpoint meant only for this component's own `#__bsms_*` tables.
+ *
+ * These tests exercise the real (read-only) methods against the real dev database rather
+ * than a mock, since the fix depends on CwmdbHelper::getObjects()'s actual table list.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmbackupTest extends ProclaimTestCase
+{
+    public function testGetTableRowCountRejectsANonProclaimTable(): void
+    {
+        $this->assertSame(0, (new Cwmbackup())->getTableRowCount('#__users'));
+    }
+
+    public function testGetExportTableStructureRejectsANonProclaimTable(): void
+    {
+        $this->assertSame('', (new Cwmbackup())->getExportTableStructure('#__users'));
+    }
+
+    public function testGetExportTableRowsRejectsANonProclaimTable(): void
+    {
+        $this->assertSame('', (new Cwmbackup())->getExportTableRows('#__users', 0, 10));
+    }
+
+    public function testGetExportTableDataRejectsANonProclaimTable(): void
+    {
+        $this->assertSame('', (new Cwmbackup())->getExportTableData('#__users'));
+    }
+
+    public function testGetTableRowCountAcceptsARealProclaimTable(): void
+    {
+        $tables = array_column(CwmdbHelper::getObjects(), 'name');
+        $this->assertNotEmpty($tables, 'test precondition: at least one Proclaim table must exist');
+
+        // A real table must not be silently rejected -- assert the call actually
+        // reaches the DB (a rejected table always returns exactly 0 via the guard;
+        // this only proves non-rejection when the count comes back > 0, so use a
+        // table this dev DB is known to have rows in).
+        $rowCount = (new Cwmbackup())->getTableRowCount('#__bsms_studies');
+
+        $this->assertGreaterThan(0, $rowCount, 'expected #__bsms_studies to have rows on j5-dev');
+    }
+
+    public function testGetExportTableDataStillHandlesVirtualTables(): void
+    {
+        // Virtual "tables" (_component_config, etc.) are handled before the
+        // allow-list check and must keep working -- they are not real table names.
+        $export = (new Cwmbackup())->getExportTableData('_component_config');
+
+        $this->assertStringContainsString('Component Configuration', $export);
+    }
+}


### PR DESCRIPTION
## Summary

`getExportTableData()`/`getTableRowCount()`/`getExportTableStructure()`/`getExportTableRows()` took `$table` straight from AJAX request input (`CwmbackupController::exportTableXHR()`, only guarded by `empty()`) and interpolated it directly into `SHOW CREATE TABLE`/`SELECT *` queries. A request for `table=#__users` would export Joomla's user table — **including password hashes** — through an endpoint meant only for this component's own `#__bsms_*` tables.

Adds `Cwmbackup::isKnownProclaimTable()`, validating against `CwmdbHelper::getObjects()`'s authoritative table list (the same source the export UI itself uses to enumerate tables), cached per-instance. Applied at all 4 methods that take a table name from external input. Virtual "tables" (`_component_config`, `_scheduled_tasks`, `_proclaim_assets`) are unaffected — the check sits after their existing dedicated branches. `getExportTable()` (the non-AJAX "Export DB" button path) is untouched — it's only ever called internally with names sourced from `CwmdbHelper::getObjects()` itself, never external input, so it was never exposed to this.

## Test plan

- [x] New tests in `tests/unit/Admin/Lib/CwmbackupTest.php` exercise the real methods against the real dev database (read-only) — this fix's correctness depends on the actual `CwmdbHelper::getObjects()` table list, not a mock.
- [x] Verified red-before/green-after via `git stash` on the source alone. **The pre-fix failure output literally dumped real bcrypt password hashes and emails from `#__users`** — concrete proof the vulnerability was real, not theoretical.
- [x] Confirmed virtual tables still work post-fix (`_component_config` export still returns real content).
- [x] Full unit suite: 1142 tests, 0 failures. `php -l` clean, `php-cs-fixer` clean.
- [x] No live/browser test: this fix is pure DB-query-construction logic in a Lib class — no routing/controller/session changes — and is already directly exercised against the real dev database by the new tests. A browser test would mainly exercise the unrelated auth/CSRF layer, which isn't touched here.

Fixes #1521