### PR TITLE
fix: CwmDebug SQL buffer reachable by anonymous visitors; guard logger calls

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -26,9 +26,31 @@ try {
 // On admin pages the debug check runs immediately; on the site side we
 // default to off and let Cwmdownload (the only front-end consumer) check
 // on demand, avoiding a DB query on every module/page load.
-if ($app->isClient('administrator') || $app->getInput()->getInt('jbsmdbg', 0) === 1) {
+// A URL parameter is not authorisation. `?jbsmdbg=1` previously switched
+// JBSMDEBUG on for *any* client, so an anonymous site visitor could enable the
+// component's debug buffer -- and CwmsermonsController::filterAjax() ships that
+// buffer to the browser as `_debug`, handing out raw SQL for the sermon listing
+// query. Honour the parameter only for a user who actually holds core.admin.
+//
+// Checked on both clients rather than restricted to the administrator client:
+// Cwmdownload logs through CwmDebug on the front end, so an admin debugging a
+// site-side download still needs ?jbsmdbg=1 to work there. Anything that fails
+// to resolve an identity falls through to "not allowed". See #1569.
+$jbsmDebugRequested = $app->getInput()->getInt('jbsmdbg', 0) === 1;
+$jbsmDebugAllowed   = false;
+
+if ($jbsmDebugRequested) {
     try {
-        if (CwmproclaimHelper::debug() === 1 || $app->getInput()->getInt('jbsmdbg', 0) === 1) {
+        $jbsmDebugUser    = $app->getIdentity();
+        $jbsmDebugAllowed = $jbsmDebugUser && $jbsmDebugUser->authorise('core.admin', 'com_proclaim');
+    } catch (\Throwable $e) {
+        $jbsmDebugAllowed = false;
+    }
+}
+
+if ($app->isClient('administrator') || $jbsmDebugAllowed) {
+    try {
+        if (CwmproclaimHelper::debug() === 1 || $jbsmDebugAllowed) {
             \define('JBSMDEBUG', 1);
         } else {
             \define('JBSMDEBUG', 0);

--- a/admin/src/Helper/CwmDebug.php
+++ b/admin/src/Helper/CwmDebug.php
@@ -78,7 +78,16 @@ class CwmDebug
 
         $entry = '[' . $category . '] ' . $message;
 
-        Log::add($entry, Log::DEBUG, 'com_proclaim.debug');
+        // An unwritable log directory makes FormattedtextLogger::addEntry()
+        // throw. Swallow it, matching CwmlogHelper::write(): logging must never
+        // be the reason a request fails. The buffer append stays outside the
+        // try so a logger failure doesn't also lose the on-screen entry.
+        // See #1569.
+        try {
+            Log::add($entry, Log::DEBUG, 'com_proclaim.debug');
+        } catch (\Throwable) {
+            // Diagnostics are best-effort.
+        }
 
         self::$buffer[] = $entry;
     }
@@ -106,7 +115,19 @@ class CwmDebug
             $entry .= ' — ' . $throwable::class . ': ' . $throwable->getMessage();
         }
 
-        Log::add($entry, Log::ERROR, 'com_proclaim');
+        // This is the call that actually mattered: error() always writes (that
+        // is its documented contract), and it is invoked from catch blocks
+        // across ~10 call sites that log and then rethrow the ORIGINAL
+        // exception -- e.g. CwmaiHelper::postJson(). An unwritable log
+        // directory made Log::add() throw RuntimeException('Cannot write to
+        // log file.') from inside those catch blocks, replacing the real error
+        // with an unrelated one and destroying the diagnostic. Swallow it, as
+        // CwmlogHelper::write() already does. See #1569.
+        try {
+            Log::add($entry, Log::ERROR, 'com_proclaim');
+        } catch (\Throwable) {
+            // Reporting a failure must not become a different failure.
+        }
 
         // Also buffer for on-screen display when debug is active
         if (self::isEnabled()) {
@@ -180,7 +201,13 @@ class CwmDebug
 
         $sql = (string) $query;
 
-        // Truncate very long queries for the buffer (full query goes to log file)
+        // Truncated for BOTH the buffer and the log file -- log() receives this
+        // same string. A previous comment here claimed the full query still
+        // reached the log file, which was never true. Left truncated rather
+        // than "fixed" to write complete SQL to disk: com_proclaim.debug.php
+        // is web-reachable under some Joomla layouts, and writing more raw SQL
+        // there is the wrong direction for a report about SQL exposure.
+        // See #1569.
         $truncated = \strlen($sql) > 500 ? substr($sql, 0, 500) . '...' : $sql;
 
         self::log($label . ': ' . $truncated, 'query');
@@ -232,6 +259,35 @@ class CwmDebug
      */
     public static function getBuffer(): array
     {
+        // Defence in depth alongside the JBSMDEBUG gate in admin/api.php.
+        // This accessor had no authorisation of any kind, unlike its sibling
+        // showToAdmin(), and its one production consumer
+        // (CwmsermonsController::filterAjax) ships the result to the browser
+        // as `_debug` on a public, CSRF-token-only endpoint. Returning an
+        // empty array rather than throwing keeps that caller's
+        // `if (!empty($debugBuffer))` working, so the key is simply omitted.
+        // See #1569.
+        if (!self::isEnabled()) {
+            return [];
+        }
+
+        try {
+            $app = Factory::getApplication();
+
+            if ($app->isClient('administrator')) {
+                return self::$buffer;
+            }
+
+            $user = $app->getIdentity();
+
+            if (!$user || !$user->authorise('core.admin', 'com_proclaim')) {
+                return [];
+            }
+        } catch (\Throwable) {
+            // No application/identity to authorise against -- disclose nothing.
+            return [];
+        }
+
         return self::$buffer;
     }
 

--- a/tests/unit/Admin/Helper/CwmDebugExposureTest.php
+++ b/tests/unit/Admin/Helper/CwmDebugExposureTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Unit tests for CwmDebug's buffer authorisation and logger resilience.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Regression coverage for #1569.
+ *
+ * 1. `?jbsmdbg=1` set JBSMDEBUG for any client, including an anonymous site
+ *    request, and CwmDebug::getBuffer() had no authorisation at all -- unlike
+ *    its sibling showToAdmin(). Its one production consumer,
+ *    CwmsermonsController::filterAjax(), ships the buffer to the browser as
+ *    `_debug` from a public endpoint guarded only by a CSRF token that any
+ *    visitor obtains by loading the sermons page. The buffer carries the raw
+ *    SQL for the listing query (table/column names, access-level WHERE
+ *    construction) via CwmDebug::logQuery().
+ *
+ * 2. log()/error() called Log::add() unguarded. error() always writes and is
+ *    invoked from catch blocks across ~10 call sites that log and then rethrow
+ *    the ORIGINAL exception; an unwritable log directory made Log::add() throw
+ *    from inside those catch blocks, masking the real error.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmDebugExposureTest extends ProclaimTestCase
+{
+    /**
+     * Read a method's source body.
+     *
+     * @param   string  $method  Method name on CwmDebug
+     *
+     * @return  string
+     */
+    private function methodBody(string $method): string
+    {
+        $ref   = new \ReflectionMethod(CwmDebug::class, $method);
+        $lines = file($ref->getFileName());
+
+        return implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 1 -- buffer authorisation
+    // -------------------------------------------------------------------------
+
+    /**
+     * getBuffer() discloses nothing when debug is off.
+     *
+     * Deliberately scoped to the isEnabled() gate rather than the
+     * authorisation branch: JBSMDEBUG is a compile-time constant that the test
+     * harness never defines, and defining it here would enable debug logging
+     * for every subsequent test in the process with no way to undo it. So this
+     * pins the disabled-path invariant, and
+     * testGetBufferIsGuardedByAnAuthorisationCheck() below carries the actual
+     * regression pin for the authorisation guard (it fails against pre-fix
+     * source; this one would not).
+     */
+    public function testGetBufferReturnsNothingWhenDebugIsDisabled(): void
+    {
+        // Populate the static directly -- log() itself no-ops while debug is
+        // off, so going through it would prove nothing either way.
+        $buffer = new \ReflectionProperty(CwmDebug::class, 'buffer');
+        $buffer->setValue(null, ['[query] SELECT * FROM #__bsms_studies WHERE access IN (1,5)']);
+
+        try {
+            $this->assertSame(
+                [],
+                CwmDebug::getBuffer(),
+                'With debug off the buffer must never be handed out, populated or not — see #1569'
+            );
+        } finally {
+            $buffer->setValue(null, []);
+        }
+    }
+
+    /**
+     * The guard must be an authorisation check, not merely "always empty".
+     */
+    public function testGetBufferIsGuardedByAnAuthorisationCheck(): void
+    {
+        $body = $this->methodBody('getBuffer');
+
+        $this->assertStringContainsString(
+            "authorise('core.admin'",
+            $body,
+            'getBuffer() must require core.admin, matching its sibling showToAdmin() — see #1569'
+        );
+        $this->assertStringContainsString(
+            'isClient(\'administrator\')',
+            $body,
+            'Administrator-client callers stay allowed so the admin display keeps working'
+        );
+        $this->assertMatchesRegularExpression(
+            '/return\s*\[\s*\]\s*;/',
+            $body,
+            'Denial must return an empty array, not throw — the caller is a JSON endpoint happy path'
+        );
+    }
+
+    /**
+     * The parameter that turns debugging on must itself be authorised. This is
+     * the upstream fix; the getBuffer() guard above is defence in depth.
+     * Asserted structurally because admin/api.php is bootstrap code that
+     * cannot be re-executed in-process.
+     */
+    public function testJbsmdbgParameterRequiresCoreAdmin(): void
+    {
+        $source = file_get_contents(\dirname(__DIR__, 4) . '/admin/api.php');
+
+        $this->assertStringContainsString(
+            "authorise('core.admin'",
+            $source,
+            '?jbsmdbg=1 must not enable debug for an unauthenticated visitor — see #1569'
+        );
+
+        // The old shape: the raw parameter alone deciding JBSMDEBUG.
+        $this->assertDoesNotMatchRegularExpression(
+            '/if\s*\(\s*CwmproclaimHelper::debug\(\)\s*===\s*1\s*\|\|\s*\$app->getInput\(\)->getInt\(\s*[\'"]jbsmdbg/',
+            $source,
+            'The unauthenticated parameter check must no longer gate JBSMDEBUG directly'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- logging must never become the failure
+    // -------------------------------------------------------------------------
+
+    /**
+     * error() is called from catch blocks that then rethrow the original
+     * exception. It must not raise one of its own.
+     */
+    public function testErrorDoesNotThrowWhenLoggingIsImpossible(): void
+    {
+        $original = new \RuntimeException('the real failure the caller cares about');
+
+        CwmDebug::error('transport failed', $original, 'test');
+
+        // Reaching here at all is the assertion: pre-fix, a logger failure
+        // propagated out and replaced $original for every caller that does
+        // log-then-rethrow.
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Structural guarantee, since forcing Joomla's logger to fail in-process
+     * is not reliably reproducible: the Log::add() call must sit inside a
+     * try/catch, and the buffer append must sit OUTSIDE it so a logger failure
+     * does not also lose the on-screen entry.
+     *
+     * @param   string  $method  CwmDebug method that logs
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('loggingMethodProvider')]
+    public function testLoggingCallsAreGuarded(string $method): void
+    {
+        $body = $this->methodBody($method);
+
+        $this->assertMatchesRegularExpression(
+            '/try\s*\{\s*Log::add\(/s',
+            $body,
+            $method . '() must guard Log::add() — an unwritable log directory otherwise masks the real error — see #1569'
+        );
+        $this->assertMatchesRegularExpression(
+            '/catch\s*\(\\\\Throwable\)/',
+            $body,
+            $method . '() must swallow logger failures, matching CwmlogHelper::write()'
+        );
+
+        $this->assertLessThan(
+            strpos($body, 'self::$buffer[]'),
+            strpos($body, 'catch (\\Throwable)'),
+            $method . '(): the buffer append must be outside the try, or a logger failure also loses the entry'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function loggingMethodProvider(): array
+    {
+        return ['log' => ['log'], 'error' => ['error']];
+    }
+
+    // -------------------------------------------------------------------------
+    // logQuery truncation -- comment corrected rather than behaviour widened
+    // -------------------------------------------------------------------------
+
+    /**
+     * The old comment claimed the full query reached the log file. It never
+     * did, and deliberately still does not: writing complete raw SQL to a
+     * web-reachable log is the wrong direction on a SQL-exposure ticket.
+     */
+    public function testLogQueryDoesNotClaimToLogFullSql(): void
+    {
+        $body = $this->methodBody('logQuery');
+
+        $this->assertStringNotContainsString(
+            'full query goes to log file',
+            $body,
+            'That claim was false — the truncated string is what reaches both sinks'
+        );
+        $this->assertStringContainsString(
+            'substr($sql, 0, 500)',
+            $body,
+            'Queries must still be truncated before they reach the buffer or the log'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1569.

### 1. Raw SQL was reachable without authentication

Chain confirmed end to end:

1. `?jbsmdbg=1` set `JBSMDEBUG` for **any** client — including an anonymous site request
2. `CwmDebug::getBuffer()` had **no authorisation at all**, unlike its sibling `showToAdmin()`
3. `CwmsermonsController::filterAjax()` ships that buffer to the browser as `_debug`, from a public endpoint guarded only by a CSRF token any visitor obtains by loading the sermons page
4. The buffer carries raw SQL for the listing query via `logQuery()` — table/column names, access-level `WHERE` construction

**Fixed primarily at the source**, not just at the accessor: `admin/api.php` now honours `?jbsmdbg=1` only for a user holding `core.admin`. Worth noting the old code checked the raw parameter in *both* the outer and inner conditions, so on a site request it bypassed the admin's actual debug setting entirely.

Gated on `core.admin` rather than `isClient('administrator')` **deliberately** — `Cwmdownload` logs through `CwmDebug` on the front end, so an admin debugging a site-side download still needs `?jbsmdbg=1` to work there. Verified no other consumer of the parameter exists (no JS, no docs, no other PHP), so nothing anonymous depended on it.

`getBuffer()` additionally returns `[]` for unauthorised callers — defence in depth. Empty array rather than an exception, since the caller does `if (!empty($debugBuffer))` and cleanly omits the key.

### 2. Unguarded `Log::add()` masked the original exception

`error()` is the one that mattered: it *always* writes (documented contract) and is called from catch blocks across ~10 call sites that log and then rethrow the **original** exception. An unwritable log directory made `Log::add()` throw from inside those catch blocks, replacing the real diagnostic with "Cannot write to log file."

Both `log()` and `error()` now wrap in `try/catch (\Throwable)`, matching `CwmlogHelper::write()`. The buffer append stays **outside** the try so a logger failure doesn't also lose the on-screen entry. The ~10 call sites are the *reason* for the fix, not part of it — untouched.

### 3. `logQuery()` comment corrected, not behaviour widened

The comment claimed the full query reached the log file. It never did — the truncated string goes to both sinks. I corrected the comment rather than changing behaviour to match it: writing complete raw SQL to `com_proclaim.debug.php`, which is web-reachable under some Joomla layouts, is the wrong direction on a ticket about SQL exposure. Flagging in case you'd prefer the opposite call.

## Testing note

One runtime test is scoped to the `isEnabled()` gate rather than the authorisation branch, because `JBSMDEBUG` is a compile-time constant the harness never defines — and defining it would enable debug logging for every later test in the process with no way to undo it. My first version of that test was **vacuous** (asserting `[] == []` regardless); it now populates the buffer directly so the assertion means something, and the authorisation guard's actual regression pin is the structural test, which does fail against pre-fix source.

## Test plan

- [x] New `CwmDebugExposureTest` (7 tests)
- [x] Confirmed red→green: **5 of 7 fail** against pre-fix source
- [x] Covers: buffer withheld when debug off (with a populated buffer), `core.admin` guard on `getBuffer()`, `?jbsmdbg=1` requires `core.admin` in api.php, both logger calls guarded with the buffer append outside the try, and the corrected `logQuery()` comment
- [x] Full suite green: 1480 tests, 5972 assertions
- [x] `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL