### PR TITLE
fix: Cwmthumbnail delete-before-write, unchecked encodes, missing resize allow-list

### DIFF
--- a/admin/src/Helper/Cwmthumbnail.php
+++ b/admin/src/Helper/Cwmthumbnail.php
@@ -127,6 +127,106 @@ class Cwmthumbnail
     }
 
     /**
+     * Resolve a path and confirm it really lands inside ALLOWED_PATHS.
+     *
+     * The previous check was `str_starts_with($relative, $prefix)` followed by
+     * Path::clean(). Path::clean() normalises separators but does NOT collapse
+     * '..', so 'images/biblestudy/studies/../../../administrator' satisfied the
+     * prefix test and still resolved outside the allowed tree once the
+     * filesystem walked it -- the same defect fixed in CwmImageMigration
+     * (#1537) and CwmImageCleanup (#1563).
+     *
+     * Resolution is lexical rather than realpath()-based: callers legitimately
+     * pass paths that do not exist yet (deleteFolder() reports success for an
+     * already-absent folder, create() writes new files), and realpath() returns
+     * false for those. Both the candidate and each allowed base go through the
+     * same normaliser so the comparison is like-for-like.
+     *
+     * @param   string  $path  Absolute path, or one relative to JPATH_ROOT
+     *
+     * @return  string|false  Normalised path, or false if outside the allow-list
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function resolveWithinAllowedPaths(string $path): string|false
+    {
+        $candidate = Path::clean(
+            str_starts_with($path, JPATH_ROOT) ? $path : JPATH_ROOT . '/' . ltrim($path, '/')
+        );
+
+        $resolved = self::normaliseLexically($candidate);
+
+        if ($resolved === false) {
+            return false;
+        }
+
+        foreach (self::ALLOWED_PATHS as $prefix) {
+            // The base goes through the same normaliser as the candidate --
+            // comparing a normalised path against a raw one silently never
+            // matches (JPATH_ROOT is './' under phpunit.xml, so the base keeps
+            // a './' the candidate has already shed).
+            $base = self::normaliseLexically(Path::clean(JPATH_ROOT . '/' . $prefix));
+
+            if ($base === false) {
+                continue;
+            }
+
+            $base = rtrim($base, \DIRECTORY_SEPARATOR);
+
+            if ($resolved === $base || str_starts_with($resolved, $base . \DIRECTORY_SEPARATOR)) {
+                return $resolved;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Collapse '.' and '..' segments without requiring the path to exist.
+     *
+     * Path::clean() normalises separators but leaves '..' in place, which is
+     * what allowed the old prefix checks to be walked out of. realpath() would
+     * collapse them but returns false for paths that do not exist yet, and
+     * callers legitimately pass those.
+     *
+     * Relative-vs-absolute is preserved rather than assumed: JPATH_ROOT is not
+     * always absolute (phpunit.xml defines it as '.'), so forcing a leading
+     * separator would turn a repo-relative path into a filesystem-root one.
+     *
+     * @param   string  $path  Path to normalise
+     *
+     * @return  string|false  Normalised path, or false if it escapes its start
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function normaliseLexically(string $path): string|false
+    {
+        $isAbsolute = str_starts_with($path, \DIRECTORY_SEPARATOR);
+        $normalised = [];
+
+        foreach (explode(\DIRECTORY_SEPARATOR, $path) as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+
+            if ($part === '..') {
+                if ($normalised === []) {
+                    // Walked out past the starting point — reject outright.
+                    return false;
+                }
+
+                array_pop($normalised);
+
+                continue;
+            }
+
+            $normalised[] = $part;
+        }
+
+        return ($isAbsolute ? \DIRECTORY_SEPARATOR : '') . implode(\DIRECTORY_SEPARATOR, $normalised);
+    }
+
+    /**
      * Delete an image folder safely (only within allowed paths)
      *
      * @param   string  $folderPath  Relative path to folder (e.g., 'images/biblestudy/studies/alias-123')
@@ -140,16 +240,9 @@ class Cwmthumbnail
         // Normalize path
         $folderPath = trim($folderPath, '/');
 
-        // CRITICAL: Validate path is within allowed scope
-        $isAllowed = false;
-        foreach (self::ALLOWED_PATHS as $prefix) {
-            if (str_starts_with($folderPath, $prefix)) {
-                $isAllowed = true;
-                break;
-            }
-        }
+        $absolutePath = self::resolveWithinAllowedPaths($folderPath);
 
-        if (!$isAllowed) {
+        if ($absolutePath === false) {
             Log::add(
                 'Attempted to delete folder outside allowed scope: ' . $folderPath,
                 Log::WARNING,
@@ -158,8 +251,6 @@ class Cwmthumbnail
 
             return false;
         }
-
-        $absolutePath = Path::clean(JPATH_ROOT . '/' . $folderPath);
 
         if (is_dir($absolutePath)) {
             $result = Folder::delete($absolutePath);
@@ -251,10 +342,24 @@ class Cwmthumbnail
         $newImagePath = $destFolder . '/' . $newFilename;
         $thumbPath    = $destFolder . '/' . $thumbName;
 
+        // Superseded files are identified now but deleted only after the
+        // replacements are confirmed on disk (see the end of this method).
+        //
+        // Previously the delete ran here, before the new image was written.
+        // $versionHash is a content hash, so re-uploading a *different* photo
+        // for the same record produces a different filename -- meaning the
+        // live image was NOT in $keepFiles and was deleted first. If the
+        // File::copy() or the thumbnail encode below then failed, create()
+        // returned false, the calling model showed a generic warning and still
+        // called parent::save() without clearing the image fields: the record
+        // pointed at files that had just been deleted, leaving a broken image
+        // site-wide. (Re-uploading the *same* file was safe, since the hash and
+        // therefore the filename matched.) See #1570.
+        $supersededFiles = [];
+
         // Handle existing destination folder
         if (is_dir($destFolder)) {
             if ($preserveOld) {
-                // Clean up old files so we don't accumulate stale images across re-uploads.
                 // Matches both versioned (name-hash.ext) and pre-versioning (name.ext) files.
                 // Protect both the new target files and the source file from deletion
                 $keepFiles = [$newFilename, $thumbName, basename($originalPath)];
@@ -271,7 +376,7 @@ class Cwmthumbnail
                     if ($oldFiles) {
                         foreach ($oldFiles as $oldFile) {
                             if (!\in_array(basename($oldFile), $keepFiles, true)) {
-                                File::delete($oldFile);
+                                $supersededFiles[] = $oldFile;
                             }
                         }
                     }
@@ -294,7 +399,9 @@ class Cwmthumbnail
         $normalizedNew      = Path::clean($newImagePath);
 
         if ($normalizedOriginal !== $normalizedNew) {
-            // Source may have been removed during cleanup above (same folder, different version hash)
+            // The cleanup that used to run before this point could remove the
+            // source itself; it is now deferred, so this can only fail if the
+            // source genuinely vanished.
             if (!is_file($originalPath)) {
                 return false;
             }
@@ -327,7 +434,18 @@ class Cwmthumbnail
         }
 
         $thumbnail = $image->resize($thumbWidth, $thumbHeight, true, self::SCALE_INSIDE);
-        $thumbnail->toFile($thumbPath, IMAGETYPE_JPEG);
+
+        // toFile() returns imagejpeg()'s bool rather than throwing. Ignoring it
+        // meant a failed encode still produced a success-shaped return, and the
+        // calling model wrote a path to a nonexistent file into the database --
+        // a 404 image on the public site with nothing logged. Returning false
+        // here is now safe for the record: the superseded files have not been
+        // deleted yet, so the previously-working image survives. See #1570.
+        if (!$thumbnail->toFile($thumbPath, IMAGETYPE_JPEG) || !is_file($thumbPath)) {
+            Log::add('Thumbnail encode failed, keeping previous image: ' . $newImagePath, Log::WARNING, 'com_proclaim');
+
+            return false;
+        }
 
         $result = [
             'image'          => $path . '/' . $newFilename,
@@ -336,22 +454,50 @@ class Cwmthumbnail
             'thumbnail_webp' => null,
         ];
 
-        // Generate WebP variants if GD supports it
+        // Generate WebP variants if GD supports it. These are optional
+        // enhancements, so a failed encode is logged and the variant is left
+        // null rather than failing the whole operation -- but the path is only
+        // reported when the file actually exists, so the model never stores a
+        // reference to a file that was not written. See #1570.
         if (\function_exists('imagewebp')) {
             $webpThumbName = 'thumb_' . $baseFilename . '-' . $versionHash . '.webp';
             $webpThumbPath = $destFolder . '/' . $webpThumbName;
-            $thumbnail->toFile($webpThumbPath, IMAGETYPE_WEBP);
-            $result['thumbnail_webp'] = $path . '/' . $webpThumbName;
+
+            if ($thumbnail->toFile($webpThumbPath, IMAGETYPE_WEBP) && is_file($webpThumbPath)) {
+                $result['thumbnail_webp'] = $path . '/' . $webpThumbName;
+            } else {
+                Log::add('WebP thumbnail encode failed for: ' . $newImagePath, Log::WARNING, 'com_proclaim');
+            }
 
             // Generate WebP of the full-size image (skip if source is already WebP)
             if ($extension !== 'webp') {
                 $webpImageName = $baseFilename . '-' . $versionHash . '.webp';
                 $webpImagePath = $destFolder . '/' . $webpImageName;
                 $fullImage     = new Image($newImagePath);
-                $fullImage->toFile($webpImagePath, IMAGETYPE_WEBP);
-                $result['image_webp'] = $path . '/' . $webpImageName;
+
+                if ($fullImage->toFile($webpImagePath, IMAGETYPE_WEBP) && is_file($webpImagePath)) {
+                    $result['image_webp'] = $path . '/' . $webpImageName;
+                } else {
+                    Log::add('WebP full-image encode failed for: ' . $newImagePath, Log::WARNING, 'com_proclaim');
+                }
             } else {
                 $result['image_webp'] = $result['image'];
+            }
+        }
+
+        // Every replacement is now confirmed on disk — retire the superseded
+        // files. Anything we just wrote is excluded defensively, in case a
+        // glob pattern above matched a name we then reused.
+        $justWritten = array_filter([
+            $newFilename,
+            $thumbName,
+            basename((string) ($result['thumbnail_webp'] ?? '')),
+            basename((string) ($result['image_webp'] ?? '')),
+        ]);
+
+        foreach ($supersededFiles as $oldFile) {
+            if (!\in_array(basename($oldFile), $justWritten, true)) {
+                File::delete($oldFile);
             }
         }
 
@@ -371,6 +517,26 @@ class Cwmthumbnail
      */
     public static function resize(string $path, int $newSize, ?int $outputType = null): bool
     {
+        // CRITICAL: this method deletes every thumb_* sibling in the target
+        // directory and writes new files there, and its only caller
+        // (CwmadminController::createThumbnailXHR) takes `image_path` straight
+        // from request input. Without this check a crafted path reached any
+        // directory on disk. deleteFolder() has always validated; resize()
+        // never did. See #1570.
+        $resolvedPath = self::resolveWithinAllowedPaths($path);
+
+        if ($resolvedPath === false) {
+            Log::add(
+                'Attempted to resize an image outside allowed scope: ' . $path,
+                Log::WARNING,
+                'com_proclaim'
+            );
+
+            return false;
+        }
+
+        $path = $resolvedPath;
+
         // Verify source image exists
         if (!is_file($path)) {
             return false;
@@ -401,13 +567,12 @@ class Cwmthumbnail
         $filenameBase  = pathinfo($filename, PATHINFO_FILENAME);
         $thumbFilename = 'thumb_' . $filenameBase . '.' . $extension;
 
-        // Delete existing thumbnails in this directory
+        // Old thumbnails are collected now but deleted only after the
+        // replacement is confirmed on disk (below). Deleting first meant a
+        // failed GD encode left the entity with no thumbnail at all, while
+        // this method still reported success. See #1570.
         $directory = \dirname($path);
         $oldThumbs = Folder::files($directory, '^thumb_' . preg_quote($filenameBase, '/'), false, true);
-
-        foreach ($oldThumbs as $thumb) {
-            File::delete($thumb);
-        }
 
         // Create new thumbnail preserving original aspect ratio
         $image        = new Image($path);
@@ -422,13 +587,37 @@ class Cwmthumbnail
             $thumbWidth  = (int) round($newSize * ($sourceWidth / $sourceHeight));
         }
 
-        $thumbnail = $image->resize($thumbWidth, $thumbHeight, true, self::SCALE_INSIDE);
-        $thumbnail->toFile($directory . '/' . $thumbFilename, $outputType);
+        $thumbnail    = $image->resize($thumbWidth, $thumbHeight, true, self::SCALE_INSIDE);
+        $newThumbPath = $directory . '/' . $thumbFilename;
 
-        // Generate WebP variant alongside
+        // Image::toFile() calls imagejpeg()/imagewebp() and returns their bool
+        // rather than throwing. The return value was ignored and this method
+        // unconditionally returned true, so a failed encode (disk full, GD
+        // hitting memory_limit) was reported as success. See #1570.
+        if (!$thumbnail->toFile($newThumbPath, $outputType) || !is_file($newThumbPath)) {
+            Log::add('Thumbnail encode failed for: ' . $path, Log::WARNING, 'com_proclaim');
+
+            return false;
+        }
+
+        // Generate WebP variant alongside. Optional: a failure here is logged
+        // and tolerated, since the primary thumbnail above already succeeded.
         if (\function_exists('imagewebp')) {
             $webpThumbFilename = 'thumb_' . $filenameBase . '.webp';
-            $thumbnail->toFile($directory . '/' . $webpThumbFilename, IMAGETYPE_WEBP);
+
+            if (!$thumbnail->toFile($directory . '/' . $webpThumbFilename, IMAGETYPE_WEBP)) {
+                Log::add('WebP thumbnail encode failed for: ' . $path, Log::WARNING, 'com_proclaim');
+            }
+        }
+
+        // Replacement confirmed — now retire the superseded thumbnails, skipping
+        // anything we just wrote.
+        $justWritten = [$thumbFilename, 'thumb_' . $filenameBase . '.webp'];
+
+        foreach ($oldThumbs as $thumb) {
+            if (!\in_array(basename($thumb), $justWritten, true)) {
+                File::delete($thumb);
+            }
         }
 
         return true;

--- a/tests/integration/Admin/Helper/CwmthumbnailSafetyTest.php
+++ b/tests/integration/Admin/Helper/CwmthumbnailSafetyTest.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Integration tests for Cwmthumbnail's write-before-delete ordering and
+ * path allow-listing.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmthumbnail;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1570.
+ *
+ * 1. create() deleted the superseded image/thumbnail *before* writing the
+ *    replacement. $versionHash is a content hash, so re-uploading a different
+ *    photo for the same record produced a different filename -- the live file
+ *    was therefore not in $keepFiles and was deleted first. A failed copy or
+ *    encode then left the record pointing at files that no longer existed,
+ *    because the calling models still call parent::save() after the generic
+ *    warning.
+ * 2/3. Image::toFile() returns imagejpeg()/imagewebp()'s bool rather than
+ *    throwing; none of the four call sites checked it, and resize() returned
+ *    true unconditionally. A failed encode was reported as success and the
+ *    path was written to the database.
+ * 4. resize() had no ALLOWED_PATHS check, unlike its sibling deleteFolder(),
+ *    while its only caller passes `image_path` straight from request input.
+ *
+ * Also fixed here: deleteFolder()'s own allow-list used
+ * str_starts_with() + Path::clean(), and Path::clean() does not collapse
+ * '..' -- the same defect fixed in CwmImageMigration (#1537) and
+ * CwmImageCleanup (#1563). Reachable only via a crafted stored path rather
+ * than directly from a request, but the same class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmthumbnail::class)]
+class CwmthumbnailSafetyTest extends IntegrationTestCase
+{
+    private string $studiesDir;
+
+    private array $createdDirs = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->studiesDir = JPATH_ROOT . '/images/biblestudy/studies';
+
+        foreach ([JPATH_ROOT . '/images', JPATH_ROOT . '/images/biblestudy', $this->studiesDir] as $dir) {
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+                $this->createdDirs[] = $dir;
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Both the sources and the thumb_-prefixed variants the helper writes.
+        foreach (['/cwm1570*', '/thumb_cwm1570*'] as $pattern) {
+            foreach (glob($this->studiesDir . $pattern) ?: [] as $leftover) {
+                @unlink($leftover);
+            }
+        }
+
+        foreach (array_reverse($this->createdDirs) as $dir) {
+            @rmdir($dir);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Write a small real JPEG so GD can actually load and resize it.
+     *
+     * @param   string  $path  Destination
+     *
+     * @return  void
+     */
+    private function writeJpeg(string $path): void
+    {
+        $im = imagecreatetruecolor(40, 30);
+        imagefilledrectangle($im, 0, 0, 40, 30, imagecolorallocate($im, 20, 120, 200));
+        imagejpeg($im, $path);
+        imagedestroy($im);
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 4 (+ deleteFolder) -- path allow-listing
+    // -------------------------------------------------------------------------
+
+    /**
+     * resize() must refuse anything outside the image directories. Its caller
+     * takes the path from request input, so this is the boundary.
+     *
+     * @param   string  $path  Attacker-shaped path
+     */
+    #[DataProvider('outOfScopePathProvider')]
+    #[TestDox('resize() refuses a path outside the allowed image directories')]
+    public function testResizeRefusesOutOfScopePaths(string $path): void
+    {
+        $this->assertFalse(
+            Cwmthumbnail::resize($path, 100),
+            'resize() deletes every thumb_* sibling and writes files — it must be scoped — see #1570'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function outOfScopePathProvider(): array
+    {
+        return [
+            'traversal out of the image tree' => ['images/biblestudy/studies/../../../configuration.php'],
+            'unrelated images subdirectory'   => ['images/headers/banner.jpg'],
+            'absolute outside root'           => ['/etc/hosts'],
+            'joomla administrator dir'        => ['administrator/index.php'],
+        ];
+    }
+
+    /**
+     * deleteFolder() previously used str_starts_with() + Path::clean(), and
+     * Path::clean() leaves '..' intact — so a path that merely *started* with
+     * an allowed prefix could still resolve elsewhere.
+     */
+    #[TestDox('deleteFolder() refuses a traversal that starts with an allowed prefix')]
+    public function testDeleteFolderRefusesTraversalBehindAnAllowedPrefix(): void
+    {
+        $this->assertFalse(
+            Cwmthumbnail::deleteFolder('images/biblestudy/studies/../../../administrator'),
+            'The prefix test must not be satisfiable by walking back out — see #1570, same class as #1537/#1563'
+        );
+    }
+
+    #[TestDox('deleteFolder() still accepts a legitimate in-scope folder')]
+    public function testDeleteFolderStillAcceptsInScopePaths(): void
+    {
+        $this->assertTrue(
+            Cwmthumbnail::deleteFolder('images/biblestudy/studies/cwm1570-nonexistent'),
+            'An in-scope folder that does not exist is a no-op success, not a scope rejection'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Findings 2 & 3 -- resize() reports truthfully and keeps the old thumbnail
+    // -------------------------------------------------------------------------
+
+    #[TestDox('resize() produces a thumbnail and reports success for a real image')]
+    public function testResizeSucceedsForARealImage(): void
+    {
+        $source = $this->studiesDir . '/cwm1570-source.jpg';
+        $this->writeJpeg($source);
+
+        $this->assertTrue(Cwmthumbnail::resize($source, 20));
+        $this->assertFileExists($this->studiesDir . '/cwm1570-source.jpg', 'The source must survive');
+
+        // Extension comes from image_type_to_extension(), which yields 'jpeg'
+        // rather than 'jpg' -- glob rather than hardcode it.
+        $this->assertNotEmpty(
+            glob($this->studiesDir . '/thumb_cwm1570-source.*'),
+            'A successful resize must actually leave a thumbnail behind'
+        );
+    }
+
+    /**
+     * The ordering guarantee: an unusable source must not cost the existing
+     * thumbnail. Pre-fix, old thumbnails were deleted before the encode.
+     */
+    #[TestDox('A failed resize leaves the previous thumbnail intact')]
+    public function testFailedResizeKeepsThePreviousThumbnail(): void
+    {
+        $source = $this->studiesDir . '/cwm1570-broken.jpg';
+        $thumb  = $this->studiesDir . '/thumb_cwm1570-broken.jpg';
+
+        // A file GD cannot decode, plus an existing thumbnail beside it.
+        file_put_contents($source, 'this is not a JPEG');
+        $this->writeJpeg($thumb);
+
+        try {
+            Cwmthumbnail::resize($source, 20);
+        } catch (\Throwable) {
+            // Joomla's Image may raise on an undecodable source; the ordering
+            // guarantee is what matters here, not how the failure surfaces.
+        }
+
+        $this->assertFileExists(
+            $thumb,
+            'The previous thumbnail must survive a failed encode — deleting first left the record with none — see #1570'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Structural pins for the write-before-delete ordering in create()
+    // -------------------------------------------------------------------------
+
+    /**
+     * create() is hard to drive end-to-end here (it needs model-shaped inputs
+     * and a writable destination tree), so the ordering contract is pinned
+     * structurally: the superseded files must be collected, and deleted only
+     * after the thumbnail write is confirmed.
+     */
+    #[TestDox('create() defers deletion of superseded files until after the writes')]
+    public function testCreateDeletesSupersededFilesOnlyAfterWriting(): void
+    {
+        $ref   = new \ReflectionMethod(Cwmthumbnail::class, 'create');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString(
+            '$supersededFiles[]',
+            $body,
+            'Old files must be collected rather than deleted inline — see #1570'
+        );
+
+        $collectAt = strpos($body, '$supersededFiles[]');
+        $writeAt   = strpos($body, 'toFile($thumbPath');
+        $deleteAt  = strpos($body, 'foreach ($supersededFiles');
+
+        $this->assertNotFalse($writeAt, 'Expected the thumbnail write to still be present');
+        $this->assertNotFalse($deleteAt, 'Expected a deferred deletion loop');
+
+        $this->assertLessThan($writeAt, $collectAt, 'Collection happens while the old names are still known');
+        $this->assertGreaterThan(
+            $writeAt,
+            $deleteAt,
+            'Deletion must happen after the replacement is confirmed on disk — see #1570'
+        );
+    }
+
+    /**
+     * Every Image::toFile() call must have its return value considered; the
+     * bug was that none of them did.
+     */
+    #[TestDox('Image::toFile() return values are checked, not discarded')]
+    public function testToFileReturnValuesAreChecked(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(Cwmthumbnail::class))->getFileName());
+
+        preg_match_all('/^\s*\$\w+->toFile\(/m', $source, $bare);
+
+        $this->assertSame(
+            [],
+            $bare[0],
+            'A bare ->toFile() call discards the write result — a failed encode then reports success — see #1570'
+        );
+    }
+}

--- a/tests/integration/Admin/Helper/CwmthumbnailSafetyTest.php
+++ b/tests/integration/Admin/Helper/CwmthumbnailSafetyTest.php
@@ -92,7 +92,11 @@ class CwmthumbnailSafetyTest extends IntegrationTestCase
         $im = imagecreatetruecolor(40, 30);
         imagefilledrectangle($im, 0, 0, 40, 30, imagecolorallocate($im, 20, 120, 200));
         imagejpeg($im, $path);
-        imagedestroy($im);
+
+        // No imagedestroy(): it has been a no-op since PHP 8.0 (GdImage is
+        // garbage-collected) and is deprecated in 8.5, which the blocking 8.5
+        // CI job turns into a failure via failOnWarning. Letting $im fall out
+        // of scope is the supported form.
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1570 — all four findings, plus a fifth found while implementing.

### 1. `create()` deleted the live image before writing its replacement

`$versionHash` is a **content hash**, so re-uploading a *different* photo for an existing record produces a different filename — meaning the live file was **not** in `$keepFiles` and was deleted first. If the copy or encode then failed, `create()` returned false but the calling models still call `parent::save()` after a generic warning, leaving the record pointing at files that had just been deleted: a broken image site-wide.

(Re-uploading the *same* file was safe — matching hash, matching filename, protected by `$keepFiles`. That's why this wouldn't show up in casual testing.)

Superseded files are now collected up front and deleted only after every replacement is confirmed on disk.

### 2. `Image::toFile()` return values were discarded

It returns `imagejpeg()`/`imagewebp()`'s bool rather than throwing, and none of the four call sites checked it; `resize()` returned `true` unconditionally. A failed encode was reported as success and the path to a nonexistent file went into the database.

Primary writes now fail the operation; optional WebP variants log and report `null` rather than claiming a file that wasn't written. Returning false is now *safe for the record*, because the old files still exist at that point.

### 3. `resize()` had the same delete-before-write ordering — same fix.

### 4. `resize()` had no path allow-list

Unlike its sibling `deleteFolder()`, while its only caller (`createThumbnailXHR`) takes `image_path` straight from request input — so a crafted path deleted every `thumb_*` file in an arbitrary directory and wrote new files there. Now scoped.

## Also fixed: a third instance of the `Path::clean()` traversal bug

`deleteFolder()`'s own allow-list used `str_starts_with()` on the relative path followed by `Path::clean()` — and `Path::clean()` **does not collapse `..`**, so a path merely *starting* with an allowed prefix could still resolve elsewhere. Same defect as #1537 (`CwmImageMigration`) and #1563 (`CwmImageCleanup`).

This mattered directly: the issue's fix direction says to give `resize()` "the same treatment `deleteFolder()` already has" — which would have **propagated the bug into a second method**. Both now share one normaliser. Reachable only via a crafted stored image path rather than a request, so lower severity than #1563, but the same class.

## Two implementation notes

Both caught by the existing suite, both worth recording:

- The shared check resolves `.`/`..` **lexically**, not via `realpath()`. `realpath()` returns false for paths that don't exist, and both callers legitimately pass those — `deleteFolder()` reports success for an already-absent folder, `create()` writes new files. My first realpath-only version broke exactly that, caught by `CwmthumbnailDeleteFolderTest`.
- Relative-vs-absolute is **preserved, not assumed**: `phpunit.xml` defines `JPATH_ROOT` as `"."`, so forcing a leading separator turned repo-relative paths into filesystem-root ones and every comparison silently missed. Candidate and allowed bases now normalise identically.

## Test plan

- [x] New `CwmthumbnailSafetyTest` (10 tests): out-of-scope path rejection for `resize()` (4 shapes incl. traversal), `deleteFolder()` traversal rejection + in-scope acceptance, real-image resize success, failed-resize-keeps-previous-thumbnail, and structural pins that superseded deletion happens *after* the write and that no bare `->toFile()` call remains
- [x] Existing `CwmthumbnailDeleteFolderTest` still green (it caught two of my own regressions during development)
- [x] Full suite green: 1490 tests, 5988 assertions
- [x] `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTZ5pbMLhPwQxQksvvuhL