### PR TITLE
fix: restrict cwmmediafile.xhr to an addon allow-list and require edit/create

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -318,6 +318,34 @@ abstract class CWMAddon
     abstract protected function upload(Input $data): mixed;
 
     /**
+     * Handler names this addon exposes to CwmmediafileController::xhr().
+     *
+     * xhr() is a generic dispatcher: it takes a `handler` name straight from
+     * the request and invokes it on the resolved addon, passing the request
+     * Input. It previously gated only on method_exists(), which made every
+     * public method on every addon callable by name -- including
+     * state-changing ones such as createLiveEvent()/cancelLiveEvent(), and
+     * with no permission check at all (see #1599).
+     *
+     * Returning an empty list here means an addon exposes nothing: an addon
+     * must opt each handler in explicitly. This mirrors getAjaxActions(),
+     * which already guards the other (handleAjaxAction) dispatch path.
+     *
+     * Only list handlers a UI actually calls through xhr(). Methods invoked
+     * server-side -- createLiveEvent() from CwmmediafileModel, cancelLiveEvent()
+     * from CwmmediafileTable -- are called directly on the addon object and do
+     * not need, and must not have, dispatcher exposure.
+     *
+     * @return  array  List of handler names callable via cwmmediafile.xhr
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [];
+    }
+
+    /**
      * Get available AJAX actions for this addon
      *
      * Override in child classes to register available AJAX actions.

--- a/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
+++ b/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
@@ -49,6 +49,20 @@ class CWMAddonDirect extends CWMAddon
     protected $description = 'Direct link server for URL-based media files.';
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'upload',
+        ];
+    }
+
+    /**
      * Upload
      *
      * @param   Input  $data  Data to upload

--- a/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
+++ b/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
@@ -53,6 +53,20 @@ class CWMAddonLegacy extends CWMAddon
     protected $description = 'Legacy Server that we brought over from 8.x.x version of proclaim';
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'upload',
+        ];
+    }
+
+    /**
      * Upload
      *
      * @param   Input  $data  Data to upload

--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -55,6 +55,20 @@ class CWMAddonLocal extends CWMAddon
     protected $description = 'Used for local server files';
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'upload',
+        ];
+    }
+
+    /**
      * Upload
      *
      * @param   Input  $data  Data to upload

--- a/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
+++ b/admin/src/Addons/Servers/Vimeo/CWMAddonVimeo.php
@@ -54,6 +54,24 @@ class CWMAddonVimeo extends CWMAddon
     protected $description = 'Used for Vimeo server access';
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by addon-vimeo-browser.es6.js (fetchFolders, fetchVideos, getMetadata)
+     * plus playlist-picker.es6.js (fetchRemotePlaylists).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'fetchFolders',
+            'fetchRemotePlaylists',
+            'fetchVideos',
+            'getMetadata',
+        ];
+    }
+
+    /**
      * URL patterns that identify Vimeo content.
      *
      * @return  string[]

--- a/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
+++ b/admin/src/Addons/Servers/Wistia/CWMAddonWistia.php
@@ -54,6 +54,22 @@ class CWMAddonWistia extends CWMAddon
     protected $description = 'Used for Wistia server access';
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by addon-wistia-browser.es6.js (fetchProjects, fetchVideos, getMetadata).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'fetchProjects',
+            'fetchVideos',
+            'getMetadata',
+        ];
+    }
+
+    /**
      * URL patterns that identify Wistia content.
      *
      * @return  string[]

--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -90,6 +90,28 @@ class CWMAddonYoutube extends CWMAddon
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Called through cwmmediafile.xhr by addon-youtube-browser.es6.js (fetchChannelPlaylists, and the \${handler}
+     * variable resolving to fetchChannelVideos/searchChannelVideos/
+     * fetchPlaylistVideos/fetchLiveVideos) plus playlist-picker.es6.js
+     * (fetchRemotePlaylists).
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getXhrHandlers(): array
+    {
+        return [
+            'fetchChannelPlaylists',
+            'fetchChannelVideos',
+            'fetchLiveVideos',
+            'fetchPlaylistVideos',
+            'fetchRemotePlaylists',
+            'searchChannelVideos',
+        ];
+    }
+
+    /**
      * Render Fields for a general view.
      *
      * @param   object  $media_form  Medea files form

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -148,22 +148,45 @@ class CwmmediafileController extends FormController
 
             return;
         }
-        $input = Factory::getApplication()->getInput();
+        $app = Factory::getApplication();
+
+        // Every UI that reaches this endpoint is a form field rendered on an
+        // edit/create screen (PlaylistPickerField, the Youtube/Vimeo/Wistia
+        // browse buttons), so require the matching permission. Previously the
+        // only gate was the CSRF token, which any authenticated backend user
+        // with com_proclaim access already has -- letting them invoke
+        // state-changing addon methods they were never granted rights to.
+        // See #1599.
+        $user = $app->getIdentity();
+
+        if (!$user || (!$user->authorise('core.edit', 'com_proclaim') && !$user->authorise('core.create', 'com_proclaim'))) {
+            throw new \RuntimeException(Text::_('JERROR_ALERTNOAUTHOR'), 403);
+        }
+
+        $input = $app->getInput();
 
         $addonType = $input->get('type', 'Legacy', 'string');
-        $handler   = $input->get('handler');
+        $handler   = (string) $input->get('handler', '', 'cmd');
 
         // Load the addon
         $addon = CWMAddon::getInstance($addonType);
 
-        if (method_exists($addon, $handler)) {
-            echo json_encode($addon->$handler($input), JSON_THROW_ON_ERROR);
-
-            $app = Factory::getApplication();
-            $app->close();
-        } else {
-            throw new \RuntimeException(Text::sprintf('Handler: "%s" does not exist!', htmlspecialchars($handler, ENT_QUOTES, 'UTF-8')), 404);
+        // Dispatch only to handlers the addon explicitly opted in. The old
+        // method_exists() check made every public method on every addon
+        // callable by request-supplied name -- including createLiveEvent()
+        // and cancelLiveEvent(), which act on the connected platform account.
+        // Those are invoked server-side (CwmmediafileModel/CwmmediafileTable)
+        // and deliberately stay off the allow-list. See #1599.
+        if (!\in_array($handler, $addon->getXhrHandlers(), true) || !method_exists($addon, $handler)) {
+            throw new \RuntimeException(
+                Text::sprintf('Handler: "%s" does not exist!', htmlspecialchars($handler, ENT_QUOTES, 'UTF-8')),
+                404
+            );
         }
+
+        echo json_encode($addon->$handler($input), JSON_THROW_ON_ERROR);
+
+        $app->close();
     }
 
     /**

--- a/tests/unit/Admin/Controller/CwmmediafileXhrDispatchTest.php
+++ b/tests/unit/Admin/Controller/CwmmediafileXhrDispatchTest.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * Unit tests for the cwmmediafile.xhr dispatch allow-list.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Controller;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Administrator\Controller\CwmmediafileController;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Regression coverage for #1599.
+ *
+ * CwmmediafileController::xhr() took a `handler` name straight from the request
+ * and invoked it on the resolved addon after only a method_exists() check, with
+ * no permission check beyond the CSRF token. That made every public method on
+ * every addon callable by name -- including CWMAddonYoutube::createLiveEvent()
+ * and cancelLiveEvent(), which act on the site's connected YouTube account. Any
+ * authenticated backend user who could reach com_proclaim could cancel the
+ * organisation's live stream without holding any Proclaim edit permission.
+ *
+ * Dispatch is now restricted to handlers each addon opts into via
+ * getXhrHandlers(), and the task requires core.edit or core.create.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmediafileXhrDispatchTest extends ProclaimTestCase
+{
+    /**
+     * Every concrete addon class.
+     *
+     * @return array<string, array{0: class-string}>
+     */
+    public static function addonClassProvider(): array
+    {
+        $base    = \dirname(__DIR__, 4) . '/admin/src/Addons/Servers';
+        $classes = [];
+
+        foreach (glob($base . '/*/CWMAddon*.php') as $file) {
+            $server = basename(\dirname($file));
+            $short  = basename($file, '.php');
+
+            $classes[$short] = [
+                'CWM\\Component\\Proclaim\\Administrator\\Addons\\Servers\\' . $server . '\\' . $short,
+            ];
+        }
+
+        return $classes;
+    }
+
+    /**
+     * An addon exposes nothing unless it opts in.
+     */
+    public function testBaseAddonExposesNoHandlersByDefault(): void
+    {
+        $method = new \ReflectionMethod(CWMAddon::class, 'getXhrHandlers');
+
+        $this->assertTrue($method->isPublic(), 'getXhrHandlers() must be callable by the controller');
+
+        // CWMAddon is abstract, so assert on the declared body rather than an
+        // instance: the default must be an empty list so an addon that says
+        // nothing exposes nothing.
+        $lines = file($method->getFileName());
+        $body  = implode('', \array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+
+        $this->assertMatchesRegularExpression(
+            '/return\s*\[\s*\]\s*;/',
+            $body,
+            'The base addon must expose no xhr handlers — opting in has to be explicit — see #1599'
+        );
+    }
+
+    /**
+     * A listed handler that does not resolve to a real public method would 500
+     * on a request the allow-list claims is valid.
+     *
+     * @param   class-string  $class  Addon under test
+     */
+    #[DataProvider('addonClassProvider')]
+    public function testEveryListedHandlerResolvesToAPublicMethod(string $class): void
+    {
+        $addon    = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $handlers = $addon->getXhrHandlers();
+
+        // Most addons legitimately expose nothing; assert the shape so the
+        // test still carries an assertion rather than passing vacuously.
+        $this->assertIsArray($handlers, $class . '::getXhrHandlers() must return an array');
+
+        foreach ($handlers as $handler) {
+            $this->assertTrue(
+                method_exists($addon, $handler),
+                $class . " lists xhr handler '{$handler}' but has no such method"
+            );
+            $this->assertTrue(
+                (new \ReflectionMethod($class, $handler))->isPublic(),
+                $class . " lists xhr handler '{$handler}' but the method is not public — xhr() could not call it"
+            );
+        }
+    }
+
+    /**
+     * The exploit surface. These are invoked server-side (CwmmediafileModel and
+     * CwmmediafileTable call them directly on the addon object with their own
+     * constructed Input) and have no JS caller, so they must never be reachable
+     * by request-supplied name.
+     *
+     * @param   class-string  $class  Addon under test
+     */
+    #[DataProvider('addonClassProvider')]
+    public function testStateChangingAndInternalMethodsAreNeverExposed(string $class): void
+    {
+        $addon    = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $handlers = $addon->getXhrHandlers();
+
+        $forbiddenNames = [
+            // State-changing, act on the connected platform account.
+            'createLiveEvent',
+            'cancelLiveEvent',
+            // Dispatchers/introspection — never meant to be request-callable.
+            'handleAjaxAction',
+            'getAjaxActions',
+            'getXhrHandlers',
+            'getXml',
+        ];
+
+        foreach ($forbiddenNames as $forbidden) {
+            $this->assertNotContains(
+                $forbidden,
+                $handlers,
+                $class . " must not expose '{$forbidden}' through the generic xhr dispatcher — see #1599"
+            );
+        }
+    }
+
+    /**
+     * Handler names the shipped admin JS calls, paired with the addon that must
+     * serve them. Derived from `handler=` in build/media_source/js — a new JS
+     * caller without a matching allow-list entry would 404 at runtime.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function jsCallerProvider(): array
+    {
+        return [
+            // addon-youtube-browser.es6.js
+            'youtube fetchChannelPlaylists' => ['Youtube', 'fetchChannelPlaylists'],
+            'youtube fetchChannelVideos'    => ['Youtube', 'fetchChannelVideos'],
+            'youtube searchChannelVideos'   => ['Youtube', 'searchChannelVideos'],
+            'youtube fetchPlaylistVideos'   => ['Youtube', 'fetchPlaylistVideos'],
+            'youtube fetchLiveVideos'       => ['Youtube', 'fetchLiveVideos'],
+            // addon-vimeo-browser.es6.js
+            'vimeo fetchFolders' => ['Vimeo', 'fetchFolders'],
+            'vimeo fetchVideos'  => ['Vimeo', 'fetchVideos'],
+            'vimeo getMetadata'  => ['Vimeo', 'getMetadata'],
+            // addon-wistia-browser.es6.js
+            'wistia fetchProjects' => ['Wistia', 'fetchProjects'],
+            'wistia fetchVideos'   => ['Wistia', 'fetchVideos'],
+            'wistia getMetadata'   => ['Wistia', 'getMetadata'],
+            // playlist-picker.es6.js (type is the server type, so both)
+            'youtube fetchRemotePlaylists' => ['Youtube', 'fetchRemotePlaylists'],
+            'vimeo fetchRemotePlaylists'   => ['Vimeo', 'fetchRemotePlaylists'],
+        ];
+    }
+
+    /**
+     * @param   string  $server   Addon directory/class suffix
+     * @param   string  $handler  Handler the JS requests
+     */
+    #[DataProvider('jsCallerProvider')]
+    public function testHandlersCalledByShippedJsRemainAllowed(string $server, string $handler): void
+    {
+        $class = 'CWM\\Component\\Proclaim\\Administrator\\Addons\\Servers\\'
+            . $server . '\\CWMAddon' . $server;
+        $addon = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+
+        $this->assertContains(
+            $handler,
+            $addon->getXhrHandlers(),
+            "The admin JS calls handler={$handler} on type={$server}; removing it from the allow-list breaks that UI"
+        );
+    }
+
+    /**
+     * The upload path #1564 restored stays reachable for the three addons that
+     * implement it.
+     *
+     * @param   string  $server  Addon serving uploads
+     */
+    #[DataProvider('uploadAddonProvider')]
+    public function testUploadRemainsAllowedForRealUploadHandlers(string $server): void
+    {
+        $class = 'CWM\\Component\\Proclaim\\Administrator\\Addons\\Servers\\'
+            . $server . '\\CWMAddon' . $server;
+        $addon = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+
+        $this->assertContains('upload', $addon->getXhrHandlers(), $server . ' must still accept uploads — see #1564');
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function uploadAddonProvider(): array
+    {
+        return ['Local' => ['Local'], 'Direct' => ['Direct'], 'Legacy' => ['Legacy']];
+    }
+
+    /**
+     * xhr() must check permissions before it dispatches. A structural
+     * assertion: a live permission test would need a user/group fixture for
+     * what is a single authorise() call.
+     */
+    public function testXhrRequiresAnEditOrCreatePermission(): void
+    {
+        $ref   = new \ReflectionMethod(CwmmediafileController::class, 'xhr');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString(
+            "authorise('core.edit', 'com_proclaim')",
+            $body,
+            'xhr() must require core.edit — the CSRF token alone is not authorisation — see #1599'
+        );
+        $this->assertStringContainsString(
+            "authorise('core.create', 'com_proclaim')",
+            $body,
+            'xhr() must also accept core.create — the browse fields render on create forms too'
+        );
+
+        // The permission check has to run before dispatch, not after.
+        $this->assertLessThan(
+            strpos($body, '$addon->$handler('),
+            strpos($body, 'authorise('),
+            'The permission check must precede dispatch'
+        );
+    }
+
+    /**
+     * The dispatcher must consult the allow-list, not just method_exists().
+     */
+    public function testXhrDispatchesOnlyThroughTheAllowList(): void
+    {
+        $ref   = new \ReflectionMethod(CwmmediafileController::class, 'xhr');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString(
+            'getXhrHandlers()',
+            $body,
+            'xhr() must validate the requested handler against the addon allow-list — see #1599'
+        );
+        $this->assertLessThan(
+            strpos($body, '$addon->$handler('),
+            strpos($body, 'getXhrHandlers()'),
+            'The allow-list check must precede dispatch'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1599 — the authz gap found while fixing #1564.

`CwmmediafileController::xhr()` took the `handler` name straight from the request and invoked it on the resolved addon after only a `method_exists()` check, gated by nothing but a CSRF token. Two independent problems:

1. **Unbounded dispatch** — every public method on every addon was callable by request-supplied name. Methods whose first parameter is `Input` matched what the dispatcher passes and therefore *executed*, including `CWMAddonYoutube::createLiveEvent()` and `cancelLiveEvent()`, which act on the site's connected YouTube account.
2. **No authorisation** — the task performed no permission check at all, so any authenticated backend user who could reach com_proclaim could invoke the above regardless of their Proclaim rights. `type=Youtube&handler=cancelLiveEvent` + a token cancelled the organisation's live stream.

## Fix

New `CWMAddon::getXhrHandlers()`, returning `[]` on the base so **an addon exposes nothing unless it opts in**. `xhr()` validates against that list before dispatching and requires `core.edit` or `core.create` on com_proclaim.

This mirrors the `getAjaxActions()` allow-list that already guards the *other* dispatch path (`handleAjaxAction()`) — `xhr()` simply never used it. Deliberately **not** rerouted through `handleAjaxAction()`: that path maps action names to zero-arg `handle{Action}Action()` methods, while these are public `Input`-taking methods with different names, so rerouting would be a rewrite of ten call sites rather than a security fix.

## How the allow-lists were derived

From what the shipped admin JS actually calls (`handler=` in `build/media_source/js`), verified per addon:

| Addon | Handlers |
|---|---|
| Youtube | `fetchChannelPlaylists`, `fetchChannelVideos`, `fetchLiveVideos`, `fetchPlaylistVideos`, `fetchRemotePlaylists`, `searchChannelVideos` |
| Vimeo | `fetchFolders`, `fetchRemotePlaylists`, `fetchVideos`, `getMetadata` |
| Wistia | `fetchProjects`, `fetchVideos`, `getMetadata` |
| Local / Direct / Legacy | `upload` |

Four of YouTube's come from a `${handler}` **variable** in `addon-youtube-browser.es6.js:347-355` rather than a literal, so a naive grep of the JS under-counts them.

## Why dropping the live-event methods is safe

`createLiveEvent()`/`cancelLiveEvent()` have **no JS caller at all**. They're invoked server-side by `CwmmediafileModel:221` and `CwmmediafileTable:391`, which call them directly on the addon object with their own constructed `Input` — unaffected by a dispatcher allow-list. Verified before removing; the live-events feature (#1298) is intact.

## The `upload` decision

`upload` is allow-listed for the three addons that implement it, keeping #1564's fix live-reachable. Being explicit: it still has **no JS caller** (the endpoint was fatal from the day it was written until #1564), so that path remains untested end-to-end. Omitting it would have silently un-fixed what #1600 just merged.

Also hardened `handler` to a `cmd` input filter, since it's used as a method name.

## Test plan

- [x] New `CwmmediafileXhrDispatchTest` (51 tests). The load-bearing ones are negative: `createLiveEvent`/`cancelLiveEvent`/`handleAjaxAction`/`getAjaxActions`/`getXml` asserted **not** present in any addon's list, so re-adding one fails the suite
- [x] Every listed handler asserted to resolve to a real *public* method — a drifted list would 404 a handler the UI needs
- [x] All 13 JS-sourced handler/addon pairs asserted still allowed, so tightening the list can't silently break a browser UI
- [x] Structural assertions that the ACL check and allow-list check both precede dispatch
- [x] Confirmed red→green (pre-fix source: `getXhrHandlers()` undefined, both controller assertions fail)
- [x] Full suite green: 1448 tests, 3005 assertions
- [x] `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL