### PR TITLE
fix: CwmpIconvert book-number mapping and 8 other logic bugs

### DIFF
--- a/admin/src/Lib/CwmpIconvert.php
+++ b/admin/src/Lib/CwmpIconvert.php
@@ -203,6 +203,18 @@ class CwmpIconvert
     private ?array $validAccessLevels = null;
 
     /**
+     * Cached published #__pipodcast rows, populated on first use.
+     * insertPodcast() is called up to 4x per study (once per media type),
+     * and reloading the whole table on every call is unnecessary -- the
+     * source table doesn't change during a single conversion run.
+     *
+     * @var array|null
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private ?array $piPodcastsCache = null;
+
+    /**
      * Convert PreachIT
      *
      * @return string
@@ -294,10 +306,7 @@ class CwmpIconvert
             $this->tnoadd++;
         } else {
             $this->tadd++;
-            $query = $db->createQuery();
-            $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_teachers'))->order($db->quoteName('id') . ' DESC');
-            $db->setQuery($query, 0, 1);
-            $this->genericteacher = $db->loadResult();
+            $this->genericteacher = $teach->id;
         }
         $query = $db->createQuery();
         $query->select('*')->from($db->quoteName('#__piteachers'));
@@ -326,13 +335,7 @@ class CwmpIconvert
                 } else {
                     $this->tadd++;
 
-                    // Get the new teacherid so we can later connect it to a study
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_teachers'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $newid               = $db->loadResult();
-                    $oldid               = $pi->id;
-                    $this->teachersids[] = ['newid' => $newid, 'oldid' => $oldid];
+                    $this->teachersids[] = ['newid' => $datateachers->id, 'oldid' => $pi->id];
                 }
             }
         }
@@ -361,13 +364,7 @@ class CwmpIconvert
                 } else {
                     $this->ladd++;
 
-                    // Get the new locationid so we can later connect it to a study
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_locations'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $newid             = $db->loadResult();
-                    $oldid             = $pi->id;
-                    $this->locations[] = ['newid' => $newid, 'oldid' => $oldid];
+                    $this->locations[] = ['newid' => $locations->id, 'oldid' => $pi->id];
                 }
             }
         }
@@ -396,13 +393,7 @@ class CwmpIconvert
                 } else {
                     $this->sradd++;
 
-                    // Get the new seriesid so we can later connect it to a study
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_series'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $newid             = $db->loadResult();
-                    $oldid             = $pi->id;
-                    $this->seriesids[] = ['newid' => $newid, 'oldid' => $oldid];
+                    $this->seriesids[] = ['newid' => $dataseries->id, 'oldid' => $pi->id];
                 }
             }
         }
@@ -441,13 +432,7 @@ class CwmpIconvert
                 } else {
                     $this->padd++;
 
-                    // Get the new podcast id so we can later connect it to a study
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_podcast'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $newid              = $db->loadResult();
-                    $oldid              = $pi->id;
-                    $this->podcastids[] = ['newid' => $newid, 'oldid' => $oldid];
+                    $this->podcastids[] = ['newid' => $podcast->id, 'oldid' => $pi->id];
                 }
             }
         }
@@ -479,14 +464,12 @@ class CwmpIconvert
                 }
 
                 $studynumber = $pi->id;
-                $booknumber  = null;
+                $booknumber  = '101';
                 $booknumber2 = null;
 
                 foreach ($books as $book) {
                     if ($book['id'] == $pi->study_book) {
                         $booknumber = $book['jbs'];
-                    } else {
-                        $booknumber = '101';
                     }
 
                     if ($book['id'] == $pi->study_book2) {
@@ -587,11 +570,7 @@ class CwmpIconvert
                 } else {
                     $this->sadd++;
 
-                    // Get the new studiesid so we can later connect it to a study
-                    $query = $db->createQuery();
-                    $query->select($db->quoteName('id'))->from($db->quoteName('#__bsms_studies'))->order($db->quoteName('id') . ' DESC');
-                    $db->setQuery($query, 0, 1);
-                    $newid              = $db->loadResult();
+                    $newid              = $datastudies->id;
                     $oldid              = $pi->id;
                     $this->studiesids[] = ['newid' => $newid, 'oldid' => $oldid];
                 }
@@ -682,7 +661,7 @@ class CwmpIconvert
             ['id' => '25', 'book_name' => 'Lamentations', 'published' => '1', 'jbs' => '125'],
             ['id' => '26', 'book_name' => 'Ezekiel', 'published' => '1', 'jbs' => '126'],
             ['id' => '27', 'book_name' => 'Daniel', 'published' => '1', 'jbs' => '127'],
-            ['id' => '28', 'book_name' => 'Hosea', 'published' => '1', 'jbs' => '129'],
+            ['id' => '28', 'book_name' => 'Hosea', 'published' => '1', 'jbs' => '128'],
             ['id' => '29', 'book_name' => 'Joel', 'published' => '1', 'jbs' => '129'],
             ['id' => '30', 'book_name' => 'Amos', 'published' => '1', 'jbs' => '130'],
             ['id' => '31', 'book_name' => 'Obadiah', 'published' => '1', 'jbs' => '131'],
@@ -770,11 +749,7 @@ class CwmpIconvert
      */
     public function insertMedia(object $pi, string $type, int $newid): bool
     {
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery();
-        $query->select('*')->from($db->quoteName('#__pifilepath'));
-        $db->setQuery($query);
-        $folders = $db->loadObjectList();
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         if ($type == 'video') {
             switch ($pi->video_type) {
@@ -918,13 +893,11 @@ class CwmpIconvert
         }
 
         if ($type == 'audio') {
-            $filename = '';
-
-            foreach ($folders as $folder) {
-                if ($folder->id == $pi->audio_folder) {
-                    $filename = $folder->folder . $pi->audio_link;
-                }
-            }
+            $query = $db->createQuery();
+            $query->select($db->quoteName('folder'))->from($db->quoteName('#__pifilepath'))->where($db->quoteName('id') . ' = ' . (int) $pi->audio_folder);
+            $db->setQuery($query);
+            $object   = $db->loadObject();
+            $filename = $object->folder . $pi->audio_link;
 
             $media         = new \stdClass();
             $media->params = json_encode([
@@ -1087,11 +1060,15 @@ class CwmpIconvert
      */
     private function insertPodcast(object $pi): ?int
     {
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery();
-        $query->select('*')->from($db->quoteName('#__pipodcast'))->where($db->quoteName('published') . ' = 1');
-        $db->setQuery($query);
-        $podcasts        = $db->loadObjectList();
+        if ($this->piPodcastsCache === null) {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->createQuery();
+            $query->select('*')->from($db->quoteName('#__pipodcast'))->where($db->quoteName('published') . ' = 1');
+            $db->setQuery($query);
+            $this->piPodcastsCache = $db->loadObjectList();
+        }
+
+        $podcasts        = $this->piPodcastsCache;
         $includeteacher  = [];
         $includeministry = [];
         $includeseries   = [];
@@ -1128,9 +1105,12 @@ class CwmpIconvert
                 $registry = new Registry();
                 $registry->loadString($podcast->teacher_list);
                 $teacher_list = $registry->toArray();
+                $registry     = new Registry();
+                $registry->loadString($pi->teacher);
+                $excludedTeachers = $registry->toArray();
                 foreach ($teacher_list as $t) {
-                    if (\in_array($t, $pi->teacher)) {
-                        return false;
+                    if (\in_array($t, $excludedTeachers)) {
+                        return null;
                     }
                 }
             }
@@ -1141,7 +1121,7 @@ class CwmpIconvert
                 $series_list = $registry->toArray();
                 foreach ($series_list as $s) {
                     if ($s == $pi->series) {
-                        return false;
+                        return null;
                     }
                 }
             }
@@ -1150,9 +1130,12 @@ class CwmpIconvert
                 $registry = new Registry();
                 $registry->loadString($podcast->ministry_list);
                 $ministry_list = $registry->toArray();
+                $registry      = new Registry();
+                $registry->loadString($pi->ministry);
+                $excludedMinistries = $registry->toArray();
                 foreach ($ministry_list as $m) {
-                    if (\in_array($m, $pi->ministry)) {
-                        return false;
+                    if (\in_array($m, $excludedMinistries)) {
+                        return null;
                     }
                 }
             }
@@ -1185,7 +1168,7 @@ class CwmpIconvert
                 $registry     = new Registry();
                 $registry->loadString($pi->teacher);
                 $teacher = $registry->toArray();
-                if (\count($teacher) > 1) {
+                if (\count($teacher_list) > 1) {
                     foreach ($teacher_list as $ti) {
                         if (\in_array($ti, $teacher) || $podcast->teacher == 0) {
                             return $this->checkMedia($includemedia, $pi, $podcast);
@@ -1193,7 +1176,7 @@ class CwmpIconvert
                     }
                 } elseif ($teacher_list[0]) {
                     $value = $teacher_list[0];
-                    if ($value == $pi->teacher) {
+                    if (\in_array($value, $teacher)) {
                         return $this->checkMedia($includemedia, $pi, $podcast);
                     }
                 }
@@ -1214,7 +1197,7 @@ class CwmpIconvert
                     }
                 } elseif ($ministry_list[0]) {
                     $value = $ministry_list[0];
-                    if ($value == $pi->ministry) {
+                    if (\in_array($value, $ministry)) {
                         return $this->checkMedia($includemedia, $pi, $podcast);
                     }
                 }
@@ -1237,7 +1220,7 @@ class CwmpIconvert
     private function checkMedia(array $includemedia, object $pi, object $podcast): ?int
     {
         //check for which media to include
-        if ($includemedia == 'all') {
+        if (\in_array('all', $includemedia, true)) {
             foreach ($this->podcastids as $pods) {
                 if ($pods['oldid'] == $podcast->id) {
                     $podcast_id = $pods['newid'];

--- a/tests/unit/Admin/Lib/CwmpIconvertTest.php
+++ b/tests/unit/Admin/Lib/CwmpIconvertTest.php
@@ -243,4 +243,218 @@ class CwmpIconvertTest extends ProclaimTestCase
         // the use-import block instead of directly above the class.
         $this->assertMatchesRegularExpression('/\*\/\s*$/', $lines[$classLine - 2]);
     }
+
+    /**
+     * Regression tests for #1528.
+     *
+     * The book-number loop's `else` branch ran on every non-matching iteration
+     * of the 66-entry book array and unconditionally overwrote $booknumber back
+     * to '101' (Genesis) -- only study_book==66 (the last array entry) ever
+     * survived. Every other imported study landed on the wrong book regardless
+     * of its actual scripture reference. $booknumber must default once before
+     * the loop and only be assigned on an actual match.
+     */
+    public function testBookNumberDefaultsBeforeLoopInsteadOfOnEveryNonMatch(): void
+    {
+        $body = self::methodBody('convertPI');
+
+        $this->assertMatchesRegularExpression(
+            "/\\\$booknumber\s*=\s*'101';.*?foreach\s*\(\\\$books as \\\$book\)/s",
+            $body,
+            'booknumber must default to \'101\' before the book-matching loop -- see #1528'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "/if \(\\\$book\['id'\] == \\\$pi->study_book\) \{\s*\\\$booknumber = \\\$book\['jbs'\];\s*\} else \{/",
+            $body,
+            'the book-matching loop must not reset booknumber to \'101\' on every non-matching iteration -- see #1528'
+        );
+    }
+
+    /**
+     * getBooks() gave Hosea (id 28) the same jbs code as Joel (id 29,
+     * '129'), instead of continuing the 100+index pattern with '128'.
+     */
+    public function testGetBooksHoseaAndJoelHaveDistinctJbsCodes(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'getBooks');
+        $books      = $reflection->invoke(new CwmpIconvert());
+        $byId       = array_column($books, 'jbs', 'id');
+
+        $this->assertSame('128', $byId['28'], 'Hosea must map to jbs 128, not duplicate Joel\'s 129 -- see #1528');
+        $this->assertSame('129', $byId['29']);
+    }
+
+    /**
+     * insertPodcast() is typed ?int but had 3 exclusion paths returning
+     * `false`, which PHP's coercive typing silently turns into `0` rather
+     * than `null` -- writing podcast_id=0 (an invalid FK) instead of leaving
+     * the field unset for excluded records.
+     */
+    public function testInsertPodcastNeverReturnsFalse(): void
+    {
+        $body = self::methodBody('insertPodcast');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/return\s+false;/',
+            $body,
+            'insertPodcast() is typed ?int -- every exclusion path must return null, not false -- see #1528'
+        );
+    }
+
+    /**
+     * The teacher/ministry exclusion checks passed the still-JSON-encoded
+     * $pi->teacher/$pi->ministry strings straight to in_array(), which
+     * requires an array haystack -- a TypeError that would abort the whole
+     * conversion whenever any podcast had teacher/ministry exclusion
+     * configured. Both must be Registry-decoded first, matching the
+     * pattern already used by the inclusion checks in the same method.
+     */
+    public function testInsertPodcastDecodesTeacherAndMinistryBeforeExclusionCheck(): void
+    {
+        $body = self::methodBody('insertPodcast');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/in_array\(\$t,\s*\$pi->teacher\)/',
+            $body,
+            'the teacher exclusion check must not pass the raw JSON-encoded $pi->teacher to in_array() -- see #1528'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/in_array\(\$m,\s*\$pi->ministry\)/',
+            $body,
+            'the ministry exclusion check must not pass the raw JSON-encoded $pi->ministry to in_array() -- see #1528'
+        );
+    }
+
+    /**
+     * checkMedia()'s "all media types" sentinel compared an array
+     * ($includemedia) to the string 'all' with ==, which is always false --
+     * podcasts configured for "all media types" (media==0) never matched
+     * anything. Exercised live: checkMedia() has no DB dependency once
+     * $podcastids is set directly on the instance.
+     */
+    public function testCheckMediaAllSentinelMatchesAgainstTheArray(): void
+    {
+        $instance             = new CwmpIconvert();
+        $instance->podcastids = [['newid' => 42, 'oldid' => 7]];
+
+        $reflection = new \ReflectionMethod(CwmpIconvert::class, 'checkMedia');
+        $pi         = (object) ['audio_link' => null, 'video_link' => null, 'slides_link' => 0];
+        $podcast    = (object) ['id' => 7];
+
+        $result = $reflection->invoke($instance, ['all'], $pi, $podcast);
+
+        $this->assertSame(42, $result, 'checkMedia() must match the \'all\' sentinel inside the $includemedia array -- see #1528');
+    }
+
+    /**
+     * The single-item teacher/ministry inclusion fallback compared the
+     * podcast's configured value against the still-encoded $pi->teacher/
+     * $pi->ministry string instead of the decoded array built two lines
+     * earlier -- essentially never true.
+     */
+    public function testInsertPodcastSingleItemInclusionComparesAgainstDecodedArray(): void
+    {
+        $body = self::methodBody('insertPodcast');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/if \(\$value == \$pi->teacher\)/',
+            $body,
+            'the single-teacher inclusion check must compare against the decoded $teacher array, not raw $pi->teacher -- see #1528'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/if \(\$value == \$pi->ministry\)/',
+            $body,
+            'the single-ministry inclusion check must compare against the decoded $ministry array, not raw $pi->ministry -- see #1528'
+        );
+    }
+
+    /**
+     * The teacher-inclusion branch guard tested \count($teacher) -- the
+     * study's own decoded teacher array -- while the loop it guards
+     * iterates $teacher_list, the podcast's configured list. The parallel
+     * ministry block correctly guards on \count($ministry_list). With the
+     * bug, a podcast configured with multiple teacher_list entries but a
+     * study with only one teacher fell into the elseif branch and checked
+     * only $teacher_list[0], silently ignoring the rest of the configured
+     * list.
+     */
+    public function testInsertPodcastTeacherInclusionGuardsOnTheConfiguredListNotTheStudy(): void
+    {
+        $body = self::methodBody('insertPodcast');
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/if \(\\\\count\(\$teacher\) > 1\)/',
+            $body,
+            'the teacher-inclusion branch must guard on \\count($teacher_list), matching the ministry block -- see #1528'
+        );
+        $this->assertMatchesRegularExpression(
+            '/if \(\\\\count\(\$teacher_list\) > 1\)/',
+            $body,
+            'the teacher-inclusion branch must guard on \\count($teacher_list), matching the ministry block -- see #1528'
+        );
+    }
+
+    /**
+     * "Last inserted id" was fetched via a fresh SELECT ... ORDER BY id DESC
+     * LIMIT 1 query at 6 call sites instead of insertObject()'s own $key
+     * parameter -- a race hazard under concurrent writes and an avoidable
+     * query per insert. Same pattern as #1525's Cwmssconvert finding.
+     */
+    public function testLastInsertedIdUsesInsertObjectKeyParamNotAFollowUpQuery(): void
+    {
+        $body = self::methodBody('convertPI');
+
+        $this->assertDoesNotMatchRegularExpression(
+            "/order\(\\\$db->quoteName\('id'\)\s*\.\s*'\s*DESC'\)/",
+            $body,
+            'must not fetch the last-inserted id via a follow-up ORDER BY id DESC query -- see #1528'
+        );
+        $this->assertSame(
+            6,
+            preg_match_all("/insertObject\('#__bsms_\w+',\s*\\\$\w+,\s*'id'\)/", $body),
+            'expected all 6 insertObject() calls (teacher x2, location, series, podcast, study) to pass \'id\' as the key argument -- see #1528'
+        );
+    }
+
+    /**
+     * insertMedia() unconditionally reloaded the entire #__pifilepath table
+     * even though only the audio branch used it -- video/notes/slides
+     * either don't need it or already do their own scoped query. Now scoped
+     * like the notes/slides branches (WHERE id = ...).
+     */
+    public function testInsertMediaOnlyQueriesPifilepathWithinTheAudioBranch(): void
+    {
+        $body = self::methodBody('insertMedia');
+
+        $this->assertDoesNotMatchRegularExpression(
+            "/^\s*\\\$query->select\('\*'\)->from\(\\\$db->quoteName\('#__pifilepath'\)\);\s*$/m",
+            $body,
+            'must not unconditionally load the whole #__pifilepath table at the top of insertMedia() -- see #1528'
+        );
+        $this->assertSame(
+            4,
+            preg_match_all("/from\(\\\$db->quoteName\('#__pifilepath'\)\)->where\(/", $body),
+            'expected 4 scoped #__pifilepath lookups (JWPlayer video, audio, notes, slides), each WHERE id = ... -- see #1528'
+        );
+    }
+
+    /**
+     * insertPodcast() reloaded the entire #__pipodcast table on every call,
+     * and it's invoked up to 4x per study inside the studies loop despite
+     * the source table never changing during a single conversion run.
+     */
+    public function testInsertPodcastCachesPipodcastAcrossCalls(): void
+    {
+        $reflection = new \ReflectionClass(CwmpIconvert::class);
+        $this->assertTrue(
+            $reflection->hasProperty('piPodcastsCache'),
+            'insertPodcast() must cache #__pipodcast on the instance instead of reloading it every call -- see #1528'
+        );
+
+        $body = self::methodBody('insertPodcast');
+        $this->assertMatchesRegularExpression(
+            '/if \(\$this->piPodcastsCache === null\)/',
+            $body
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1528 -- the last of 8 issues filed from the Lib-wide review (#1521-#1528). `CwmpIconvert.php` (the PreachIT importer) had 9 distinct logic bugs; the 9th (teacher-inclusion branch guard) was caught by a second-opinion review during implementation and wasn't in the original issue text.

- Book-number default moved outside the match loop (was set on every non-match, only correct by accident for Revelation)
- Hosea's `jbs` code fixed (was a duplicate of Joel's)
- `insertPodcast()` teacher/ministry exclusion checks now Registry-decode before `in_array()` instead of comparing against raw JSON strings
- **Teacher-inclusion branch guard fixed**: tested `count($teacher)` (the study's own array) while the loop it guards iterates `$teacher_list` (the podcast's configured list) -- the parallel ministry block correctly guards on `count($ministry_list)`. A podcast configured with multiple `teacher_list` entries but a study with only one teacher fell into the single-item branch and checked only `$teacher_list[0]`, silently ignoring the rest of the configured list
- `insertPodcast()` no longer returns `false` from a method typed `?int`
- `checkMedia()`'s `'all'` sentinel now checked via `in_array()` against the array instead of a direct string comparison
- 6 "last inserted id" follow-up `SELECT ... ORDER BY id DESC` queries replaced with `insertObject()`'s own `$key` parameter (same race/pattern as #1525's `Cwmssconvert` fix)
- `insertMedia()` no longer loads the entire `#__pifilepath` table unconditionally; the audio branch now does its own scoped query like notes/slides already did
- `insertPodcast()` caches `#__pipodcast` on the instance instead of reloading it up to 4x per study

Per #1513/#1515, this file has no confirmed real-world use (no PreachIT source data available to test against locally), so all tests are structural/reflection-based except one live behavioral test for the `checkMedia()` sentinel fix.

## Test plan

- [x] 10 new regression tests added, each verified RED (fails against the pre-fix code via `git stash`) before GREEN
- [x] Full `CwmpIconvertTest` suite: 22/22 passing
- [x] Full unit suite: 1190/1190 passing
- [x] `composer lint:fix` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe