### PR TITLE
fix: CwmdbHelper execute() bool contract and unanchored table allow-list match

### DIFF
--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -218,7 +218,7 @@ class CwmdbHelper
      * @param   ?string  $from   Where the source of the query comes from
      * @param   ?int     $limit  Set the Limit of the query
      *
-     * @return bool true if success, or error string if failed
+     * @return bool true if the query ran, false if it failed
      *
      * @throws  \Exception
      * @since   7.0
@@ -230,13 +230,28 @@ class CwmdbHelper
         }
 
         $db = Factory::getContainer()->get(DatabaseInterface::class);
-        $db->setQuery($query, 0, $limit);
 
-        if (!$db->execute()) {
+        // DatabaseDriver::execute() returns true or throws -- it never returns
+        // false -- so the old `if (!$db->execute())` branch was unreachable and
+        // every real SQL failure escaped as an uncaught exception instead of the
+        // false this method's contract promises. CwmadminController::copyTables()
+        // calls this three times per table with no try/catch and relies on a
+        // false return to abort cleanly. See #1566.
+        //
+        // setQuery() is inside the try on purpose: the MySQLi driver prepares
+        // the statement eagerly, so a bad table name or syntax error -- the
+        // most common failure here -- throws from setQuery(), before execute()
+        // is ever reached. Guarding execute() alone would still let those
+        // escape.
+        try {
+            $db->setQuery($query, 0, $limit);
+            $db->execute();
+        } catch (\RuntimeException $e) {
             Factory::getApplication()->enqueueMessage(
-                $from . Text::sprintf('JBS_INS_SQL_UPDATE_ERRORS', $db->stderr(true)),
+                $from . Text::sprintf('JBS_INS_SQL_UPDATE_ERRORS', $e->getMessage()),
                 'warning'
             );
+            Log::add($from . 'FAILED: ' . $query . ' -- ' . $e->getMessage(), Log::ERROR, 'com_proclaim');
 
             return false;
         }
@@ -292,7 +307,17 @@ class CwmdbHelper
         $objects   = [];
 
         foreach ($tables as $table) {
-            if (str_contains($table, $prefix) && str_contains($table, $bsms)) {
+            // Anchored, not a substring test. getTableList() returns every
+            // table in the schema, which on shared-database hosting includes
+            // other Joomla installs' tables. An unanchored
+            // str_contains($table, $prefix) matched a sibling table that merely
+            // contained this prefix somewhere -- e.g. with prefix 'jos_', the
+            // table 'myjos_bsms_studies' matched, and substr_replace() then
+            // stripped a fixed prefix-length from the front regardless,
+            // yielding the mangled '#__s_bsms_studies'. That bogus name was
+            // handed to every consumer of this list: the backup/restore and
+            // migration loops, and Cwmbackup's export allow-list. See #1566.
+            if (str_starts_with($table, $prefix . $bsms)) {
                 $table = substr_replace($table, '#__', 0, $prelength);
 
                 // Skip legacy version tracking table (replaced by #__schemas)
@@ -509,10 +534,30 @@ class CwmdbHelper
                 $query = trim($query);
 
                 if ($query !== '' && $query[0] !== '#') {
-                    $db->setQuery($query);
-
-                    if (!$db->execute()) {
-                        $app->enqueueMessage(Text::sprintf('JBS_INS_SQL_UPDATE_ERRORS', ' in ' . $value), 'error');
+                    // execute() throws rather than returning false, so this
+                    // never returned the documented false and instead
+                    // propagated out of CwminstallModel::realRun() -- which
+                    // calls resetdb() as its migration-rollback recovery step
+                    // and has no try/catch. resetStack() then never ran,
+                    // leaving a dirty migration stack plus a fatal error
+                    // instead of the intended "not migrated" warning. Exactly
+                    // the situation this recovery path exists to handle (a
+                    // half-created table erroring on re-create) triggered it.
+                    // setQuery() is inside the try because the MySQLi driver
+                    // prepares eagerly and throws there first. See #1566.
+                    try {
+                        $db->setQuery($query);
+                        $db->execute();
+                    } catch (\RuntimeException $e) {
+                        $app->enqueueMessage(
+                            Text::sprintf('JBS_INS_SQL_UPDATE_ERRORS', ' in ' . $value . ': ' . $e->getMessage()),
+                            'error'
+                        );
+                        Log::add(
+                            'resetdb() failed in ' . $value . ': ' . $e->getMessage(),
+                            Log::ERROR,
+                            'com_proclaim'
+                        );
 
                         return false;
                     }

--- a/tests/integration/Admin/Helper/CwmdbHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmdbHelperTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Integration tests for CwmdbHelper's execute() contract and table allow-list.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1566.
+ *
+ * 1. performDB() and resetdb() both gated error handling on
+ *    `if (!$db->execute())`. DatabaseDriver::execute() returns true or throws
+ *    -- it never returns false -- so those branches were unreachable and every
+ *    real SQL failure escaped as an uncaught exception instead of the false
+ *    both methods' contracts promise. Callers rely on that false:
+ *    CwmadminController::copyTables() to abort a table copy cleanly, and
+ *    CwminstallModel::realRun() to run resetStack() during migration-rollback
+ *    recovery (neither wraps the call in try/catch).
+ *
+ * 2. getObjects() used an unanchored str_contains() prefix test. On shared
+ *    -database hosting getTableList() returns other installs' tables too, and
+ *    a sibling table merely containing the prefix produced a mangled '#__'
+ *    name that was handed to every consumer -- including the export allow-list
+ *    Cwmbackup uses to keep the AJAX endpoint away from tables like #__users.
+ *
+ * Exercised against the real driver because the whole point is what the real
+ * execute() does on a real failure; a stubbed driver would return whatever the
+ * stub was told to.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmdbHelper::class)]
+class CwmdbHelperTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 1 -- performDB() honours its documented bool contract
+    // -------------------------------------------------------------------------
+
+    #[TestDox('performDB() returns false instead of throwing when the query fails')]
+    public function testPerformDbReturnsFalseOnAFailingQuery(): void
+    {
+        // Pre-fix this raised ExecutionFailureException straight out of the
+        // helper; copyTables() has no try/catch, so a failing CREATE TABLE
+        // aborted the loop mid-run instead of reporting a clean failure.
+        $result = CwmdbHelper::performDB(
+            'SELECT * FROM ' . $this->db->quoteName('#__cwm_table_that_does_not_exist_1566'),
+            'test: '
+        );
+
+        $this->assertFalse($result, 'A failing query must return false, not throw — see #1566');
+    }
+
+    #[TestDox('performDB() still returns true for a query that succeeds')]
+    public function testPerformDbReturnsTrueOnSuccess(): void
+    {
+        $result = CwmdbHelper::performDB(
+            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__bsms_studies')
+        );
+
+        $this->assertTrue($result, 'A valid query must still report success');
+    }
+
+    #[TestDox('performDB() rejects an empty query without touching the database')]
+    public function testPerformDbRejectsEmptyQuery(): void
+    {
+        $this->assertFalse(CwmdbHelper::performDB(''));
+    }
+
+    #[TestDox('A failing query is reported, not silently swallowed')]
+    public function testPerformDbSurfacesTheFailureToTheOperator(): void
+    {
+        $app = Factory::getApplication();
+
+        // Drain anything already queued so the assertion sees only our message.
+        $app->getMessageQueue(true);
+
+        CwmdbHelper::performDB(
+            'SELECT * FROM ' . $this->db->quoteName('#__cwm_table_that_does_not_exist_1566'),
+            'test: '
+        );
+
+        $messages = $app->getMessageQueue(true);
+
+        $this->assertNotEmpty(
+            $messages,
+            'Returning false must not mean failing silently — the operator needs to know'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- getObjects() anchors its prefix match
+    // -------------------------------------------------------------------------
+
+    #[TestDox('getObjects() returns this component\'s tables, all well-formed')]
+    public function testGetObjectsReturnsWellFormedProclaimTables(): void
+    {
+        $names = array_column(CwmdbHelper::getObjects(), 'name');
+
+        $this->assertNotEmpty($names, 'The component\'s own tables must still be discovered');
+
+        foreach ($names as $name) {
+            $this->assertStringStartsWith(
+                '#__bsms_',
+                $name,
+                'A mangled name here reaches the backup/restore loops and the export allow-list — see #1566'
+            );
+        }
+    }
+
+    #[TestDox('A sibling install\'s table that merely contains the prefix is not matched')]
+    public function testUnanchoredPrefixMatchIsRejected(): void
+    {
+        $prefix = $this->db->getPrefix();
+
+        // The shape that broke it: a table from another install sharing the
+        // schema, whose name contains this site's prefix but does not start
+        // with it. Asserted against the same predicate getObjects() now uses,
+        // since creating a real sibling table is not worth the fixture.
+        $sibling = 'my' . $prefix . 'bsms_studies';
+
+        $this->assertTrue(
+            str_contains($sibling, $prefix),
+            'Precondition: the old unanchored test would have matched this'
+        );
+        $this->assertFalse(
+            str_starts_with($sibling, $prefix . 'bsms_'),
+            'The anchored test must reject a table that only contains the prefix'
+        );
+
+        // And confirm no such mangled entry is present in the live result.
+        $names = array_column(CwmdbHelper::getObjects(), 'name');
+
+        foreach ($names as $name) {
+            $this->assertDoesNotMatchRegularExpression(
+                '/^#__[a-z]*_bsms_/',
+                $name,
+                'A double-prefixed name is the signature of the unanchored match — see #1566'
+            );
+        }
+    }
+
+    #[TestDox('The legacy #__bsms_update table stays excluded')]
+    public function testLegacyUpdateTableRemainsExcluded(): void
+    {
+        $names = array_column(CwmdbHelper::getObjects(), 'name');
+
+        $this->assertNotContains(
+            '#__bsms_update',
+            $names,
+            'The legacy version table is superseded by #__schemas and must stay filtered out'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1566.

### 1. `execute()` never returns `false`, so both error branches were dead code

`performDB()` and `resetdb()` gated error handling on `if (!$db->execute())`. Verified in core: `DatabaseDriver::execute()` returns `true` or throws — it never returns `false`. So both false-branches were unreachable and every real SQL failure escaped as an uncaught exception instead of the `false` both contracts promise.

Two callers depend on that `false` and have no try/catch of their own:
- `CwmadminController::copyTables()` — expects `false` to abort a table copy cleanly
- `CwminstallModel::realRun()` — calls `resetdb()` as its **migration-rollback recovery** step; a throw there skipped `resetStack()`, leaving a dirty migration stack and a fatal error instead of the intended "not migrated" warning — in exactly the half-created-table situation that recovery path exists to handle

**The issue's stated fix direction isn't sufficient on its own.** Wrapping `execute()` still leaves the most common failure uncaught: the MySQLi driver **prepares statements eagerly**, so a bad table name or syntax error throws from `setQuery()`, before `execute()` is ever reached. The new tests caught this — they still errored with the exception escaping until `setQuery()` was moved inside the try. Both calls are now guarded.

### 2. `getObjects()` used an unanchored prefix match

`getTableList()` returns every table in the schema, so on shared-database hosting a sibling install's table that merely *contains* this prefix matched — and `substr_replace()` then stripped a fixed prefix-length from the front regardless, producing a mangled name. Demonstrated concretely:

| table | old match | anchored | result |
|---|---|---|---|
| `jos_bsms_studies` | ✅ | ✅ | `#__bsms_studies` |
| `myjos_bsms_studies` | ✅ | ❌ | `#__s_bsms_studies` ← mangled |

Now anchored with `str_starts_with($table, $prefix . $bsms)`.

**Scope correction:** the issue frames this as weakening the #1521 export allow-list. It does feed that allow-list, but the mangled name doesn't resolve to a real table, so it isn't an escalation path — a request for it fails at query time. The real damage is correctness: that bogus name is also handed to the backup, restore, upgrade and migration loops that iterate this list.

## Not addressed here

The issue's closing note — ~60% of this file's public methods have no callers, and `fixupcss()` double-escapes CSS values. That's a dead-code cleanup pass, not a bug fix.

## Test plan

- [x] New `CwmdbHelperTest` integration suite (7 tests) against the real driver — the whole point is what the *real* `execute()` does on a *real* failure; a stubbed driver would return whatever the stub was told to
- [x] Confirmed red→green: pre-fix source errors with `Table ... doesn't exist` escaping the helper on both failure tests
- [x] Covers: failing query returns false, success still returns true, empty query rejected, failure surfaced to the operator, well-formed table names, unanchored-match rejection, legacy `#__bsms_update` still excluded
- [x] Verified live that `getObjects()` still returns all 27 real tables with zero malformed entries
- [x] Full suite green: 1462 tests, 3081 assertions
- [x] `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL