### PR TITLE
fix: remove dead Cwmstats::getTopScoreSite() method

### DIFF
--- a/admin/src/Lib/Cwmstats.php
+++ b/admin/src/Lib/Cwmstats.php
@@ -23,7 +23,6 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Database\DatabaseInterface;
@@ -970,115 +969,5 @@ class Cwmstats
         self::$cache['hasPublishedPodcasts'] = $result;
 
         return $result;
-    }
-
-    /**
-     * Top Score Site
-     *
-     * @return bool|string
-     *
-     * @throws \Exception
-     * @since 9.0.0
-     */
-    public function getTopScoreSite(): bool|string
-    {
-        $input = Factory::getApplication()->getInput();
-        $t     = $input->get('t', 1, 'int');
-
-        $admin  = Cwmparams::getAdmin();
-        $limit  = (int) $admin->params->get('popular_limit', 25);
-        $format = (int) $admin->params->get('format_popular', 0);
-
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery();
-        $query->select($db->quoteName(['s.id', 's.studytitle', 's.alias', 's.hits', 's.studydate', 's.access']))
-            ->select('SUM(' . $db->quoteName('m.downloads') . ' + ' . $db->quoteName('m.plays') . ') as added')
-            ->from($db->quoteName('#__bsms_mediafiles', 'm'))
-            ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('m.study_id') . ' = ' . $db->quoteName('s.id'))
-            ->whereIn($db->quoteName('m.published'), [1, 2])
-            ->whereIn($db->quoteName('s.published'), [1, 2]);
-
-        // LEFT JOIN platform stats for format_popular >= 2 (ministry-created content only)
-        if ($format >= 2) {
-            $query->select(
-                'COALESCE(SUM(CASE WHEN ' . $db->quoteName('m.content_origin') . ' = 0 THEN '
-                . $db->quoteName('ps.play_count') . ' ELSE 0 END), 0) AS platform_plays'
-            );
-            $query->leftJoin(
-                $db->quoteName('#__bsms_platform_stats', 'ps')
-                . ' ON ' . $db->quoteName('ps.media_id') . ' = ' . $db->quoteName('m.id')
-            );
-        }
-
-        $query->group($db->quoteName(['s.id', 's.studytitle', 's.alias', 's.hits', 's.studydate', 's.access']));
-
-        $db->setQuery($query);
-        $items = $db->loadObjectList() ?: [];
-
-        // Check permissions for this view by running through the records and removing those the user doesn't have permission to see
-        $user   = Factory::getApplication()->getIdentity();
-        $groups = $user->getAuthorisedViewLevels();
-
-        $final = [];
-
-        foreach ($items as $item) {
-            if (($item->access > 1) && !\in_array($item->access, $groups, true)) {
-                continue;
-            }
-
-            $name          = $item->studytitle ?: $item->id;
-            $platformPlays = (int) ($item->platform_plays ?? 0);
-
-            $total = match ($format) {
-                0       => (int) $item->added + (int) $item->hits,
-                1       => (int) $item->added,
-                2       => (int) $item->added + $platformPlays,
-                3       => (int) $item->added + (int) $item->hits + $platformPlays,
-                default => (int) $item->added,
-            };
-
-            $slug  = $item->alias ? ($item->id . ':' . $item->alias) : $item->id . ':'
-                . str_replace(' ', '-', htmlspecialchars_decode($item->studytitle, ENT_QUOTES));
-
-            $selectvalue   = Route::_('index.php?option=com_proclaim&view=cwmsermon&id=' . $slug . '&t=' . $t);
-            $selectdisplay = $name . ' - ' . Text::_('JBS_CMN_SCORE') . ': ' . $total;
-
-            $final[] = [
-                'score'   => $total,
-                'select'  => $selectvalue,
-                'display' => $selectdisplay,
-            ];
-        }
-
-        // Sort by score descending
-        usort($final, function ($a, $b) {
-            return $b['score'] <=> $a['score'];
-        });
-
-        // Slice to limit
-        if ($limit > 0) {
-            $final = \array_slice($final, 0, $limit);
-        }
-
-        $options = [
-            HTMLHelper::_('select.option', '', Text::_('JBS_CMN_SELECT_POPULAR_STUDY')),
-        ];
-
-        foreach ($final as $topscore) {
-            $options[] = HTMLHelper::_('select.option', $topscore['select'], $topscore['display']);
-        }
-
-        return HTMLHelper::_(
-            'select.genericlist',
-            $options,
-            'urlList',
-            [
-                'list.attr'   => 'class="form-select chzn-color-state valid form-control-success" onchange="window.location.href=this.value" size="1"',
-                'list.select' => '',
-                'option.key'  => 'value',
-                'option.text' => 'text',
-                'id'          => 'urlList',
-            ]
-        );
     }
 }

--- a/tests/integration/Admin/Lib/CwmstatsCacheTest.php
+++ b/tests/integration/Admin/Lib/CwmstatsCacheTest.php
@@ -95,4 +95,27 @@ class CwmstatsCacheTest extends IntegrationTestCase
         $this->assertNotNull($return, 'getPersistentCache() must declare a return type');
         $this->assertStringContainsString('CallbackController', (string) $return);
     }
+
+    /**
+     * Regression test for #1527.
+     *
+     * getTopScoreSite() was dead code: its only call site was a
+     * commented-out `@todo not ready for live` stub in
+     * site/src/View/Cwmsermons/HtmlView.php, itself removed in
+     * ec2c9ec3b (2024-03-21) -- so the method never had a live caller.
+     * It also diverged from every sibling in this class (no
+     * CwmlocationHelper::applySecurityFilter() call, no LIMIT, no
+     * caching). Removed rather than fixed, since nothing calls it.
+     * getTopScore() -- the sibling actually used by
+     * admin/tmpl/cwmcpanel/default.php -- is unaffected.
+     */
+    public function testGetTopScoreSiteIsRemoved(): void
+    {
+        $this->assertFalse(method_exists(Cwmstats::class, 'getTopScoreSite'));
+    }
+
+    public function testGetTopScoreStillExists(): void
+    {
+        $this->assertTrue(method_exists(Cwmstats::class, 'getTopScore'));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1527, resolving it as "confirmed dead code, removed" per the issue's own ask.

`getTopScoreSite()` diverged from every sibling method in `Cwmstats` (no `CwmlocationHelper::applySecurityFilter()`, no `LIMIT`/`ORDER BY`, no caching, the only public non-static method in an otherwise fully static class), and a repo-wide grep found zero callers anywhere.

Went one step further than a grep to be sure this wasn't a false negative: git history shows its only would-be call site was **already commented out** behind a `@todo not ready for live and could be slowing down site. // Searched all code and not seeing it used in core.` note in `site/src/View/Cwmsermons/HtmlView.php` -- and that commented-out stub was itself deleted over two years ago, in `ec2c9ec3b` (2024-03-21, "Some Todo Cleanup"). The method never had a live caller at any point this repo's history can show.

This also corrects a stale project memory (`investigate-score-format-popular.md`, from closed issue #1195) that had described `getTopScoreSite()` as the live frontend consumer of the `format_popular` popularity-scoring feature. It wasn't -- `getTopScore()` is the one actually used, by `admin/tmpl/cwmcpanel/default.php:631` (the admin dashboard's "top 5" widget). #1195's overall conclusion (that `format_popular` itself is a functional, non-dead feature) stands; it was wrong about this one method specifically.

Removed the method rather than fixing it, per the issue's "if genuinely unused, delete it" instruction. Also removed the `HTMLHelper` import, which was only used inside the deleted method (`Route`/`Cwmparams`/`Text` are still used by sibling methods, verified before removal). `format_popular`/`popular_limit` in `admin/forms/admin.xml` are untouched -- both are still read by `getTopScore()`.

## Test plan

- [x] `tests/integration/Admin/Lib/CwmstatsCacheTest.php`: added `testGetTopScoreSiteIsRemoved()` (method no longer exists) and `testGetTopScoreStillExists()` (the live sibling is unaffected).
- [x] Verified red-before/green-after via `git stash` on the source file only.
- [x] Full integration suite passes (162 tests) and full unit suite passes (1180 tests).
- [x] `php-cs-fixer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe