### PR TITLE
fix: multi-campus location filtering fatal-on-enable + fail-open bypass (#1561)

### DIFF
--- a/admin/src/Field/LocationListField.php
+++ b/admin/src/Field/LocationListField.php
@@ -132,7 +132,7 @@ class LocationListField extends ListField
         foreach ($rows as $row) {
             $id = (int) $row->id;
 
-            if ($enabled && !$isAdmin && !empty($allowedIds)) {
+            if ($enabled && !$isAdmin) {
                 if (!\in_array($id, $allowedIds, true)) {
                     if ($id !== $currentId) {
                         continue;

--- a/admin/src/Helper/CwmcountHelper.php
+++ b/admin/src/Helper/CwmcountHelper.php
@@ -188,6 +188,11 @@ class CwmcountHelper
                             . ' OR ' . $db->quoteName('t.location_id') . ' IN ('
                             . implode(',', array_map('intval', $accessible)) . '))'
                         );
+                    } else {
+                        // core.admin already excluded above, so an empty $accessible here
+                        // means a real zero-access user, not a super admin -- restrict to
+                        // unassigned records instead of adding no predicate. See #1561.
+                        $query->where($db->quoteName('t.location_id') . ' IS NULL');
                     }
                 }
 
@@ -211,6 +216,11 @@ class CwmcountHelper
                             . ' OR ' . $db->quoteName('s.location_id') . ' IN ('
                             . implode(',', array_map('intval', $accessible)) . '))'
                         );
+                    } else {
+                        // core.admin already excluded above, so an empty $accessible here
+                        // means a real zero-access user, not a super admin -- restrict to
+                        // unassigned records instead of adding no predicate. See #1561.
+                        $query->where($db->quoteName('s.location_id') . ' IS NULL');
                     }
                 }
 

--- a/admin/src/Helper/CwmlocationHelper.php
+++ b/admin/src/Helper/CwmlocationHelper.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
@@ -124,12 +125,11 @@ class CwmlocationHelper
      */
     public static function getUserAccessibleLocationsForEdit(int $userId = 0, int $currentId = 0): array
     {
-        $visible = self::getUserLocations($userId);
-
-        // Empty = super admin (all locations allowed)
-        if (empty($visible)) {
+        if (self::isSuperAdmin($userId)) {
             return [];
         }
+
+        $visible = self::getUserLocations($userId);
 
         // Ensure the currently-saved location is always present
         if ($currentId > 0 && !\in_array($currentId, $visible, true)) {
@@ -141,11 +141,75 @@ class CwmlocationHelper
     }
 
     /**
+     * Validate that a user may assign a record to the given location, throwing
+     * if not.
+     *
+     * The edit-form dropdown (LocationListField) already restricts what a
+     * non-admin user can pick, but nothing previously enforced that
+     * server-side -- a restricted user could submit any location_id directly
+     * (devtools, a raw POST) and it would persist unchecked. Call this at the
+     * top of save() before any data is written. See #1561.
+     *
+     * Looking up the record's current location_id (when $recordId > 0) means
+     * saving a record without changing its location is never blocked just
+     * because the user lacks access to that location -- only an actual
+     * attempt to move it to an inaccessible location is denied, matching
+     * getUserAccessibleLocationsForEdit()'s existing "always include the
+     * current value" semantics.
+     *
+     * @param   string  $table       Table name owning the location_id column, e.g. '#__bsms_studies'.
+     * @param   int     $recordId    Existing record ID (0 = new record).
+     * @param   int     $locationId  Submitted location_id (0 or less = none, always allowed).
+     * @param   int     $userId      Joomla user ID (0 = current user).
+     *
+     * @return  void
+     *
+     * @throws  \RuntimeException  If the user may not assign this location.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function assertLocationAssignable(
+        string $table,
+        int $recordId,
+        int $locationId,
+        int $userId = 0
+    ): void {
+        if ($locationId <= 0 || !self::isEnabled() || self::isSuperAdmin($userId)) {
+            return;
+        }
+
+        $currentId = 0;
+
+        if ($recordId > 0) {
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+            $currentId = (int) $db->setQuery(
+                $db->createQuery()
+                    ->select($db->quoteName('location_id'))
+                    ->from($db->quoteName($table))
+                    ->where($db->quoteName('id') . ' = :id')
+                    ->bind(':id', $recordId, ParameterType::INTEGER)
+            )->loadResult();
+        }
+
+        $allowed = self::getUserAccessibleLocationsForEdit($userId, $currentId);
+
+        if (!\in_array($locationId, $allowed, true)) {
+            throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
+        }
+    }
+
+    /**
      * Apply a location visibility filter to a query.
      *
      * Does nothing when:
      *   - location filtering is disabled in component config, or
      *   - the user is a super admin.
+     *
+     * A non-admin user with zero accessible locations (a real, valid config --
+     * not the same thing as a super admin, see isSuperAdmin()) is restricted to
+     * records with no location assigned at all, rather than seeing every
+     * location. See #1561.
      *
      * @param   QueryInterface  $query   The query to filter.
      * @param   string          $alias   Table alias owning the location_id column.
@@ -157,19 +221,46 @@ class CwmlocationHelper
      */
     public static function applyLocationFilter(QueryInterface $query, string $alias, int $userId = 0): void
     {
-        if (!self::isEnabled()) {
+        if (!self::isEnabled() || self::isSuperAdmin($userId)) {
             return;
         }
 
         $locations = self::getUserLocations($userId);
+        $db        = Factory::getContainer()->get(DatabaseInterface::class);
 
-        // Empty = super admin — no filter needed
         if (empty($locations)) {
+            $query->where($db->quoteName($alias . '.location_id') . ' IS NULL');
+
             return;
         }
 
-        $db = Factory::getContainer()->get(DatabaseInterface::class);
         $query->whereIn($db->quoteName($alias . '.location_id'), $locations);
+    }
+
+    /**
+     * Determine whether a user is a super admin, exempt from all location filtering.
+     *
+     * getUserLocations()/getUserAccessibleLocationsForEdit() also return an
+     * empty array for an authenticated non-admin with zero accessible
+     * locations -- a real, valid configuration, not a super admin. Conflating
+     * the two let every consumer fail open (treat "zero access" as "no
+     * restriction"). Callers that need to distinguish the two cases must
+     * check this method directly rather than inferring admin status from an
+     * empty location array. See #1561.
+     *
+     * @param   int  $userId  Joomla user ID (0 = current user).
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function isSuperAdmin(int $userId = 0): bool
+    {
+        $user = $userId > 0
+            ? Factory::getContainer()->get('user.factory')->loadUserById($userId)
+            : Factory::getApplication()->getIdentity();
+
+        return $user->authorise('core.admin');
     }
 
     /**
@@ -234,10 +325,9 @@ class CwmlocationHelper
                 $db->quoteName('#__bsms_studies', 's')
                 . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('st.study_id')
             )
-            ->where($db->quoteName('t.user_id') . ' = :userId1')
+            ->where($db->quoteName('t.user_id') . ' = :userId')
             ->where($db->quoteName('s.location_id') . ' IS NOT NULL')
-            ->where($db->quoteName('s.location_id') . ' > 0')
-            ->bind(':userId1', $userId, ParameterType::INTEGER);
+            ->where($db->quoteName('s.location_id') . ' > 0');
 
         // Legacy path: teachers → studies.teacher_id
         $query2 = $db->createQuery()
@@ -247,12 +337,18 @@ class CwmlocationHelper
                 $db->quoteName('#__bsms_studies', 's')
                 . ' ON ' . $db->quoteName('s.teacher_id') . ' = ' . $db->quoteName('t.id')
             )
-            ->where($db->quoteName('t.user_id') . ' = :userId2')
+            ->where($db->quoteName('t.user_id') . ' = :userId')
             ->where($db->quoteName('s.location_id') . ' IS NOT NULL')
-            ->where($db->quoteName('s.location_id') . ' > 0')
-            ->bind(':userId2', $userId, ParameterType::INTEGER);
+            ->where($db->quoteName('s.location_id') . ' > 0');
 
-        $db->setQuery('(' . $query1 . ') UNION (' . $query2 . ')');
+        // Both branches share the single :userId placeholder, bound once here.
+        // DatabaseQuery::union() only merges SQL text, not bound parameters
+        // (getBounded() returns whichever query object is passed to setQuery()),
+        // so query2 must never carry its own separately-bound placeholder name --
+        // that value would silently be lost. See #1561.
+        $query1->union($query2)->bind(':userId', $userId, ParameterType::INTEGER);
+
+        $db->setQuery($query1);
 
         return array_map('intval', $db->loadColumn() ?: []);
     }

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -386,9 +386,17 @@ class CwmmessageModel extends AdminModel
         $data['image'] = $image->url;
         $this->cleanCache();
 
+        // The front end calls this model and uses a_id to avoid id clashes,
+        // so resolve the real record id before validating its location.
         if ($input->get('a_id')) {
             $data['id'] = $input->get('a_id');
         }
+
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_studies',
+            (int) ($data['id'] ?? 0),
+            (int) ($data['location_id'] ?? 0)
+        );
 
         // Correct legacy thumb_ paths submitted from pre-migration records
         $imageBasename = basename($data['image']);
@@ -1061,7 +1069,11 @@ class CwmmessageModel extends AdminModel
         if ($locationId > 0 && CwmlocationHelper::isEnabled() && !$user->authorise('core.admin')) {
             $accessible = CwmlocationHelper::getUserLocations((int) $user->id);
 
-            if (!empty($accessible) && !\in_array($locationId, $accessible, true)) {
+            // core.admin already excluded above, so an empty $accessible here
+            // means a real zero-access user, not a super admin -- in_array()
+            // against an empty array is always false, so this denies rather
+            // than silently skipping the check. See #1561.
+            if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
         }

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -128,6 +128,12 @@ class CwmpodcastModel extends AdminModel
      */
     public function save($data): bool
     {
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_podcast',
+            (int) ($data['id'] ?? 0),
+            (int) ($data['location_id'] ?? 0)
+        );
+
         if (!parent::save($data)) {
             return false;
         }
@@ -234,7 +240,11 @@ class CwmpodcastModel extends AdminModel
         if ($locationId > 0 && CwmlocationHelper::isEnabled() && !$user->authorise('core.admin')) {
             $accessible = CwmlocationHelper::getUserLocations((int) $user->id);
 
-            if (!empty($accessible) && !\in_array($locationId, $accessible, true)) {
+            // core.admin already excluded above, so an empty $accessible here
+            // means a real zero-access user, not a super admin -- in_array()
+            // against an empty array is always false, so this denies rather
+            // than silently skipping the check. See #1561.
+            if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
         }

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -191,6 +191,12 @@ class CwmserieModel extends AdminModel
      */
     public function save($data): bool
     {
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_series',
+            (int) ($data['id'] ?? 0),
+            (int) ($data['location_id'] ?? 0)
+        );
+
         /** @var Registry $params */
         $params        = Cwmparams::getAdmin()->params;
         $app           = Factory::getApplication();
@@ -527,7 +533,11 @@ class CwmserieModel extends AdminModel
         if ($locationId > 0 && CwmlocationHelper::isEnabled() && !$user->authorise('core.admin')) {
             $accessible = CwmlocationHelper::getUserLocations((int) $user->id);
 
-            if (!empty($accessible) && !\in_array($locationId, $accessible, true)) {
+            // core.admin already excluded above, so an empty $accessible here
+            // means a real zero-access user, not a super admin -- in_array()
+            // against an empty array is always false, so this denies rather
+            // than silently skipping the check. See #1561.
+            if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
         }

--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -190,6 +190,12 @@ class CwmserverModel extends AdminModel
      */
     public function save($data): bool
     {
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_servers',
+            (int) ($data['id'] ?? 0),
+            (int) ($data['location_id'] ?? 0)
+        );
+
         $db         = Factory::getContainer()->get(DatabaseInterface::class);
         $text       = '';
 
@@ -470,7 +476,11 @@ class CwmserverModel extends AdminModel
         if ($locationId > 0 && CwmlocationHelper::isEnabled() && !$user->authorise('core.admin')) {
             $accessible = CwmlocationHelper::getUserLocations((int) $user->id);
 
-            if (!empty($accessible) && !\in_array($locationId, $accessible, true)) {
+            // core.admin already excluded above, so an empty $accessible here
+            // means a real zero-access user, not a super admin -- in_array()
+            // against an empty array is always false, so this denies rather
+            // than silently skipping the check. See #1561.
+            if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
         }

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -55,6 +55,12 @@ class CwmtemplateModel extends AdminModel
      */
     public function save($data): bool
     {
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_templates',
+            (int) ($data['id'] ?? 0),
+            (int) ($data['location_id'] ?? 0)
+        );
+
         // Make sure we cannot unpublished default template.
         if ($data['id'] == '1' && $data['published'] != '1') {
             Factory::getApplication()->enqueueMessage(Text::_('JBS_TPL_DEFAULT_ERROR'), 'error');
@@ -258,7 +264,11 @@ class CwmtemplateModel extends AdminModel
         if ($locationId > 0 && CwmlocationHelper::isEnabled() && !$user->authorise('core.admin')) {
             $accessible = CwmlocationHelper::getUserLocations((int) $user->id);
 
-            if (!empty($accessible) && !\in_array($locationId, $accessible, true)) {
+            // core.admin already excluded above, so an empty $accessible here
+            // means a real zero-access user, not a super admin -- in_array()
+            // against an empty array is always false, so this denies rather
+            // than silently skipping the check. See #1561.
+            if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
         }

--- a/tests/integration/Admin/Helper/CwmlocationHelperFailOpenTest.php
+++ b/tests/integration/Admin/Helper/CwmlocationHelperFailOpenTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * Integration tests for #1561's fail-open fix: getUserLocations()'s empty-array
+ * return is ambiguous between "super admin" and "authenticated non-admin with
+ * zero accessible locations" -- every consumer used to resolve that ambiguity
+ * toward "no restriction." These tests set up the exact configuration where the
+ * two cases collide (every location mapped to a group the test user isn't in)
+ * and assert the zero-access user is now restricted, not shown everything.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmlocationHelper::class)]
+class CwmlocationHelperFailOpenTest extends IntegrationTestCase
+{
+    private const REGISTERED_GROUP  = 2;
+    private const SUPER_USERS_GROUP = 8;
+
+    private ?DatabaseDriver $db = null;
+
+    private int $extensionId = 0;
+
+    private string $originalParams = '';
+
+    private int $zeroAccessUserId = 0;
+
+    private int $superAdminUserId = 0;
+
+    private int $inaccessibleLocationId = 0;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        $this->zeroAccessUserId = $this->insertUser('Zero Access', self::REGISTERED_GROUP);
+        $this->superAdminUserId = $this->insertUser('Full Access', self::SUPER_USERS_GROUP);
+
+        $this->enableLocationFilteringWithFullMapping();
+
+        CwmlocationHelper::resetCache();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+        }
+
+        $this->resetStaticCache(ComponentHelper::class, 'components', []);
+        CwmlocationHelper::resetCache();
+
+        parent::tearDown();
+    }
+
+    #[TestDox('isSuperAdmin() distinguishes a Super Users member from a zero-access Registered user')]
+    public function testIsSuperAdmin(): void
+    {
+        $this->assertTrue(CwmlocationHelper::isSuperAdmin($this->superAdminUserId));
+        $this->assertFalse(CwmlocationHelper::isSuperAdmin($this->zeroAccessUserId));
+    }
+
+    #[TestDox('getUserLocations() confirms the test user genuinely has zero accessible locations (precondition)')]
+    public function testZeroAccessUserHasNoLocations(): void
+    {
+        $this->assertSame([], CwmlocationHelper::getUserLocations($this->zeroAccessUserId));
+    }
+
+    #[TestDox('applyLocationFilter() restricts a zero-access user to location_id IS NULL instead of adding no predicate')]
+    public function testApplyLocationFilterFailsClosedForZeroAccessUser(): void
+    {
+        $query = $this->db->createQuery()->select('*')->from($this->db->quoteName('#__bsms_studies', 's'));
+
+        CwmlocationHelper::applyLocationFilter($query, 's', $this->zeroAccessUserId);
+
+        $sql = (string) $query;
+
+        $this->assertStringContainsString(
+            'location_id` IS NULL',
+            $sql,
+            'A zero-access non-admin must be restricted to unassigned records, not shown everything'
+        );
+    }
+
+    #[TestDox('applyLocationFilter() adds no predicate at all for a super admin')]
+    public function testApplyLocationFilterSkipsSuperAdmin(): void
+    {
+        $query = $this->db->createQuery()->select('*')->from($this->db->quoteName('#__bsms_studies', 's'));
+
+        CwmlocationHelper::applyLocationFilter($query, 's', $this->superAdminUserId);
+
+        $sql = (string) $query;
+
+        $this->assertStringNotContainsString('location_id', $sql, 'A super admin query must not be filtered at all');
+    }
+
+    #[TestDox('assertLocationAssignable() throws when a zero-access user assigns a new record to an inaccessible location')]
+    public function testAssertLocationAssignableDeniesZeroAccessUserOnNewRecord(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_studies',
+            0,
+            $this->inaccessibleLocationId,
+            $this->zeroAccessUserId
+        );
+    }
+
+    #[TestDox('assertLocationAssignable() allows a super admin to assign any location')]
+    public function testAssertLocationAssignableAllowsSuperAdmin(): void
+    {
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_studies',
+            0,
+            $this->inaccessibleLocationId,
+            $this->superAdminUserId
+        );
+
+        $this->addToAssertionCount(1); // No exception thrown = pass.
+    }
+
+    #[TestDox('assertLocationAssignable() does not block re-saving an existing record without changing its (inaccessible) location')]
+    public function testAssertLocationAssignableAllowsUnchangedLocationOnExistingRecord(): void
+    {
+        $studyId = $this->insertStudy($this->inaccessibleLocationId);
+
+        // Same location the record already has -- must not be blocked even
+        // though the user has no general access to it.
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_studies',
+            $studyId,
+            $this->inaccessibleLocationId,
+            $this->zeroAccessUserId
+        );
+
+        $this->addToAssertionCount(1); // No exception thrown = pass.
+    }
+
+    #[TestDox('assertLocationAssignable() throws when a zero-access user tries to move an existing record to a different inaccessible location')]
+    public function testAssertLocationAssignableDeniesChangingToInaccessibleLocation(): void
+    {
+        $otherLocationId = $this->insertLocation('Test Campus (also inaccessible)');
+        $studyId         = $this->insertStudy($this->inaccessibleLocationId);
+
+        // The new location isn't in the group mapping built during setUp(),
+        // which would make it an "unrestricted" location (accessible to
+        // everyone by design) rather than the inaccessible one this test
+        // needs -- re-map every location to Super Users only now that it exists.
+        $this->enableLocationFilteringWithFullMapping();
+        CwmlocationHelper::resetCache();
+
+        $this->expectException(\RuntimeException::class);
+
+        CwmlocationHelper::assertLocationAssignable(
+            '#__bsms_studies',
+            $studyId,
+            $otherLocationId,
+            $this->zeroAccessUserId
+        );
+    }
+
+    #[TestDox('assertLocationAssignable() is a no-op when location_id is 0 (none)')]
+    public function testAssertLocationAssignableSkipsZeroLocation(): void
+    {
+        CwmlocationHelper::assertLocationAssignable('#__bsms_studies', 0, 0, $this->zeroAccessUserId);
+
+        $this->addToAssertionCount(1); // No exception thrown = pass.
+    }
+
+    /**
+     * @param   int  $locationId  Location ID to assign.
+     *
+     * @return  int  Study ID.
+     */
+    private function insertStudy(int $locationId): int
+    {
+        $row = (object) [
+            'studytitle'  => 'Test Study ' . uniqid('', true),
+            'alias'       => 'test-study-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'messagetype' => 1,
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'location_id' => $locationId,
+            'params'      => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Configure enable_location_filtering=1 with every currently-published
+     * location mapped to the Super Users group only, so the Registered-group
+     * test user has zero group-based access, no unrestricted locations remain
+     * (every location is in the mapping), and no teacher link exists for them.
+     *
+     * @return  void
+     */
+    private function enableLocationFilteringWithFullMapping(): void
+    {
+        $row = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select(['extension_id', 'params'])
+                ->from($this->db->quoteName('#__extensions'))
+                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
+                ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'))
+        )->loadObject();
+
+        $this->extensionId    = (int) $row->extension_id;
+        $this->originalParams = (string) $row->params;
+
+        $locationIds = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('id'))
+                ->from($this->db->quoteName('#__bsms_locations'))
+                ->where($this->db->quoteName('published') . ' = 1')
+        )->loadColumn() ?: [];
+
+        // Always insert a dedicated location under our own control (rather
+        // than relying on whatever happens to already exist) so tests that
+        // need a specific, guaranteed-inaccessible location ID are deterministic.
+        $this->inaccessibleLocationId = $this->insertLocation('Test Campus (inaccessible)');
+        $locationIds[]                = $this->inaccessibleLocationId;
+
+        $mapping = [];
+
+        foreach ($locationIds as $id) {
+            $mapping[(string) $id] = [self::SUPER_USERS_GROUP];
+        }
+
+        $decoded                              = json_decode($this->originalParams, true) ?: [];
+        $decoded['enable_location_filtering'] = 1;
+        $decoded['location_group_mapping']    = json_encode($mapping, JSON_THROW_ON_ERROR);
+        $encoded                              = json_encode($decoded, JSON_THROW_ON_ERROR);
+
+        $this->db->setQuery(
+            $this->db->createQuery()
+                ->update($this->db->quoteName('#__extensions'))
+                ->set($this->db->quoteName('params') . ' = :params')
+                ->where($this->db->quoteName('extension_id') . ' = :id')
+                ->bind(':params', $encoded)
+                ->bind(':id', $this->extensionId, \Joomla\Database\ParameterType::INTEGER)
+        )->execute();
+
+        // Force ComponentHelper to re-read from the DB instead of its request cache.
+        $this->resetStaticCache(ComponentHelper::class, 'components', []);
+    }
+
+    /**
+     * @param   string  $name     Display name.
+     * @param   int     $groupId  Joomla user group ID to assign.
+     *
+     * @return  int  User ID.
+     */
+    private function insertUser(string $name, int $groupId): int
+    {
+        $row = (object) [
+            'name'         => $name,
+            'username'     => 'test_' . strtolower(str_replace(' ', '_', $name)) . '_' . uniqid(),
+            'email'        => strtolower(str_replace(' ', '.', $name)) . '.' . uniqid() . '@example.test',
+            'password'     => '',
+            'block'        => 0,
+            'sendEmail'    => 0,
+            'registerDate' => '2026-01-01 00:00:00',
+            'params'       => '{}',
+        ];
+
+        $this->db->insertObject('#__users', $row);
+        $userId = (int) $this->db->insertid();
+
+        $mapRow = (object) [
+            'user_id'  => $userId,
+            'group_id' => $groupId,
+        ];
+        $this->db->insertObject('#__user_usergroup_map', $mapRow);
+
+        return $userId;
+    }
+
+    /**
+     * @param   string  $name  Location display name.
+     *
+     * @return  int  Location ID.
+     */
+    private function insertLocation(string $name): int
+    {
+        $row = (object) [
+            'location_text' => $name,
+            'published'     => 1,
+            'params'        => '',
+            'sortname1'     => '',
+            'sortname2'     => '',
+            'sortname3'     => '',
+            'language'      => '*',
+            'metakey'       => '',
+            'metadesc'      => '',
+            'metadata'      => '',
+            'xreference'    => '',
+        ];
+
+        $this->db->insertObject('#__bsms_locations', $row);
+
+        return (int) $this->db->insertid();
+    }
+}

--- a/tests/integration/Admin/Helper/CwmlocationHelperFailOpenTest.php
+++ b/tests/integration/Admin/Helper/CwmlocationHelperFailOpenTest.php
@@ -237,16 +237,41 @@ class CwmlocationHelperFailOpenTest extends IntegrationTestCase
      */
     private function enableLocationFilteringWithFullMapping(): void
     {
-        $row = $this->db->setQuery(
-            $this->db->createQuery()
-                ->select(['extension_id', 'params'])
-                ->from($this->db->quoteName('#__extensions'))
-                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
-                ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'))
-        )->loadObject();
+        // CI's DB fixture imports Proclaim's raw SQL schema directly, not
+        // through the Joomla installer, so #__extensions has no com_proclaim
+        // row at all -- unlike a fully-installed dev site. Find-or-create it,
+        // and only resolve extensionId/originalParams once even though this
+        // method may be called more than once per test.
+        if ($this->extensionId === 0) {
+            $row = $this->db->setQuery(
+                $this->db->createQuery()
+                    ->select(['extension_id', 'params'])
+                    ->from($this->db->quoteName('#__extensions'))
+                    ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
+                    ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'))
+            )->loadObject();
 
-        $this->extensionId    = (int) $row->extension_id;
-        $this->originalParams = (string) $row->params;
+            if ($row === null) {
+                $extRow = (object) [
+                    'name'           => 'com_proclaim',
+                    'type'           => 'component',
+                    'element'        => 'com_proclaim',
+                    'folder'         => '',
+                    'client_id'      => 1,
+                    'enabled'        => 1,
+                    'manifest_cache' => '',
+                    'params'         => '{}',
+                    'custom_data'    => '',
+                ];
+                $this->db->insertObject('#__extensions', $extRow);
+
+                $this->extensionId    = (int) $this->db->insertid();
+                $this->originalParams = '{}';
+            } else {
+                $this->extensionId    = (int) $row->extension_id;
+                $this->originalParams = (string) $row->params;
+            }
+        }
 
         $locationIds = $this->db->setQuery(
             $this->db->createQuery()

--- a/tests/integration/Admin/Helper/CwmlocationHelperIntegrationTest.php
+++ b/tests/integration/Admin/Helper/CwmlocationHelperIntegrationTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * Integration tests for CwmlocationHelper's DB-touching methods.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1561: getTeacherLocations() built its UNION query by
+ * string-concatenating two bound Query objects, which silently discards both
+ * bound parameters -- fatal on real MySQL ("No data supplied for parameters").
+ * None of the prior unit tests touched a real database, so this bug shipped
+ * undetected. Each test runs inside a transaction that is rolled back.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmlocationHelper::class)]
+class CwmlocationHelperIntegrationTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        CwmlocationHelper::resetCache();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+        }
+
+        CwmlocationHelper::resetCache();
+
+        parent::tearDown();
+    }
+
+    #[TestDox('getTeacherLocations() does not throw and finds a location via the many-to-many study_teachers path')]
+    public function testGetTeacherLocationsManyToManyPath(): void
+    {
+        $userId     = 90001;
+        $locationId = $this->insertLocation('Campus A');
+        $teacherId  = $this->insertTeacher($userId);
+        $studyId    = $this->insertStudy($locationId);
+
+        $this->insertStudyTeacher($studyId, $teacherId);
+
+        $result = CwmlocationHelper::getTeacherLocations($userId);
+
+        $this->assertSame([$locationId], $result);
+    }
+
+    #[TestDox('getTeacherLocations() does not throw and finds a location via the legacy studies.teacher_id path')]
+    public function testGetTeacherLocationsLegacyPath(): void
+    {
+        $userId     = 90002;
+        $locationId = $this->insertLocation('Campus B');
+        $teacherId  = $this->insertTeacher($userId);
+        $this->insertStudy($locationId, $teacherId);
+
+        $result = CwmlocationHelper::getTeacherLocations($userId);
+
+        $this->assertSame([$locationId], $result);
+    }
+
+    #[TestDox('getTeacherLocations() merges both paths into one deduplicated result')]
+    public function testGetTeacherLocationsCombinesBothPathsWithoutDuplicates(): void
+    {
+        $userId       = 90003;
+        $sharedLoc    = $this->insertLocation('Campus C');
+        $legacyOnlyId = $this->insertLocation('Campus D');
+        $teacherId    = $this->insertTeacher($userId);
+
+        // Many-to-many: same location as the legacy-path study below.
+        $mtmStudy = $this->insertStudy($sharedLoc);
+        $this->insertStudyTeacher($mtmStudy, $teacherId);
+
+        // Legacy path: one shared location, one exclusive to this path.
+        $this->insertStudy($sharedLoc, $teacherId);
+        $this->insertStudy($legacyOnlyId, $teacherId);
+
+        $result = CwmlocationHelper::getTeacherLocations($userId);
+        sort($result);
+
+        $this->assertCount(2, $result, 'Duplicate location from the shared study must be collapsed by DISTINCT');
+        $this->assertContains($sharedLoc, $result);
+        $this->assertContains($legacyOnlyId, $result);
+    }
+
+    #[TestDox('getTeacherLocations() returns an empty array for a user with no teacher record')]
+    public function testGetTeacherLocationsReturnsEmptyForUnknownUser(): void
+    {
+        $result = CwmlocationHelper::getTeacherLocations(90099);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @param   string  $name  Location display name.
+     *
+     * @return  int  Location ID.
+     */
+    private function insertLocation(string $name): int
+    {
+        $row = (object) [
+            'location_text' => $name,
+            'published'     => 1,
+            'params'        => '',
+            'sortname1'     => '',
+            'sortname2'     => '',
+            'sortname3'     => '',
+            'language'      => '*',
+            'metakey'       => '',
+            'metadesc'      => '',
+            'metadata'      => '',
+            'xreference'    => '',
+        ];
+
+        $this->db->insertObject('#__bsms_locations', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   int  $userId  Joomla user ID to link.
+     *
+     * @return  int  Teacher ID.
+     */
+    private function insertTeacher(int $userId): int
+    {
+        $row = (object) [
+            'teachername' => 'Test Teacher ' . $userId,
+            'alias'       => 'test-teacher-' . $userId,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'user_id'     => $userId,
+            'address'     => '',
+        ];
+
+        $this->db->insertObject('#__bsms_teachers', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   int       $locationId  Location ID to assign.
+     * @param   int|null  $teacherId   Legacy teacher_id column (null = unset).
+     *
+     * @return  int  Study ID.
+     */
+    private function insertStudy(int $locationId, ?int $teacherId = null): int
+    {
+        $row = (object) [
+            'studytitle'  => 'Test Study ' . uniqid('', true),
+            'alias'       => 'test-study-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'messagetype' => 1,
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'location_id' => $locationId,
+            'teacher_id'  => $teacherId,
+            'params'      => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   int  $studyId    Study ID.
+     * @param   int  $teacherId  Teacher ID.
+     *
+     * @return  void
+     */
+    private function insertStudyTeacher(int $studyId, int $teacherId): void
+    {
+        $row = (object) [
+            'study_id'   => $studyId,
+            'teacher_id' => $teacherId,
+            'ordering'   => 0,
+        ];
+
+        $this->db->insertObject('#__bsms_study_teachers', $row);
+    }
+}


### PR DESCRIPTION
Fixes #1561 — all three findings.

This bug is release-gating severity, not routine backlog: multi-campus location filtering has been fatal-on-enable for every non-super-admin since it shipped, with a fail-open bypass underneath if that crash were ever naively caught. Verified all three claims directly against source/Joomla core before fixing (see issue for the verification detail), not just trusting the review report.

## 1. `getTeacherLocations()` UNION query silently discarded bound parameters — fatal on real MySQL

`$db->setQuery('(' . $query1 . ') UNION (' . $query2 . ')')` stringifies both query objects' SQL text but drops their bound `:userId1`/`:userId2` values — `DatabaseDriver::setQuery(string)` wraps the raw text in a fresh `Query` with an empty bound array. Reached unconditionally for any non-super-admin the moment `enable_location_filtering=1` (the only earlier return in `getUserLocations()` is the `core.admin` bypass). Confirmed via a live MySQLi reproduction: `ExecutionFailureException: No data supplied for parameters`.

Fixed by sharing one `:userId` placeholder across both query branches and binding it once on the query passed to `union()`/`setQuery()` — confirmed empirically that Joomla's mysqli driver correctly substitutes a single bound value into every occurrence of a repeated named placeholder across a unioned query.

## 2. `getUserLocations()`'s empty return was ambiguous between "super admin" and "zero access" — every consumer failed open

Added `CwmlocationHelper::isSuperAdmin()` so callers check admin status directly instead of inferring it from an empty array, and fixed every consumer that was resolving the ambiguity toward "no restriction":
- `applyLocationFilter()` now restricts a zero-access user to `location_id IS NULL` instead of skipping the filter.
- `getUserAccessibleLocationsForEdit()` now checks `isSuperAdmin()` explicitly.
- `LocationListField` no longer skips its restriction loop when the accessible-location list happens to be empty.
- All 5 `batchLocation()` copies (Message/Series/Podcast/Server/Template models) — `in_array($x, [], true)` is always `false`, so dropping the redundant `!empty($accessible) &&` short-circuit makes them fail closed.
- `CwmcountHelper`'s identical bug (same root cause, independently found) — zero-access users no longer see pending-count badges across every campus.

## 3. No model validated `location_id` server-side — the edit-form dropdown was decorative

Added `CwmlocationHelper::assertLocationAssignable()`, called at the top of each of the five entities' `save()`. It looks up the record's *current* `location_id` first, so re-saving a record without changing its location is never blocked just because the user lacks general access to it — only an actual attempt to move it to an inaccessible location throws.

## Test plan
- [x] New integration tests (`CwmlocationHelperIntegrationTest`, `CwmlocationHelperFailOpenTest`) cover all three findings against a real database — real UNION query execution, real `enable_location_filtering`/`location_group_mapping` config, real users/groups.
- [x] Confirmed red→green individually for each finding: every new test fails against the pre-fix code (UNION crash, missing `isSuperAdmin()`/`assertLocationAssignable()`) and passes with the fix.
- [x] Full suite green: `composer test` — 1423 tests, 2844 assertions.
- [x] `php-cs-fixer` clean on all changed files.
