### PR TITLE
fix: CwmmigrationHelper batch-skip, junction-row orphaning, TOCTOU doc

### DIFF
--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -381,6 +381,24 @@ class CwmmigrationHelper
                 );
                 $db->execute();
 
+                // UPDATE IGNORE above silently skips a dup->keeper reassignment
+                // whenever the target (study_id, keeper_id) already exists --
+                // either because the study already had a keeper row, or because
+                // another dup for the same merge group was reassigned to it
+                // earlier in this same statement. Any junction row still
+                // pointing at a dup_id at this point is exactly that skipped
+                // case: its update failed, and the dup teacher is about to be
+                // deleted below, so it must go too. The study already retains
+                // the relationship via the row that *did* get remapped to
+                // keeper_id (or the keeper row it collided with), so removing
+                // it here is a safe cleanup, not a data loss.
+                $db->setQuery(
+                    'DELETE st FROM ' . $db->quoteName('#__bsms_study_teachers') . ' st '
+                    . 'INNER JOIN ' . $db->quoteName('#__bsms_teachers_merge') . ' m ON st.'
+                    . $db->quoteName('teacher_id') . ' = m.dup_id'
+                );
+                $db->execute();
+
                 // Delete junction rows that became duplicates after reassignment
                 $db->setQuery(
                     'DELETE st1 FROM ' . $db->quoteName('#__bsms_study_teachers') . ' st1 '
@@ -927,6 +945,17 @@ class CwmmigrationHelper
      * Create a location record named after the given Joomla view level.
      * If a location with the same name already exists it is reused (idempotent).
      *
+     * Not safe against concurrent calls for the same name: the check-then-insert
+     * below has a TOCTOU window, and #__bsms_locations has no unique constraint
+     * on location_text to catch it. Deliberately left unfixed -- a unique index
+     * would need a de-dup migration first, since an install that already hit
+     * this exact race would already carry the duplicate rows a blind
+     * ADD UNIQUE INDEX would fail against; a SELECT ... FOR UPDATE lock would
+     * scan (and lock) the whole table since location_text is unindexed. The
+     * caller-level idempotency guard (Scenario 2B in detectMigrationScenario())
+     * covers sequential re-runs, which is the realistic case for a one-time
+     * admin migration wizard step.
+     *
      * @param   \stdClass  $accessLevel  Object with ->id and ->title properties.
      *
      * @return  int  The location ID (new or existing).
@@ -1155,6 +1184,9 @@ class CwmmigrationHelper
     /**
      * Create a "Main Campus" default location if none exists yet.
      *
+     * Same TOCTOU caveat as createLocationFromAccess() above -- see its
+     * docblock for why this is deliberately left unfixed.
+     *
      * @return  int  The location ID (new or existing).
      *
      * @since   10.1.0
@@ -1371,15 +1403,24 @@ class CwmmigrationHelper
 
                 $targetServerId = $targetServerIds[$targetType];
 
-                // Migrate in batches
-                $offset = 0;
-                $limit  = 25;
+                // Migrate in batches. getLegacyMediaFileIds() re-queries
+                // WHERE server_id = $server['id'] fresh on every call, and a
+                // successful migrateMediaBatch() moves rows out of that same
+                // pool by changing their server_id -- so the pool shrinks out
+                // from under a naive `$offset += $limit` loop and later pages
+                // get silently skipped. Track only failed rows in the offset:
+                // they're the ones that stay in the pool (same id-ordered
+                // position) after a batch, so re-querying at
+                // offset = failedInGroup always skips exactly the
+                // already-attempted failures and never a not-yet-tried row.
+                $limit         = 25;
+                $failedInGroup = 0;
 
                 while (true) {
                     $ids = CwmserverMigrationHelper::getLegacyMediaFileIds(
                         $server['id'],
                         $detectedType,
-                        $offset,
+                        $failedInGroup,
                         $limit
                     );
 
@@ -1397,12 +1438,12 @@ class CwmmigrationHelper
                     $report['migrated'] += $batchResult['migrated'];
                     $report['errors']    = array_merge($report['errors'], $batchResult['errors']);
 
+                    $failedInGroup += \count($ids) - $batchResult['migrated'];
+
                     // If we got fewer IDs than the limit, this group is exhausted
                     if (\count($ids) < $limit) {
                         break;
                     }
-
-                    $offset += $limit;
                 }
             }
         }

--- a/admin/src/Helper/CwmserverMigrationHelper.php
+++ b/admin/src/Helper/CwmserverMigrationHelper.php
@@ -498,7 +498,7 @@ class CwmserverMigrationHelper
             'media'       => '{}',
             'location_id' => $locationId,
             'created'     => (new \Joomla\CMS\Date\Date())->toSql(),
-            'created_by'  => (int) $user->id,
+            'created_by'  => $user ? (int) $user->id : 0,
         ];
 
         $db->insertObject('#__bsms_servers', $data, 'id');

--- a/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
@@ -57,6 +57,22 @@ class CwmmigrationHelperTest extends ProclaimTestCase
             $legacyServer->published   = 1;
             $db->insertObject('#__bsms_servers', $legacyServer, 'id');
 
+            // Pre-seed an existing 'local' target server so getExistingServersByType()
+            // finds one to reuse and migrateLegacyServers() never calls
+            // createServerForType() -- that method reads
+            // Factory::getApplication()->getIdentity()->id unconditionally, which is
+            // null in the PHPUnit CLI context (no logged-in user) and triggers a
+            // PHP warning that PHPUnit's strict-output-checking treats as a failure.
+            // That's a pre-existing gap unrelated to #1538; sidestepping it here
+            // keeps this test scoped to the offset/pagination bug it's about.
+            $targetServer              = new \stdClass();
+            $targetServer->server_name = 'ZZTEST Local Server ' . uniqid();
+            $targetServer->type        = 'local';
+            $targetServer->params      = '{}';
+            $targetServer->media       = '{}';
+            $targetServer->published   = 1;
+            $db->insertObject('#__bsms_servers', $targetServer, 'id');
+
             for ($i = 1; $i <= 60; $i++) {
                 $row            = new \stdClass();
                 $row->study_id  = null;

--- a/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Regression tests for #1538, found during a Helper-folder-wide bug-hunting
+ * review (sequel to #1521-#1528).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmigrationHelperTest extends ProclaimTestCase
+{
+    /**
+     * migrateLegacyServers()'s batch loop advanced `$offset` by a fixed
+     * `$limit` each call, but getLegacyMediaFileIds() re-queries
+     * `WHERE server_id = ...` fresh every time and migrateMediaBatch()
+     * removes successfully-migrated rows from that same pool by changing
+     * their server_id. As the pool shrinks, a fixed offset skips rows.
+     * Fixed by tracking only failed rows in the offset (they're the ones
+     * that stay in the pool), mirroring the pattern already used by
+     * server-migration.js for the same interaction.
+     *
+     * Calls migrateLegacyServers() itself (not a re-implementation of its
+     * loop) against a real fixture legacy server with 60 media files -- more
+     * than one 25-row batch -- and asserts every one of them ends up moved
+     * off that server. Whatever other real legacy servers already exist on
+     * the test DB are left alone by the assertion (they may or may not have
+     * media of their own); only the fixture server's outcome is checked, so
+     * this is safe to run against any DB state.
+     */
+    public function testMigrateLegacyServersMovesAllFixtureRowsDespiteAShrinkingPool(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart();
+
+        try {
+            $legacyServer              = new \stdClass();
+            $legacyServer->server_name = 'ZZTEST Legacy Server ' . uniqid();
+            $legacyServer->type        = 'legacy';
+            $legacyServer->params      = '{}';
+            $legacyServer->media       = '{}';
+            $legacyServer->published   = 1;
+            $db->insertObject('#__bsms_servers', $legacyServer, 'id');
+
+            for ($i = 1; $i <= 60; $i++) {
+                $row            = new \stdClass();
+                $row->study_id  = null;
+                $row->server_id = $legacyServer->id;
+                $row->metadata  = '';
+                $row->ordering  = 0;
+                $row->published = 1;
+                $row->language  = '*';
+                $row->params    = json_encode(['filename' => 'sermon' . $i . '.mp3', 'player' => '']);
+                $db->insertObject('#__bsms_mediafiles', $row);
+            }
+
+            CwmmigrationHelper::migrateLegacyServers();
+
+            $stillOnLegacyServer = (int) $db->setQuery(
+                $db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__bsms_mediafiles'))
+                    ->where($db->quoteName('server_id') . ' = ' . (int) $legacyServer->id)
+            )->loadResult();
+
+            $this->assertSame(
+                0,
+                $stillOnLegacyServer,
+                'all 60 fixture rows across 3 batches must be moved off the legacy server -- see #1538'
+            );
+        } finally {
+            $db->transactionRollback();
+        }
+    }
+
+    /**
+     * fixTeacherAliases()'s UPDATE IGNORE silently skipped a dup->keeper
+     * junction-row reassignment whenever the study already had a junction
+     * row for the keeper, permanently orphaning that row once the dup
+     * teacher was deleted a few statements later. Fixed with a DELETE for
+     * any junction row still pointing at a dup_id immediately after the
+     * UPDATE IGNORE -- provably safe, since the study already retains the
+     * relationship via whichever row *did* get remapped to keeper_id.
+     * Verified by hand against j5-dev with 3 fixture scenarios (dup
+     * colliding with an existing keeper row, two dups + keeper on one
+     * study, a dup with no keeper row) before writing this test.
+     */
+    public function testFixTeacherAliasesDoesNotOrphanJunctionRowsSkippedByUpdateIgnore(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart();
+
+        try {
+            $sharedName = 'ZZTEST Duplicate Teacher ' . uniqid();
+
+            $keeper              = new \stdClass();
+            $keeper->teachername = $sharedName;
+            $keeper->alias       = 'zztest-keeper-' . uniqid();
+            $keeper->list_show   = 0;
+            $keeper->published   = 0;
+            $keeper->access      = 1;
+            $keeper->language    = '*';
+            $keeper->address     = '';
+            $db->insertObject('#__bsms_teachers', $keeper, 'id');
+
+            $dup              = new \stdClass();
+            $dup->teachername = $sharedName;
+            $dup->alias       = 'zztest-dup-' . uniqid();
+            $dup->list_show   = 0;
+            $dup->published   = 0;
+            $dup->access      = 1;
+            $dup->language    = '*';
+            $dup->address     = '';
+            $db->insertObject('#__bsms_teachers', $dup, 'id');
+
+            $this->assertGreaterThan(0, $keeper->id);
+            $this->assertGreaterThan($keeper->id, $dup->id, 'fixture must insert the keeper first so it has the lower id');
+
+            $fakeStudyId = 9_999_502;
+
+            // Study already has a junction row for BOTH the keeper and the dup --
+            // this is exactly the collision case that orphaned a row pre-fix.
+            $keeperLink             = new \stdClass();
+            $keeperLink->study_id   = $fakeStudyId;
+            $keeperLink->teacher_id = $keeper->id;
+            $db->insertObject('#__bsms_study_teachers', $keeperLink);
+
+            $dupLink             = new \stdClass();
+            $dupLink->study_id   = $fakeStudyId;
+            $dupLink->teacher_id = $dup->id;
+            $db->insertObject('#__bsms_study_teachers', $dupLink);
+
+            CwmmigrationHelper::fixTeacherAliases();
+
+            $remaining = $db->setQuery(
+                $db->createQuery()
+                    ->select($db->quoteName('teacher_id'))
+                    ->from($db->quoteName('#__bsms_study_teachers'))
+                    ->where($db->quoteName('study_id') . ' = ' . (int) $fakeStudyId)
+            )->loadColumn();
+
+            $this->assertSame(
+                [$keeper->id],
+                array_map('intval', $remaining),
+                'exactly one junction row must survive, pointing at the keeper -- see #1538'
+            );
+
+            $dupStillExists = (int) $db->setQuery(
+                $db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__bsms_teachers'))
+                    ->where($db->quoteName('id') . ' = ' . (int) $dup->id)
+            )->loadResult();
+
+            $this->assertSame(0, $dupStillExists, 'the duplicate teacher must have been deleted by the merge');
+        } finally {
+            $db->transactionRollback();
+        }
+    }
+}

--- a/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmmigrationHelperTest.php
@@ -58,13 +58,14 @@ class CwmmigrationHelperTest extends ProclaimTestCase
             $db->insertObject('#__bsms_servers', $legacyServer, 'id');
 
             // Pre-seed an existing 'local' target server so getExistingServersByType()
-            // finds one to reuse and migrateLegacyServers() never calls
-            // createServerForType() -- that method reads
-            // Factory::getApplication()->getIdentity()->id unconditionally, which is
-            // null in the PHPUnit CLI context (no logged-in user) and triggers a
-            // PHP warning that PHPUnit's strict-output-checking treats as a failure.
-            // That's a pre-existing gap unrelated to #1538; sidestepping it here
-            // keeps this test scoped to the offset/pagination bug it's about.
+            // finds one to reuse, keeping this test focused on the offset/pagination
+            // bug rather than server-creation behavior. (Discovered along the way:
+            // createServerForType() read Factory::getApplication()->getIdentity()->id
+            // unconditionally, which is null in the PHPUnit CLI context and produced a
+            // warning CI's strict-output-checking treated as a failure -- install SQL
+            // seeds 3 real legacy servers, and migrateLegacyServers() processes them
+            // too, so this pre-seed alone didn't avoid the crash. Fixed at the source
+            // in CwmserverMigrationHelper::createServerForType() instead.)
             $targetServer              = new \stdClass();
             $targetServer->server_name = 'ZZTEST Local Server ' . uniqid();
             $targetServer->type        = 'local';

--- a/tests/unit/Admin/Helper/CwmserverMigrationHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmserverMigrationHelperTest.php
@@ -18,6 +18,8 @@ use CWM\Component\Proclaim\Administrator\Addons\Servers\Wistia\CWMAddonWistia;
 use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -1120,5 +1122,44 @@ class CwmserverMigrationHelperTest extends ProclaimTestCase
         self::assertSame('https://example.com/video', $result['filename']);
         self::assertSame('8', $result['player']);
         self::assertSame('{customtag}something{/customtag}', $result['mediacode']);
+    }
+
+    /**
+     * createServerForType() read Factory::getApplication()->getIdentity()->id
+     * unconditionally. getIdentity() can legitimately return null outside a
+     * real request context (a CLI script, a scheduled task, PHPUnit's own CLI
+     * process) -- discovered when a #1538 regression test that calls
+     * CwmmigrationHelper::migrateLegacyServers() (which calls this method)
+     * triggered exactly that in CI, where no identity is ever set up.
+     */
+    public function testCreateServerForTypeDoesNotDereferenceANullIdentity(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart();
+
+        try {
+            $id = CwmserverMigrationHelper::createServerForType('local', 'ZZTEST Direct Call ' . uniqid());
+
+            $this->assertGreaterThan(0, $id, 'must return a valid new server id -- see #1538');
+        } finally {
+            $db->transactionRollback();
+        }
+    }
+
+    public function testCreateServerForTypeGuardsAgainstANullIdentity(): void
+    {
+        $reflection = new \ReflectionMethod(CwmserverMigrationHelper::class, 'createServerForType');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\'created_by\'\s*=>\s*\(int\)\s*\$user->id/',
+            $body,
+            'must not dereference $user->id unconditionally -- getIdentity() can return null -- see #1538'
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1538 -- found during a Helper-folder-wide bug-hunting review (sequel to #1521-#1528).

- **Batch-skip bug**: `migrateLegacyServers()`'s batch loop advanced `$offset` by a fixed `$limit` each call, but `getLegacyMediaFileIds()` re-queries `WHERE server_id = ...` fresh every time, and `migrateMediaBatch()` removes successfully-migrated rows from that same pool by changing their `server_id`. As the pool shrinks, a fixed offset silently skips rows. Reproduced empirically with a live 60-row/25-batch fixture against the pre-fix code: exactly 25 rows got permanently stuck, matching the predicted skip pattern. Fixed by tracking only failed rows in the offset (they're the ones that stay in the pool), mirroring the pattern already used by `server-migration.js` for the same interaction.
- **Junction-row orphaning**: `fixTeacherAliases()`'s `UPDATE IGNORE` silently skipped a dup->keeper junction-row reassignment whenever the study already had a junction row for the keeper, permanently orphaning that row once the dup teacher was deleted a few statements later. My first attempt at a fix (a temp-table self-join dedupe) turned out to hit a real MySQL restriction -- verified by hand against j5-dev, it throws `ERROR 1137: Can't reopen table` -- so it was scrapped before it ever reached a commit. The shipped fix is a single additional `DELETE` for any junction row still pointing at a `dup_id` immediately after the `UPDATE IGNORE`, verified by hand against 3 fixture scenarios (dup colliding with an existing keeper row, two dups + keeper on one study, a dup with no keeper row) before writing the regression test.
- **TOCTOU race, documented not fixed**: `createLocationFromAccess()`/`createDefaultLocation()`'s check-then-insert race is real, but neither candidate fix is proportionate -- a unique-index migration would need a de-dup pass first (an install that already hit this exact race would already carry the duplicate rows a blind `ADD UNIQUE INDEX` would fail against), and a locking `SELECT ... FOR UPDATE` would scan/lock the whole table since `location_text` is unindexed. Documented with a comment so it isn't re-flagged; the caller-level idempotency guard already covers the realistic case (sequential re-runs of a one-time admin wizard step).

## Test plan

- [x] New regression test file `CwmmigrationHelperTest.php`: 2 tests, both calling the real shipped methods (`CwmmigrationHelper::migrateLegacyServers()` and `CwmmigrationHelper::fixTeacherAliases()`) end-to-end against live fixture rows, wrapped in `transactionStart()`/`transactionRollback()` so nothing touches real data
- [x] Both verified RED against the pre-fix code (`git stash`) before GREEN -- the batch-skip test reproduced the exact "25 of 60 stuck" failure mode
- [x] Full unit suite: 1195/1195 passing
- [x] `composer lint:fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe