### PR TITLE
fix: CwmserverMigrationHelper external-host filename corruption, legacy-ID precedence

### DIFF
--- a/admin/src/Helper/CwmserverMigrationHelper.php
+++ b/admin/src/Helper/CwmserverMigrationHelper.php
@@ -337,22 +337,41 @@ class CwmserverMigrationHelper
         array $allParams = []
     ): string {
         // Phase 1: Legacy player type / ID overrides
+        //
+        // Order matters when more than one legacy ID field is populated at
+        // once (a realistic state for hand-edited legacy records). This must
+        // match the live renderer's precedence in Cwmmedia.php, which sets
+        // $player->player from docMan_id, then unconditionally overrides it
+        // from article_id, then unconditionally overrides it again from
+        // virtueMart_id -- i.e. last-match-wins, so virtuemart beats
+        // article beats docman. Checking in [docman, article, virtuemart]
+        // order and returning on first match (as this loop used to) is the
+        // exact inverse and can migrate content to a different addon than
+        // what the site was actually rendering.
         $legacyIdFields = [
             ['4', 'docMan_id',     'docman'],
             ['5', 'article_id',    'article'],
             ['6', 'virtueMart_id', 'virtuemart'],
         ];
 
+        $legacyMatch = null;
+
         foreach ($legacyIdFields as [$legacyPlayer, $paramKey, $type]) {
             if ($player === $legacyPlayer) {
-                return $type;
+                $legacyMatch = $type;
+
+                continue;
             }
 
             $val = $allParams[$paramKey] ?? '';
 
             if ($val !== '' && $val !== '0' && $val !== '-1') {
-                return $type;
+                $legacyMatch = $type;
             }
+        }
+
+        if ($legacyMatch !== null) {
+            return $legacyMatch;
         }
 
         // Early exit: genuinely empty records (no filename, no mediacode, no legacy IDs)
@@ -874,9 +893,17 @@ class CwmserverMigrationHelper
             }
         }
 
-        // Strip any http(s):// prefix for local files
-        $stripped = preg_replace('/^https?:\/\/[^\/]+\//i', '', $filename);
-
-        return $stripped ?? $filename;
+        // Neither prefix check matched -- this filename was not served by
+        // the legacy server being migrated. Do NOT strip its host: a blind
+        // host-strip here previously produced a bare relative path (e.g.
+        // 'podcasts/sermon123.mp3' from an S3/CDN URL) that mediaBuildUrl()
+        // then silently concatenated onto the *new* local server's own base
+        // path -- a URL pointing at a file that was never actually moved
+        // there, and no trace left of where it really lives. Returning the
+        // untouched absolute URL preserves that information instead of
+        // destroying it, even though rendering it correctly end-to-end may
+        // still need admin follow-up depending on the target local server's
+        // own configured base path.
+        return $filename;
     }
 }

--- a/tests/unit/Admin/Helper/CwmserverMigrationHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmserverMigrationHelperTest.php
@@ -274,6 +274,45 @@ class CwmserverMigrationHelperTest extends ProclaimTestCase
         self::assertSame('virtuemart', $result);
     }
 
+    /**
+     * When more than one legacy ID field is populated at once (a realistic
+     * state for hand-edited legacy records), detectContentType() must match
+     * the live renderer's precedence in Cwmmedia.php: docMan_id is checked
+     * first but unconditionally overridden by article_id, which is in turn
+     * unconditionally overridden by virtueMart_id -- i.e. last-match-wins,
+     * so virtuemart beats article beats docman. Checking in
+     * [docman, article, virtuemart] order and returning on first match was
+     * the exact inverse -- see #1540.
+     */
+    public function testDetectContentTypeLegacyIdPrecedenceMatchesLiveRendererWhenMultipleSet(): void
+    {
+        $result = CwmserverMigrationHelper::detectContentType(
+            '',
+            '',
+            '',
+            '',
+            ['docMan_id' => '15', 'article_id' => '42', 'virtueMart_id' => '0']
+        );
+        self::assertSame(
+            'article',
+            $result,
+            'article_id overrides docMan_id in the renderer -- must not return docman just because it was checked first'
+        );
+
+        $result = CwmserverMigrationHelper::detectContentType(
+            '',
+            '',
+            '',
+            '',
+            ['docMan_id' => '15', 'article_id' => '42', 'virtueMart_id' => '7']
+        );
+        self::assertSame(
+            'virtuemart',
+            $result,
+            'virtueMart_id overrides both docMan_id and article_id in the renderer -- must win when all three are set'
+        );
+    }
+
     // -------------------------------------------------------------------------
     // detectContentType() with AllVideos shortcodes
     // -------------------------------------------------------------------------
@@ -570,6 +609,53 @@ class CwmserverMigrationHelperTest extends ProclaimTestCase
 
         self::assertSame('audio.mp3', $result['filename']);
         self::assertSame('0', $result['player']);
+    }
+
+    /**
+     * stripLegacyPrefix() must not strip a host that doesn't belong to the
+     * legacy server being migrated. The old fallback stripped ANY
+     * http(s)://host/ prefix unconditionally, turning an S3/CDN URL into a
+     * bare relative path that mediaBuildUrl() then silently concatenated
+     * onto the *new* local server's own base path -- pointing at a file
+     * that was never actually moved there. See #1540.
+     */
+    public function testStripLegacyPrefixDoesNotStripAnUnrelatedHost(): void
+    {
+        $legacyParams = [
+            'path'     => 'legacy.example.com/legacy-media',
+            'protocol' => 'https://',
+        ];
+
+        $result = CwmserverMigrationHelper::stripLegacyPrefix(
+            'https://cdn.otherhost.com/podcasts/sermon123.mp3',
+            $legacyParams
+        );
+
+        self::assertSame(
+            'https://cdn.otherhost.com/podcasts/sermon123.mp3',
+            $result,
+            'a foreign host must be left untouched, not stripped into a bare relative path -- see #1540'
+        );
+    }
+
+    /**
+     * Sanity check the fix didn't also break the case it's meant to
+     * preserve: a filename actually served by the legacy server being
+     * migrated must still have its prefix stripped.
+     */
+    public function testStripLegacyPrefixStillStripsTheConfiguredLegacyServerPrefix(): void
+    {
+        $legacyParams = [
+            'path'     => 'legacy.example.com/legacy-media',
+            'protocol' => 'https://',
+        ];
+
+        $result = CwmserverMigrationHelper::stripLegacyPrefix(
+            'https://legacy.example.com/legacy-media/sermons/audio.mp3',
+            $legacyParams
+        );
+
+        self::assertSame('sermons/audio.mp3', $result);
     }
 
     public function testTransformParamsEmbed(): void


### PR DESCRIPTION
## Summary

Fixes two bugs in the legacy-server media migration path, found during a Helper-folder-wide bug-hunting review (sequel to #1521-#1528).

1. **`stripLegacyPrefix()` corrupted filenames for externally-hosted "local" media.** When a filename's host didn't match the legacy server's own configured protocol+path, the code fell through to a blind host-strip regex that stripped *any* host, not just the legacy server's. A URL like `https://cdn.otherhost.com/podcasts/sermon123.mp3` became the bare relative path `podcasts/sermon123.mp3`, which `mediaBuildUrl()` then silently concatenated onto the *new* local server's own base path — pointing at a file that was never actually moved there. Now leaves the filename untouched when no configured legacy-server prefix matches, instead of corrupting it.
2. **`detectContentType()`'s legacy-ID precedence was inverted relative to the live renderer.** The migration helper checked `[docman, article, virtuemart]` and returned on first match; the site renderer (`Cwmmedia.php`) checks the same fields but each later check unconditionally *overrides* the previous, so real precedence is `virtuemart > article > docman` — exactly backwards. A hand-edited legacy record with more than one ID field set would migrate to a different addon than what the site was actually rendering. Rewrote to track the last match instead of the first, matching the renderer.

Note: this PR also touches `CwmserverMigrationHelper.php`, which already picked up an unrelated null-identity guard in `createServerForType()` from #1538/PR #1544 — that fix is not part of this PR, it landed earlier and is just present in the file's history.

## Test plan

- [x] Added 4 regression tests to the existing `tests/unit/Admin/Helper/CwmserverMigrationHelperTest.php` — verified RED against pre-fix code (2 failed for the intended reason), then GREEN
- [x] Full unit suite: 1212/1212
- [x] Lint clean

Fixes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe