### PR TITLE
test: seed fixtures so CI-vacuous integration tests exercise their real branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,13 +154,15 @@ jobs:
           sed 's/#__/proclaim_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
           mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
 
-      - name: Create Joomla #__schemaorg table
+      - name: Create Joomla #__schemaorg and #__scheduler_tasks tables
         run: |
-          # base.sql (imported above) doesn't include this table -- it's
+          # base.sql (imported above) doesn't include these tables -- they're
           # defined in Joomla core's extensions.sql, which also carries a lot
           # of unrelated seed data we don't want in the test fixture. The
           # schemaorg system plugin (and CwmschemaorgHelper's per-item sync)
-          # read/write #__schemaorg directly, so integration tests need it.
+          # read/write #__schemaorg directly, and Cwmbackup's scheduled-tasks
+          # export needs #__scheduler_tasks to exist to exercise its real
+          # (non-"table not found") branch, so integration tests need both.
           mysql -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test -e "
             CREATE TABLE IF NOT EXISTS \`proclaim_schemaorg\` (
               \`id\` int unsigned NOT NULL AUTO_INCREMENT,
@@ -169,6 +171,32 @@ jobs:
               \`schemaType\` varchar(100),
               \`schema\` text,
               PRIMARY KEY (\`id\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+            CREATE TABLE IF NOT EXISTS \`proclaim_scheduler_tasks\` (
+              \`id\` int unsigned NOT NULL AUTO_INCREMENT,
+              \`asset_id\` int unsigned NOT NULL DEFAULT 0,
+              \`title\` varchar(255) NOT NULL DEFAULT '',
+              \`type\` varchar(128) NOT NULL,
+              \`execution_rules\` text,
+              \`cron_rules\` text,
+              \`state\` tinyint NOT NULL DEFAULT 0,
+              \`last_exit_code\` int NOT NULL DEFAULT 0,
+              \`last_execution\` datetime,
+              \`next_execution\` datetime,
+              \`times_executed\` int DEFAULT 0,
+              \`times_failed\` int DEFAULT 0,
+              \`locked\` datetime,
+              \`priority\` smallint NOT NULL DEFAULT 0,
+              \`ordering\` int NOT NULL DEFAULT 0,
+              \`cli_exclusive\` smallint NOT NULL DEFAULT 0,
+              \`params\` text NOT NULL,
+              \`note\` text,
+              \`created\` datetime NOT NULL,
+              \`created_by\` int unsigned NOT NULL DEFAULT 0,
+              \`checked_out\` int unsigned,
+              \`checked_out_time\` datetime,
+              PRIMARY KEY (\`id\`),
+              KEY \`idx_type\` (\`type\`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
           "
 
@@ -317,13 +345,15 @@ jobs:
           sed 's/#__/proclaim_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
           mysql --force -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
 
-      - name: Create Joomla #__schemaorg table
+      - name: Create Joomla #__schemaorg and #__scheduler_tasks tables
         run: |
-          # base.sql (imported above) doesn't include this table -- it's
+          # base.sql (imported above) doesn't include these tables -- they're
           # defined in Joomla core's extensions.sql, which also carries a lot
           # of unrelated seed data we don't want in the test fixture. The
           # schemaorg system plugin (and CwmschemaorgHelper's per-item sync)
-          # read/write #__schemaorg directly, so integration tests need it.
+          # read/write #__schemaorg directly, and Cwmbackup's scheduled-tasks
+          # export needs #__scheduler_tasks to exist to exercise its real
+          # (non-"table not found") branch, so integration tests need both.
           mysql -h 127.0.0.1 -u proclaim_test -pproclaim_test proclaim_test -e "
             CREATE TABLE IF NOT EXISTS \`proclaim_schemaorg\` (
               \`id\` int unsigned NOT NULL AUTO_INCREMENT,
@@ -332,6 +362,32 @@ jobs:
               \`schemaType\` varchar(100),
               \`schema\` text,
               PRIMARY KEY (\`id\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+            CREATE TABLE IF NOT EXISTS \`proclaim_scheduler_tasks\` (
+              \`id\` int unsigned NOT NULL AUTO_INCREMENT,
+              \`asset_id\` int unsigned NOT NULL DEFAULT 0,
+              \`title\` varchar(255) NOT NULL DEFAULT '',
+              \`type\` varchar(128) NOT NULL,
+              \`execution_rules\` text,
+              \`cron_rules\` text,
+              \`state\` tinyint NOT NULL DEFAULT 0,
+              \`last_exit_code\` int NOT NULL DEFAULT 0,
+              \`last_execution\` datetime,
+              \`next_execution\` datetime,
+              \`times_executed\` int DEFAULT 0,
+              \`times_failed\` int DEFAULT 0,
+              \`locked\` datetime,
+              \`priority\` smallint NOT NULL DEFAULT 0,
+              \`ordering\` int NOT NULL DEFAULT 0,
+              \`cli_exclusive\` smallint NOT NULL DEFAULT 0,
+              \`params\` text NOT NULL,
+              \`note\` text,
+              \`created\` datetime NOT NULL,
+              \`created_by\` int unsigned NOT NULL DEFAULT 0,
+              \`checked_out\` int unsigned,
+              \`checked_out_time\` datetime,
+              PRIMARY KEY (\`id\`),
+              KEY \`idx_type\` (\`type\`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
           "
 

--- a/tests/integration/Admin/Helper/CwmcountHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmcountHelperTest.php
@@ -16,15 +16,26 @@ namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
 use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test class for CwmcountHelper.
  *
+ * Seeds known rows inside a rolled-back transaction and asserts exact count
+ * deltas. The prior version of this file asserted only invariants
+ * (non-negative, subset-of-total) with no fixture — on CI's empty database
+ * every count is 0, so 0 <= 0 held even if getCountByState() ignored $state
+ * entirely or double-counted rows; the tests could not fail from the
+ * regressions they were written to guard.
+ *
  * @since  __DEPLOY_VERSION__
  */
 class CwmcountHelperTest extends IntegrationTestCase
 {
+    private ?DatabaseDriver $db = null;
+
     /**
      * Skip the whole class when no live database is available.
      *
@@ -37,44 +48,123 @@ class CwmcountHelperTest extends IntegrationTestCase
         if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
             $this->markTestSkipped('Live database not available for count integration test.');
         }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        // The helper caches counts per request keyed by table+state; without a
+        // reset, a count taken before this test's fixtures were inserted would
+        // be served back after them.
+        $this->resetStaticCache(CwmcountHelper::class, 'cache', []);
     }
 
-    #[TestDox('getCountByState(state 0) returns a non-negative unpublished count')]
-    public function testUnpublishedCountIsNonNegative(): void
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
     {
-        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost — nothing to roll back.
+            }
+        }
 
-        $this->assertIsInt($unpublished);
-        $this->assertGreaterThanOrEqual(0, $unpublished, 'Unpublished study count must not be negative');
+        $this->resetStaticCache(CwmcountHelper::class, 'cache', []);
+
+        parent::tearDown();
     }
 
-    #[TestDox('Unpublished count never exceeds the non-trashed total')]
-    public function testUnpublishedCountWithinTotal(): void
+    /**
+     * Insert a study row in the given published state.
+     *
+     * @param   int  $published  Published state value
+     *
+     * @return  void
+     */
+    private function insertStudy(int $published): void
     {
-        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
-        $total       = CwmcountHelper::getTotalCount('#__bsms_studies');
+        $row = (object) [
+            'studytitle'  => 'Count Fixture ' . uniqid('', true),
+            'alias'       => 'count-fixture-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'teacher_id'  => 0,
+            'series_id'   => 0,
+            'messagetype' => 1,
+            'booknumber'  => 101,
+            'published'   => $published,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'params'      => '{}',
+        ];
 
-        $this->assertLessThanOrEqual(
-            $total,
-            $unpublished,
-            'Unpublished count should be a subset of the non-trashed total'
+        $this->db->insertObject('#__bsms_studies', $row);
+    }
+
+    #[TestDox('Each published state is counted independently and exactly')]
+    public function testStateCountsMatchSeededFixturesExactly(): void
+    {
+        // Baselines first: the dev DB has pre-existing rows, CI has none.
+        // Exact-delta assertions work identically in both environments.
+        $basePublished   = CwmcountHelper::getCountByState('#__bsms_studies', 1);
+        $baseUnpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
+        $baseArchived    = CwmcountHelper::getCountByState('#__bsms_studies', 2);
+        $baseTotal       = CwmcountHelper::getTotalCount('#__bsms_studies');
+
+        $this->insertStudy(1);
+        $this->insertStudy(0);
+        $this->insertStudy(0);
+        $this->insertStudy(2);
+        $this->insertStudy(-2);
+
+        $this->resetStaticCache(CwmcountHelper::class, 'cache', []);
+
+        $this->assertSame(
+            $basePublished + 1,
+            CwmcountHelper::getCountByState('#__bsms_studies', 1),
+            'Exactly one published fixture was added — a wrong delta means $state is being ignored or rows double-counted'
+        );
+        $this->assertSame(
+            $baseUnpublished + 2,
+            CwmcountHelper::getCountByState('#__bsms_studies', 0),
+            'Exactly two unpublished fixtures were added'
+        );
+        $this->assertSame(
+            $baseArchived + 1,
+            CwmcountHelper::getCountByState('#__bsms_studies', 2),
+            'Exactly one archived fixture was added'
+        );
+        $this->assertSame(
+            $baseTotal + 4,
+            CwmcountHelper::getTotalCount('#__bsms_studies'),
+            'The non-trashed total must include published+unpublished+archived fixtures but exclude the trashed one'
         );
     }
 
-    #[TestDox('Published, unpublished and archived are counted independently')]
-    public function testStateCountsAreIndependent(): void
+    #[TestDox('The per-request cache serves the cached value until reset')]
+    public function testCountIsCachedPerRequest(): void
     {
-        // Each state is a distinct, separately-cached query; their sum cannot
-        // exceed the non-trashed total (which excludes only state -2).
-        $published   = CwmcountHelper::getCountByState('#__bsms_studies', 1);
-        $unpublished = CwmcountHelper::getCountByState('#__bsms_studies', 0);
-        $archived    = CwmcountHelper::getCountByState('#__bsms_studies', 2);
-        $total       = CwmcountHelper::getTotalCount('#__bsms_studies');
+        $before = CwmcountHelper::getCountByState('#__bsms_studies', 0);
 
-        $this->assertLessThanOrEqual(
-            $total,
-            $published + $unpublished + $archived,
-            'Sum of published/unpublished/archived must not exceed the non-trashed total'
+        $this->insertStudy(0);
+
+        // Same key, no reset: must serve the cached pre-insert value. This is
+        // the documented per-request caching contract (sendQuickIconResponse()
+        // and the cpanel stats intentionally share one query per request).
+        $this->assertSame(
+            $before,
+            CwmcountHelper::getCountByState('#__bsms_studies', 0),
+            'Without a cache reset the helper must serve the per-request cached count'
+        );
+
+        $this->resetStaticCache(CwmcountHelper::class, 'cache', []);
+
+        $this->assertSame(
+            $before + 1,
+            CwmcountHelper::getCountByState('#__bsms_studies', 0),
+            'After a cache reset the new row must be visible'
         );
     }
 }

--- a/tests/integration/Admin/Lib/CwmbackupEnhancedTest.php
+++ b/tests/integration/Admin/Lib/CwmbackupEnhancedTest.php
@@ -10,15 +10,27 @@ namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
 
 use CWM\Component\Proclaim\Administrator\Lib\Cwmbackup;
 use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
 
 /**
- * Test class for enhanced Cwmbackup functionality
+ * Test class for enhanced Cwmbackup functionality.
+ *
+ * Seeds the rows each export needs inside a rolled-back transaction so the
+ * REAL export branch is exercised in every environment. The prior version
+ * asserted disjunctively ("UPDATE or no-config comment", "DELETE or no-tasks
+ * comment or table-not-found") — on CI, which has no com_proclaim extension
+ * row and (before the ci.yml fixture) no scheduler table at all, only the
+ * fallback branches ever ran, so a regression breaking the actual export SQL
+ * on configured sites passed everywhere.
  *
  * @package  Proclaim.Tests
  * @since    10.1.0
  */
 class CwmbackupEnhancedTest extends IntegrationTestCase
 {
+    private ?DatabaseDriver $db = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -30,10 +42,89 @@ class CwmbackupEnhancedTest extends IntegrationTestCase
         if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
             $this->markTestSkipped('Database not available — configure build.properties with a Joomla path.');
         }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost — nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
     }
 
     /**
-     * Test component config export returns valid SQL
+     * Ensure a com_proclaim #__extensions row with non-empty params exists.
+     *
+     * Find-or-insert (same pattern as CwmlocationHelperFailOpenTest): the dev
+     * DB has a real row from a full install, CI's base.sql-only fixture has
+     * the table but no row. Runs inside the test transaction, so an inserted
+     * or updated row rolls back.
+     *
+     * @return  void
+     */
+    private function ensureComponentConfigRow(): void
+    {
+        $row = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName(['extension_id', 'params']))
+                ->from($this->db->quoteName('#__extensions'))
+                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
+                ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'))
+        )->loadObject();
+
+        if ($row === null) {
+            $extRow = (object) [
+                'name'           => 'com_proclaim',
+                'type'           => 'component',
+                'element'        => 'com_proclaim',
+                'folder'         => '',
+                'client_id'      => 1,
+                'enabled'        => 1,
+                'manifest_cache' => '',
+                'params'         => '{"backup_fixture":"1"}',
+                'custom_data'    => '',
+            ];
+            $this->db->insertObject('#__extensions', $extRow);
+
+            return;
+        }
+
+        if (empty($row->params)) {
+            $update               = new \stdClass();
+            $update->extension_id = (int) $row->extension_id;
+            $update->params       = '{"backup_fixture":"1"}';
+            $this->db->updateObject('#__extensions', $update, 'extension_id');
+        }
+    }
+
+    /**
+     * Insert a proclaim.% scheduler task row for the export to find.
+     *
+     * @return  void
+     */
+    private function insertProclaimTask(): void
+    {
+        $row = (object) [
+            'title'   => 'Backup Fixture Task',
+            'type'    => 'proclaim.backupfixture',
+            'state'   => 0,
+            'params'  => '{}',
+            'created' => '2026-01-15 10:00:00',
+        ];
+
+        $this->db->insertObject('#__scheduler_tasks', $row);
+    }
+
+    /**
+     * Test component config export returns the real UPDATE statement.
      *
      * @return void
      *
@@ -41,20 +132,31 @@ class CwmbackupEnhancedTest extends IntegrationTestCase
      */
     public function testGetComponentConfigExportReturnsValidSQL(): void
     {
+        $this->ensureComponentConfigRow();
+
         $backup = new Cwmbackup();
         $result = $backup->getComponentConfigExport();
 
         $this->assertIsString($result);
         $this->assertStringContainsString('Component Configuration', $result);
 
-        $this->assertTrue(
-            str_contains($result, 'UPDATE') || str_contains($result, 'No component configuration found'),
-            'Result should contain UPDATE statement or no-config comment'
+        // With a config row guaranteed present, the export must take the
+        // real branch — an UPDATE that restores the params on import.
+        $this->assertStringContainsString('UPDATE', $result, 'A present config row must produce an UPDATE statement');
+        $this->assertStringContainsString(
+            "'com_proclaim'",
+            $result,
+            'The UPDATE must target the com_proclaim extension row'
+        );
+        $this->assertStringNotContainsString(
+            'No component configuration found',
+            $result,
+            'The no-config fallback must not fire when a config row exists'
         );
     }
 
     /**
-     * Test scheduled tasks export returns valid SQL
+     * Test scheduled tasks export returns the real DELETE + INSERT statements.
      *
      * @return void
      *
@@ -62,17 +164,35 @@ class CwmbackupEnhancedTest extends IntegrationTestCase
      */
     public function testGetScheduledTasksExportReturnsValidSQL(): void
     {
+        // CI creates #__scheduler_tasks explicitly (ci.yml fixture step); a
+        // missing table here is an environment bug, not an acceptable branch.
+        $this->assertContains(
+            $this->db->getPrefix() . 'scheduler_tasks',
+            $this->db->getTableList(),
+            '#__scheduler_tasks must exist in the test DB — check the CI schema fixture step'
+        );
+
+        $this->insertProclaimTask();
+
         $backup = new Cwmbackup();
         $result = $backup->getScheduledTasksExport();
 
         $this->assertIsString($result);
         $this->assertStringContainsString('Scheduled Tasks', $result);
 
-        $this->assertTrue(
-            str_contains($result, 'DELETE') ||
-            str_contains($result, 'No scheduled tasks found') ||
-            str_contains($result, 'table not found'),
-            'Result should contain DELETE statement or appropriate comment'
+        // With a proclaim.% task guaranteed present, the export must take the
+        // real branch: clean-slate DELETE plus an INSERT per task.
+        $this->assertStringContainsString('DELETE FROM', $result, 'A present task must produce the clean-slate DELETE');
+        $this->assertStringContainsString('INSERT INTO', $result, 'A present task must produce an INSERT');
+        $this->assertStringContainsString(
+            'proclaim.backupfixture',
+            $result,
+            "The seeded task's type must appear in the INSERT"
+        );
+        $this->assertStringNotContainsString(
+            'No scheduled tasks found',
+            $result,
+            'The no-tasks fallback must not fire when a proclaim task exists'
         );
     }
 

--- a/tests/integration/Site/Model/CwmsermonsModuleStateTest.php
+++ b/tests/integration/Site/Model/CwmsermonsModuleStateTest.php
@@ -36,6 +36,69 @@ use PHPUnit\Framework\Attributes\TestDox;
 class CwmsermonsModuleStateTest extends IntegrationTestCase
 {
     /**
+     * @var  \Joomla\Database\DatabaseDriver|null
+     */
+    private ?\Joomla\Database\DatabaseDriver $db = null;
+
+    /**
+     * Open a transaction so seeded studies roll back.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Live database/container not available for model integration test.');
+        }
+
+        $this->db = Factory::getContainer()->get(\Joomla\Database\DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost — nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Insert a published, publicly-visible study the module query will match.
+     *
+     * @return  void
+     */
+    private function insertPublishedStudy(): void
+    {
+        $row = (object) [
+            'studytitle'  => 'Module Fixture ' . uniqid('', true),
+            'alias'       => 'module-fixture-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'teacher_id'  => 0,
+            'series_id'   => 0,
+            'messagetype' => 1,
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'params'      => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+    }
+
+    /**
      * Build a real CwmsermonsModel through a component MVCFactory.
      *
      * bootComponent() falls back to a LegacyComponent/LegacyFactory in the test
@@ -209,10 +272,24 @@ class CwmsermonsModuleStateTest extends IntegrationTestCase
     #[TestDox('Empty-string filter params return the same items as no filters (regression)')]
     public function testEmptyParamsDoNotFilterEverythingOut(): void
     {
+        // Seed rows the module query matches. Without this, CI's empty
+        // database made both counts 0 and 0 == 0 stayed green even with the
+        // guarded bug present ([""] filtering out every sermon) — the test
+        // was vacuous exactly where it mattered.
+        $this->insertPublishedStudy();
+        $this->insertPublishedStudy();
+        $this->insertPublishedStudy();
+
         // Baseline: no filter params at all.
         $baseline = $this->createModel();
         $baseline->setModuleState($this->moduleParams());
         $baselineCount = \count($this->items($baseline));
+
+        $this->assertGreaterThan(
+            0,
+            $baselineCount,
+            'Baseline must see the seeded studies — a zero baseline makes the comparison below vacuous'
+        );
 
         // Same request, but every dropdown unset as [""] — the bug condition.
         $empty = $this->createModel();


### PR DESCRIPTION
## Summary

Fixes the three tests deferred from the correctness pass (#1596) — each passed trivially on CI's empty database, where the regression it guards produced the same observable result (zero) as correct behavior.

1. **`CwmcountHelperTest`** — was invariant-only (`>= 0`, subset-of-total) with no fixture; `0 <= 0` held even if `getCountByState()` ignored `$state` entirely. Now seeds studies in every published state inside a rolled-back transaction and asserts **exact baseline-relative deltas** per state (works identically on the row-having dev DB and empty CI). **Mutation-verified**: making the state predicate ignore `$state` fails the new test and passed the old one. Also pins the per-request cache contract.

2. **`CwmsermonsModuleStateTest`** — the `[""]`-params regression test compared baseline vs empty-params item counts, both 0 in CI, so the guarded bug (unset module dropdowns filtering out every sermon) was invisible there. Now seeds three published studies and asserts the baseline is non-zero before comparing.

3. **`CwmbackupEnhancedTest`** — disjunctive assertions ("UPDATE **or** no-config comment"; "DELETE **or** no-tasks **or** table-not-found") meant CI only ever exercised the fallback branches; the real export SQL could break on every configured site undetected. Now find-or-inserts a `com_proclaim` `#__extensions` row (same pattern as `CwmlocationHelperFailOpenTest`) and seeds a `proclaim.%` scheduler task inside the transaction, then **requires** the real branch and explicitly forbids the fallback comments. Mutation-verified on the task-query predicate.

## CI fixture change

`#__scheduler_tasks` is created alongside `#__schemaorg` in both jobs' fixture step (it lives in Joomla core's `extensions.sql`, which CI doesn't import). Its absence in CI was itself the reason the "table not found" fallback was the only branch that ever ran there — the test now treats a missing table as an environment bug rather than an acceptable outcome.

## Test plan

- [x] Full suite green locally: 1374 tests, 2762 assertions
- [x] Two mutation spot-checks red→green (state-ignoring count predicate; task-query predicate)
- [x] `php-cs-fixer` clean
- [x] All seeding is transaction-scoped DML — nothing persists in either environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL