### PR TITLE
fix: CwmcsvimportHelper access-control bypass, date-parsing corruption

### DIFF
--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -272,6 +272,7 @@ class CwmcsvimportHelper
     {
         $autoCreate = (bool) ($settings['auto_create'] ?? true);
         $db         = Factory::getContainer()->get(DatabaseInterface::class);
+        $user       = Factory::getApplication()->getIdentity();
 
         $fields = [];
 
@@ -296,7 +297,12 @@ class CwmcsvimportHelper
         }
 
         if (!empty($rowData['location'])) {
-            $locationId = self::resolveOrCreateLocation($rowData['location'], $autoCreate);
+            // Must go through processLocation(), not resolveOrCreateLocation()
+            // directly -- the insert path (importRow()) enforces that the
+            // target location is within the current user's accessible
+            // locations to avoid cross-campus leaks; this update path must
+            // enforce the same rule, not silently skip it.
+            $locationId = self::processLocation($rowData['location'], $autoCreate, (int) ($user ? $user->id : 0));
 
             if ($locationId > 0) {
                 $fields[] = $db->quoteName('location_id') . ' = ' . $locationId;
@@ -420,6 +426,17 @@ class CwmcsvimportHelper
     /**
      * Resolve or auto-create a series by name.
      *
+     * Not safe against concurrent imports referencing the same not-yet-existing
+     * name: the check-then-insert below has a TOCTOU window, and #__bsms_series
+     * has no unique constraint on series_text to catch it -- same story for
+     * resolveOrCreateLocation()/resolveOrCreateMessageType()/resolveOrCreateTopic()
+     * below. Deliberately left unfixed: a unique index would need a de-dup
+     * migration first, since an install that already hit this race would
+     * already carry the duplicate rows a blind ADD UNIQUE INDEX would fail
+     * against. (Teachers are the exception -- #__bsms_teachers does have a
+     * unique alias constraint, so a collision there throws and is caught as a
+     * row error instead of silently duplicating.)
+     *
      * @param   string  $name        Series name
      * @param   bool    $autoCreate  Whether to auto-create if not found
      *
@@ -485,6 +502,8 @@ class CwmcsvimportHelper
 
     /**
      * Resolve or auto-create a location by name.
+     *
+     * TOCTOU race, same as resolveOrCreateSeries() above -- see its docblock.
      *
      * @param   string  $name        Location name
      * @param   bool    $autoCreate  Whether to auto-create if not found
@@ -552,6 +571,8 @@ class CwmcsvimportHelper
     /**
      * Resolve or auto-create a message type by name.
      *
+     * TOCTOU race, same as resolveOrCreateSeries() above -- see its docblock.
+     *
      * @param   string  $name        Message type name
      * @param   bool    $autoCreate  Whether to auto-create if not found
      *
@@ -617,6 +638,8 @@ class CwmcsvimportHelper
 
     /**
      * Resolve or auto-create a topic by name.
+     *
+     * TOCTOU race, same as resolveOrCreateSeries() above -- see its docblock.
      *
      * @param   string  $name        Topic name
      * @param   bool    $autoCreate  Whether to auto-create if not found
@@ -874,9 +897,22 @@ class CwmcsvimportHelper
         foreach ($formats as $format) {
             $date = \DateTime::createFromFormat($format, $input);
 
-            if ($date !== false) {
-                return $date->format('Y-m-d');
+            if ($date === false) {
+                continue;
             }
+
+            // createFromFormat() alone accepts out-of-range components via
+            // lenient overflow (e.g. "25/03/2024" against 'm/d/Y' silently
+            // becomes month 25 -> Jan 2026, instead of falling through to
+            // 'd/m/Y' below), silently corrupting any DD/MM/YYYY date whose
+            // day is > 12. getLastErrors() flags exactly that case.
+            $errors = $date->getLastErrors();
+
+            if ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) {
+                continue;
+            }
+
+            return $date->format('Y-m-d');
         }
 
         // Fallback to strtotime

--- a/tests/unit/Admin/Helper/CwmcsvimportHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmcsvimportHelperTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcsvimportHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1539, found during a Helper-folder-wide bug-hunting
+ * review (sequel to #1521-#1528).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmcsvimportHelperTest extends ProclaimTestCase
+{
+    /**
+     * parseDate() tried 'm/d/Y' before 'd/m/Y' using createFromFormat()
+     * non-strictly and without checking getLastErrors(). PHP's lenient
+     * component overflow means a clearly non-US date like "25/03/2024"
+     * (day > 12) was silently accepted by the 'm/d/Y' branch -- month 25
+     * rolls over into a different year/month entirely -- instead of falling
+     * through to 'd/m/Y', silently corrupting the imported studydate.
+     */
+    public function testParseDateFallsThroughToDayMonthYearWhenMonthOverflows(): void
+    {
+        $this->assertSame(
+            '2024-03-25',
+            CwmcsvimportHelper::parseDate('25/03/2024'),
+            'day > 12 must fall through to d/m/Y instead of overflowing m/d/Y into a nonsense date -- see #1539'
+        );
+    }
+
+    public function testParseDateStillPrefersMonthDayYearForGenuinelyAmbiguousDates(): void
+    {
+        // Both m/d/Y and d/m/Y could parse this; the fix must not change the
+        // existing (documented) US-first preference for the truly ambiguous case.
+        $this->assertSame('2024-01-15', CwmcsvimportHelper::parseDate('01/15/2024'));
+    }
+
+    public function testParseDateAcceptsValidDayMonthYear(): void
+    {
+        $this->assertSame('2024-01-15', CwmcsvimportHelper::parseDate('15/01/2024'));
+    }
+
+    public function testParseDateRejectsAnOutOfRangeDateInEveryFormat(): void
+    {
+        // Neither m/d/Y nor d/m/Y can make sense of month=13; must not silently
+        // roll over into a different date via strtotime() either.
+        $this->assertNull(CwmcsvimportHelper::parseDate('13/13/2024'));
+    }
+
+    public function testParseDateAcceptsIsoFormat(): void
+    {
+        $this->assertSame('2024-01-15', CwmcsvimportHelper::parseDate('2024-01-15'));
+    }
+
+    public function testParseDateAcceptsNamedMonthFormat(): void
+    {
+        $this->assertSame('2024-01-15', CwmcsvimportHelper::parseDate('Jan 15, 2024'));
+    }
+
+    public function testParseDateReturnsNullForEmptyInput(): void
+    {
+        $this->assertNull(CwmcsvimportHelper::parseDate(null));
+        $this->assertNull(CwmcsvimportHelper::parseDate(''));
+        $this->assertNull(CwmcsvimportHelper::parseDate('   '));
+    }
+
+    /**
+     * updateExistingRow() resolved the location via resolveOrCreateLocation()
+     * directly, bypassing the access-control check that processLocation()
+     * enforces on the insert path (importRow()) -- "must be within the
+     * current user's accessible locations to avoid cross-campus leaks", per
+     * processLocation()'s own docblock. A restricted (non-core.admin) user's
+     * CSV update could silently move a study to a campus/location they
+     * aren't authorized to write to.
+     */
+    public function testUpdateExistingRowUsesProcessLocationForAccessControl(): void
+    {
+        $reflection = new \ReflectionMethod(CwmcsvimportHelper::class, 'updateExistingRow');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\$locationId\s*=\s*self::resolveOrCreateLocation\(/',
+            $body,
+            'must not resolve the location via the unchecked resolveOrCreateLocation() -- see #1539'
+        );
+        $this->assertMatchesRegularExpression(
+            '/\$locationId\s*=\s*self::processLocation\(/',
+            $body,
+            'must go through processLocation() so the access-control check applies -- see #1539'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1539 -- found during a Helper-folder-wide bug-hunting review (sequel to #1521-#1528).

- **Access-control bypass (security)**: `updateExistingRow()` resolved the location via `resolveOrCreateLocation()` directly instead of `processLocation()`, bypassing the access-control check the insert path (`importRow()`) enforces -- "must be within the current user's accessible locations to avoid cross-campus leaks", per `processLocation()`'s own docblock. Currently unreachable via the shipped UI (the only caller sits behind a blanket `core.admin` gate), but a live hole for any future, less-restrictive caller.
- **Date-parsing corruption**: `parseDate()` tried `'m/d/Y'` before `'d/m/Y'` using `createFromFormat()` non-strictly and without checking `getLastErrors()`. PHP's lenient component overflow meant a clearly non-US date like `"25/03/2024"` (day > 12) was silently accepted by the `'m/d/Y'` branch -- month 25 rolls over into a different year/month entirely -- instead of falling through to `'d/m/Y'`, silently corrupting `studydate` for any CSV using DD/MM/YYYY dates. Fixed by checking `getLastErrors()` after each format attempt and falling through on any warning/error.
- **TOCTOU race, documented not fixed**: `resolveOrCreateSeries()`/`Location()`/`MessageType()`/`Topic()`'s check-then-insert race is real, same reasoning as #1538's `createLocationFromAccess()`/`createDefaultLocation()` -- none of the 4 tables have a unique constraint, and adding one would need a de-dup migration first (an install that already hit this race would already carry the duplicate rows a blind `ADD UNIQUE INDEX` would fail against).

## Test plan

- [x] New regression test file `CwmcsvimportHelperTest.php`: 8 tests -- live behavioral tests for `parseDate()` covering the overflow bug, a genuinely-ambiguous case (unchanged US-first preference), valid `d/m/Y`, an out-of-range date in every format, ISO/named-month formats, and empty input; a structural test for the `processLocation()` fix
- [x] All 4 behavior-relevant tests verified RED against the pre-fix code (`git stash`) before GREEN
- [x] Full unit suite: 1205/1205 passing
- [x] `composer lint:fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe