### PR TITLE
fix: CwmyoutubeQuota fail-open write failures, TOCTOU lost-update race, DST-unsafe reset

### DIFF
--- a/admin/src/Addons/Servers/Youtube/youtube.xml
+++ b/admin/src/Addons/Servers/Youtube/youtube.xml
@@ -20,9 +20,6 @@
             <field name="youtube_daily_quota" type="number" default="10000" min="100" max="1000000"
                    label="JBS_ADDON_YOUTUBE_DAILY_QUOTA"
                    description="JBS_ADDON_YOUTUBE_DAILY_QUOTA_DESC" filter="int"/>
-            <field name="youtube_quota_reset_hour" type="number" default="7" min="0" max="23"
-                   label="JBS_ADDON_YOUTUBE_QUOTA_RESET_HOUR"
-                   description="JBS_ADDON_YOUTUBE_QUOTA_RESET_HOUR_DESC" filter="int"/>
         </fieldset>
         <fieldset name="youtube_oauth" label="JBS_ADDON_YOUTUBE_OAUTH_SETTINGS">
             <field name="oauth_note" type="note" label="JBS_ADDON_YOUTUBE_OAUTH_NOTE"

--- a/admin/src/Helper/CwmyoutubeQuota.php
+++ b/admin/src/Helper/CwmyoutubeQuota.php
@@ -27,8 +27,9 @@ use Joomla\Registry\Registry;
  * YouTube Data API v3 daily quota.  This class provides a file-based
  * counter that both systems read/write so neither can starve the other.
  *
- * The daily budget and reset hour are configured per-server on the YouTube
- * server record (youtube_daily_quota and youtube_quota_reset_hour params).
+ * The daily budget is configured per-server on the YouTube server record
+ * (youtube_daily_quota param). The quota-day boundary itself is derived
+ * from the real America/Los_Angeles timezone, not a configurable value.
  *
  * Quota file location: JPATH_CACHE/mod_proclaim_youtube/quota_{serverId}.json
  *
@@ -72,6 +73,25 @@ class CwmyoutubeQuota
     private static array $serverParamsCache = [];
 
     /**
+     * Per-server flag set when a write to the quota file has failed during
+     * this request. Once set, hasQuota() fails closed (denies further
+     * usage) instead of silently behaving as though nothing was consumed.
+     *
+     * This is process-local, in-memory state -- it resets every request,
+     * so a broken disk is only caught after at least one write attempt
+     * fails within the current request. That's still a meaningful
+     * improvement over the prior behavior (permanently and silently
+     * failing open forever): it stops a long-running batch (e.g. the
+     * platform-stats sync task, which can make many API calls in one
+     * process run) from continuing unprotected after the first failure.
+     * See #1549.
+     *
+     * @var    array<int, bool>
+     * @since  __DEPLOY_VERSION__
+     */
+    private static array $persistenceBroken = [];
+
+    /**
      * Get the configured daily quota budget from the server's params.
      *
      * Falls back to 10 000 (the YouTube default for new API keys).
@@ -91,6 +111,12 @@ class CwmyoutubeQuota
 
     /**
      * Get the UTC hour when the quota resets (YouTube resets at midnight PT).
+     *
+     * @deprecated __DEPLOY_VERSION__ No longer consulted by currentQuotaDate()
+     *             -- the quota-day boundary is now computed directly from the
+     *             America/Los_Angeles timezone (DST-aware), since no single
+     *             static UTC hour is correct year-round. See #1549. Will be
+     *             removed in a future major version.
      *
      * @param   int  $serverId  YouTube server record ID
      *
@@ -117,16 +143,21 @@ class CwmyoutubeQuota
      */
     public static function recordUsage(int $serverId, int $units): void
     {
-        $data          = self::loadQuotaFile($serverId);
-        $currentDate   = self::currentQuotaDate($serverId);
+        $currentDate = self::currentQuotaDate();
 
-        if (($data['date'] ?? '') !== $currentDate) {
-            $data = ['date' => $currentDate, 'used' => 0];
+        $ok = self::mutateQuotaFile($serverId, static function (array $data) use ($currentDate, $units): array {
+            if (($data['date'] ?? '') !== $currentDate) {
+                $data = ['date' => $currentDate, 'used' => 0];
+            }
+
+            $data['used'] = ($data['used'] ?? 0) + max(0, $units);
+
+            return $data;
+        });
+
+        if (!$ok) {
+            self::$persistenceBroken[$serverId] = true;
         }
-
-        $data['used'] = ($data['used'] ?? 0) + max(0, $units);
-
-        self::saveQuotaFile($serverId, $data);
     }
 
     /**
@@ -142,7 +173,7 @@ class CwmyoutubeQuota
     {
         $data = self::loadQuotaFile($serverId);
 
-        if (($data['date'] ?? '') !== self::currentQuotaDate($serverId)) {
+        if (($data['date'] ?? '') !== self::currentQuotaDate()) {
             return 0;
         }
 
@@ -175,6 +206,13 @@ class CwmyoutubeQuota
      */
     public static function hasQuota(int $serverId, int $neededUnits = 1): bool
     {
+        // A write failure this request means we can no longer trust the
+        // local counter to reflect real usage -- fail closed rather than
+        // silently letting unlimited calls through. See #1549.
+        if (!empty(self::$persistenceBroken[$serverId])) {
+            return false;
+        }
+
         return self::getRemaining($serverId) >= $neededUnits;
     }
 
@@ -193,13 +231,16 @@ class CwmyoutubeQuota
      */
     public static function markExhausted(int $serverId): void
     {
-        $budget = self::getDailyBudget($serverId);
-        $data   = [
-            'date' => self::currentQuotaDate($serverId),
-            'used' => $budget,
-        ];
+        $budget      = self::getDailyBudget($serverId);
+        $currentDate = self::currentQuotaDate();
 
-        self::saveQuotaFile($serverId, $data);
+        $ok = self::mutateQuotaFile($serverId, static function (array $data) use ($currentDate, $budget): array {
+            return ['date' => $currentDate, 'used' => $budget];
+        });
+
+        if (!$ok) {
+            self::$persistenceBroken[$serverId] = true;
+        }
     }
 
     /**
@@ -248,29 +289,29 @@ class CwmyoutubeQuota
         if (file_exists($file)) {
             @unlink($file);
         }
+
+        unset(self::$persistenceBroken[$serverId]);
     }
 
     /**
-     * Compute the "quota date" string based on the configured reset hour.
+     * Compute the "quota date" string.
      *
-     * YouTube resets at midnight Pacific Time (UTC-7 / UTC-8 depending on DST).
-     * The reset hour config lets sites align with the actual reset.
-     *
-     * @param   int  $serverId  YouTube server record ID
+     * YouTube resets at midnight Pacific Time. Derived directly from the
+     * real IANA timezone (DST-aware) rather than a static UTC "reset hour"
+     * -- no single fixed offset is correct for both PST and PDT, and the
+     * seasonal boundary itself moves twice a year. Being off by even one
+     * hour around that boundary, combined with a genuine quota-exceeded
+     * response landing in the mismatched window, could self-amplify into
+     * up to ~23 hours of falsely reporting "exhausted" after Google's real
+     * quota had already reset. See #1549.
      *
      * @return  string  Date string like "2026-02-28"
      *
      * @since   10.1.0
      */
-    private static function currentQuotaDate(int $serverId): string
+    private static function currentQuotaDate(): string
     {
-        $resetHour = self::getResetHour($serverId);
-        $now       = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-
-        // If we haven't passed the reset hour yet, we're still on "yesterday's" quota day
-        if ((int) $now->format('G') < $resetHour) {
-            $now = $now->modify('-1 day');
-        }
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('America/Los_Angeles'));
 
         return $now->format('Y-m-d');
     }
@@ -293,7 +334,8 @@ class CwmyoutubeQuota
     }
 
     /**
-     * Load the quota data from the file.
+     * Load the quota data from the file, using a shared lock so a read
+     * cannot observe a torn write from mutateQuotaFile().
      *
      * @param   int  $serverId  Server ID
      *
@@ -309,15 +351,43 @@ class CwmyoutubeQuota
             return ['date' => '', 'used' => 0];
         }
 
-        $raw = @file_get_contents($file);
+        $fp = @fopen($file, 'r');
 
-        if ($raw === false) {
+        if ($fp === false) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Quota file could not be opened for reading',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+
+            return ['date' => '', 'used' => 0];
+        }
+
+        $raw = '';
+
+        if (flock($fp, LOCK_SH)) {
+            $raw = stream_get_contents($fp);
+            flock($fp, LOCK_UN);
+        }
+
+        fclose($fp);
+
+        if ($raw === '' || $raw === false) {
             return ['date' => '', 'used' => 0];
         }
 
         try {
             $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
+            // File exists but isn't valid JSON -- distinct from "no file
+            // yet" and worth surfacing, since it silently drops today's
+            // accumulated usage count. See #1549.
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_WARNING,
+                'Quota file contained invalid JSON, resetting to zero',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+
             return ['date' => '', 'used' => 0];
         }
 
@@ -325,25 +395,97 @@ class CwmyoutubeQuota
     }
 
     /**
-     * Persist the quota data to disk.
+     * Atomically load, mutate, and persist the quota data for a server
+     * under a single exclusive lock held for the whole read-modify-write
+     * sequence -- prevents the lost-update race where two concurrent
+     * recordUsage()/markExhausted() calls both read the same starting
+     * value and one silently overwrites the other's increment. See #1549.
      *
-     * @param   int    $serverId  Server ID
-     * @param   array  $data      Quota data
+     * @param   int       $serverId  Server ID
+     * @param   callable  $mutator   array $data -> array $newData
      *
-     * @return  void
+     * @return  bool  True if the write succeeded
      *
-     * @since   10.1.0
+     * @since   __DEPLOY_VERSION__
      */
-    private static function saveQuotaFile(int $serverId, array $data): void
+    private static function mutateQuotaFile(int $serverId, callable $mutator): bool
     {
         $siteId = substr(md5(JPATH_CACHE), 0, 8);
         $dir    = JPATH_ROOT . '/media/com_proclaim/youtube_cache/' . $siteId;
 
-        if (!is_dir($dir)) {
-            @mkdir($dir, 0755, true);
+        if (!is_dir($dir) && !@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Quota directory could not be created',
+                ['server_id' => $serverId, 'dir' => $dir]
+            );
+
+            return false;
         }
 
-        @file_put_contents(self::quotaFilePath($serverId), json_encode($data), LOCK_EX);
+        $file = self::quotaFilePath($serverId);
+        $fp   = @fopen($file, 'c+');
+
+        if ($fp === false) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Quota file could not be opened for writing',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+
+            return false;
+        }
+
+        if (!flock($fp, LOCK_EX)) {
+            fclose($fp);
+
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Quota file could not be locked for writing',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+
+            return false;
+        }
+
+        $raw     = stream_get_contents($fp);
+        $current = ['date' => '', 'used' => 0];
+
+        if (\is_string($raw) && $raw !== '') {
+            try {
+                $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+                if (\is_array($decoded)) {
+                    $current = $decoded;
+                }
+            } catch (\JsonException $e) {
+                // Corrupt content under the lock -- treat as fresh, same as
+                // loadQuotaFile()'s handling outside the lock.
+            }
+        }
+
+        $new     = $mutator($current);
+        $encoded = json_encode($new);
+        $written = false;
+
+        if ($encoded !== false) {
+            rewind($fp);
+            $written = ftruncate($fp, 0) && fwrite($fp, $encoded) !== false;
+            fflush($fp);
+        }
+
+        flock($fp, LOCK_UN);
+        fclose($fp);
+
+        if (!$written) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Quota file write failed',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+        }
+
+        return $written;
     }
 
     /**

--- a/tests/unit/Admin/Helper/CwmyoutubeQuotaTest.php
+++ b/tests/unit/Admin/Helper/CwmyoutubeQuotaTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1549, found during a Helper-folder-wide bug-hunting
+ * review, tier 2 (external I/O + security surface, sequel to #1537-#1542).
+ *
+ * No test file existed for this class before.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmyoutubeQuotaTest extends ProclaimTestCase
+{
+    /**
+     * A serverId well outside any real server range, used for every test so
+     * fixtures never collide with real quota data on a dev DB.
+     */
+    private const TEST_SERVER_ID = 999999;
+
+    private string $quotaFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mirrors the private CwmyoutubeQuota::quotaFilePath() path scheme
+        // (siteId = first 8 chars of md5(JPATH_CACHE)) so tests can seed/
+        // inspect/corrupt the file directly.
+        $siteId          = substr(md5(JPATH_CACHE), 0, 8);
+        $dir             = JPATH_ROOT . '/media/com_proclaim/youtube_cache/' . $siteId;
+        $this->quotaFile = $dir . '/quota_' . self::TEST_SERVER_ID . '.json';
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        CwmyoutubeQuota::resetQuota(self::TEST_SERVER_ID);
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore permissions before deleting -- a 0000-mode file/dir left
+        // over from the fail-closed test would otherwise refuse unlink().
+        if (is_dir(\dirname($this->quotaFile))) {
+            @chmod(\dirname($this->quotaFile), 0755);
+        }
+
+        if (file_exists($this->quotaFile)) {
+            @chmod($this->quotaFile, 0644);
+            @unlink($this->quotaFile);
+        }
+
+        CwmyoutubeQuota::resetQuota(self::TEST_SERVER_ID);
+
+        parent::tearDown();
+    }
+
+    public function testRecordUsageAccumulatesAcrossCalls(): void
+    {
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 100);
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 50);
+
+        $this->assertSame(150, CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID));
+    }
+
+    public function testMarkExhaustedSetsUsedToTheDailyBudget(): void
+    {
+        // No server row exists for this fake ID, so getDailyBudget() falls
+        // back to the documented default of 10000.
+        CwmyoutubeQuota::markExhausted(self::TEST_SERVER_ID);
+
+        $this->assertSame(10000, CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID));
+        $this->assertFalse(CwmyoutubeQuota::hasQuota(self::TEST_SERVER_ID, 1));
+    }
+
+    public function testHasQuotaReturnsFalseOnceRemainingIsBelowNeededUnits(): void
+    {
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 9999);
+
+        $this->assertTrue(CwmyoutubeQuota::hasQuota(self::TEST_SERVER_ID, 1));
+        $this->assertFalse(CwmyoutubeQuota::hasQuota(self::TEST_SERVER_ID, 2));
+    }
+
+    /**
+     * The core #1549 regression: a write failure must not silently and
+     * permanently disable quota enforcement. Before the fix, hasQuota()
+     * derived its answer purely from loadQuotaFile() -- if every write
+     * silently no-ops (disk full, permissions), the file never reflects
+     * any usage, getUsedToday() stays 0 forever, and hasQuota() is
+     * unconditionally true.
+     *
+     * Reproduced by making the quota file read-only so mutateQuotaFile()'s
+     * fopen($file, 'c+') fails to open for writing -- recordUsage() must
+     * then flip the in-process fail-closed flag, and hasQuota() must
+     * report false even though the (unwritable, stale) file still shows
+     * plenty of remaining budget.
+     */
+    public function testHasQuotaFailsClosedAfterAWriteFailureInsteadOfStayingOpenForever(): void
+    {
+        if (posix_getuid() === 0) {
+            $this->markTestSkipped('Running as root bypasses filesystem permission checks.');
+        }
+
+        file_put_contents($this->quotaFile, json_encode(['date' => 'not-today', 'used' => 0]));
+        chmod($this->quotaFile, 0444);
+
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 100);
+
+        $this->assertFalse(
+            CwmyoutubeQuota::hasQuota(self::TEST_SERVER_ID, 1),
+            'a write failure must fail quota checks closed, not leave them silently permissive -- see #1549'
+        );
+    }
+
+    /**
+     * Corrupt/partial JSON in the quota file (e.g. from a crash mid-write)
+     * must not silently look identical to "no usage recorded yet" -- it
+     * should still be usable (falls back to a fresh day) but is logged as
+     * a distinct condition. This test only asserts the fallback behavior
+     * still works safely; the logging itself isn't asserted since
+     * CwmyoutubeLogHelper writes to a shared file-based log outside this
+     * test's fixture scope.
+     */
+    public function testCorruptQuotaFileFallsBackToFreshRatherThanCrashing(): void
+    {
+        file_put_contents($this->quotaFile, '{not valid json');
+
+        $used = CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID);
+
+        $this->assertSame(0, $used);
+    }
+
+    /**
+     * Two sequential recordUsage() calls must both land -- i.e. the second
+     * call's read-modify-write must see the first call's write, not a
+     * stale pre-write snapshot. This is the structural guarantee that
+     * closes the TOCTOU lost-update race: recordUsage() now performs its
+     * load+modify+save entirely inside one flock(LOCK_EX)-held critical
+     * section (mutateQuotaFile()) instead of two separate file operations.
+     */
+    public function testSequentialRecordUsageCallsDoNotLoseEitherIncrement(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 10);
+        }
+
+        $this->assertSame(50, CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID));
+    }
+
+    public function testResetQuotaClearsUsageBackToZero(): void
+    {
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 500);
+        CwmyoutubeQuota::resetQuota(self::TEST_SERVER_ID);
+
+        $this->assertSame(0, CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID));
+    }
+
+    /**
+     * The quota-day boundary is meant to reflect YouTube's actual reset
+     * (midnight Pacific Time), which the fix now derives from the real
+     * America/Los_Angeles timezone rather than a manually-configured UTC
+     * offset. Sanity-checks the format and that it's a real, parseable
+     * calendar date -- exact value depends on "now", which the test can't
+     * freeze (Date::now()-style calls aren't available in this harness).
+     */
+    public function testGetUsedTodayIsScopedToTheCurrentPacificTimeQuotaDay(): void
+    {
+        CwmyoutubeQuota::recordUsage(self::TEST_SERVER_ID, 1);
+
+        $this->assertSame(1, CwmyoutubeQuota::getUsedToday(self::TEST_SERVER_ID));
+
+        $raw  = json_decode(file_get_contents($this->quotaFile), true);
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $raw['date'] ?? '');
+
+        $this->assertNotFalse($date, 'stored quota date must be a valid Y-m-d string');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four bugs in the shared YouTube API quota tracker, found during a Helper-folder-wide bug-hunting review, tier 2 (external I/O + security surface — sequel to #1537-#1542, tier 1).

1. **Silent write failures permanently disabled quota protection (fail-open).** `saveQuotaFile()` suppressed and never checked `mkdir()`/`file_put_contents()` failures. On any host where `media/` isn't writable, every `recordUsage()`/`markExhausted()` call silently no-op'd — the counter stayed at 0 forever, `hasQuota()` was unconditionally true, and the app kept calling YouTube's API after real quota was gone (risking API-key-level throttling/suspension). Now checks every write, logs failures, and fails closed (denies further usage) for the rest of the request once a write is known to have failed.
2. **TOCTOU lost-update race.** `recordUsage()`'s load-then-save was two separate, unlocked file operations — two concurrent callers (frontend polling + a backend cron, exactly the scenario this class's own docblock describes) could both read the same value and one would silently overwrite the other's increment. Replaced with a single `fopen('c+')+flock(LOCK_EX)` critical section spanning the whole read-modify-write.
3. **Silent data loss on corrupt JSON.** Corrupt/partial quota-file content was swallowed with no logging, indistinguishable from "no data yet." Now logged as a warning, and reads happen under a shared lock so they can't observe a torn write.
4. **DST-unsafe quota-day boundary.** The reset boundary was approximated with a static UTC hour admins had to manually flip twice a year — get it wrong and a genuine quota-exceeded response could self-amplify into up to ~23 hours of falsely reporting "exhausted." Now derived directly from the `America/Los_Angeles` timezone (DST-aware, always correct). The now-dead `youtube_quota_reset_hour` settings field is removed from `youtube.xml`; `getResetHour()` is kept but marked `@deprecated`.

## Test plan

- [x] Added `tests/unit/Admin/Helper/CwmyoutubeQuotaTest.php` (no test file existed for this class before) — 8 tests, including a fail-closed regression (makes the quota file read-only to reproduce the write failure), verified RED against pre-fix code then GREEN
- [x] Full unit suite: 1222/1222
- [x] Lint clean

Fixes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe