### PR TITLE
fix: Cwmrestore reads backuprestore via getCmd(), not getWord()

### DIFF
--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -102,52 +102,6 @@ class Cwmrestore
     }
 
     /**
-     * Alter tables for Blob
-     *
-     * @return bool
-     *
-     * @since 7.0.0
-     */
-    protected static function tablesToBlob(): bool
-    {
-        $backuptables = self::getObjects();
-
-        $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-        foreach ($backuptables as $backuptable) {
-            if (substr_count($backuptable['name'], 'studies')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('studytext') . ' BLOB';
-                $db->setQuery($query);
-                $db->execute();
-
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('studytext2') . ' BLOB';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'podcast')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('description') . ' BLOB';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'series')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('description') . ' BLOB';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'teachers')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('information') . ' BLOB';
-                $db->setQuery($query);
-                $db->execute();
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Tables to preserve during restore.
      *
      * These tables contain downloaded/cached data that is expensive to
@@ -199,50 +153,6 @@ class Cwmrestore
     /**
      * Modify tables to Text
      *
-     * @return bool
-     *
-     * @since 9.0.0
-     */
-    protected static function tablesToText(): bool
-    {
-        $backuptables = self::getObjects();
-
-        $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-        foreach ($backuptables as $backuptable) {
-            if (substr_count($backuptable['name'], 'studies')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('studytext') . ' TEXT';
-                $db->setQuery($query);
-                $db->execute();
-
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('studytext2') . ' TEXT';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'podcast')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('description') . ' TEXT';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'series')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('description') . ' TEXT';
-                $db->setQuery($query);
-                $db->execute();
-            }
-
-            if (substr_count($backuptable['name'], 'teachers')) {
-                $query = 'ALTER TABLE ' . $db->quoteName($backuptable['name']) . ' MODIFY ' . $db->quoteName('information') . ' TEXT';
-                $db->setQuery($query);
-                $db->execute();
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Import DB
      *
      * @param bool $parent Switch to see if it is coming from migration or restore.
@@ -252,11 +162,11 @@ class Cwmrestore
      * @throws \Exception
      * @since 9.0.0
      */
-    public function importdb($parent): bool|array
+    public function importdb(bool $parent): bool|array
     {
         $input         = Factory::getApplication()->getInput();
         $installType   = $input->getPath('install_directory');
-        $backupRestore = $input->getWord('backuprestore', '');
+        $backupRestore = $input->getCmd('backuprestore', '');
         $dBo           = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Restore form prior backup files located on the server.
@@ -315,8 +225,10 @@ class Cwmrestore
                 }
 
                 // Fix the Proclaim Database schema after restore
-                $DatabaseModel = new DatabaseModel();
-                $DatabaseModel->fix([$cid]);
+                /** @var DatabaseModel $databaseModel */
+                $databaseModel = Factory::getApplication()->bootComponent('com_installer')
+                    ->getMVCFactory()->createModel('Database', 'Administrator', ['ignore_request' => true]);
+                $databaseModel->fix([$cid]);
 
                 // Run PHP data migration steps that ChangeSet cannot handle
                 self::runPostRestoreDataFixes();
@@ -358,7 +270,7 @@ class Cwmrestore
      * @throws \Exception
      * @since 9.0.0
      */
-    public static function restoreDB($backuprestore): bool
+    public static function restoreDB(string $backuprestore): bool
     {
         $app = Factory::getApplication();
         $db  = Factory::getContainer()->get(DatabaseInterface::class);
@@ -417,7 +329,9 @@ class Cwmrestore
             if ($cid) {
                 self::resetSchemaVersion($cid);
 
-                $databaseModel = new DatabaseModel();
+                /** @var DatabaseModel $databaseModel */
+                $databaseModel = Factory::getApplication()->bootComponent('com_installer')
+                    ->getMVCFactory()->createModel('Database', 'Administrator', ['ignore_request' => true]);
                 $databaseModel->fix([$cid]);
             }
         } catch (\Exception $e) {

--- a/tests/unit/Admin/Lib/CwmrestoreTest.php
+++ b/tests/unit/Admin/Lib/CwmrestoreTest.php
@@ -115,4 +115,92 @@ class CwmrestoreTest extends ProclaimTestCase
 
         $this->assertMatchesRegularExpression('/isSafeRestoreStatement\(/', $body);
     }
+
+    /**
+     * Regression tests for #1523.
+     *
+     * importdb() read the selected server-side backup filename via
+     * $input->getWord('backuprestore', ''), whose 'word' filter strips
+     * everything except letters and underscores. Real backup filenames
+     * (proclaim-backup_SiteName_YYYY-MM-DD_vX.X.X.sql) always contain
+     * digits and a dot, so the value could never contain '.sql' after
+     * filtering -- the substr_count($backupRestore, '.sql') check at the
+     * top of importdb() was permanently false, making "restore from
+     * server backup folder" dead on arrival. getCmd()'s 'cmd' filter
+     * allows [A-Za-z0-9_.-], which matches the actual filename format.
+     */
+    public function testImportdbReadsBackupRestoreViaGetCmdNotGetWord(): void
+    {
+        $body = self::methodBody('importdb');
+
+        $this->assertMatchesRegularExpression(
+            '/->getCmd\(\s*.backuprestore./',
+            $body,
+            'importdb() must read backuprestore via getCmd(), not getWord() -- see #1523'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/->getWord\(\s*.backuprestore./',
+            $body,
+            'importdb() must not read backuprestore via getWord() -- its filter strips digits and dots, ' .
+                'so a real "proclaim-backup_Site_2026-08-04_v10.5.6.sql" filename could never survive -- see #1523'
+        );
+    }
+
+    /**
+     * Proves the actual bug, not just the code shape: Joomla's 'word' filter
+     * mangles a realistic backup filename into something that can never
+     * contain '.sql', while 'cmd' passes it through unchanged.
+     */
+    public function testWordFilterCannotSurviveARealBackupFilenameButCmdFilterCan(): void
+    {
+        $filter   = new \Joomla\Filter\InputFilter();
+        $filename = 'proclaim-backup_SiteName_2026-08-04_v10.5.6.sql';
+
+        $this->assertStringNotContainsString(
+            '.sql',
+            $filter->clean($filename, 'word'),
+            "word filter unexpectedly preserved '.sql' -- if this ever changes, #1523's root cause is gone"
+        );
+        $this->assertSame($filename, $filter->clean($filename, 'cmd'));
+    }
+
+    public function testImportdbAndRestoreDbHaveTypedParameters(): void
+    {
+        $importdb = new \ReflectionMethod(Cwmrestore::class, 'importdb');
+        $this->assertSame('bool', (string) $importdb->getParameters()[0]->getType());
+
+        $restoreDb = new \ReflectionMethod(Cwmrestore::class, 'restoreDB');
+        $this->assertSame('string', (string) $restoreDb->getParameters()[0]->getType());
+    }
+
+    /**
+     * tablesToBlob()/tablesToText() were grep-confirmed unused anywhere in
+     * the repo -- dead code found during the same review as #1523.
+     */
+    public function testDeadTableConversionMethodsAreRemoved(): void
+    {
+        $this->assertFalse(method_exists(Cwmrestore::class, 'tablesToBlob'));
+        $this->assertFalse(method_exists(Cwmrestore::class, 'tablesToText'));
+    }
+
+    /**
+     * importdb() and restoreDB() built the com_installer DatabaseModel via
+     * `new DatabaseModel()`, inconsistent with the MVCFactory-based
+     * UpdateModel creation three lines below it in the same method.
+     */
+    public function testDatabaseModelIsCreatedViaMvcFactory(): void
+    {
+        $body = self::methodBody('importdb') . self::methodBody('restoreDB');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/new DatabaseModel\(\)/',
+            $body,
+            'DatabaseModel must not be directly instantiated -- see #1523'
+        );
+        $this->assertSame(
+            2,
+            preg_match_all('/bootComponent\(.com_installer.\)\s*\n?\s*->getMVCFactory\(\)->createModel\(.Database./', $body),
+            'expected both DatabaseModel creation sites to go through MVCFactory -- see #1523'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1523.

`importdb()` read the selected server-side backup filename via `$input->getWord('backuprestore', '')`. Joomla's `word` filter strips everything except letters and underscores. Real backup filenames (`proclaim-backup_SiteName_YYYY-MM-DD_vX.X.X.sql`) always contain digits and a dot, so the filtered value could never contain `.sql` -- the `substr_count($backupRestore, '.sql')` check gating the entire "restore from server backup folder" feature was permanently false, making that feature dead on arrival. Switched to `getCmd()`, whose `cmd` filter (`[A-Za-z0-9_.-]`) matches the actual filename format.

Also fixed, from the same review pass (noted in #1523 as "worth a pass while in this file, not urgent enough for their own issue"):

- Removed `tablesToBlob()`/`tablesToText()` -- grep-confirmed unused anywhere in the repo.
- `importdb($parent)` and `restoreDB($backuprestore)` now have `bool`/`string` parameter types instead of none (verified against actual call sites in `CwmadminController`, which always pass a bool literal or the `bool $parent = true` param).
- Both `DatabaseModel` creation sites now go through MVCFactory (`bootComponent('com_installer')->getMVCFactory()->createModel('Database', 'Administrator', ...)`) instead of `new DatabaseModel()`, matching the `UpdateModel` pattern already used three lines below one of them in the same method.

## Test plan

- [x] New regression tests in `tests/unit/Admin/Lib/CwmrestoreTest.php`:
  - Structural assertion that `importdb()` calls `getCmd()` and not `getWord()` for `backuprestore`.
  - A live test against Joomla's actual `InputFilter` proving the bug empirically: a realistic filename survives the `cmd` filter unchanged but loses `.sql` under the `word` filter.
  - Reflection assertions on the new parameter types.
  - `method_exists()` assertions that the two dead methods are gone.
  - Structural assertion that both `DatabaseModel` creation sites use `MVCFactory`.
- [x] Verified red-before/green-after via `git stash` on the source file only -- 4 tests fail on old code, all others (including the pre-existing #1522 safety-check tests) unaffected.
- [x] Full unit suite passes (1164 tests).
- [x] `php-cs-fixer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe