### PR TITLE
fix: CwmplaylistSyncHelper fatal-flag write-back stop, logger fail-open, quota/upgrade-helper fixes (#1553)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,152 @@ jobs:
           JTEST_DB_PASSWORD: proclaim_test
           JTEST_DB_PREFIX: proclaim_
 
+  # Forward-compatibility coverage for the next PHP release. Not a required
+  # check — 8.3 (php-checks, above) is the supported floor and must pass;
+  # this job exists to surface 8.5 breakage early without blocking merges
+  # until the codebase is verified clean against it.
+  php-checks-85:
+    name: PHP Lint & Tests (8.5, non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_USER: proclaim_test
+          MYSQL_PASSWORD: proclaim_test
+          MYSQL_ROOT_PASSWORD: proclaim_test
+          MYSQL_DATABASE: proclaim_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, json, xml, mysqli
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php85-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php85-composer-
+
+      - name: Clone joomla-cms for test framework
+        run: git clone --depth 1 --branch 5.4.3 https://github.com/joomla/joomla-cms.git $GITHUB_WORKSPACE/../joomla-cms
+
+      - name: Cache joomla-cms composer dependencies
+        id: joomla-cms-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/../joomla-cms/libraries/vendor
+          key: joomla-cms-vendor-5.4.3-${{ runner.os }}-php85
+
+      - name: Install joomla-cms composer dependencies
+        if: steps.joomla-cms-cache.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/../joomla-cms
+          composer install --no-dev --no-interaction --prefer-dist
+
+      - name: Generate minimal configuration.php for tests
+        run: |
+          cat > $GITHUB_WORKSPACE/../joomla-cms/configuration.php <<'PHP'
+          <?php
+          class JConfig
+          {
+              public $dbtype          = 'mysqli';
+              public $host            = '127.0.0.1';
+              public $user            = 'proclaim_test';
+              public $password        = 'proclaim_test';
+              public $db              = 'proclaim_test';
+              public $dbprefix        = 'proclaim_';
+              public $secret          = 'proclaim-test-secret-key-0123456789abcdef';
+              public $sitename        = 'Proclaim Test';
+              public $editor          = 'none';
+              public $captcha         = '0';
+              public $language        = 'en-GB';
+              public $mailer          = 'smtp';
+              public $mailfrom        = 'test@example.com';
+              public $fromname        = 'Proclaim Test';
+              public $sendmail        = '/usr/sbin/sendmail';
+              public $smtpauth        = '0';
+              public $smtpuser        = '';
+              public $smtppass        = '';
+              public $smtphost        = 'localhost';
+              public $smtpsecure      = 'none';
+              public $smtpport        = '25';
+              public $caching         = '0';
+              public $cache_handler   = 'file';
+              public $cachetime       = '15';
+              public $MetaDesc        = '';
+              public $MetaAuthor      = '1';
+              public $sef             = '1';
+              public $sef_rewrite     = '0';
+              public $sef_suffix      = '0';
+              public $unicodeslugs    = '0';
+              public $tmp_path        = '/tmp';
+              public $log_path        = '/tmp';
+              public $offline         = '0';
+              public $debug           = '0';
+              public $debug_lang      = '0';
+              public $error_reporting = 'default';
+              public $cookie_domain   = '';
+              public $cookie_path     = '';
+              public $lifetime        = '15';
+              public $session_handler = 'database';
+              public $session_metadata = '1';
+              public $force_ssl       = '0';
+              public $log_deprecated  = '0';
+          }
+          PHP
+
+      - name: Install Composer dependencies
+        run: composer install --dev --no-interaction --prefer-dist
+
+      - name: Import Joomla core database schema
+        run: |
+          sed 's/#__/proclaim_/g' $GITHUB_WORKSPACE/../joomla-cms/installation/sql/mysql/base.sql > /tmp/joomla-base.sql
+          mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/joomla-base.sql 2>&1 | grep -v "doesn't exist" || true
+
+      - name: Import Proclaim database schema
+        run: |
+          sed 's/#__/proclaim_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
+          mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
+
+      - name: Check PHP syntax
+        run: composer lint:syntax
+
+      - name: Check query builder usage
+        run: composer lint:queries
+
+      - name: Run PHPUnit tests
+        run: composer test
+        env:
+          JOOMLA_CMS_PATH: /home/runner/work/Proclaim/joomla-cms
+          JTEST_DB_HOST: 127.0.0.1
+          JTEST_DB_NAME: proclaim_test
+          JTEST_DB_USER: proclaim_test
+          JTEST_DB_PASSWORD: proclaim_test
+          JTEST_DB_PREFIX: proclaim_
+
   js-checks:
     name: JS Lint & Tests
     runs-on: ubuntu-latest

--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -813,21 +813,27 @@ abstract class CWMAddon
      * Called by the sync engine to ensure a video Proclaim considers a member of
      * a playlist (e.g. via the playlist's linked series) is actually in that
      * playlist on the platform. Override in a write-back-capable addon. Must
-     * return ['success' => bool, 'error' => ?string]. The engine only calls this
-     * for videos not already recorded as members, but a duplicate insert should
-     * still fail gracefully.
+     * return ['success' => bool, 'error' => ?string, 'fatal' => ?bool]. The engine
+     * only calls this for videos not already recorded as members, but a duplicate
+     * insert should still fail gracefully.
+     *
+     * 'fatal' tells the caller this failure is systemic (quota exhausted, OAuth
+     * unusable) rather than specific to this one video/playlist — further calls in
+     * the same batch would only repeat it, so the caller stops early instead of
+     * burning quota on doomed retries. Omit (or false) for a per-item failure that
+     * later items may still succeed at.
      *
      * @param   int     $serverId          The server record ID.
      * @param   string  $remotePlaylistId  The platform playlist ID.
      * @param   string  $remoteVideoId     The platform video ID to add.
      *
-     * @return  array{success: bool, error?: string}
+     * @return  array{success: bool, error?: string, fatal?: bool}
      *
      * @since   10.3.3
      */
     public function addPlaylistMembership(int $serverId, string $remotePlaylistId, string $remoteVideoId): array
     {
-        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED')];
+        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED'), 'fatal' => true];
     }
 
     /**
@@ -835,20 +841,21 @@ abstract class CWMAddon
      *
      * Called by the sync engine when a media file's playlist assignment is removed
      * and the site opted in to platform-side removal. Override in a write-back-capable
-     * addon. Must return ['success' => bool, 'error' => ?string]. A video that is
-     * already absent from the playlist should be treated as a success (idempotent).
+     * addon. Must return ['success' => bool, 'error' => ?string, 'fatal' => ?bool]. A
+     * video that is already absent from the playlist should be treated as a success
+     * (idempotent). See addPlaylistMembership() for the meaning of 'fatal'.
      *
      * @param   int     $serverId          The server record ID.
      * @param   string  $remotePlaylistId  The platform playlist ID.
      * @param   string  $remoteVideoId     The platform video ID to remove.
      *
-     * @return  array{success: bool, error?: string}
+     * @return  array{success: bool, error?: string, fatal?: bool}
      *
      * @since   10.3.3
      */
     public function removePlaylistMembership(int $serverId, string $remotePlaylistId, string $remoteVideoId): array
     {
-        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED')];
+        return ['success' => false, 'error' => Text::_('JBS_PLAYLIST_NOT_SUPPORTED'), 'fatal' => true];
     }
 
     /**

--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -2702,11 +2702,11 @@ class CWMAddonYoutube extends CWMAddon
         $client = $this->createOAuthClient($serverId);
 
         if (!$client || !$client->getAccessToken()) {
-            return ['success' => false, 'error' => 'YouTube OAuth not connected. Connect in server settings.'];
+            return ['success' => false, 'error' => 'YouTube OAuth not connected. Connect in server settings.', 'fatal' => true];
         }
 
         if (!CwmyoutubeQuota::hasQuota($serverId, CwmyoutubeQuota::COST_PLAYLIST_INSERT)) {
-            return ['success' => false, 'error' => 'YouTube daily quota exhausted'];
+            return ['success' => false, 'error' => 'YouTube daily quota exhausted', 'fatal' => true];
         }
 
         try {
@@ -2728,11 +2728,18 @@ class CWMAddonYoutube extends CWMAddon
 
             return ['success' => true];
         } catch (Exception $e) {
+            $fatal = false;
+
             if ($e->getCode() === 403 && CwmyoutubeQuota::isQuotaExceededError($e->getMessage())) {
                 CwmyoutubeQuota::markExhausted($serverId);
+                $fatal = true;
+            } elseif ($e->getCode() === 401) {
+                // Token revoked/expired mid-run — every further call would fail
+                // identically until the admin reconnects OAuth.
+                $fatal = true;
             }
 
-            return ['success' => false, 'error' => 'YouTube API error: ' . $e->getMessage()];
+            return ['success' => false, 'error' => 'YouTube API error: ' . $e->getMessage(), 'fatal' => $fatal];
         } catch (\Exception $e) {
             return ['success' => false, 'error' => $e->getMessage()];
         }
@@ -2762,14 +2769,14 @@ class CWMAddonYoutube extends CWMAddon
         $client = $this->createOAuthClient($serverId);
 
         if (!$client || !$client->getAccessToken()) {
-            return ['success' => false, 'error' => 'YouTube OAuth not connected. Connect in server settings.'];
+            return ['success' => false, 'error' => 'YouTube OAuth not connected. Connect in server settings.', 'fatal' => true];
         }
 
         // Quota: playlistItems.list (1) + playlistItems.delete (50).
         $cost = CwmyoutubeQuota::COST_PLAYLIST_ITEMS + CwmyoutubeQuota::COST_PLAYLIST_DELETE;
 
         if (!CwmyoutubeQuota::hasQuota($serverId, $cost)) {
-            return ['success' => false, 'error' => 'YouTube daily quota exhausted'];
+            return ['success' => false, 'error' => 'YouTube daily quota exhausted', 'fatal' => true];
         }
 
         try {
@@ -2795,11 +2802,18 @@ class CWMAddonYoutube extends CWMAddon
 
             return ['success' => true];
         } catch (Exception $e) {
+            $fatal = false;
+
             if ($e->getCode() === 403 && CwmyoutubeQuota::isQuotaExceededError($e->getMessage())) {
                 CwmyoutubeQuota::markExhausted($serverId);
+                $fatal = true;
+            } elseif ($e->getCode() === 401) {
+                // Token revoked/expired mid-run — every further call would fail
+                // identically until the admin reconnects OAuth.
+                $fatal = true;
             }
 
-            return ['success' => false, 'error' => 'YouTube API error: ' . $e->getMessage()];
+            return ['success' => false, 'error' => 'YouTube API error: ' . $e->getMessage(), 'fatal' => $fatal];
         } catch (\Exception $e) {
             return ['success' => false, 'error' => $e->getMessage()];
         }

--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -642,7 +642,7 @@ final class CwmplaylistSyncHelper
             $error           = (string) ($res['error'] ?? 'unknown error');
             $out['errors'][] = \sprintf('Playlist "%s" (#%d): add video %s failed: %s', (string) $pl->title, $playlistId, $videoId, $error);
 
-            if (stripos($error, 'quota') !== false || stripos($error, 'oauth') !== false) {
+            if (!empty($res['fatal'])) {
                 $stopped = true;
             }
 
@@ -815,7 +815,7 @@ final class CwmplaylistSyncHelper
             $error           = (string) ($res['error'] ?? 'unknown error');
             $out['errors'][] = \sprintf('Playlist "%s" (#%d): remove video %s failed: %s', (string) $pl->title, $playlistId, $videoId, $error);
 
-            if (stripos($error, 'quota') !== false || stripos($error, 'oauth') !== false) {
+            if (!empty($res['fatal'])) {
                 $stopped = true;
             }
         }
@@ -878,16 +878,18 @@ final class CwmplaylistSyncHelper
             return 0;
         }
 
-        // Identify the video using any playlist-capable platform's extractor — a
-        // media file's URL is the source of truth, regardless of which server
-        // type it is filed under.
-        $videoId = self::extractAnyRemoteId((string) $decoded['filename']);
-
-        if ($videoId === null) {
-            return 0;
-        }
-
         try {
+            // Identify the video using any playlist-capable platform's extractor —
+            // a media file's URL is the source of truth, regardless of which
+            // server type it is filed under. getPlaylistCapableServers() runs an
+            // unguarded query, so this must stay inside the try: a transient DB
+            // error here must not surface after parent::store() already succeeded.
+            $videoId = self::extractAnyRemoteId((string) $decoded['filename']);
+
+            if ($videoId === null) {
+                return 0;
+            }
+
             $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             // Clear links that no longer match (the media file's URL changed).
@@ -1461,6 +1463,19 @@ final class CwmplaylistSyncHelper
     /**
      * Find an existing playlist by remote ID and server.
      *
+     * #__bsms_playlists has no unique constraint on (remote_playlist_id, server_id),
+     * so two importChannelPlaylists() runs racing each other (e.g. a scheduled sync
+     * overlapping a manual admin-triggered one) can each pass this lookup and both
+     * insert a row for the same remote playlist — a select-then-insert TOCTOU. A
+     * proper fix needs a unique index plus a de-dup migration first: existing sites
+     * that already hit the race may carry duplicate rows, and #__bsms_mediafiles'
+     * manual playlist assignments reference playlist IDs directly, so de-duping
+     * would also have to remap those — deliberately left as a follow-up rather than
+     * bundled here (see #1553). In the meantime, ORDER BY id makes the outcome of a
+     * duplicate deterministic: the lowest-id (originally-created) row always wins
+     * and keeps syncing, rather than each sync run nondeterministically picking a
+     * different duplicate to update.
+     *
      * @param   DatabaseInterface  $db        Database driver.
      * @param   string             $remoteId  YouTube playlist ID.
      * @param   int            $serverId  Server ID.
@@ -1479,6 +1494,8 @@ final class CwmplaylistSyncHelper
                 ->where($db->quoteName('server_id') . ' = :sid')
                 ->bind(':rid', $remoteId, \Joomla\Database\ParameterType::STRING)
                 ->bind(':sid', $serverId, \Joomla\Database\ParameterType::INTEGER)
+                ->order($db->quoteName('id') . ' ASC')
+                ->setLimit(1)
         )->loadResult() ?? 0);
     }
 }

--- a/admin/src/Helper/CwmupgradeHelper.php
+++ b/admin/src/Helper/CwmupgradeHelper.php
@@ -19,7 +19,7 @@ use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\MVC\Model\DatabaseModel;
+use Joomla\Component\Installer\Administrator\Model\DatabaseModel;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 

--- a/admin/src/Helper/CwmyoutubeFileCache.php
+++ b/admin/src/Helper/CwmyoutubeFileCache.php
@@ -351,7 +351,7 @@ class CwmyoutubeFileCache
         }
 
         // Use fopen + flock for atomic read-write (prevents race conditions)
-        $fp = @fopen($file, 'c');
+        $fp = @fopen($file, 'cb');
 
         if ($fp === false) {
             CwmyoutubeLogHelper::log(
@@ -731,7 +731,7 @@ class CwmyoutubeFileCache
             return null;
         }
 
-        $fp = @fopen($file, 'r');
+        $fp = @fopen($file, 'rb');
 
         if ($fp === false) {
             return null;

--- a/admin/src/Helper/CwmyoutubeLogHelper.php
+++ b/admin/src/Helper/CwmyoutubeLogHelper.php
@@ -66,8 +66,10 @@ class CwmyoutubeLogHelper
     {
         $dir = JPATH_CACHE . self::LOG_DIR;
 
-        if (!is_dir($dir)) {
-            @mkdir($dir, 0755, true);
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+            error_log(\sprintf('[Proclaim] CwmyoutubeLogHelper: directory "%s" was not created', $dir));
+
+            return;
         }
 
         $file = JPATH_CACHE . self::LOG_FILE;
@@ -75,12 +77,18 @@ class CwmyoutubeLogHelper
         // Auto-rotate before writing
         self::rotate($file);
 
-        $entry = json_encode([
-            'timestamp' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
-            'level'     => $level,
-            'message'   => $message,
-            'context'   => $context,
-        ], JSON_UNESCAPED_SLASHES);
+        try {
+            $entry = json_encode([
+                'timestamp' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
+                'level'     => $level,
+                'message'   => $message,
+                'context'   => $context,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (\JsonException $e) {
+            error_log(\sprintf('[Proclaim] CwmyoutubeLogHelper: failed to encode log entry: %s', $e->getMessage()));
+
+            return;
+        }
 
         @file_put_contents($file, $entry . "\n", FILE_APPEND | LOCK_EX);
     }

--- a/admin/src/Helper/CwmyoutubeQuota.php
+++ b/admin/src/Helper/CwmyoutubeQuota.php
@@ -257,13 +257,9 @@ class CwmyoutubeQuota
         // Check for Google's specific daily quota error reason
         if (stripos($message, 'quotaExceeded') !== false) {
             // Exclude transient rate limits (rateLimitExceeded, userRateLimitExceeded)
-            // which share the 403 status but don't mean daily quota is gone
-            if (stripos($message, 'rateLimitExceeded') !== false
-                || stripos($message, 'userRateLimitExceeded') !== false) {
-                return false;
-            }
-
-            return true;
+            // which share status 403 but don't mean daily quota is gone
+            return !(stripos($message, 'rateLimitExceeded') !== false
+                || stripos($message, 'userRateLimitExceeded') !== false);
         }
 
         return false;
@@ -307,13 +303,12 @@ class CwmyoutubeQuota
      *
      * @return  string  Date string like "2026-02-28"
      *
+     * @throws \DateMalformedStringException
      * @since   10.1.0
      */
     private static function currentQuotaDate(): string
     {
-        $now = new \DateTimeImmutable('now', new \DateTimeZone('America/Los_Angeles'));
-
-        return $now->format('Y-m-d');
+        return (new \DateTimeImmutable('now', new \DateTimeZone('America/Los_Angeles')))->format('Y-m-d');
     }
 
     /**
@@ -341,6 +336,7 @@ class CwmyoutubeQuota
      *
      * @return  array{date: string, used: int}
      *
+     * @throws \JsonException
      * @since   10.1.0
      */
     private static function loadQuotaFile(int $serverId): array
@@ -351,7 +347,7 @@ class CwmyoutubeQuota
             return ['date' => '', 'used' => 0];
         }
 
-        $fp = @fopen($file, 'r');
+        $fp = @fopen($file, 'rb');
 
         if ($fp === false) {
             CwmyoutubeLogHelper::log(
@@ -363,7 +359,7 @@ class CwmyoutubeQuota
             return ['date' => '', 'used' => 0];
         }
 
-        $raw = '';
+        $raw = false;
 
         if (flock($fp, LOCK_SH)) {
             $raw = stream_get_contents($fp);
@@ -406,6 +402,7 @@ class CwmyoutubeQuota
      *
      * @return  bool  True if the write succeeded
      *
+     * @throws \JsonException
      * @since   __DEPLOY_VERSION__
      */
     private static function mutateQuotaFile(int $serverId, callable $mutator): bool
@@ -424,7 +421,7 @@ class CwmyoutubeQuota
         }
 
         $file = self::quotaFilePath($serverId);
-        $fp   = @fopen($file, 'c+');
+        $fp   = @fopen($file, 'cb+');
 
         if ($fp === false) {
             CwmyoutubeLogHelper::log(

--- a/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
+++ b/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
@@ -264,7 +264,7 @@ class CwmplaylistMembershipPushTest extends IntegrationTestCase
         $playlistId = $this->insertPlaylist($this->seriesId, 1);
 
         // First insert fails with a quota error → the loop breaks before the second.
-        $addon = $this->fakeAddon(['__default__' => ['success' => false, 'error' => 'quotaExceeded']]);
+        $addon = $this->fakeAddon(['__default__' => ['success' => false, 'error' => 'quotaExceeded', 'fatal' => true]]);
 
         $result = CwmplaylistSyncHelper::pushMemberships($this->db, $addon, $playlistId, false);
 
@@ -282,7 +282,7 @@ class CwmplaylistMembershipPushTest extends IntegrationTestCase
      * deliberately overridden to a no-op so the double needs no config on disk,
      * and ID extraction delegates to the real YouTube extractor.
      *
-     * @param   array<string,array{success:bool,error?:string}>  $results  Result map.
+     * @param   array<string,array{success:bool,error?:string,fatal?:bool}>  $results  Result map.
      *
      * @return  CWMAddon
      */
@@ -292,7 +292,7 @@ class CwmplaylistMembershipPushTest extends IntegrationTestCase
             /** @var array<int,array{videoId:string,playlistId:string}> */
             public array $calls = [];
 
-            /** @var array<string,array{success:bool,error?:string}> */
+            /** @var array<string,array{success:bool,error?:string,fatal?:bool}> */
             private array $results;
 
             public function __construct(array $results = [])

--- a/tests/unit/Admin/Controller/CwmplaylistControllerTest.php
+++ b/tests/unit/Admin/Controller/CwmplaylistControllerTest.php
@@ -45,7 +45,6 @@ class CwmplaylistControllerTest extends ProclaimTestCase
     public function testAccessTableIsSet(): void
     {
         $reflection = new \ReflectionProperty(CwmplaylistController::class, 'accessTable');
-        $reflection->setAccessible(true);
 
         $instance = $reflection->getDeclaringClass()->newInstanceWithoutConstructor();
 


### PR DESCRIPTION
Addresses #1553 (findings 2 and 3 fully; finding 1 gets an interim mitigation, not the full fix — see below). Also includes a couple of adjacent fixes found while reviewing the same files.

## Finding 2 — `linkMediafileToPlaylists()` could throw despite its "never throws" contract
`extractAnyRemoteId()` now runs inside the `try` block (mirroring `setManualPlaylistAssignments()`), so a transient DB error in `getPlaylistCapableServers()` can no longer surface after `parent::store()` has already succeeded.

## Finding 3 — fragile `stripos($error, 'quota'|'oauth')` circuit breaker
`CWMAddon::addPlaylistMembership()`/`removePlaylistMembership()` now document and return a `'fatal'` key alongside `success`/`error`. `CWMAddonYoutube` sets it on OAuth-not-connected, quota-exhausted, and (newly) a 401 mid-run (token revoked/expired — every further call would fail identically). `CwmplaylistSyncHelper::pushMemberships()`/removal path read `$res['fatal']` instead of pattern-matching the free-text error message, so a 401 that doesn't happen to contain "oauth" no longer burns quota on doomed retries for the rest of the batch.

## Finding 1 — duplicate-playlist TOCTOU (interim mitigation only)
The real fix needs a `UNIQUE KEY (remote_playlist_id, server_id)` migration plus a de-dup pass (existing sites may already carry duplicates, and `#__bsms_mediafiles` manual playlist assignments reference playlist IDs directly, so de-duping has to remap those too) — deliberately left as a follow-up rather than bundled here. In the meantime, `findPlaylistId()` now does `ORDER BY id ASC LIMIT 1`, so if a duplicate does exist, the outcome is at least deterministic (lowest-id/originally-created row always wins) instead of a different row winning on every sync run.

## Adjacent fixes found while reviewing
- **`CwmyoutubeQuota`**: binary-safe `fopen()` modes (`rb`/`cb+`) so CRLF translation can't corrupt the JSON payload on Windows; `$raw` now initializes to `false` (matching `stream_get_contents()`'s actual failure return) instead of `''`; added missing `@throws` docs; simplified the `quotaExceeded` boolean check.
- **`CwmupgradeHelper`**: fixed an import — `Joomla\CMS\MVC\Model\DatabaseModel` doesn't exist in Joomla core; corrected to `Joomla\Component\Installer\Administrator\Model\DatabaseModel`, the real class with the `fix()` method this code calls.
- **`CwmyoutubeLogHelper::log()`**: this logger is called from deep inside failure branches throughout the addon specifically to record errors *without* disrupting the caller's own fail-safe fallback (e.g. `CwmyoutubeQuota::loadQuotaFile()`'s unwrapped call on a failed `fopen()`). An in-progress version of this branch had made `log()` throw on a failed `mkdir()` or a JSON-encoding error, which would have propagated out through every one of those unwrapped call sites and broken the very fallback logging was meant to protect. Restored the "never throws" contract — both failure paths now fall back to `error_log()` and return instead of throwing.
- **`CwmyoutubeFileCache`**: binary-safe `fopen()` modes; removed a stray `@throws JsonException` doc tag on `setSearchThrottle()` that already catches its own `json_encode()` failure internally.
- **CI**: added a `php-checks-85` job (`continue-on-error: true`) running the full lint/test pipeline against PHP 8.5 for forward-compat coverage, without touching the existing required `PHP Lint & Tests` (8.3) check or its status-check name.

## Test plan
- [x] Existing PHPUnit suite passes locally
- [ ] CI green on this PR (8.3 required, 8.5 informational)
- Not covered by tests: `CwmplaylistSyncHelper`'s DB-touching methods remain untested (noted in #1553's "Test gap" section, unchanged by this PR)
