### PR TITLE
fix: Cwmssconvert stops double-escaping bios and fixes crosswalk overwrite

### DIFF
--- a/admin/src/Lib/Cwmssconvert.php
+++ b/admin/src/Lib/Cwmssconvert.php
@@ -98,29 +98,23 @@ class Cwmssconvert
             $teachername       = $teacher->name;
             $data->teachername = $teachername;
             $data->website     = $teacher->website;
-            $data->information = $db->escape($teacher->bio);
+            $data->information = $teacher->bio;
             $data->image       = $teacher->pic;
             $data->thumb       = $teacher->pic;
             $data->published   = $teacher->state;
             $data->ordering    = $teacher->ordering;
             $data->catid       = $teacher->catid;
-            $data->short       = $db->escape($teacher->bio);
+            $data->short       = $teacher->bio;
             $data->alias       = $teacher->alias;
 
-            if (!$db->insertObject('#__bsms_teachers', $data)) {
+            if (!$db->insertObject('#__bsms_teachers', $data, 'id')) {
                 $result_table .= '<tr><td>' . Text::_('JBS_IBM_ERROR_OCCURED_CREATING_TEACHERS') . '</td></tr>';
             }
-
-            // Get the last teacherid
-            $query = $db->createQuery();
-            $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_teachers'))->order($db->quoteName('id'));
-            $db->setQuery($query, 0, 1);
-            $lastteacher = $db->loadResult();
 
             // Add the new teacher id to the object for cross walk of series and teachers
             foreach ($seriesspeakers as $speakers) {
                 if ($speakers->speaker_id == $teacher->id) {
-                    $speakers->newid = $lastteacher;
+                    $speakers->newid = $data->id;
                 }
             }
         } // End teachers foreach
@@ -156,29 +150,26 @@ class Cwmssconvert
                 $data->published        = $published;
                 $data->series_thumbnail = $series_thumbnail;
 
+                // Default when no crosswalk match is found for this series.
+                $data->teacher = $id;
+
                 foreach ($seriesspeakers as $speakers) {
                     if ($speakers->series_id == $single->id) {
                         $data->teacher = $speakers->newid;
-                    } else {
-                        $data->teacher = $id;
+                        break;
                     }
                 }
 
                 $data->alias    = $single->alias;
                 $data->ordering = $single->ordering;
 
-                if (!$db->insertObject('#__bsms_series', $data)) {
+                if (!$db->insertObject('#__bsms_series', $data, 'id')) {
                     $result_table .= '<tr><td>' . Text::_('JBS_IBM_ERROR_OCCURED_SS_SERIES') . '</td></tr>';
                 } else {
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_studies'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $lastseries = $db->loadResult();
-
-                    // Add the new teacher id to the object for cross walk of series and teachers
+                    // Add the new series id to the object for cross walk of series and teachers
                     foreach ($seriesspeakers as $speakers) {
                         if ($speakers->series_id == $single->id) {
-                            $speakers->newseriesid = $lastseries;
+                            $speakers->newseriesid = $data->id;
                         }
                     }
                 }
@@ -230,7 +221,7 @@ class Cwmssconvert
      *
      * @since 9.0.0
      */
-    public function newStudies($sermon, $seriesspeakers): void
+    public function newStudies(object $sermon, array $seriesspeakers): void
     {
         $db   = Factory::getContainer()->get(DatabaseInterface::class);
         $data = new \stdClass();
@@ -268,14 +259,10 @@ class Cwmssconvert
         $data->published = $sermon->state;
         $data->alias     = $sermon->alias;
 
-        $db->insertObject('#__bsms_studies', $data);
-        $query = $db->createQuery();
-        $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_studies'))->order($db->quoteName('id') . ' DESC');
+        $db->insertObject('#__bsms_studies', $data, 'id');
 
-        $db->setQuery($query, 0, 1);
-        $study              = $db->loadAssoc();
         $data1              = new \stdClass();
-        $data1->study_id    = $study['id'];
+        $data1->study_id    = $data->id;
         $data1->server_id   = $this->serverid;
         $data1->filename    = $sermon->audiofile;
         $data1->published   = 1;
@@ -288,7 +275,7 @@ class Cwmssconvert
 
         if ($sermon->videofile) {
             $data2              = new \stdClass();
-            $data2->study_id    = $study['id'];
+            $data2->study_id    = $data->id;
             $data2->server      = $this->serverid;
             $data2->filename    = $sermon->videofile;
             $data2->published   = 1;
@@ -310,7 +297,7 @@ class Cwmssconvert
      *
      * @since 9.0.0
      */
-    public function getVerses($sermon): \stdClass
+    public function getVerses(?string $sermon): \stdClass
     {
         $sermonscripture             = new \stdClass();
         $sermonscripture->booknumber = '101';

--- a/tests/unit/Admin/Lib/CwmssconvertTest.php
+++ b/tests/unit/Admin/Lib/CwmssconvertTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmssconvert;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1525.
+ *
+ * convertSS() is not exercised end-to-end here: it reads from SermonSpeaker's
+ * own tables (#__sermon_sermons, #__sermon_speakers, #__sermon_series), none
+ * of which exist outside a real SermonSpeaker install, and unconditionally
+ * writes into #__bsms_servers/teachers/series. These are structural/source
+ * assertions instead, matching the pattern used for other DB-touching
+ * converters in this test suite (e.g. CwmpIconvertTest).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmssconvertTest extends ProclaimTestCase
+{
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(Cwmssconvert::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+    }
+
+    /**
+     * $db->escape($teacher->bio) pre-escaped the string before insertObject()
+     * escaped it again internally -- apostrophes/backslashes in imported bios
+     * got double-escaped (e.g. "O'Brien" stored as literal "O''Brien").
+     */
+    public function testTeacherBioIsNotPreEscapedBeforeInsertObject(): void
+    {
+        $body = self::methodBody('convertSS');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\$db->escape\(\s*\$teacher->bio\s*\)/',
+            $body,
+            'teacher bio must not be pre-escaped -- insertObject() already escapes it, ' .
+                'and doing both corrupts apostrophes/backslashes -- see #1525'
+        );
+        $this->assertSame(
+            2,
+            preg_match_all('/\$data->(information|short)\s*=\s*\$teacher->bio;/', $body),
+            'expected both information and short to be assigned $teacher->bio directly -- see #1525'
+        );
+    }
+
+    /**
+     * The series/teacher crosswalk loop's else branch ran on every
+     * non-matching iteration and unconditionally overwrote $data->teacher,
+     * so a correct match found early could be clobbered by a later
+     * non-matching iteration -- the final value depended on iteration order
+     * rather than the actual match.
+     */
+    public function testSeriesCrosswalkStopsAtFirstMatchInsteadOfOverwriting(): void
+    {
+        $body = self::methodBody('convertSS');
+
+        $this->assertMatchesRegularExpression(
+            '/\$data->teacher = \$id;.*?foreach \(\$seriesspeakers as \$speakers\) \{\s*if \(\$speakers->series_id == \$single->id\) \{\s*\$data->teacher = \$speakers->newid;\s*break;/s',
+            $body,
+            'the series crosswalk must default to $id, then break on the first real match -- see #1525'
+        );
+    }
+
+    /**
+     * "Last inserted id" was fetched via a fresh SELECT ... ORDER BY id DESC
+     * LIMIT 1 query instead of using insertObject()'s own $key parameter --
+     * a race hazard under concurrent writes, an avoidable query inside a
+     * loop, and (for series) the query targeted the wrong table entirely
+     * (#__bsms_studies instead of #__bsms_series), corrupting every
+     * series-to-teacher crosswalk id downstream.
+     */
+    public function testInsertsUseTheInsertObjectKeyParameterNotAFollowUpQuery(): void
+    {
+        $convertSsBody  = self::methodBody('convertSS');
+        $newStudiesBody = self::methodBody('newStudies');
+
+        $this->assertSame(
+            3,
+            preg_match_all(
+                "/insertObject\('#__bsms_(teachers|series|studies)',\s*\\\$data,\s*'id'\)/",
+                $convertSsBody . $newStudiesBody
+            ),
+            'teachers/series/studies inserts must pass \'id\' as the third insertObject() argument -- see #1525'
+        );
+        // The one remaining ORDER BY id DESC in convertSS() is the
+        // unrelated server-record lookup (out of scope for #1525); none
+        // should remain for teachers/series/studies follow-up lookups, and
+        // none at all in newStudies().
+        $this->assertSame(
+            0,
+            preg_match_all('/from\(\$db->quoteName\(.#__bsms_(teachers|series|studies).\)\)\s*->order\(/', $convertSsBody),
+            'must not fetch the last-inserted teacher/series/study id via a follow-up ORDER BY id query -- see #1525'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/->order\(/',
+            $newStudiesBody,
+            'newStudies() must not fetch the last-inserted study id via a follow-up ORDER BY id query -- see #1525'
+        );
+    }
+
+    public function testNewStudiesAndGetVersesHaveTypedParameters(): void
+    {
+        $newStudies = new \ReflectionMethod(Cwmssconvert::class, 'newStudies');
+        $this->assertSame('object', (string) $newStudies->getParameters()[0]->getType());
+        $this->assertSame('array', (string) $newStudies->getParameters()[1]->getType());
+
+        $getVerses = new \ReflectionMethod(Cwmssconvert::class, 'getVerses');
+        $this->assertSame('?string', (string) $getVerses->getParameters()[0]->getType());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1525. Three real data-corruption/mis-association bugs in the SermonSpeaker-to-Proclaim importer, found during a Lib-wide review.

1. **Double-escaping.** `$data->information = $db->escape($teacher->bio);` pre-escaped the string, then `insertObject()` escaped it again internally -- apostrophes/backslashes in imported bios got double-escaped (e.g. `O'Brien` stored as literal `O''Brien`). Dropped the `$db->escape()` calls.

2. **Series/teacher crosswalk overwrite.** The crosswalk loop's `else` branch ran on every non-matching iteration and unconditionally overwrote `$data->teacher`, so a correct match found early could be clobbered by a later non-matching iteration -- the final value depended on iteration order, not the actual match. Now defaults once before the loop and `break`s on the first real match.

3. **"Last inserted id" via a follow-up `ORDER BY id [DESC] LIMIT 1` query.** Race hazard under concurrent writes, plus an avoidable query inside a loop. Two things made this worse than described in the issue once I looked closely: the teacher-id lookup didn't even have `DESC` (it was returning the *lowest* id in the table, not the newest), and the series-id lookup queried `#__bsms_studies` instead of `#__bsms_series` -- a copy-paste bug that fed a study id into every series-to-teacher crosswalk id downstream, corrupting the study/series/teacher linkage. Switched all three `insertObject()` calls (teachers, series, studies) to pass `'id'` as the key argument, matching the pattern already used for mediafiles three lines below one of them.

Also typed `newStudies()`'s and `getVerses()`'s parameters per project convention (items 4 and 5 from the issue -- raw `insertObject()` bypassing Table-layer validation, and the 66-branch book-detection fragility -- are explicitly out of scope per the issue text, which called them lower-value cleanup for a legacy one-time-migration tool).

## Test plan

- [x] New `tests/unit/Admin/Lib/CwmssconvertTest.php` (structural/source assertions, matching the pattern used for other DB-touching converters like `CwmpIconvertTest` -- `convertSS()` reads from SermonSpeaker's own tables, none of which exist outside a real SermonSpeaker install, so it isn't exercised end-to-end):
  - No `$db->escape()` call remains on `$teacher->bio`; both `information` and `short` are assigned directly.
  - The crosswalk loop defaults `$data->teacher = $id` before the loop and `break`s on match.
  - All three `insertObject()` calls (teachers/series/studies) pass `'id'` as the key argument; no follow-up `ORDER BY id` query remains for any of them (the one remaining `ORDER BY id DESC` in `convertSS()` is the unrelated server-record lookup, explicitly out of scope for #1525).
  - Reflection assertions on the new parameter types.
- [x] Verified red-before/green-after via `git stash` on the source file only -- all 4 tests fail on old code.
- [x] Full unit suite passes (1172 tests).
- [x] `php-cs-fixer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe