### PR TITLE
fix: CwmImageMigration path traversal and 2 efficiency bugs

### DIFF
--- a/admin/src/Helper/CwmImageMigration.php
+++ b/admin/src/Helper/CwmImageMigration.php
@@ -967,6 +967,11 @@ class CwmImageMigration
      * Then checks if `findExistingMigratedFiles()` can locate files in the expected
      * alias-ID or bare-ID folder for that record.
      *
+     * Intentionally has no SQL WHERE clause narrowing the row set: "broken" (file
+     * missing on disk) can only be determined by stat-ing every non-empty thumbnail
+     * path, so any SQL filter that excluded non-empty-but-broken rows would silently
+     * under-report candidates. Every row genuinely needs to be considered.
+     *
      * @param   string  $type   Record type: 'studies', 'teachers', or 'series'
      * @param   int     $limit  Maximum records to return (0 = unlimited)
      *
@@ -1182,7 +1187,10 @@ class CwmImageMigration
         $db        = Factory::getContainer()->get(DatabaseInterface::class);
         $params    = Cwmparams::getAdmin()->params;
         $thumbSize = (int) $params->get($cfg['sizeParam'], $cfg['sizeDefault']);
-        $processed = 0;
+
+        // First pass: find which bare-ID folders on disk qualify for this page,
+        // without touching the DB yet.
+        $eligibleIds = [];
 
         foreach ($subDirs as $dirName) {
             if ($dirName === '.' || $dirName === '..' || !ctype_digit($dirName)) {
@@ -1191,24 +1199,24 @@ class CwmImageMigration
 
             $absDir = $baseDir . '/' . $dirName;
 
-            if (!is_dir($absDir)) {
+            if (!is_dir($absDir) || !self::dirHasImageFiles($absDir)) {
                 continue;
             }
 
-            if (!self::dirHasImageFiles($absDir)) {
-                continue;
-            }
-
-            if ($processed >= $limit) {
+            if (\count($eligibleIds) >= $limit) {
                 $result['remaining']++;
 
                 continue;
             }
 
-            $processed++;
-            $id = (int) $dirName;
+            $eligibleIds[$dirName] = (int) $dirName;
+        }
 
-            // Look up the DB record
+        // Batch-fetch the DB records for this page of folders in a single query
+        // instead of one SELECT per folder.
+        $rowsById = [];
+
+        if (!empty($eligibleIds)) {
             $query = $db->createQuery();
 
             // Only select the columns needed for folder naming — the source
@@ -1216,25 +1224,31 @@ class CwmImageMigration
             switch ($type) {
                 case 'studies':
                     $query->select($db->quoteName(['id', 'studytitle', 'alias']))
-                        ->from($db->quoteName('#__bsms_studies'))
-                        ->where($db->quoteName('id') . ' = ' . $id);
+                        ->from($db->quoteName('#__bsms_studies'));
                     break;
 
                 case 'teachers':
                     $query->select($db->quoteName(['id', 'teachername', 'alias']))
-                        ->from($db->quoteName('#__bsms_teachers'))
-                        ->where($db->quoteName('id') . ' = ' . $id);
+                        ->from($db->quoteName('#__bsms_teachers'));
                     break;
 
                 case 'series':
                     $query->select($db->quoteName(['id', 'series_text', 'alias']))
-                        ->from($db->quoteName('#__bsms_series'))
-                        ->where($db->quoteName('id') . ' = ' . $id);
+                        ->from($db->quoteName('#__bsms_series'));
                     break;
             }
 
+            $query->whereIn($db->quoteName('id'), array_values($eligibleIds));
             $db->setQuery($query);
-            $row = $db->loadObject();
+
+            foreach ($db->loadObjectList() as $row) {
+                $rowsById[(int) $row->id] = $row;
+            }
+        }
+
+        foreach ($eligibleIds as $dirName => $id) {
+            $absDir = $baseDir . '/' . $dirName;
+            $row    = $rowsById[$id] ?? null;
 
             if (!$row) {
                 $result['skipped']++;
@@ -1770,7 +1784,8 @@ class CwmImageMigration
         foreach ($folderPaths as $relPath) {
             $relPath = trim($relPath, '/');
 
-            // SAFETY: Validate path is within allowed scope
+            // Cheap prefix pre-check (defense in depth only -- Path::clean() never
+            // collapses '../' segments, so this alone cannot be trusted as the scope guard)
             $isAllowed = false;
 
             foreach ($allowedBases as $base) {
@@ -1789,6 +1804,15 @@ class CwmImageMigration
 
             if (!is_dir($absDir)) {
                 $errors[] = 'Folder not found: ' . $relPath;
+                continue;
+            }
+
+            // SAFETY: authoritative scope check -- resolves '../' and symlinks before
+            // anything is deleted, unlike the string prefix check above
+            $realDir = realpath($absDir);
+
+            if ($realDir === false || !self::isWithinAllowedBases($realDir, $allowedBases)) {
+                $errors[] = 'Path not allowed: ' . $relPath;
                 continue;
             }
 
@@ -1811,6 +1835,35 @@ class CwmImageMigration
         }
 
         return ['deleted' => $deleted, 'errors' => $errors];
+    }
+
+    /**
+     * Check whether a resolved real path is within (or equal to) one of the
+     * allowed base directories, using realpath() so '../' traversal and
+     * symlinks can't escape the intended scope.
+     *
+     * @param   string  $realDir       Resolved real path of the target directory
+     * @param   array   $allowedBases  Allowed base paths, relative to JPATH_ROOT
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function isWithinAllowedBases(string $realDir, array $allowedBases): bool
+    {
+        foreach ($allowedBases as $base) {
+            $realBase = realpath(JPATH_ROOT . '/' . $base);
+
+            if ($realBase === false) {
+                continue;
+            }
+
+            if ($realDir === $realBase || str_starts_with($realDir . \DIRECTORY_SEPARATOR, $realBase . \DIRECTORY_SEPARATOR)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/Admin/Helper/CwmImageMigrationTest.php
+++ b/tests/unit/Admin/Helper/CwmImageMigrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmImageMigration;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1537: CwmImageMigration::deleteLegacyFiles() validated
+ * the requested path against its allowed-base allow-list with a plain
+ * str_starts_with() on the raw, un-cleaned path. Path::clean() only normalizes
+ * separators -- it never collapses '../' -- so a path like
+ * 'images/biblestudy/../../<anything>' passed the check while resolving
+ * completely outside the allowed scope, letting any core.admin-level user
+ * delete arbitrary files. Fixed by resolving the real path with realpath()
+ * and checking it against the allowed bases' real paths before any deletion.
+ *
+ * Also covers the recoverBareIdFolders() N+1 fix: one SELECT per bare-ID
+ * folder replaced with a single batched WHERE id IN (...) query.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmImageMigrationTest extends ProclaimTestCase
+{
+    private string $biblestudyDir;
+
+    private bool $createdBiblestudyDir = false;
+
+    private string $traversalTargetDir;
+
+    private string $legitTargetDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->biblestudyDir = JPATH_ROOT . '/images/biblestudy';
+
+        if (!is_dir($this->biblestudyDir)) {
+            mkdir($this->biblestudyDir, 0777, true);
+            $this->createdBiblestudyDir = true;
+        }
+
+        $this->traversalTargetDir = JPATH_ROOT . '/cwm_test_traversal_target_' . uniqid();
+        mkdir($this->traversalTargetDir, 0777, true);
+        file_put_contents($this->traversalTargetDir . '/secret.jpg', 'not really an image');
+
+        $this->legitTargetDir = $this->biblestudyDir . '/cwm_test_legit_' . uniqid();
+        mkdir($this->legitTargetDir, 0777, true);
+        file_put_contents($this->legitTargetDir . '/photo.jpg', 'not really an image');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->traversalTargetDir)) {
+            @unlink($this->traversalTargetDir . '/secret.jpg');
+            @rmdir($this->traversalTargetDir);
+        }
+
+        if (is_dir($this->legitTargetDir)) {
+            @unlink($this->legitTargetDir . '/photo.jpg');
+            @rmdir($this->legitTargetDir);
+        }
+
+        if ($this->createdBiblestudyDir && is_dir($this->biblestudyDir)) {
+            @rmdir($this->biblestudyDir);
+
+            $imagesDir = \dirname($this->biblestudyDir);
+
+            if (is_dir($imagesDir) && \count(scandir($imagesDir)) === 2) {
+                @rmdir($imagesDir);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function testDeleteLegacyFilesRejectsPathTraversalEscapingAllowedBase(): void
+    {
+        $payload = 'images/biblestudy/../../' . basename($this->traversalTargetDir);
+
+        $result = CwmImageMigration::deleteLegacyFiles([$payload]);
+
+        $this->assertSame(0, $result['deleted'], 'must not delete anything reached via ../ traversal -- see #1537');
+        $this->assertFileExists(
+            $this->traversalTargetDir . '/secret.jpg',
+            'the file outside the allowed base must survive the traversal attempt -- see #1537'
+        );
+        $this->assertNotEmpty($result['errors']);
+    }
+
+    public function testDeleteLegacyFilesStillDeletesWithinAllowedBase(): void
+    {
+        $payload = 'images/biblestudy/' . basename($this->legitTargetDir);
+
+        $result = CwmImageMigration::deleteLegacyFiles([$payload]);
+
+        $this->assertSame(1, $result['deleted'], 'a genuinely in-scope folder must still be cleaned up');
+        $this->assertFileDoesNotExist($this->legitTargetDir . '/photo.jpg');
+    }
+
+    public function testRecoverBareIdFoldersQueriesTheDatabaseOnceNotOncePerFolder(): void
+    {
+        $reflection = new \ReflectionMethod(CwmImageMigration::class, 'recoverBareIdFolders');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString(
+            'whereIn(',
+            $body,
+            'expected the per-folder DB lookup to be replaced with a single batched WHERE id IN (...) query -- see #1537'
+        );
+
+        $this->assertSame(
+            1,
+            preg_match_all('/\$db->setQuery\(\$query\)/', $body),
+            'expected exactly one lookup query (batched), not one per eligible folder -- see #1537'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1537 -- found during a Helper-folder-wide bug-hunting review (sequel to #1521-#1528).

- **Path traversal (security)**: `deleteLegacyFiles()`'s allowed-scope check ran `str_starts_with()` on the raw, un-cleaned path. `Path::clean()` only normalizes separators -- it never collapses `../` -- so `images/biblestudy/../../../../other/dir` passed the prefix check while resolving completely outside the allowed scope. Any `core.admin`-level account (delegable, not full Super User) could delete arbitrary image-extension files anywhere the web server can write. Fixed by resolving the real path with `realpath()` and checking it against the allowed bases' real paths before any file is touched.
- **N+1**: `recoverBareIdFolders()` issued one `SELECT` per eligible bare-ID folder inside its batch loop (bounded by `$limit`, default 10, so not a storm, but still avoidable); replaced with a single batched `WHERE id IN (...)` query.
- **`getRelinkCandidates()` left unchanged**: this one doesn't have a safe fix. "Broken" (file missing on disk) can only be determined by `stat`-ing every non-empty thumbnail path, so any SQL `WHERE` filter would silently under-report candidates instead of just being slower. Documented with a comment so it isn't re-flagged in a future pass.

## Test plan

- [x] New regression test file `CwmImageMigrationTest.php`: 3 tests, live filesystem-based traversal test (creates a real target directory, attempts the exact attack payload, asserts the file survives), a legit-deletion-still-works sanity test, and a structural test for the batched query
- [x] All 3 verified RED against the pre-fix code (`git stash`) before GREEN
- [x] Full unit suite: 1193/1193 passing
- [x] `composer lint:fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe