### PR TITLE
fix: Cwmuploadscript upload() unreachable via type mismatch, Legal Extensions ignored

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -309,13 +309,13 @@ abstract class CWMAddon
     /**
      * Upload
      *
-     * @param ?array $data Data to upload
+     * @param   Input  $data Data to upload
      *
      * @return mixed
      *
      * @since 9.0.0
      */
-    abstract protected function upload(?array $data): mixed;
+    abstract protected function upload(Input $data): mixed;
 
     /**
      * Get available AJAX actions for this addon

--- a/admin/src/Addons/Servers/Article/CWMAddonArticle.php
+++ b/admin/src/Addons/Servers/Article/CWMAddonArticle.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Article;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use Joomla\Input\Input;
 
 /**
  * Article Server Addon
@@ -158,7 +159,7 @@ class CWMAddonArticle extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         return false;
     }

--- a/admin/src/Addons/Servers/Dailymotion/CWMAddonDailymotion.php
+++ b/admin/src/Addons/Servers/Dailymotion/CWMAddonDailymotion.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Dailymotion;
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -356,7 +357,7 @@ class CWMAddonDailymotion extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Dailymotion videos are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
+++ b/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
@@ -21,6 +21,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmuploadscript;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -50,14 +51,14 @@ class CWMAddonDirect extends CWMAddon
     /**
      * Upload
      *
-     * @param ?array $data  Data to upload
+     * @param   Input  $data  Data to upload
      *
      * @return array
      *
      * @throws \Exception
      * @since 10.1.0
      */
-    public function upload(?array $data): array
+    public function upload(Input $data): array
     {
         return (new Cwmuploadscript())->upload($data);
     }

--- a/admin/src/Addons/Servers/Docman/CWMAddonDocman.php
+++ b/admin/src/Addons/Servers/Docman/CWMAddonDocman.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Docman;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use Joomla\Input\Input;
 
 /**
  * DOCman Server Addon
@@ -158,7 +159,7 @@ class CWMAddonDocman extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         return false;
     }

--- a/admin/src/Addons/Servers/Embed/CWMAddonEmbed.php
+++ b/admin/src/Addons/Servers/Embed/CWMAddonEmbed.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Embed;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use Joomla\Input\Input;
 
 /**
  * Embed Server Addon
@@ -135,7 +136,7 @@ class CWMAddonEmbed extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Embed codes are entered directly, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Facebook/CWMAddonFacebook.php
+++ b/admin/src/Addons/Servers/Facebook/CWMAddonFacebook.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Facebook;
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -356,7 +357,7 @@ class CWMAddonFacebook extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         return false;
     }

--- a/admin/src/Addons/Servers/Googledrive/CWMAddonGoogledrive.php
+++ b/admin/src/Addons/Servers/Googledrive/CWMAddonGoogledrive.php
@@ -20,6 +20,7 @@ use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -311,7 +312,7 @@ class CWMAddonGoogledrive extends CWMAddon
      *
      * @since   10.2.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Google Drive files are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
+++ b/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
@@ -22,6 +22,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmuploadscript;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -54,14 +55,14 @@ class CWMAddonLegacy extends CWMAddon
     /**
      * Upload
      *
-     * @param ?array $data  Data to upload
+     * @param   Input  $data  Data to upload
      *
      * @return array
      *
      * @throws \Exception
      * @since 9.0.0
      */
-    public function upload(?array $data): array
+    public function upload(Input $data): array
     {
         return (new Cwmuploadscript())->upload($data);
     }

--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -56,14 +57,14 @@ class CWMAddonLocal extends CWMAddon
     /**
      * Upload
      *
-     * @param ?array $data  Data to upload
+     * @param   Input  $data  Data to upload
      *
      * @return array
      *
      * @throws \Exception
      * @since 9.0.0
      */
-    public function upload(?array $data): array
+    public function upload(Input $data): array
     {
         return (new Cwmuploadscript())->upload($data);
     }

--- a/admin/src/Addons/Servers/Resi/CWMAddonResi.php
+++ b/admin/src/Addons/Servers/Resi/CWMAddonResi.php
@@ -21,6 +21,7 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -641,7 +642,7 @@ class CWMAddonResi extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Resi.io videos are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Rumble/CWMAddonRumble.php
+++ b/admin/src/Addons/Servers/Rumble/CWMAddonRumble.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Rumble;
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -341,7 +342,7 @@ class CWMAddonRumble extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Rumble videos are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Soundcloud/CWMAddonSoundcloud.php
+++ b/admin/src/Addons/Servers/Soundcloud/CWMAddonSoundcloud.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Soundcloud;
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Helper\CwmserverMigrationHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
 /**
@@ -345,7 +346,7 @@ class CWMAddonSoundcloud extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         return false;
     }

--- a/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
+++ b/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
@@ -1163,7 +1163,7 @@ class CWMAddonVimeo extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Vimeo videos are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Virtuemart/CWMAddonVirtuemart.php
+++ b/admin/src/Addons/Servers/Virtuemart/CWMAddonVirtuemart.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Addons\Servers\Virtuemart;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use Joomla\Input\Input;
 
 /**
  * VirtueMart Server Addon
@@ -158,7 +159,7 @@ class CWMAddonVirtuemart extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         return false;
     }

--- a/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
+++ b/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
@@ -965,7 +965,7 @@ class CWMAddonWistia extends CWMAddon
      *
      * @since   10.1.0
      */
-    protected function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Wistia videos are referenced by URL, not uploaded
         return false;

--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -77,13 +77,13 @@ class CWMAddonYoutube extends CWMAddon
     /**
      * Upload
      *
-     * @param ?array $data  Data to upload
+     * @param   Input  $data  Data to upload
      *
      * @return array
      *
      * @since 9.0.0
      */
-    public function upload(?array $data): mixed
+    protected function upload(Input $data): mixed
     {
         // Holds for nothing
         return $data;

--- a/admin/src/Helper/Cwmuploadscript.php
+++ b/admin/src/Helper/Cwmuploadscript.php
@@ -25,6 +25,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
 use Joomla\Input\Input;
+use Joomla\Registry\Registry;
 
 /**
  * Class UploadScript
@@ -46,14 +47,21 @@ class Cwmuploadscript
     /**
      * Upload media files
      *
-     * @param   Input|array  $data  Data to upload
+     * Reached through CwmmediafileController::xhr(), which passes the request
+     * Input object straight through to the addon's upload(). The declared type
+     * was previously an untyped `$data` documented as `Input|array`, while the
+     * body only ever used the Input API -- and the addon overrides declared
+     * `?array`, so every call raised a TypeError before this method was even
+     * entered. Typed to what is actually passed and actually used. See #1564.
+     *
+     * @param   Input  $data  Request input carrying the upload target path
      *
      * @return array
      *
      * @throws \Exception
      * @since 9.0.0
      */
-    public function upload($data): array
+    public function upload(Input $data): array
     {
         Session::checkToken('get') or die('Invalid Token');
         $params = ComponentHelper::getParams('com_proclaim');
@@ -108,6 +116,8 @@ class Cwmuploadscript
         PluginHelper::importPlugin('content');
         $app = Factory::getApplication();
 
+        self::applyConfiguredExtensions($params);
+
         if (!$mediaHelper->canUpload($file, 'com_proclaim')) {
             // The file can't be uploaded
             return ['data' => '', 'error' => 'The file can\'t be uploaded by types allowed'];
@@ -136,6 +146,40 @@ class Cwmuploadscript
                 'size'     => $_FILES['file']['size'],
             ],
         ];
+    }
+
+    /**
+     * Make the admin's configured "Legal Extensions" the list actually enforced.
+     *
+     * MediaHelper::canUpload() reads its extension allow-list from
+     * `restrict_uploads_extensions` (com_media's key name), which
+     * com_proclaim's config.xml never defines -- it defines `upload_extensions`
+     * instead. Registry::get() therefore fell back to Joomla's hardcoded
+     * default list every time, so the admin's setting was silently ignored:
+     * adding e.g. `vtt` to "Legal Extensions" still got the upload rejected,
+     * with no way to fix it from the UI.
+     *
+     * canUpload() re-reads the params internally via
+     * ComponentHelper::getParams('com_proclaim'), which returns this same
+     * cached Registry instance, so setting the key here is observed by it.
+     *
+     * Copied only when non-empty -- an empty list would make canUpload()
+     * reject every file, which is worse than falling back to Joomla's
+     * defaults (the pre-fix behaviour).
+     *
+     * @param   Registry  $params  com_proclaim's params (the shared instance)
+     *
+     * @return  void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    protected static function applyConfiguredExtensions(Registry $params): void
+    {
+        $legalExtensions = trim((string) $params->get('upload_extensions', ''));
+
+        if ($legalExtensions !== '') {
+            $params->set('restrict_uploads_extensions', $legalExtensions);
+        }
     }
 
     /**

--- a/tests/integration/Admin/Addons/CwmliveEventTest.php
+++ b/tests/integration/Admin/Addons/CwmliveEventTest.php
@@ -316,7 +316,7 @@ class CwmliveEventTest extends IntegrationTestCase
                 return '';
             }
 
-            protected function upload(?array $data): mixed
+            protected function upload(\Joomla\Input\Input $data): mixed
             {
                 return null;
             }

--- a/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
+++ b/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
@@ -350,7 +350,7 @@ class CwmplaylistMembershipPushTest extends IntegrationTestCase
                 return '';
             }
 
-            protected function upload(?array $data): mixed
+            protected function upload(\Joomla\Input\Input $data): mixed
             {
                 return null;
             }

--- a/tests/unit/Admin/Helper/CwmuploadscriptTest.php
+++ b/tests/unit/Admin/Helper/CwmuploadscriptTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Unit tests for Cwmuploadscript and the addon upload() contract.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Administrator\Helper\Cwmuploadscript;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\Input\Input;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression coverage for #1564.
+ *
+ * 1. CwmmediafileController::xhr() dispatches `$addon->$handler($input)` with a
+ *    Joomla\Input\Input object, but CWMAddon::upload() and all 16 overrides
+ *    declared `?array $data`. `handler=upload` passed method_exists(), then PHP
+ *    threw an uncaught TypeError before Cwmuploadscript::upload() was entered --
+ *    every validation inside it (size limits, canUpload(), File::upload()) was
+ *    dead code, and the endpoint returned a crash instead of the JSON xhr()
+ *    promises.
+ *
+ * 2. The admin's "Legal Extensions" setting (`upload_extensions`) was never
+ *    enforced: MediaHelper::canUpload() reads `restrict_uploads_extensions`,
+ *    a key com_proclaim's config.xml does not define, so Registry::get()
+ *    always fell through to Joomla's hardcoded default list.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmuploadscriptTest extends ProclaimTestCase
+{
+    // -------------------------------------------------------------------------
+    // Finding 1 -- the upload() type contract
+    // -------------------------------------------------------------------------
+
+    /**
+     * Every addon that ships an upload() override, plus the abstract base.
+     *
+     * @return array<string, array{0: class-string}>
+     */
+    public static function addonClassProvider(): array
+    {
+        $base    = \dirname(__DIR__, 4) . '/admin/src/Addons/Servers';
+        $classes = ['CWMAddon (base)' => [CWMAddon::class]];
+
+        foreach (glob($base . '/*/CWMAddon*.php') as $file) {
+            $server = basename(\dirname($file));
+            $short  = basename($file, '.php');
+
+            $classes[$short] = [
+                'CWM\\Component\\Proclaim\\Administrator\\Addons\\Servers\\' . $server . '\\' . $short,
+            ];
+        }
+
+        return $classes;
+    }
+
+    /**
+     * The dispatcher hands upload() an Input object. Any override drifting back
+     * to `?array` (or any other non-Input type) reintroduces the fatal
+     * TypeError, so pin the declared type on every implementation.
+     *
+     * @param   class-string  $class  Addon class under test
+     */
+    #[DataProvider('addonClassProvider')]
+    public function testUploadAcceptsAnInputObject(string $class): void
+    {
+        $method = new \ReflectionMethod($class, 'upload');
+        $params = $method->getParameters();
+
+        $this->assertCount(1, $params, $class . '::upload() must take exactly one parameter');
+
+        $type = $params[0]->getType();
+
+        $this->assertNotNull($type, $class . '::upload() must declare its parameter type');
+        $this->assertSame(
+            Input::class,
+            (string) $type,
+            $class . '::upload() must accept the Input object xhr() actually passes — see #1564'
+        );
+        $this->assertFalse(
+            $type->allowsNull(),
+            $class . '::upload() is always passed an Input; a nullable type invites the old ?array shape back'
+        );
+    }
+
+    /**
+     * Cwmuploadscript is the shared implementation the three real handlers
+     * delegate to, and its body only ever uses the Input API.
+     */
+    public function testCwmuploadscriptUploadAcceptsAnInputObject(): void
+    {
+        $method = new \ReflectionMethod(Cwmuploadscript::class, 'upload');
+        $type   = $method->getParameters()[0]->getType();
+
+        $this->assertNotNull($type, 'Cwmuploadscript::upload() must declare its parameter type');
+        $this->assertSame(Input::class, (string) $type);
+    }
+
+    /**
+     * xhr() reaches any *public* addon method by name, so the public upload()
+     * surface must be exactly the three addons that genuinely accept uploads.
+     * Everything else is a `return false;` stub that has no business being
+     * callable from the generic dispatcher.
+     */
+    public function testOnlyRealUploadHandlersArePublic(): void
+    {
+        $public = [];
+
+        foreach (self::addonClassProvider() as $row) {
+            $class = $row[0];
+
+            if ((new \ReflectionMethod($class, 'upload'))->isPublic()) {
+                $public[] = (new \ReflectionClass($class))->getShortName();
+            }
+        }
+
+        sort($public);
+
+        $this->assertSame(
+            ['CWMAddonDirect', 'CWMAddonLegacy', 'CWMAddonLocal'],
+            $public,
+            'Only the addons that actually perform uploads may expose upload() publicly — see #1564'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- the configured extension list is what gets enforced
+    // -------------------------------------------------------------------------
+
+    /**
+     * Invoke the protected copy helper.
+     *
+     * @param   Registry  $params  Params to mutate
+     *
+     * @return  void
+     */
+    private function applyConfiguredExtensions(Registry $params): void
+    {
+        $method = new \ReflectionMethod(Cwmuploadscript::class, 'applyConfiguredExtensions');
+        $method->invoke(null, $params);
+    }
+
+    /**
+     * The admin's configured list must land on the key MediaHelper reads.
+     */
+    public function testConfiguredLegalExtensionsBecomeTheEnforcedList(): void
+    {
+        $params = new Registry(['upload_extensions' => 'vtt,mp3,mp4']);
+
+        $this->assertNull(
+            $params->get('restrict_uploads_extensions'),
+            'Precondition: com_proclaim does not define the key MediaHelper reads'
+        );
+
+        $this->applyConfiguredExtensions($params);
+
+        $this->assertSame(
+            'vtt,mp3,mp4',
+            $params->get('restrict_uploads_extensions'),
+            "The admin's Legal Extensions must be the list canUpload() enforces — see #1564"
+        );
+    }
+
+    /**
+     * Surrounding whitespace must not defeat the non-empty guard, and must not
+     * reach the allow-list as a leading empty element.
+     */
+    public function testWhitespaceOnlyValueIsTreatedAsUnset(): void
+    {
+        $params = new Registry(['upload_extensions' => '   ']);
+
+        $this->applyConfiguredExtensions($params);
+
+        $this->assertNull(
+            $params->get('restrict_uploads_extensions'),
+            'A whitespace-only list must fall back to Joomla defaults, not be copied through'
+        );
+    }
+
+    /**
+     * An empty/absent setting must leave the key unset so Joomla's default list
+     * applies. Writing '' would make canUpload() reject every file — a worse
+     * failure than the bug being fixed.
+     */
+    #[DataProvider('emptyExtensionProvider')]
+    public function testEmptyConfigurationFallsBackToJoomlaDefaults(array $config): void
+    {
+        $params = new Registry($config);
+
+        $this->applyConfiguredExtensions($params);
+
+        $this->assertNull(
+            $params->get('restrict_uploads_extensions'),
+            'An empty Legal Extensions setting must not be copied through — it would reject every upload'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: array}>
+     */
+    public static function emptyExtensionProvider(): array
+    {
+        return [
+            'key absent'   => [[]],
+            'empty string' => [['upload_extensions' => '']],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1564. Both findings verified against source before implementing — the issue text was partly stale (`Cwmuploadscript::upload()` was untyped `$data`, not `?array` as written; the mismatch actually lived in the addon overrides), and the affected signature set was wider than the issue's "three callers".

### 1. The entire upload feature was dead code

`CwmmediafileController::xhr()` dispatches `$addon->$handler($input)` with a `Joomla\Input\Input` object, but `CWMAddon::upload()` and **all 16** addon overrides declared `?array $data`. `handler=upload` passed `method_exists()`, then PHP threw an uncaught `TypeError` before `Cwmuploadscript::upload()` was ever entered — so every check inside it (post/memory size limits, `upload_maxsize`, `makeSafe()`, `canUpload()`, the `onContentBeforeSave` hook, `File::upload()`) never ran.

Retyped to `Input` on the base, all 16 overrides, and `Cwmuploadscript::upload()` itself. **Verified at runtime rather than by lint**: every addon class now autoloads cleanly, which is what actually proves parameter covariance — an incompatible override is a fatal at class-declaration time, and `php -l` cannot see it. Two test doubles implement the same contract and were updated in step (the suite caught them as a hard fatal).

`CWMAddonYoutube::upload()` was a public `return $data;` stub — made `protected` to match the 12 other no-op stubs, since public methods are reachable by name through the generic dispatcher and this one does nothing.

### 2. The admin's "Legal Extensions" setting was silently ignored

`MediaHelper::canUpload()` reads `restrict_uploads_extensions` (com_media's key name), which com_proclaim's config.xml never defines — it defines `upload_extensions`. **Confirmed empirically**: `upload_extensions` is populated while `restrict_uploads_extensions` reads `NULL`, so Joomla's hardcoded default list was always what got enforced. An admin adding `vtt` still got the upload rejected with no way to fix it from the UI.

Fixed by copying the configured value onto the key `canUpload()` reads, in a new testable `applyConfiguredExtensions()` seam. **Confirmed the mechanism is actually observed** — `ComponentHelper::getParams()` memoizes one Registry per component and `canUpload()` re-reads through it, so the `set()` is seen; checked empirically rather than assumed, since a `set()` the callee ignored would look fixed and do nothing.

Deliberately a **copy, not a config.xml rename**: renaming the field would silently reset every existing site's configured value to the new default on upgrade. Only copied when non-empty — writing `''` would make `canUpload()` reject every file, worse than the bug being fixed.

## Filed separately: #1599

While tracing the dispatcher I found `xhr()` invokes **any public method on any addon** by request-supplied name, with **no permission check** (only a CSRF token). Several are state-changing and take `Input`, so they *execute* — including `CWMAddonYoutube::createLiveEvent()` and `cancelLiveEvent()` on the site's connected account. Filed as #1599 rather than expanded into this PR: the fix is an allow-list rewrite of the dispatcher (the codebase already has the right pattern in `handleAjaxAction()`/`getAjaxActions()`) plus an ACL gate, with its own blast radius. Notably this is *why* finding 1 was fixed by retyping the signatures rather than by normalising `Input`→array in `xhr()` — the latter would widen what the unbounded dispatcher can feed every handler.

## Known remaining gap (not in scope)

`upload_mime`/`upload_mime_illegal` and `image_extensions` are likewise Proclaim-only keys that `canUpload()` never reads, so those config fields remain decorative on this path.

## Test plan

- [x] New `CwmuploadscriptTest` (23 tests): data-provider pins the `Input` parameter type on the base + all 16 overrides, asserts the public `upload()` surface is exactly the three real handlers, and covers the extension-copy behaviour incl. empty/whitespace fallback
- [x] Confirmed red→green: against pre-fix source the type tests fail across every addon and the extension tests error on the missing method
- [x] Full suite green: 1397 tests, 2838 assertions
- [x] `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL