### PR TITLE
fix: CwmschemaorgHelper stored XSS, Smart Sync hash mismatch, divergent sync builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,24 @@ jobs:
           sed 's/#__/proclaim_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
           mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
 
+      - name: Create Joomla #__schemaorg table
+        run: |
+          # base.sql (imported above) doesn't include this table -- it's
+          # defined in Joomla core's extensions.sql, which also carries a lot
+          # of unrelated seed data we don't want in the test fixture. The
+          # schemaorg system plugin (and CwmschemaorgHelper's per-item sync)
+          # read/write #__schemaorg directly, so integration tests need it.
+          mysql -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test -e "
+            CREATE TABLE IF NOT EXISTS \`proclaim_schemaorg\` (
+              \`id\` int unsigned NOT NULL AUTO_INCREMENT,
+              \`itemId\` int unsigned,
+              \`context\` varchar(100),
+              \`schemaType\` varchar(100),
+              \`schema\` text,
+              PRIMARY KEY (\`id\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+          "
+
       - name: Check PHP syntax
         run: composer lint:syntax
 
@@ -299,6 +317,24 @@ jobs:
         run: |
           sed 's/#__/proclaim_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
           mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
+
+      - name: Create Joomla #__schemaorg table
+        run: |
+          # base.sql (imported above) doesn't include this table -- it's
+          # defined in Joomla core's extensions.sql, which also carries a lot
+          # of unrelated seed data we don't want in the test fixture. The
+          # schemaorg system plugin (and CwmschemaorgHelper's per-item sync)
+          # read/write #__schemaorg directly, so integration tests need it.
+          mysql -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test -e "
+            CREATE TABLE IF NOT EXISTS \`proclaim_schemaorg\` (
+              \`id\` int unsigned NOT NULL AUTO_INCREMENT,
+              \`itemId\` int unsigned,
+              \`context\` varchar(100),
+              \`schemaType\` varchar(100),
+              \`schema\` text,
+              PRIMARY KEY (\`id\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+          "
 
       - name: Check PHP syntax
         run: composer lint:syntax

--- a/admin/src/Helper/CwmschemaorgHelper.php
+++ b/admin/src/Helper/CwmschemaorgHelper.php
@@ -60,7 +60,7 @@ class CwmschemaorgHelper
         }
 
         // Date published
-        if (!empty($item->studydate)) {
+        if (!empty($item->studydate) && $item->studydate !== '0000-00-00 00:00:00') {
             $data['datePublished'] = self::toIso8601($item->studydate);
         }
 
@@ -162,7 +162,7 @@ class CwmschemaorgHelper
                 );
             }
 
-            if (!empty($item->studydate)) {
+            if (!empty($item->studydate) && $item->studydate !== '0000-00-00 00:00:00') {
                 $sermonData['datePublished'] = self::toIso8601($item->studydate);
             }
 
@@ -298,7 +298,7 @@ class CwmschemaorgHelper
                 );
             }
 
-            if (!empty($study->studydate)) {
+            if (!empty($study->studydate) && $study->studydate !== '0000-00-00 00:00:00') {
                 $part['datePublished'] = self::toIso8601($study->studydate);
             }
 
@@ -541,7 +541,12 @@ class CwmschemaorgHelper
         try {
             $document    = Factory::getApplication()->getDocument();
             $prettyPrint = \defined('JDEBUG') && JDEBUG ? JSON_PRETTY_PRINT : 0;
-            $json        = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | $prettyPrint);
+            // No JSON_UNESCAPED_SLASHES: a "</script" sequence in any string value
+            // (e.g. studytitle, which bypasses InputFilter via filter="trim") would
+            // otherwise survive verbatim into the JSON and terminate this <script>
+            // tag early, letting the rest be parsed as HTML/JS. JSON_HEX_TAG rewrites
+            // every '<'/'>' as a \uXXXX escape so no literal angle bracket survives.
+            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE | $prettyPrint);
         } catch (\Exception $e) {
             return;
         }
@@ -642,14 +647,34 @@ class CwmschemaorgHelper
      */
     private static function collectSocialLinks(object $item): array
     {
-        $links  = [];
-        $fields = ['facebooklink', 'twitterlink', 'bloglink', 'website', 'link1', 'link2'];
+        $links = [];
 
-        foreach ($fields as $field) {
-            $value = $item->$field ?? '';
+        // Prefer the social_links subform JSON — populated by the PreachIT
+        // importer and the newer admin UI, which the legacy link1-3 columns
+        // are not. Mirrors buildTeacherSchemaFromRow()'s resolution order.
+        if (!empty($item->social_links) && \is_string($item->social_links)) {
+            try {
+                $decoded = json_decode($item->social_links, true, 512, JSON_THROW_ON_ERROR);
 
-            if (\is_string($value) && $value !== '' && filter_var($value, FILTER_VALIDATE_URL)) {
-                $links[] = $value;
+                foreach ($decoded as $link) {
+                    if (!empty($link['url']) && filter_var($link['url'], FILTER_VALIDATE_URL)) {
+                        $links[] = $link['url'];
+                    }
+                }
+            } catch (\Throwable) {
+                // Malformed JSON — fall through to the legacy fields below.
+            }
+        }
+
+        if (empty($links)) {
+            $fields = ['facebooklink', 'twitterlink', 'bloglink', 'website', 'link1', 'link2', 'link3'];
+
+            foreach ($fields as $field) {
+                $value = $item->$field ?? '';
+
+                if (\is_string($value) && $value !== '' && filter_var($value, FILTER_VALIDATE_URL)) {
+                    $links[] = $value;
+                }
             }
         }
 
@@ -888,102 +913,7 @@ class CwmschemaorgHelper
                 continue;
             }
 
-            $schema = ['@type' => 'CreativeWork'];
-
-            if (!empty($msg->studytitle)) {
-                $schema['headline'] = $msg->studytitle;
-            }
-
-            if (!empty($msg->studyintro)) {
-                $schema['description'] = self::cleanDescription($msg->studyintro);
-            }
-
-            if (!empty($msg->studydate) && $msg->studydate !== '0000-00-00 00:00:00') {
-                $schema['datePublished'] = $msg->studydate;
-            }
-
-            if (!empty($msg->modified) && $msg->modified !== '0000-00-00 00:00:00') {
-                $schema['dateModified'] = $msg->modified;
-            }
-
-            if (!empty($msg->image)) {
-                $schema['image'] = $msg->image;
-            }
-
-            // Teacher names
-            $tQuery = $db->createQuery()
-                ->select($db->quoteName('t.teachername'))
-                ->from($db->quoteName('#__bsms_teachers', 't'))
-                ->innerJoin(
-                    $db->quoteName('#__bsms_study_teachers', 'st') . ' ON '
-                    . $db->quoteName('st.teacher_id') . ' = ' . $db->quoteName('t.id')
-                )
-                ->where($db->quoteName('st.study_id') . ' = ' . (int) $msg->id)
-                ->order($db->quoteName('st.ordering') . ' ASC');
-            $names = $db->setQuery($tQuery)->loadColumn() ?: [];
-
-            if (!empty($names)) {
-                $schema['author'] = ['@type' => 'Person', 'name' => implode(', ', $names)];
-            }
-
-            // Custom fields: series, topics, genre, location
-            $customFields = [];
-
-            if (!empty($msg->series_id) && (int) $msg->series_id > 0) {
-                $sQuery = $db->createQuery()
-                    ->select($db->quoteName('series_text'))
-                    ->from($db->quoteName('#__bsms_series'))
-                    ->where($db->quoteName('id') . ' = ' . (int) $msg->series_id);
-                $seriesName = $db->setQuery($sQuery)->loadResult();
-
-                if ($seriesName) {
-                    $customFields[] = ['genericTitle' => 'isPartOf', 'genericValue' => $seriesName];
-                }
-            }
-
-            if (!empty($msg->messagetype) && (int) $msg->messagetype > 0) {
-                $mtQuery = $db->createQuery()
-                    ->select($db->quoteName('message_type'))
-                    ->from($db->quoteName('#__bsms_message_type'))
-                    ->where($db->quoteName('id') . ' = ' . (int) $msg->messagetype);
-                $msgType = $db->setQuery($mtQuery)->loadResult();
-
-                if ($msgType) {
-                    $customFields[] = ['genericTitle' => 'genre', 'genericValue' => Text::_($msgType)];
-                }
-            }
-
-            if (!empty($msg->location_id) && (int) $msg->location_id > 0) {
-                $lQuery = $db->createQuery()
-                    ->select($db->quoteName('location_text'))
-                    ->from($db->quoteName('#__bsms_locations'))
-                    ->where($db->quoteName('id') . ' = ' . (int) $msg->location_id);
-                $location = $db->setQuery($lQuery)->loadResult();
-
-                if ($location) {
-                    $customFields[] = ['genericTitle' => 'locationCreated', 'genericValue' => $location];
-                }
-            }
-
-            // Topics
-            $topQuery = $db->createQuery()
-                ->select($db->quoteName('t.topic_text'))
-                ->from($db->quoteName('#__bsms_topics', 't'))
-                ->innerJoin(
-                    $db->quoteName('#__bsms_studytopics', 'st') . ' ON '
-                    . $db->quoteName('st.topic_id') . ' = ' . $db->quoteName('t.id')
-                )
-                ->where($db->quoteName('st.study_id') . ' = ' . (int) $msg->id);
-            $topics = $db->setQuery($topQuery)->loadColumn() ?: [];
-
-            if (!empty($topics)) {
-                $translated     = array_map(static fn ($t) => Text::_($t), $topics);
-                $customFields[] = ['genericTitle' => 'about', 'genericValue' => implode(', ', $translated)];
-            }
-
-            if (!empty($customFields)) {
-                $schema['genericField'] = $customFields;
-            }
+            $schema = self::buildSermonSchemaFromRow($db, $msg);
 
             self::upsertSchemaRow($db, (int) $msg->id, $context, 'Sermon', $schema);
             $synced++;
@@ -1021,60 +951,7 @@ class CwmschemaorgHelper
                 continue;
             }
 
-            $schema = ['@type' => 'Person'];
-
-            if (!empty($teacher->teachername)) {
-                $schema['name'] = $teacher->teachername;
-            }
-
-            if (!empty($teacher->title)) {
-                $schema['jobTitle'] = $teacher->title;
-            }
-
-            if (!empty($teacher->short)) {
-                $schema['description'] = self::cleanDescription($teacher->short);
-            } elseif (!empty($teacher->information)) {
-                $schema['description'] = self::cleanDescription($teacher->information);
-            }
-
-            if (!empty($teacher->teacher_image)) {
-                $schema['image'] = $teacher->teacher_image;
-            } elseif (!empty($teacher->teacher_thumbnail)) {
-                $schema['image'] = $teacher->teacher_thumbnail;
-            }
-
-            if (!empty($teacher->website)) {
-                $schema['url'] = $teacher->website;
-            }
-
-            // Social links → sameAs
-            $sameAs = [];
-
-            if (!empty($teacher->social_links) && \is_string($teacher->social_links)) {
-                try {
-                    $links = json_decode($teacher->social_links, true, 512, JSON_THROW_ON_ERROR);
-
-                    foreach ($links as $link) {
-                        if (!empty($link['url']) && filter_var($link['url'], FILTER_VALIDATE_URL)) {
-                            $sameAs[] = ['value' => $link['url']];
-                        }
-                    }
-                } catch (\Throwable) {
-                    // Malformed JSON
-                }
-            }
-
-            if (empty($sameAs)) {
-                foreach (['facebooklink', 'twitterlink', 'bloglink', 'link1', 'link2', 'link3'] as $field) {
-                    if (!empty($teacher->$field) && filter_var($teacher->$field, FILTER_VALIDATE_URL)) {
-                        $sameAs[] = ['value' => $teacher->$field];
-                    }
-                }
-            }
-
-            if (!empty($sameAs)) {
-                $schema['sameAs'] = $sameAs;
-            }
+            $schema = self::buildTeacherSchemaFromRow($teacher);
 
             self::upsertSchemaRow($db, (int) $teacher->id, $context, 'Teacher', $schema);
             $synced++;
@@ -1112,19 +989,7 @@ class CwmschemaorgHelper
                 continue;
             }
 
-            $schema = ['@type' => 'CreativeWorkSeries'];
-
-            if (!empty($series->series_text)) {
-                $schema['name'] = $series->series_text;
-            }
-
-            if (!empty($series->description)) {
-                $schema['description'] = self::cleanDescription($series->description);
-            }
-
-            if (!empty($series->series_thumbnail)) {
-                $schema['image'] = $series->series_thumbnail;
-            }
+            $schema = self::buildSeriesSchemaFromRow($series);
 
             self::upsertSchemaRow($db, (int) $series->id, $context, 'Series', $schema);
             $synced++;
@@ -1194,10 +1059,11 @@ class CwmschemaorgHelper
             return true;
         }
 
-        unset($data['_autoHash']);
-        ksort($data);
-
-        return $storedHash !== substr(md5(json_encode($data, JSON_UNESCAPED_UNICODE)), 0, 12);
+        // Must strip the same keys computeAutoHash() strips when it stamped
+        // this row, or every row carrying a non-empty _customFields/_fieldHashes
+        // (written by the schemaorg plugin's per-field Smart Sync) permanently
+        // mismatches and Smart Sync can never touch it again.
+        return $storedHash !== self::computeAutoHash($data);
     }
 
     /**
@@ -1255,6 +1121,65 @@ class CwmschemaorgHelper
 
         if ($orgName !== '') {
             $schema['publisher'] = ['@type' => 'Organization', 'name' => $orgName];
+        }
+
+        // Custom fields: series, genre, location, topics
+        $customFields = [];
+
+        if (!empty($msg->series_id) && (int) $msg->series_id > 0) {
+            $sQuery = $db->createQuery()
+                ->select($db->quoteName('series_text'))
+                ->from($db->quoteName('#__bsms_series'))
+                ->where($db->quoteName('id') . ' = ' . (int) $msg->series_id);
+            $seriesName = $db->setQuery($sQuery)->loadResult();
+
+            if ($seriesName) {
+                $customFields[] = ['genericTitle' => 'isPartOf', 'genericValue' => $seriesName];
+            }
+        }
+
+        if (!empty($msg->messagetype) && (int) $msg->messagetype > 0) {
+            $mtQuery = $db->createQuery()
+                ->select($db->quoteName('message_type'))
+                ->from($db->quoteName('#__bsms_message_type'))
+                ->where($db->quoteName('id') . ' = ' . (int) $msg->messagetype);
+            $msgType = $db->setQuery($mtQuery)->loadResult();
+
+            if ($msgType) {
+                $customFields[] = ['genericTitle' => 'genre', 'genericValue' => Text::_($msgType)];
+            }
+        }
+
+        if (!empty($msg->location_id) && (int) $msg->location_id > 0) {
+            $lQuery = $db->createQuery()
+                ->select($db->quoteName('location_text'))
+                ->from($db->quoteName('#__bsms_locations'))
+                ->where($db->quoteName('id') . ' = ' . (int) $msg->location_id);
+            $location = $db->setQuery($lQuery)->loadResult();
+
+            if ($location) {
+                $customFields[] = ['genericTitle' => 'locationCreated', 'genericValue' => $location];
+            }
+        }
+
+        // Topics
+        $topQuery = $db->createQuery()
+            ->select($db->quoteName('t.topic_text'))
+            ->from($db->quoteName('#__bsms_topics', 't'))
+            ->innerJoin(
+                $db->quoteName('#__bsms_studytopics', 'st') . ' ON '
+                . $db->quoteName('st.topic_id') . ' = ' . $db->quoteName('t.id')
+            )
+            ->where($db->quoteName('st.study_id') . ' = ' . (int) $msg->id);
+        $topics = $db->setQuery($topQuery)->loadColumn() ?: [];
+
+        if (!empty($topics)) {
+            $translated     = array_map(static fn ($t) => Text::_($t), $topics);
+            $customFields[] = ['genericTitle' => 'about', 'genericValue' => implode(', ', $translated)];
+        }
+
+        if (!empty($customFields)) {
+            $schema['genericField'] = $customFields;
         }
 
         return $schema;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -58,6 +58,9 @@
 		<testsuite name="Site Bible Tests">
 			<directory>tests/unit/Site/Bible</directory>
 		</testsuite>
+		<testsuite name="Plugin Schemaorg Tests">
+			<directory>tests/unit/Plugin/Schemaorg</directory>
+		</testsuite>
 
 		<!-- Integration suites: one per tests/integration subtree -->
 		<testsuite name="Integration Admin Helper Tests">

--- a/plugins/schemaorg/proclaim/src/Extension/Proclaim.php
+++ b/plugins/schemaorg/proclaim/src/Extension/Proclaim.php
@@ -456,9 +456,42 @@ final class Proclaim extends CMSPlugin implements SubscriberInterface
 
                 $entry['sameAs'] = !empty($flat) ? $flat : null;
             }
+
+            // Defense in depth: Joomla core's system schemaorg plugin serializes
+            // this @graph with Registry::toString('JSON', ['bitmask' =>
+            // JSON_UNESCAPED_SLASHES | ...]) — no JSON_HEX_TAG — then embeds the
+            // result directly inside a <script type="application/ld+json"> tag.
+            // A literal "</script" in any string value (e.g. an unfiltered
+            // studytitle) would terminate that tag early. We don't control core's
+            // encode call, so neutralize '<'/'>' here, the last point before
+            // handoff, rather than relying on an upstream fix.
+            $entry = self::sanitizeForScriptEmbedding($entry);
         }
 
         $schema->set('@graph', $graph);
+    }
+
+    /**
+     * Recursively replace '<' and '>' in string values with HTML entities so
+     * no value can contain a literal "</script" sequence once serialized.
+     *
+     * @param   mixed  $value  Schema value (array or scalar)
+     *
+     * @return  mixed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function sanitizeForScriptEmbedding(mixed $value): mixed
+    {
+        if (\is_array($value)) {
+            return array_map([self::class, 'sanitizeForScriptEmbedding'], $value);
+        }
+
+        if (\is_string($value)) {
+            return str_replace(['<', '>'], ['&lt;', '&gt;'], $value);
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
+++ b/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
@@ -144,7 +144,6 @@ class CwmschemaorgHelperIntegrationTest extends IntegrationTestCase
         $teacherId = $this->insertTeacher('Pastor Jane');
 
         $method = new \ReflectionMethod(CwmschemaorgHelper::class, 'syncTeachers');
-        $method->setAccessible(true);
         $result = $method->invoke(null, $this->db, CwmschemaorgHelper::SYNC_SMART);
 
         $this->assertGreaterThan(0, $result['synced']);
@@ -164,7 +163,6 @@ class CwmschemaorgHelperIntegrationTest extends IntegrationTestCase
     private function invokeIsManuallyEdited(int $itemId, string $context): ?bool
     {
         $method = new \ReflectionMethod(CwmschemaorgHelper::class, 'isManuallyEdited');
-        $method->setAccessible(true);
 
         return $method->invoke(null, $this->db, $itemId, $context);
     }

--- a/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
+++ b/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
@@ -1,0 +1,366 @@
+<?php
+
+/**
+ * Integration tests for CwmschemaorgHelper's DB-touching methods.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1562:
+ *
+ * - isManuallyEdited() only stripped `_autoHash` before re-hashing, while
+ *   computeAutoHash() (used to stamp the hash in the first place) strips
+ *   `_autoHash`, `_customFields`, `_fieldHashes`, and `_editedFields`. Any
+ *   row carrying a non-empty `_customFields`/`_fieldHashes` -- which the
+ *   schemaorg plugin's per-field Smart Sync writes on every admin save --
+ *   permanently mismatched and could never be Smart Synced again.
+ * - syncOne()'s sermon/teacher builders diverged from the bulk syncMessages()/
+ *   syncTeachers() field sets (missing genericField / worksFor respectively),
+ *   so alternating "Reset Schema" and "Sync All" silently dropped fields.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmschemaorgHelper::class)]
+class CwmschemaorgHelperIntegrationTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    #[TestDox('isManuallyEdited() does not misclassify a row hash-stamped with _customFields/_fieldHashes present')]
+    public function testIsManuallyEditedFalseWhenStoredDataCarriesTrackingKeys(): void
+    {
+        // Mirrors what the schemaorg plugin's onSchemaPrepareSave() persists:
+        // fresh auto-generated fields plus non-null _customFields/_fieldHashes,
+        // hashed via the same 4-key strip computeAutoHash() uses.
+        $schema = [
+            'headline'      => 'Test Sermon',
+            '_customFields' => ['headline'],
+            '_fieldHashes'  => ['headline' => 'abc12345'],
+        ];
+        $schema['_autoHash'] = CwmschemaorgHelper::computeAutoHash($schema);
+
+        $itemId = $this->insertSchemaRow('com_proclaim.cwmmessage', 'Sermon', $schema);
+
+        $this->assertFalse(
+            $this->invokeIsManuallyEdited($itemId, 'com_proclaim.cwmmessage'),
+            'A row hash-stamped with _customFields/_fieldHashes present must not be treated as manually edited'
+        );
+    }
+
+    #[TestDox('isManuallyEdited() still returns true when a stored field genuinely diverges from its auto-hash')]
+    public function testIsManuallyEditedTrueWhenStoredDataDiverged(): void
+    {
+        $schema               = ['headline' => 'Original'];
+        $schema['_autoHash']  = CwmschemaorgHelper::computeAutoHash($schema);
+        // Simulate a hand-edit after the hash was stamped (e.g. a direct DB
+        // edit, or a row from before Smart Sync existed).
+        $schema['headline'] = 'Admin-customized headline';
+
+        $itemId = $this->insertSchemaRow('com_proclaim.cwmmessage', 'Sermon', $schema);
+
+        $this->assertTrue(
+            $this->invokeIsManuallyEdited($itemId, 'com_proclaim.cwmmessage'),
+            'A row whose stored fields no longer hash to _autoHash must still be flagged as manually edited'
+        );
+    }
+
+    #[TestDox('syncOne() for a sermon builds the same genericField set as the bulk sync path (series/genre/location/topics)')]
+    public function testSyncOneSermonIncludesGenericFieldFromSeriesGenreLocationTopics(): void
+    {
+        $locationId = $this->insertLocation('Main Campus');
+        $seriesId   = $this->insertSeries('Parables of Jesus');
+        $typeId     = $this->insertMessageType('Sermon');
+        $topicId    = $this->insertTopic('Compassion');
+        $studyId    = $this->insertStudy($locationId, $seriesId, $typeId);
+
+        $this->insertStudyTopic($studyId, $topicId);
+
+        $synced = CwmschemaorgHelper::syncOne($studyId, 'com_proclaim.cwmmessage');
+        $this->assertTrue($synced);
+
+        $schema = $this->loadStoredSchema($studyId, 'com_proclaim.cwmmessage');
+
+        $this->assertArrayHasKey('genericField', $schema);
+
+        $titles = array_column($schema['genericField'], 'genericTitle');
+
+        $this->assertContains('isPartOf', $titles);
+        $this->assertContains('genre', $titles);
+        $this->assertContains('locationCreated', $titles);
+        $this->assertContains('about', $titles);
+    }
+
+    #[TestDox('Bulk sync (syncTeachers) includes worksFor, matching the syncOne()/buildTeacherSchemaFromRow() path')]
+    public function testBulkSyncTeacherIncludesWorksFor(): void
+    {
+        // syncOne() already routed through buildTeacherSchemaFromRow() (which
+        // has always included worksFor) even before this fix -- the actual
+        // divergence was in syncTeachers()'s separate inline builder used by
+        // the "Sync All" bulk path, so this must exercise syncTeachers()
+        // directly (private, reached via reflection) rather than syncOne().
+        $teacherId = $this->insertTeacher('Pastor Jane');
+
+        $method = new \ReflectionMethod(CwmschemaorgHelper::class, 'syncTeachers');
+        $method->setAccessible(true);
+        $result = $method->invoke(null, $this->db, CwmschemaorgHelper::SYNC_SMART);
+
+        $this->assertGreaterThan(0, $result['synced']);
+
+        $schema = $this->loadStoredSchema($teacherId, 'com_proclaim.teacher');
+
+        $this->assertArrayHasKey('worksFor', $schema);
+        $this->assertEquals('Organization', $schema['worksFor']['@type']);
+    }
+
+    /**
+     * @param   int     $itemId   Item ID.
+     * @param   string  $context  Context string.
+     *
+     * @return  bool|null
+     */
+    private function invokeIsManuallyEdited(int $itemId, string $context): ?bool
+    {
+        $method = new \ReflectionMethod(CwmschemaorgHelper::class, 'isManuallyEdited');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $this->db, $itemId, $context);
+    }
+
+    /**
+     * @param   string  $context     Context string.
+     * @param   string  $schemaType  Schema type name.
+     * @param   array   $schema      Schema data (already hash-stamped).
+     *
+     * @return  int  itemId used for the inserted row.
+     */
+    private function insertSchemaRow(string $context, string $schemaType, array $schema): int
+    {
+        static $nextItemId = 91000;
+
+        $itemId = $nextItemId++;
+
+        $row             = new \stdClass();
+        $row->itemId     = $itemId;
+        $row->context    = $context;
+        $row->schemaType = $schemaType;
+        $row->schema     = json_encode($schema, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+        $this->db->insertObject('#__schemaorg', $row);
+
+        return $itemId;
+    }
+
+    /**
+     * @param   int     $itemId   Item ID.
+     * @param   string  $context  Context string.
+     *
+     * @return  array
+     */
+    private function loadStoredSchema(int $itemId, string $context): array
+    {
+        $query = $this->db->createQuery()
+            ->select($this->db->quoteName('schema'))
+            ->from($this->db->quoteName('#__schemaorg'))
+            ->where($this->db->quoteName('itemId') . ' = ' . $itemId)
+            ->where($this->db->quoteName('context') . ' = ' . $this->db->quote($context));
+        $stored = $this->db->setQuery($query)->loadResult();
+
+        $this->assertNotNull($stored, 'Expected a stored schema row after syncOne()');
+
+        return json_decode($stored, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param   string  $name  Location display name.
+     *
+     * @return  int  Location ID.
+     */
+    private function insertLocation(string $name): int
+    {
+        $row = (object) [
+            'location_text' => $name,
+            'published'     => 1,
+            'params'        => '',
+            'sortname1'     => '',
+            'sortname2'     => '',
+            'sortname3'     => '',
+            'language'      => '*',
+            'metakey'       => '',
+            'metadesc'      => '',
+            'metadata'      => '',
+            'xreference'    => '',
+        ];
+
+        $this->db->insertObject('#__bsms_locations', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   string  $name  Series name.
+     *
+     * @return  int  Series ID.
+     */
+    private function insertSeries(string $name): int
+    {
+        $row = (object) [
+            'series_text' => $name,
+            'alias'       => 'test-series-' . uniqid('', true),
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_series', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   string  $name  Message type name.
+     *
+     * @return  int  Message type ID.
+     */
+    private function insertMessageType(string $name): int
+    {
+        $row = (object) [
+            'message_type' => $name,
+            'alias'        => 'test-type-' . uniqid('', true),
+            'published'    => 1,
+            'access'       => 1,
+        ];
+
+        $this->db->insertObject('#__bsms_message_type', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   string  $name  Topic text.
+     *
+     * @return  int  Topic ID.
+     */
+    private function insertTopic(string $name): int
+    {
+        $row = (object) [
+            'topic_text' => $name,
+            'published'  => 1,
+            'access'     => 1,
+            'language'   => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_topics', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   int  $studyId  Study ID.
+     * @param   int  $topicId  Topic ID.
+     *
+     * @return  void
+     */
+    private function insertStudyTopic(int $studyId, int $topicId): void
+    {
+        $row = (object) [
+            'study_id' => $studyId,
+            'topic_id' => $topicId,
+            'access'   => 1,
+        ];
+
+        $this->db->insertObject('#__bsms_studytopics', $row);
+    }
+
+    /**
+     * @param   int  $locationId  Location ID.
+     * @param   int  $seriesId    Series ID.
+     * @param   int  $typeId      Message type ID.
+     *
+     * @return  int  Study ID.
+     */
+    private function insertStudy(int $locationId, int $seriesId, int $typeId): int
+    {
+        $row = (object) [
+            'studytitle'  => 'Test Study ' . uniqid('', true),
+            'alias'       => 'test-study-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'messagetype' => (string) $typeId,
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'location_id' => $locationId,
+            'series_id'   => $seriesId,
+            'params'      => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   string  $name  Teacher display name.
+     *
+     * @return  int  Teacher ID.
+     */
+    private function insertTeacher(string $name): int
+    {
+        $row = (object) [
+            'teachername' => $name,
+            'alias'       => 'test-teacher-' . uniqid('', true),
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'address'     => '',
+        ];
+
+        $this->db->insertObject('#__bsms_teachers', $row);
+
+        return (int) $this->db->insertid();
+    }
+}

--- a/tests/unit/Admin/Helper/CwmschemaorgHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmschemaorgHelperTest.php
@@ -13,6 +13,7 @@ namespace CWM\Component\Proclaim\Tests\Admin\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
 
 /**
  * Test class for CwmschemaorgHelper
@@ -299,6 +300,57 @@ class CwmschemaorgHelperTest extends ProclaimTestCase
         $this->assertEquals('https://twitter.com/valid', $result['sameAs'][0]);
     }
 
+    /**
+     * Regression test for #1562 finding 5: collectSocialLinks() ignored the
+     * social_links subform JSON and link3, unlike buildTeacherSchemaFromRow()
+     * (used by the sync path). The PreachIT importer writes social_links
+     * directly, bypassing the legacy facebooklink/twitterlink/... columns.
+     *
+     * @return void
+     */
+    public function testBuildTeacherDetailPrefersSocialLinksJsonOverLegacyFields(): void
+    {
+        $item               = new \stdClass();
+        $item->teachername  = 'Teacher';
+        $item->social_links = json_encode([
+            ['url' => 'https://mastodon.example.com/@teacher'],
+            ['url' => 'not-a-url'],
+        ]);
+        // Legacy fields present but must be ignored once social_links resolves.
+        $item->facebooklink = 'https://facebook.com/legacy';
+        $item->website      = '';
+        $item->link1        = '';
+        $item->link2        = '';
+        $item->link3        = '';
+
+        $result = CwmschemaorgHelper::buildTeacherDetail($item, 'https://example.com/teacher/1');
+
+        $this->assertEquals(['https://mastodon.example.com/@teacher'], $result['sameAs']);
+    }
+
+    /**
+     * Regression test for #1562 finding 5: link3 was missing from the
+     * legacy-field fallback list.
+     *
+     * @return void
+     */
+    public function testBuildTeacherDetailFallsBackToLink3(): void
+    {
+        $item               = new \stdClass();
+        $item->teachername  = 'Teacher';
+        $item->facebooklink = '';
+        $item->twitterlink  = '';
+        $item->bloglink     = '';
+        $item->website      = '';
+        $item->link1        = '';
+        $item->link2        = '';
+        $item->link3        = 'https://example.com/teacher-profile';
+
+        $result = CwmschemaorgHelper::buildTeacherDetail($item, 'https://example.com/teacher/1');
+
+        $this->assertEquals(['https://example.com/teacher-profile'], $result['sameAs']);
+    }
+
     // ----- Series Detail Tests -----
 
     /**
@@ -340,6 +392,31 @@ class CwmschemaorgHelperTest extends ProclaimTestCase
 
         $this->assertEquals('CreativeWorkSeries', $result['@type']);
         $this->assertArrayNotHasKey('hasPart', $result);
+    }
+
+    /**
+     * Regression test for #1562 finding 4: buildSermonDetail(), buildSermonList(),
+     * and buildSeriesDetail() emitted a literal '0000-00-00 00:00:00' MySQL zero-date
+     * sentinel as datePublished, unlike syncMessages()/buildSermonSchemaFromRow()
+     * which already guarded against it.
+     *
+     * @return void
+     */
+    public function testZeroDateSentinelOmitsDatePublished(): void
+    {
+        $sermonItem            = $this->makeMinimalSermonItem();
+        $sermonItem->studydate = '0000-00-00 00:00:00';
+        $detail                = CwmschemaorgHelper::buildSermonDetail($sermonItem, 'https://example.com/sermon/1', '');
+        $this->assertArrayNotHasKey('datePublished', $detail);
+
+        $list = CwmschemaorgHelper::buildSermonList([$sermonItem], 'https://example.com/sermons', '');
+        $this->assertArrayNotHasKey('datePublished', $list['itemListElement'][0]['item']);
+
+        $seriesItem            = $this->makeSeriesItem();
+        $study                 = $this->makeStudies()[0];
+        $study->studydate      = '0000-00-00 00:00:00';
+        $seriesResult          = CwmschemaorgHelper::buildSeriesDetail($seriesItem, [$study], 'https://example.com/series/5', '');
+        $this->assertArrayNotHasKey('datePublished', $seriesResult['hasPart'][0]);
     }
 
     // ----- cleanDescription Tests -----
@@ -408,5 +485,70 @@ class CwmschemaorgHelperTest extends ProclaimTestCase
 
         $listItem = $result['itemListElement'][0]['item'];
         $this->assertEquals('Pastor John', $listItem['author']['name']);
+    }
+
+    // ----- inject() XSS Tests (#1562 finding 1) -----
+
+    /**
+     * Regression test for #1562 finding 1: inject() used JSON_UNESCAPED_SLASHES
+     * with no JSON_HEX_TAG, so a "</script" sequence in any string value (e.g.
+     * an unfiltered studytitle) survived verbatim into the JSON-LD payload and
+     * terminated the surrounding <script> tag early, letting the rest of the
+     * value be parsed as HTML/JS.
+     *
+     * Swaps Factory::$application for a fake with a getDocument() stub so
+     * inject() runs its real json_encode()/addCustomTag() logic without a full
+     * Joomla application bootstrap.
+     *
+     * @return void
+     */
+    public function testInjectNeutralizesScriptBreakoutInMaliciousTitle(): void
+    {
+        $originalApplication = Factory::$application;
+
+        // A fake app with a getDocument() stub is sufficient: inject() calls
+        // Factory::getApplication()->getDocument()->addCustomTag() without any
+        // type hint enforcing CMSApplicationInterface/HtmlDocument.
+        $box       = new \stdClass();
+        $box->html = null;
+
+        $app = new class ($box) {
+            public function __construct(private $box)
+            {
+            }
+
+            public function getDocument()
+            {
+                $box = $this->box;
+
+                return new class ($box) {
+                    public function __construct(private $box)
+                    {
+                    }
+
+                    public function addCustomTag($html)
+                    {
+                        $this->box->html = $html;
+                    }
+                };
+            }
+        };
+
+        Factory::$application = $app;
+
+        try {
+            CwmschemaorgHelper::inject([
+                '@context' => 'https://schema.org',
+                '@type'    => 'CreativeWork',
+                'name'     => 'Evil</script><script>alert(document.cookie)</script>',
+            ]);
+        } finally {
+            Factory::$application = $originalApplication;
+        }
+
+        $this->assertNotNull($box->html, 'inject() must call addCustomTag()');
+        // Only our own closing </script> tag may appear -- the malicious
+        // title's two "</script" sequences must be neutralized.
+        $this->assertSame(1, substr_count(strtolower($box->html), '</script'));
     }
 }

--- a/tests/unit/Plugin/Schemaorg/ProclaimScriptEmbeddingTest.php
+++ b/tests/unit/Plugin/Schemaorg/ProclaimScriptEmbeddingTest.php
@@ -57,7 +57,6 @@ class ProclaimScriptEmbeddingTest extends ProclaimTestCase
     private function sanitize(mixed $value): mixed
     {
         $method = new \ReflectionMethod(\CWM\Plugin\Schemaorg\Proclaim\Extension\Proclaim::class, 'sanitizeForScriptEmbedding');
-        $method->setAccessible(true);
 
         return $method->invoke(null, $value);
     }

--- a/tests/unit/Plugin/Schemaorg/ProclaimScriptEmbeddingTest.php
+++ b/tests/unit/Plugin/Schemaorg/ProclaimScriptEmbeddingTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Unit tests for the schemaorg/proclaim plugin's script-embedding sanitizer.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Plugin\Schemaorg;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression coverage for #1562 finding 1 (stored XSS via JSON-LD injection).
+ *
+ * inject() in CwmschemaorgHelper is skipped for any item that already has a
+ * #__schemaorg row (see hasJoomlaSchema()) -- which is every item ever saved
+ * through the admin form. For those, structured data is rendered entirely by
+ * Joomla core's plugins/system/schemaorg, which serializes the @graph with
+ * JSON_UNESCAPED_SLASHES and no JSON_HEX_TAG before embedding it directly in
+ * a <script type="application/ld+json"> tag -- the same vulnerability class
+ * as finding 1, just in code this repo doesn't own. Since the schemaorg/
+ * proclaim plugin's onSchemaBeforeCompileHead() runs immediately before that
+ * serialization, it is the last point this codebase can intercept the data,
+ * so sanitizeForScriptEmbedding() neutralizes '<'/'>' there as defense in
+ * depth for the common (stored-schema) render path.
+ *
+ * The plugin class lives outside composer's autoload map (it's loaded via
+ * Joomla's plugin system at runtime, not PSR-4), so it's require_once'd
+ * directly here and reached via reflection since sanitizeForScriptEmbedding()
+ * is a private static pure function with no Joomla application dependency.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ProclaimScriptEmbeddingTest extends ProclaimTestCase
+{
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(\CWM\Plugin\Schemaorg\Proclaim\Extension\Proclaim::class)) {
+            require_once \dirname(__DIR__, 4) . '/plugins/schemaorg/proclaim/src/Extension/Proclaim.php';
+        }
+    }
+
+    /**
+     * @param   mixed  $value  Value to sanitize.
+     *
+     * @return  mixed
+     */
+    private function sanitize(mixed $value): mixed
+    {
+        $method = new \ReflectionMethod(\CWM\Plugin\Schemaorg\Proclaim\Extension\Proclaim::class, 'sanitizeForScriptEmbedding');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $value);
+    }
+
+    /**
+     * @return void
+     */
+    public function testNeutralizesScriptBreakoutInString(): void
+    {
+        $malicious = 'Evil</script><script>alert(document.cookie)</script>';
+
+        $result = $this->sanitize($malicious);
+
+        $this->assertStringNotContainsStringIgnoringCase('</script', $result);
+        $this->assertStringContainsString('&lt;/script&gt;', $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRecursivelySanitizesNestedArrays(): void
+    {
+        $entry = [
+            '@type'        => 'CreativeWork',
+            'headline'     => 'Fine title',
+            'author'       => ['@type' => 'Person', 'name' => '</script><script>alert(1)</script>'],
+            'genericField' => [
+                ['genericTitle' => 'about', 'genericValue' => '<img src=x onerror=alert(1)>'],
+            ],
+        ];
+
+        $result = $this->sanitize($entry);
+
+        $this->assertStringNotContainsStringIgnoringCase('</script', $result['author']['name']);
+        $this->assertStringNotContainsString('<img', $result['genericField'][0]['genericValue']);
+        // Untouched values pass through unchanged.
+        $this->assertSame('Fine title', $result['headline']);
+        $this->assertSame('CreativeWork', $result['@type']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testNonStringScalarsAndNullPassThroughUnchanged(): void
+    {
+        $this->assertSame(42, $this->sanitize(42));
+        $this->assertNull($this->sanitize(null));
+        $this->assertTrue($this->sanitize(true));
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #1562. All 5 of the 6 filed findings are fixed; finding 6 (unbounded bulk sync) is deferred to a follow-up issue -- see rationale below.

1. **Stored XSS** — `inject()` combined `JSON_UNESCAPED_SLASHES` with an unescaped `studytitle` (whose `filter="trim"` bypasses `InputFilter::clean()`), letting a `</script><script>...` payload break out of the injected JSON-LD `<script>` tag. Dropped `JSON_UNESCAPED_SLASHES`, added `JSON_HEX_TAG`/`JSON_HEX_AMP`.

   `inject()` only runs when no `#__schemaorg` row exists for the item -- false for anything ever saved through the admin form. That common case renders entirely through Joomla core's `plugins/system/schemaorg`, which serializes with the same unsafe flags and is code this repo doesn't own. Since our `onSchemaBeforeCompileHead()` hook runs immediately before that serialization, it's the last point we can intercept the data, so it now also neutralizes `<`/`>` there as defense in depth for the path we can't directly fix.

2. **Smart Sync hash mismatch** — `isManuallyEdited()` only stripped `_autoHash` before re-hashing, while `computeAutoHash()` (used to stamp the hash) strips 4 keys (`_autoHash`, `_customFields`, `_fieldHashes`, `_editedFields`). Any row carrying a non-empty `_customFields`/`_fieldHashes` -- written by the plugin's per-field Smart Sync on every admin save -- permanently mismatched and could never be Smart Synced again. Now delegates to `computeAutoHash()` directly so the two can't drift apart again.

3. **Divergent sync builders** — `syncOne()`'s builders and the bulk `syncMessages()`/`syncTeachers()`/`syncSeries()` paths built different field sets for the same row (missing `genericField`/`worksFor` respectively). Merged the logic into the shared per-context builders and made the bulk functions call them instead of duplicating.

4. **Zero-date sentinel** — `buildSermonDetail()`, `buildSermonList()`, `buildSeriesDetail()` were missing the `'0000-00-00 00:00:00'` guard already present in the sync path, emitting invalid `datePublished` JSON-LD.

5. **`collectSocialLinks()` fallback gap** — ignored `social_links` JSON and `link3`, unlike the parallel sync-path logic; missed links for teachers created via the PreachIT importer.

## Deferred: finding 6 (unbounded bulk sync)

Routing `syncMessages()` through the shared per-item builder (finding 3) actually entrenches the N+1 query pattern, since the builder does its own teacher/topic/series/location lookups per call. Batching those into upfront `IN(...)` queries needs a prefetched-map calling convention for the shared builders, which is a bigger, separate change. Will file a follow-up issue mirroring the #1553 → #1560 precedent.

## Test plan

- [x] New unit tests in `CwmschemaorgHelperTest.php` (finding 1 via a `Factory::$application` swap, findings 4 & 5)
- [x] New `tests/unit/Plugin/Schemaorg/ProclaimScriptEmbeddingTest.php` for the plugin-side defense-in-depth sanitizer (finding 1, common render path)
- [x] New `tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php` with real DB fixtures (finding 2 positive + negative cases, finding 3 sermon `genericField` + teacher `worksFor`)
- [x] All new tests confirmed red on pre-fix code, green after
- [x] Full suite green: `composer test` (1434 tests, 2873 assertions)
- [x] `php-cs-fixer --dry-run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL