### PR TITLE
fix: CwmpodcastTrackHelper proxy drops Location header, Host-header-based misrouting

### DIFF
--- a/admin/src/Helper/CwmpodcastTrackHelper.php
+++ b/admin/src/Helper/CwmpodcastTrackHelper.php
@@ -255,7 +255,9 @@ class CwmpodcastTrackHelper
      *
      * @param   string  $target           Absolute URL of the live media
      * @param   string  $mimeType         Content-Type to declare
-     * @param   string  $host             Raw incoming Host header (may include a port)
+     * @param   string  $host             This site's own configured hostname (from
+     *                                    Uri::root(), NOT the incoming Host header --
+     *                                    see isLocalHost()), may include a port
      * @param   string  $range            Raw incoming Range header, if any
      * @param   string  $ifModifiedSince  Raw incoming If-Modified-Since header, if any
      * @param   string  $ifNoneMatch      Raw incoming If-None-Match header, if any
@@ -491,7 +493,16 @@ class CwmpodcastTrackHelper
             CURLOPT_RESOLVE        => [$host . ':' . $port . ':' . $safeIp],
             CURLOPT_CONNECTTIMEOUT => 15,
             CURLOPT_TIMEOUT        => 0,
-            CURLOPT_HEADERFUNCTION => static function ($curlHandle, string $headerLine): int {
+            // This endpoint is unauthenticated and unrate-limited, so a
+            // slow/stalled upstream host is a resource-exhaustion vector --
+            // set_time_limit(0) above plus TIMEOUT=0 mean nothing else
+            // bounds how long a worker stays pinned. A LOW_SPEED guard
+            // (not a hard total-time cap) aborts only a genuinely stalled
+            // transfer, so legitimately large episode files can still
+            // stream for as long as they need to. See #1552.
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME  => 60,
+            CURLOPT_HEADERFUNCTION  => static function ($curlHandle, string $headerLine): int {
                 $trimmed = trim($headerLine);
 
                 if ($trimmed === '') {
@@ -504,7 +515,16 @@ class CwmpodcastTrackHelper
                     return \strlen($headerLine);
                 }
 
-                if (preg_match('/^(Content-Type|Content-Length|Content-Range|Accept-Ranges|Last-Modified|ETag|Cache-Control|Expires):/i', $trimmed)) {
+                // Location is relayed too: CURLOPT_FOLLOWLOCATION is off (see
+                // above), so without this a redirect from upstream (e.g. an
+                // http->https upgrade, or a CDN 301/302-ing to a signed URL --
+                // the common case, given the "external host" storage model
+                // this method exists for) reached the client as a bare 3xx
+                // status with no Location and no body. This restores the
+                // pre-#1424 trust model for that case: the *client* follows
+                // the redirect itself, same as it always did, not curl -- no
+                // new SSRF surface. See #1552.
+                if (preg_match('/^(Content-Type|Content-Length|Content-Range|Accept-Ranges|Last-Modified|ETag|Cache-Control|Expires|Location):/i', $trimmed)) {
                     header($trimmed);
                 }
 
@@ -590,23 +610,30 @@ class CwmpodcastTrackHelper
      * Is the media target on this same site, so it can be streamed directly
      * off local disk rather than proxied from an external host?
      *
-     * parse_url()'s PHP_URL_HOST never includes a port, but the raw Host
-     * header does whenever the site isn't on the default port (every local
-     * dev site this was tested against runs on :8890) — comparing them
-     * as-is always mismatched on those sites and silently sent every local
-     * file down the remote-proxy path instead. Strip the port from both
-     * sides before comparing.
+     * $siteHost must be this site's own configured hostname (Uri::root()),
+     * NOT the incoming request's Host header. The Host header is
+     * client-supplied and rewritable by any reverse proxy/CDN in front of
+     * the site, so it can legitimately differ from the site's real
+     * hostname in form (e.g. "site.com" vs "www.site.com") with no
+     * attacker involved at all -- comparing against it caused local media
+     * to be misrouted down the remote-proxy path (which then either
+     * self-proxies or 404s, depending on what that hostname resolves to)
+     * on any such mismatch. See #1552.
      *
-     * @param   string  $requestHost  Raw incoming Host header (may include a port)
-     * @param   string  $target       Absolute URL of the live media
+     * parse_url()'s PHP_URL_HOST never includes a port, but $siteHost may
+     * (every local dev site this was tested against runs on :8890) —
+     * strip the port from both sides before comparing.
+     *
+     * @param   string  $siteHost  This site's own configured hostname (may include a port)
+     * @param   string  $target    Absolute URL of the live media
      *
      * @return  bool
      *
      * @since   10.5.4
      */
-    private static function isLocalHost(string $requestHost, string $target): bool
+    private static function isLocalHost(string $siteHost, string $target): bool
     {
-        $hostOnly   = strtolower(explode(':', $requestHost, 2)[0]);
+        $hostOnly   = strtolower(explode(':', $siteHost, 2)[0]);
         $targetHost = strtolower((string) (parse_url($target, PHP_URL_HOST) ?: ''));
 
         return $hostOnly !== '' && $targetHost !== '' && $hostOnly === $targetHost;

--- a/site/src/Controller/CwmpodcastController.php
+++ b/site/src/Controller/CwmpodcastController.php
@@ -23,6 +23,7 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmpodcastTrackHelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
@@ -178,7 +179,15 @@ class CwmpodcastController extends BaseController
             $mimeType   = $storedMime !== '' ? $storedMime : 'application/octet-stream';
         }
 
-        $host            = (string) $this->input->server->getString('HTTP_HOST', '');
+        // Deliberately NOT the incoming Host header: that's client-supplied
+        // and (via reverse proxies/CDNs) reverse-proxy-rewritable, so it can
+        // legitimately differ from this site's own configured hostname in
+        // form (e.g. "site.com" vs "www.site.com") even with no attacker
+        // involved. Comparing against it made isLocalHost() misroute local
+        // media to the remote-proxy path on any such mismatch. Uri::root()
+        // reflects Joomla's own site configuration (the "Live Site URL"
+        // when set) instead. See #1552.
+        $host            = (string) (parse_url(Uri::root(), PHP_URL_HOST) ?: '');
         $range           = (string) $this->input->server->getString('HTTP_RANGE', '');
         $ifModifiedSince = (string) $this->input->server->getString('HTTP_IF_MODIFIED_SINCE', '');
         $ifNoneMatch     = (string) $this->input->server->getString('HTTP_IF_NONE_MATCH', '');

--- a/tests/unit/Admin/Helper/CwmpodcastTrackHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmpodcastTrackHelperTest.php
@@ -110,4 +110,117 @@ class CwmpodcastTrackHelperTest extends ProclaimTestCase
             CwmpodcastTrackHelper::resolveGuid($db, 0, null, 'https://example.org/media/new.mp3')
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Regression tests for #1552
+    // -------------------------------------------------------------------------
+
+    private function invokeIsLocalHost(string $siteHost, string $target): bool
+    {
+        $method = new \ReflectionMethod(CwmpodcastTrackHelper::class, 'isLocalHost');
+
+        return $method->invoke(null, $siteHost, $target);
+    }
+
+    public function testIsLocalHostMatchesOnSiteConfiguredHostname(): void
+    {
+        $this->assertTrue($this->invokeIsLocalHost('nfsda.org', 'https://nfsda.org/media/sermon.mp3'));
+    }
+
+    public function testIsLocalHostStripsPortFromBothSidesBeforeComparing(): void
+    {
+        $this->assertTrue($this->invokeIsLocalHost('nfsda.org:8890', 'https://nfsda.org/media/sermon.mp3'));
+    }
+
+    public function testIsLocalHostReturnsFalseForAGenuinelyExternalHost(): void
+    {
+        $this->assertFalse($this->invokeIsLocalHost('nfsda.org', 'https://cdn.otherhost.com/media/sermon.mp3'));
+    }
+
+    /**
+     * track() must derive $host from Uri::root() (this site's own
+     * configured hostname), not the raw, client-supplied and
+     * reverse-proxy-rewritable HTTP_HOST request header -- comparing
+     * against the latter could misroute genuinely local media down the
+     * remote-proxy path on a benign hostname-form mismatch (e.g.
+     * "site.com" vs "www.site.com"), with no attacker involved. Checked
+     * structurally against the controller source. See #1552.
+     */
+    public function testTrackDerivesHostFromUriRootNotTheRequestHostHeader(): void
+    {
+        $reflection = new \ReflectionMethod(
+            \CWM\Component\Proclaim\Site\Controller\CwmpodcastController::class,
+            'track'
+        );
+        $lines = file($reflection->getFileName());
+        $body  = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringNotContainsString(
+            "getString('HTTP_HOST'",
+            $body,
+            'must not derive $host from the raw HTTP_HOST request header -- see #1552'
+        );
+        $this->assertStringContainsString(
+            'Uri::root()',
+            $body,
+            'must derive $host from Uri::root() -- see #1552'
+        );
+    }
+
+    /**
+     * streamRemoteFile()'s header relay allow-list previously excluded
+     * Location, so a 3xx from the upstream media host (e.g. an
+     * http->https upgrade, or a CDN 301/302-ing to a signed URL) reached
+     * the client as a bare redirect status with no Location and no body
+     * -- breaking playback for the exact "external host" case this
+     * method exists to support. CURLOPT_FOLLOWLOCATION stays off; only
+     * the header is now relayed so the client follows it itself, same as
+     * the pre-#1424 behavior. Checked structurally: exercising the real
+     * header-relay closure requires a live HTTP fetch this suite doesn't
+     * perform. See #1552.
+     */
+    public function testStreamRemoteFileRelaysTheLocationHeader(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpodcastTrackHelper::class, 'streamRemoteFile');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/preg_match\(\'\/\^\([^)]*\|Location\)[^)]*\)/',
+            $body,
+            'the relayed-header allow-list must include Location -- see #1552'
+        );
+        $this->assertStringContainsString(
+            'CURLOPT_FOLLOWLOCATION => false',
+            $body,
+            'curl itself must still not follow redirects -- only the header is relayed, see #1552'
+        );
+    }
+
+    /**
+     * This endpoint is unauthenticated and unrate-limited, with
+     * set_time_limit(0) and CURLOPT_TIMEOUT=0 -- nothing else bounds how
+     * long a worker stays pinned to a slow/stalled upstream host. A
+     * LOW_SPEED guard (not a hard total-time cap) must be present so a
+     * stalled transfer aborts while a large legitimately-slow episode
+     * download can still complete. See #1552.
+     */
+    public function testStreamRemoteFileSetsALowSpeedStallGuard(): void
+    {
+        $reflection = new \ReflectionMethod(CwmpodcastTrackHelper::class, 'streamRemoteFile');
+        $lines      = file($reflection->getFileName());
+        $body       = implode(
+            '',
+            \array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1)
+        );
+
+        $this->assertStringContainsString('CURLOPT_LOW_SPEED_LIMIT', $body);
+        $this->assertStringContainsString('CURLOPT_LOW_SPEED_TIME', $body);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes three bugs in the podcast download tracking/proxy endpoint, found during a Helper-folder-wide bug-hunting review, tier 2 (external I/O + security surface — sequel to #1537-#1542, tier 1). The prior SSRF fix in this file (v10.5.4/10.5.5) was re-verified in detail during the review and confirmed solid — not touched here.

1. **Redirects from upstream lost their `Location` header.** `CURLOPT_FOLLOWLOCATION` is (correctly) off, but the header relay allow-list excluded `Location` too — so a clean 3xx from the upstream media host (an http→https upgrade, or a CDN 301/302-ing to a signed URL — the common case per this endpoint's own docblock) reached the client as a bare redirect with no `Location` and no body, breaking playback for exactly the case this method exists to support. Added `Location` to the allow-list; curl itself still never follows redirects, so no new SSRF surface.
2. **Local/remote routing keyed off the untrusted `Host` header.** `isLocalHost()` compared the target's host against the raw, client-supplied, reverse-proxy-rewritable `HTTP_HOST` header — which can legitimately differ from the site's real hostname in form (`site.com` vs `www.site.com`) with no attacker involved. A mismatch misrouted local media down the remote-proxy path. Now derived from `Uri::root()` (this site's own configured hostname) instead.
3. **(Secondary) No stall/idle timeout.** This unauthenticated, unrate-limited endpoint had `set_time_limit(0)` + `CURLOPT_TIMEOUT => 0` with nothing else bounding a slow/stalled upstream. Added `CURLOPT_LOW_SPEED_LIMIT`/`CURLOPT_LOW_SPEED_TIME` so a stalled transfer aborts while legitimately large/slow downloads still complete.

## Test plan

- [x] Added 6 regression tests to the existing `tests/unit/Admin/Helper/CwmpodcastTrackHelperTest.php` — verified RED against pre-fix code (3 of 6 new tests failed for the intended reasons) then GREEN
- [x] Full unit suite: 1234/1234
- [x] Lint clean

Fixes #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjYm69R9GVBeuJsHjh4tLe