### PR TITLE
fix: CwmyoutubeFileCache public cache dir has no access control, silent write failures, torn reads

### DIFF
--- a/admin/src/Helper/CwmyoutubeFileCache.php
+++ b/admin/src/Helper/CwmyoutubeFileCache.php
@@ -66,9 +66,22 @@ class CwmyoutubeFileCache
         ];
 
         try {
-            @file_put_contents($file, json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), LOCK_EX);
+            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
         } catch (\JsonException $e) {
             // Video data contained unencodable values — skip caching
+            return;
+        }
+
+        if (@file_put_contents($file, $json, LOCK_EX) === false) {
+            // This is the last-resort fallback the class docblock promises
+            // "ensures module can always show a video instead of 'no video
+            // available'" -- a silent write failure here means that
+            // guarantee silently stops holding with no trace. See #1551.
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_ERROR,
+                'Failed to write last-known-video fallback cache',
+                ['server_id' => $serverId, 'file' => $file]
+            );
         }
     }
 
@@ -86,14 +99,9 @@ class CwmyoutubeFileCache
     public static function getLastKnownVideo(int $serverId): ?array
     {
         $file = self::dir() . '/last_video_' . $serverId . '.json';
+        $raw  = self::readWithSharedLock($file);
 
-        if (!file_exists($file)) {
-            return null;
-        }
-
-        $raw = @file_get_contents($file);
-
-        if ($raw === false) {
+        if ($raw === null) {
             return null;
         }
 
@@ -134,9 +142,18 @@ class CwmyoutubeFileCache
         ];
 
         try {
-            @file_put_contents($file, json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES), LOCK_EX);
+            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
         } catch (\JsonException $e) {
             // Skip caching
+            return;
+        }
+
+        if (@file_put_contents($file, $json, LOCK_EX) === false) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_WARNING,
+                'Failed to write video cache entry',
+                ['cache_key' => $cacheKey, 'file' => $file]
+            );
         }
     }
 
@@ -152,14 +169,9 @@ class CwmyoutubeFileCache
     public static function getVideoCache(string $cacheKey): ?array
     {
         $file = self::dir() . '/vcache_' . md5($cacheKey) . '.json';
+        $raw  = self::readWithSharedLock($file);
 
-        if (!file_exists($file)) {
-            return null;
-        }
-
-        $raw = @file_get_contents($file);
-
-        if ($raw === false) {
+        if ($raw === null) {
             return null;
         }
 
@@ -246,9 +258,18 @@ class CwmyoutubeFileCache
         ];
 
         try {
-            @file_put_contents($file, json_encode($data, JSON_THROW_ON_ERROR), LOCK_EX);
+            $json = json_encode($data, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             // Should never happen with string data — skip caching
+            return;
+        }
+
+        if (@file_put_contents($file, $json, LOCK_EX) === false) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_WARNING,
+                'Failed to write scheduled-start cache entry',
+                ['server_id' => $serverId, 'video_id' => $videoId, 'file' => $file]
+            );
         }
     }
 
@@ -268,14 +289,9 @@ class CwmyoutubeFileCache
     public static function getStoredScheduledStart(int $serverId, string $videoId): string
     {
         $file = self::dir() . '/schedule_' . $serverId . '_' . self::sanitizeId($videoId) . '.json';
+        $raw  = self::readWithSharedLock($file);
 
-        if (!file_exists($file)) {
-            return '';
-        }
-
-        $raw = @file_get_contents($file);
-
-        if ($raw === false) {
+        if ($raw === null) {
             return '';
         }
 
@@ -338,15 +354,29 @@ class CwmyoutubeFileCache
         $fp = @fopen($file, 'c');
 
         if ($fp === false) {
+            CwmyoutubeLogHelper::log(
+                CwmyoutubeLogHelper::LEVEL_WARNING,
+                'Failed to open search throttle file for writing',
+                ['server_id' => $serverId, 'file' => $file]
+            );
+
             return;
         }
 
         if (flock($fp, LOCK_EX)) {
             ftruncate($fp, 0);
             rewind($fp);
-            fwrite($fp, $json);
+            $written = fwrite($fp, $json);
             fflush($fp);
             flock($fp, LOCK_UN);
+
+            if ($written === false) {
+                CwmyoutubeLogHelper::log(
+                    CwmyoutubeLogHelper::LEVEL_WARNING,
+                    'Failed to write search throttle file',
+                    ['server_id' => $serverId, 'file' => $file]
+                );
+            }
         }
 
         fclose($fp);
@@ -366,28 +396,9 @@ class CwmyoutubeFileCache
     public static function getSearchThrottle(int $serverId): ?array
     {
         $file = self::dir() . '/search_throttle_' . $serverId . '.json';
+        $raw  = self::readWithSharedLock($file);
 
-        if (!file_exists($file)) {
-            return null;
-        }
-
-        // Use fopen + flock for consistent reads (prevents torn reads during writes)
-        $fp = @fopen($file, 'r');
-
-        if ($fp === false) {
-            return null;
-        }
-
-        $raw = '';
-
-        if (flock($fp, LOCK_SH)) {
-            $raw = stream_get_contents($fp);
-            flock($fp, LOCK_UN);
-        }
-
-        fclose($fp);
-
-        if ($raw === '' || $raw === false) {
+        if ($raw === null) {
             return null;
         }
 
@@ -624,10 +635,15 @@ class CwmyoutubeFileCache
      */
     private static function ensureDir(): void
     {
-        $dir = self::dir();
+        $dir     = self::dir();
+        $existed = is_dir($dir);
 
-        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+        if (!$existed && !mkdir($dir, 0755, true) && !is_dir($dir)) {
             throw new \RuntimeException(\sprintf('Directory "%s" was not created', $dir));
+        }
+
+        if (!$existed) {
+            self::writeAccessDenyFiles($dir);
         }
 
         // One-time migration from old JPATH_CACHE location
@@ -637,6 +653,100 @@ class CwmyoutubeFileCache
             $migrated = true;
             self::migrateFromOldLocation();
         }
+    }
+
+    /**
+     * Write deny-all .htaccess/web.config into a newly created cache
+     * directory.
+     *
+     * Unlike media/backup/ (which ships these files statically since its
+     * directory is created at install time), this directory is created
+     * dynamically at runtime and had no equivalent protection -- its
+     * contents (quota counters, cached video metadata, scheduled-stream
+     * times) were directly web-servable with no auth check. See #1551.
+     *
+     * @param   string  $dir  The cache directory that was just created
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function writeAccessDenyFiles(string $dir): void
+    {
+        $htaccess = $dir . '/.htaccess';
+
+        if (!file_exists($htaccess)) {
+            @file_put_contents(
+                $htaccess,
+                "<IfModule !mod_authz_core.c>\n"
+                . "Order deny,allow\n"
+                . "Deny from all\n"
+                . "</IfModule>\n"
+                . "<IfModule mod_authz_core.c>\n"
+                . "  <RequireAll>\n"
+                . "    Require all denied\n"
+                . "  </RequireAll>\n"
+                . "</IfModule>\n"
+            );
+        }
+
+        $webConfig = $dir . '/web.config';
+
+        if (!file_exists($webConfig)) {
+            @file_put_contents(
+                $webConfig,
+                "<?xml version=\"1.0\"?>\n"
+                . "<configuration>\n"
+                . "    <system.webServer>\n"
+                . "        <security>\n"
+                . "            <requestFiltering>\n"
+                . "                <fileExtensions allowUnlisted=\"false\" />\n"
+                . "            </requestFiltering>\n"
+                . "        </security>\n"
+                . "    </system.webServer>\n"
+                . "</configuration>\n"
+            );
+        }
+    }
+
+    /**
+     * Read a cache file's contents under a shared lock.
+     *
+     * Pairs with the LOCK_EX writes used throughout this class -- without
+     * this, a reader could open the file mid-write (after truncation but
+     * before the new content is fully flushed) and see a torn/partial
+     * document. This is the same pattern getSearchThrottle() already used
+     * correctly; the other three read methods in this class didn't apply
+     * it. See #1551.
+     *
+     * @param   string  $file  Absolute path to the cache file
+     *
+     * @return  string|null  File contents, or null if missing/unreadable
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function readWithSharedLock(string $file): ?string
+    {
+        if (!file_exists($file)) {
+            return null;
+        }
+
+        $fp = @fopen($file, 'r');
+
+        if ($fp === false) {
+            return null;
+        }
+
+        $raw = '';
+
+        if (flock($fp, LOCK_SH)) {
+            $raw = stream_get_contents($fp);
+            flock($fp, LOCK_UN);
+        }
+
+        fclose($fp);
+
+        return ($raw === '' || $raw === false) ? null : $raw;
     }
 
     /**

--- a/tests/unit/Admin/Helper/CwmyoutubeFileCacheTest.php
+++ b/tests/unit/Admin/Helper/CwmyoutubeFileCacheTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeFileCache;
+use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeLogHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression tests for #1551, found during a Helper-folder-wide bug-hunting
+ * review, tier 2 (external I/O + security surface, sequel to #1537-#1542).
+ *
+ * No test file existed for this class before.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmyoutubeFileCacheTest extends ProclaimTestCase
+{
+    private const TEST_SERVER_ID = 999999;
+
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $siteId         = substr(md5(JPATH_CACHE), 0, 8);
+        $this->cacheDir = JPATH_ROOT . '/media/com_proclaim/youtube_cache/' . $siteId;
+
+        // Start from a clean slate so ensureDir() deterministically hits its
+        // "directory did not exist yet" branch in the access-control test.
+        $this->removeCacheDir();
+
+        CwmyoutubeLogHelper::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore permissions before deleting -- a 0000-mode fixture left
+        // over from a fail-write test would otherwise refuse removal.
+        if (is_dir($this->cacheDir)) {
+            @chmod($this->cacheDir, 0755);
+        }
+
+        $file = $this->cacheDir . '/last_video_' . self::TEST_SERVER_ID . '.json';
+
+        if (file_exists($file)) {
+            @chmod($file, 0644);
+        }
+
+        $this->removeCacheDir();
+
+        parent::tearDown();
+    }
+
+    private function removeCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            return;
+        }
+
+        foreach (scandir($this->cacheDir) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            @chmod($this->cacheDir . '/' . $entry, 0644);
+            @unlink($this->cacheDir . '/' . $entry);
+        }
+
+        @rmdir($this->cacheDir);
+    }
+
+    public function testStoreAndRetrieveLastKnownVideo(): void
+    {
+        CwmyoutubeFileCache::storeLastKnownVideo(self::TEST_SERVER_ID, ['id' => 'abc123', 'title' => 'Test']);
+
+        $video = CwmyoutubeFileCache::getLastKnownVideo(self::TEST_SERVER_ID);
+
+        $this->assertSame('abc123', $video['id'] ?? null);
+    }
+
+    public function testStoreAndRetrieveVideoCacheWithinTtl(): void
+    {
+        CwmyoutubeFileCache::storeVideoCache('test-key', ['id' => 'xyz789'], 300);
+
+        $video = CwmyoutubeFileCache::getVideoCache('test-key');
+
+        $this->assertSame('xyz789', $video['id'] ?? null);
+    }
+
+    public function testStoreAndRetrieveScheduledStart(): void
+    {
+        CwmyoutubeFileCache::storeScheduledStart(self::TEST_SERVER_ID, 'vid123', '2026-08-05T12:00:00Z');
+
+        $this->assertSame(
+            '2026-08-05T12:00:00Z',
+            CwmyoutubeFileCache::getStoredScheduledStart(self::TEST_SERVER_ID, 'vid123')
+        );
+    }
+
+    /**
+     * The cache directory (quota counters, cached video metadata,
+     * scheduled-stream times) sat inside the public webroot with no
+     * .htaccess/web.config -- unlike the sibling media/backup/ convention
+     * -- meaning its contents were directly web-servable with no auth
+     * check. ensureDir() must now write deny-all access files the first
+     * time it creates the directory. See #1551.
+     */
+    public function testEnsureDirWritesAccessDenyFilesOnFirstCreation(): void
+    {
+        $this->assertDirectoryDoesNotExist($this->cacheDir, 'setUp() must have removed the cache dir first');
+
+        // Any public method that calls ensureDir() triggers the creation.
+        CwmyoutubeFileCache::storeLastKnownVideo(self::TEST_SERVER_ID, ['id' => 'trigger']);
+
+        $this->assertFileExists($this->cacheDir . '/.htaccess');
+        $this->assertStringContainsString('Deny from all', file_get_contents($this->cacheDir . '/.htaccess'));
+        $this->assertStringContainsString('Require all denied', file_get_contents($this->cacheDir . '/.htaccess'));
+
+        $this->assertFileExists($this->cacheDir . '/web.config');
+    }
+
+    /**
+     * A write failure to the last-resort "always show a video" fallback
+     * cache must not vanish silently -- the class docblock promises this
+     * cache "ensures module can always show a video instead of 'no video
+     * available'"; if a write failure isn't even logged, an admin has no
+     * way to discover why that guarantee stopped holding. See #1551.
+     */
+    public function testStoreLastKnownVideoLogsOnWriteFailure(): void
+    {
+        if (posix_getuid() === 0) {
+            $this->markTestSkipped('Running as root bypasses filesystem permission checks.');
+        }
+
+        CwmyoutubeFileCache::storeLastKnownVideo(self::TEST_SERVER_ID, ['id' => 'first']);
+
+        $file = $this->cacheDir . '/last_video_' . self::TEST_SERVER_ID . '.json';
+        chmod($file, 0444);
+
+        CwmyoutubeFileCache::storeLastKnownVideo(self::TEST_SERVER_ID, ['id' => 'second']);
+
+        $entries = CwmyoutubeLogHelper::getEntries(10, CwmyoutubeLogHelper::LEVEL_ERROR);
+        $found   = false;
+
+        foreach ($entries as $entry) {
+            if (str_contains($entry['message'] ?? '', 'last-known-video')) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'a write failure must be logged, not silently dropped -- see #1551');
+    }
+
+    /**
+     * Structural guard: getLastKnownVideo(), getVideoCache(), and
+     * getStoredScheduledStart() must read under the same shared-lock
+     * pattern getSearchThrottle() already used correctly, instead of a
+     * bare file_get_contents() that can observe a torn write. Verified by
+     * source inspection since a true concurrent-write race isn't
+     * reproducible deterministically in a single-threaded test.
+     */
+    public function testReadMethodsUseTheSharedLockHelperNotBareFileGetContents(): void
+    {
+        $reflection = new \ReflectionClass(CwmyoutubeFileCache::class);
+        $lines      = file($reflection->getFileName());
+
+        foreach (['getLastKnownVideo', 'getVideoCache', 'getStoredScheduledStart'] as $method) {
+            $m    = $reflection->getMethod($method);
+            $body = implode(
+                '',
+                \array_slice($lines, $m->getStartLine() - 1, $m->getEndLine() - $m->getStartLine() + 1)
+            );
+
+            $this->assertStringContainsString(
+                'readWithSharedLock',
+                $body,
+                "{$method}() must read via readWithSharedLock() -- see #1551"
+            );
+            $this->assertStringNotContainsString(
+                '@file_get_contents(',
+                $body,
+                "{$method}() must not use a bare file_get_contents() -- see #1551"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes three bugs in the shared YouTube file-based cache, found during a Helper-folder-wide bug-hunting review, tier 2 (external I/O + security surface — sequel to #1537-#1542, tier 1).

1. **Public cache directory had no access control.** `media/com_proclaim/youtube_cache/` is inside the public webroot and was created at runtime with no `.htaccess`/`web.config` — unlike the sibling `media/backup/` directory, which ships both statically. Its contents (quota counters, cached video metadata, scheduled-stream times) were directly web-servable with no auth check. `ensureDir()` now writes deny-all access files the first time it creates the directory.
2. **Every write path silently swallowed failures.** `storeLastKnownVideo()` is the documented last-resort fallback ("ensures module can always show a video instead of 'no video available'") — a silent write failure there meant that guarantee silently stopped holding with no trace. All five write paths now check their result and log failures.
3. **Torn-read risk on 3 of 4 cache pairs.** Three read methods used a bare `file_get_contents()` against a `LOCK_EX`-written file, with no `flock()` at all — while the fourth pair (`setSearchThrottle`/`getSearchThrottle`) already correctly used `fopen`+`flock(LOCK_SH)`, with a docblock explicitly noting it "prevents torn reads during writes." Extracted that correct pattern into a shared helper and applied it everywhere.

## Test plan

- [x] Added `tests/unit/Admin/Helper/CwmyoutubeFileCacheTest.php` (no test file existed for this class before) — 6 tests, verified RED against pre-fix code (3 of 6 failed for the intended reasons) then GREEN
- [x] Full unit suite: 1228/1228
- [x] Lint clean

Fixes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe