### PR TITLE
fix: Cwmrestore restricts executed statements to Cwmbackup's own SQL shapes

### DIFF
--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -39,6 +39,69 @@ use Joomla\Filesystem\Path;
 class Cwmrestore
 {
     /**
+     * Core Joomla tables that Cwmbackup's own export methods legitimately write
+     * to (component config, ACL rules, scheduled tasks) alongside Proclaim's own
+     * `#__bsms_*` tables (which are discovered dynamically via CwmdbHelper).
+     *
+     * @var string[]
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private const array ALLOWED_RESTORE_TABLES = ['#__extensions', '#__assets', '#__scheduler_tasks'];
+
+    /**
+     * Cached list of Proclaim's own table names, populated on first use.
+     *
+     * @var string[]|null
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static ?array $bsmsTables = null;
+
+    /**
+     * Reject any SQL statement from a restore file that isn't one of the shapes
+     * (and target tables) Cwmbackup itself is known to generate.
+     *
+     * restoreDB()/installdb() execute every statement in an uploaded/selected
+     * backup file with essentially no validation -- only two substr_count()
+     * checks for literal marker strings, trivially satisfied by embedding them
+     * anywhere (even a comment) while the rest of the file contains arbitrary
+     * SQL. This is Super-User-gated, so not a remote-anonymous vector, but a
+     * compromised admin account or a supply-chain-tainted backup file shared
+     * between sites has far more reach than this feature needs. Restricting to
+     * the statement shapes and tables Cwmbackup actually produces is defense in
+     * depth, not a hard sandbox -- see #1522 for the full threat discussion.
+     *
+     * @param   string  $statement  A single SQL statement (already trimmed, non-empty, non-comment)
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function isSafeRestoreStatement(string $statement): bool
+    {
+        $pattern = '/^(?:CREATE\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?|ALTER\s+TABLE|INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+`?(?<table>#__[a-z0-9_]+)`?/i';
+
+        if (!preg_match($pattern, $statement, $matches)) {
+            Log::add('Rejected restore statement (unrecognized shape): ' . substr($statement, 0, 120), Log::WARNING, 'com_proclaim');
+
+            return false;
+        }
+
+        if (self::$bsmsTables === null) {
+            self::$bsmsTables = array_column(CwmdbHelper::getObjects(), 'name');
+        }
+
+        if (\in_array($matches['table'], self::$bsmsTables, true) || \in_array($matches['table'], self::ALLOWED_RESTORE_TABLES, true)) {
+            return true;
+        }
+
+        Log::add('Rejected restore statement targeting non-Proclaim table: ' . $matches['table'], Log::WARNING, 'com_proclaim');
+
+        return false;
+    }
+
+    /**
      * Alter tables for Blob
      *
      * @return bool
@@ -327,10 +390,18 @@ class Cwmrestore
         foreach ($queries as $query) {
             $query = trim($query);
 
-            if ($query !== '' && $query[0] !== '#') {
-                $db->setQuery($query);
-                $db->execute();
+            if ($query === '' || $query[0] === '#') {
+                continue;
             }
+
+            if (!self::isSafeRestoreStatement($query)) {
+                $app->enqueueMessage(Text::_('JBS_IBM_NOT_DB'), 'error');
+
+                return false;
+            }
+
+            $db->setQuery($query);
+            $db->execute();
         }
 
         // After restoring, reset the schema version and run DatabaseModel::fix()
@@ -563,14 +634,22 @@ class Cwmrestore
         foreach ($queries as $query) {
             $query = trim($query);
 
-            if ($query !== '' && $query[0] !== '#') {
-                $db->setQuery($query);
+            if ($query === '' || $query[0] === '#') {
+                continue;
+            }
 
-                if (!$db->execute()) {
-                    $app->enqueueMessage(Text::sprintf('JBS_IBM_INSTALLDB_ERRORS', $db->stderr(true)), 'error');
+            if (!self::isSafeRestoreStatement($query)) {
+                $app->enqueueMessage(Text::_('JBS_IBM_NOT_DB'), 'error');
 
-                    return false;
-                }
+                return false;
+            }
+
+            $db->setQuery($query);
+
+            if (!$db->execute()) {
+                $app->enqueueMessage(Text::sprintf('JBS_IBM_INSTALLDB_ERRORS', $db->stderr(true)), 'error');
+
+                return false;
             }
         }
 

--- a/tests/unit/Admin/Lib/CwmrestoreTest.php
+++ b/tests/unit/Admin/Lib/CwmrestoreTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmrestore;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression tests for #1522.
+ *
+ * restoreDB()/installdb() executed every statement in an uploaded/selected backup
+ * file with only two substr_count() checks for literal marker strings -- trivially
+ * satisfied while the rest of the file contained arbitrary SQL (DROP DATABASE,
+ * GRANT, writes to #__users/#__extensions, etc.). isSafeRestoreStatement() now
+ * restricts execution to the statement shapes and tables Cwmbackup itself is known
+ * to generate.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmrestoreTest extends ProclaimTestCase
+{
+    private static function isSafeRestoreStatement(string $statement): bool
+    {
+        $reflection = new \ReflectionMethod(Cwmrestore::class, 'isSafeRestoreStatement');
+
+        return $reflection->invoke(null, $statement);
+    }
+
+    public static function legitimateStatementProvider(): array
+    {
+        return [
+            'CREATE TABLE on a bsms table' => [
+                'CREATE TABLE `#__bsms_studies` (`id` int NOT NULL) ENGINE=InnoDB;',
+            ],
+            'DROP TABLE IF EXISTS on a bsms table' => [
+                'DROP TABLE IF EXISTS `#__bsms_studies`;',
+            ],
+            'INSERT INTO a bsms table' => [
+                "INSERT INTO `#__bsms_studies` SET `id`='1',`studytitle`='Test';",
+            ],
+            'UPDATE #__extensions (component config restore)' => [
+                "UPDATE `#__extensions` SET `params` = '{}' WHERE `element` = 'com_proclaim';",
+            ],
+            'UPDATE #__assets (ACL restore)' => [
+                "UPDATE `#__assets` SET `rules` = '{}' WHERE `name` = 'com_proclaim';",
+            ],
+            'DELETE FROM #__scheduler_tasks (scheduled task restore)' => [
+                "DELETE FROM `#__scheduler_tasks` WHERE `type` LIKE 'proclaim.%';",
+            ],
+            'INSERT INTO ... SELECT (per-record ACL relink)' => [
+                "INSERT INTO `#__assets` (`parent_id`, `lft`) SELECT p.`id`, 0 FROM `#__assets` p WHERE p.`name` = 'com_proclaim';",
+            ],
+        ];
+    }
+
+    #[DataProvider('legitimateStatementProvider')]
+    public function testAcceptsStatementShapesCwmbackupActuallyGenerates(string $statement): void
+    {
+        $this->assertTrue(self::isSafeRestoreStatement($statement), 'rejected a statement shape Cwmbackup legitimately produces: ' . $statement);
+    }
+
+    public static function maliciousStatementProvider(): array
+    {
+        return [
+            'DROP DATABASE'                                                       => ['DROP DATABASE j5_dev;'],
+            'GRANT ALL'                                                           => ["GRANT ALL PRIVILEGES ON *.* TO 'attacker'@'%';"],
+            'UPDATE #__users password'                                            => ["UPDATE `#__users` SET `password` = 'hacked' WHERE `id` = 1;"],
+            'INSERT INTO #__users'                                                => ["INSERT INTO `#__users` SET `username`='backdoor',`password`='x';"],
+            'DROP TABLE on core users table'                                      => ['DROP TABLE `#__users`;'],
+            'marker strings hidden in a comment, real payload is a DROP DATABASE' => [
+                "-- #__bsms_admin_genesis #__bsms_studies\nDROP DATABASE j5_dev;",
+            ],
+            'SELECT INTO OUTFILE'                   => ["SELECT * FROM `#__bsms_studies` INTO OUTFILE '/tmp/leak.csv';"],
+            'unrecognized statement shape entirely' => ['SET GLOBAL general_log = 1;'],
+        ];
+    }
+
+    #[DataProvider('maliciousStatementProvider')]
+    public function testRejectsStatementsOutsideCwmbackupsKnownShapes(string $statement): void
+    {
+        $this->assertFalse(self::isSafeRestoreStatement($statement), 'accepted a statement that should have been rejected: ' . $statement);
+    }
+
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(Cwmrestore::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    public function testRestoreDbCallsTheSafetyCheckBeforeExecuting(): void
+    {
+        $body = self::methodBody('restoreDB');
+
+        $this->assertMatchesRegularExpression('/isSafeRestoreStatement\(/', $body);
+    }
+
+    public function testInstalldbCallsTheSafetyCheckBeforeExecuting(): void
+    {
+        $body = self::methodBody('installdb');
+
+        $this->assertMatchesRegularExpression('/isSafeRestoreStatement\(/', $body);
+    }
+}


### PR DESCRIPTION
## Summary

`restoreDB()`/`installdb()` executed every statement in an uploaded/selected backup file with only two `substr_count()` checks for literal marker strings (`#__bsms_admin_genesis` / `#__bsms_studies`) — trivially satisfied by embedding them anywhere (even a SQL comment) while the rest of the file contained arbitrary SQL: `DROP DATABASE`, `GRANT`, writes to `#__users`/`#__extensions`, or `LOAD_FILE`/`INTO OUTFILE` if the DB user has FILE privilege.

Adds `Cwmrestore::isSafeRestoreStatement()`, which restricts execution to the 6 statement shapes (`CREATE`/`DROP`/`ALTER TABLE`, `INSERT`/`UPDATE`, `DELETE FROM`) and tables that `Cwmbackup` itself is actually known to generate:
- Proclaim's own `#__bsms_*` tables (discovered dynamically via `CwmdbHelper::getObjects()`, same source the export UI itself uses)
- `#__extensions`, `#__assets`, `#__scheduler_tasks` — the 3 core Joomla tables `Cwmbackup::getComponentConfigExport()`/`getProclaimAssetsExport()`/`getScheduledTasksExport()` legitimately write to (component config, ACL rules, scheduled tasks)

Applied at both `restoreDB()` and `installdb()`'s statement-execution loops — any statement outside those shapes aborts the restore immediately rather than executing it or silently skipping it (fail closed).

This is Super-User-gated, so not a remote-anonymous vector, but a real defense-in-depth gap for a feature whose entire job is "execute untrusted file content as SQL" — a compromised admin account or a supply-chain-tainted backup file shared between sites had far more reach than the feature needs.

## Test plan

- [x] New tests in `tests/unit/Admin/Lib/CwmrestoreTest.php` — a data-provider suite covering all 7 legitimate statement shapes `Cwmbackup` actually produces (verified against its real source) plus 8 attack shapes (DROP DATABASE, GRANT, writes to `#__users`, marker-strings-hidden-in-a-comment, `SELECT ... INTO OUTFILE`, unrecognized statement types) — plus structural tests confirming both call sites invoke the new check.
- [x] Verified red-before/green-after via `git stash` on the source alone (15 errors + 2 failures pre-fix, 0 post-fix).
- [x] Full unit suite: 1153 tests, 0 failures. `php -l` clean, `php-cs-fixer` clean.
- [x] No live/browser test: same rationale as #1521/PR #1529 — pure statement-validation logic, already directly exercised.

Fixes #1522