### PR TITLE
build: raise Node floor and CI runners to 24 (active LTS; 20 is EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install npm dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install npm dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
 
       - name: Install npm dependencies and build assets

--- a/.github/workflows/vendor-check.yml
+++ b/.github/workflows/vendor-check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install root deps
         run: |

--- a/.github/workflows/vendor-check.yml
+++ b/.github/workflows/vendor-check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install root deps
         run: |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Joomla-Bible-Study/Proclaim.git"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Joomla-Bible-Study/Proclaim.git"
   },
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.0.0",
     "npm": ">=10.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Node 20 reached end-of-life on 2026-04-30, so `package.json`'s `engines.node >= 20.0.0` was advertising support for an unsupported runtime — and two CI workflows (`ci.yml`'s JS job, `vendor-check.yml`) were still running on it.

Rather than stopping at the maintenance LTS (22), this goes straight to **Node 24, the current Active LTS** (LTS since October 2025, maintenance until April 2028 — a year longer than 22). The `engines` field only gates the dev/build toolchain, so there's no downstream-compatibility audience served by a lower floor.

- `engines.node`: `>=20.0.0` → `>=24.0.0`
- `ci.yml`, `vendor-check.yml`: `node-version: '20'` → `'24'`
- `e2e.yml`: `'22'` → `'24'` (consistency — every workflow on the same LTS)
- `engines.npm >= 10.1.0` unchanged (Node 24 ships npm 11.x, which satisfies it)

These were the only Node-version references in the repo (no `.nvmrc`, no doc mentions).

## Test plan

- [x] `npm test` green locally (232 Jest tests)
- [x] package.json and all three workflows validate
- [x] CI on this PR runs the JS job on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL