### PR TITLE
fix: key and daily-rotate the analytics session hash

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -1193,7 +1193,7 @@ CREATE TABLE IF NOT EXISTS `#__bsms_analytics_events` (
     `os`              VARCHAR(50) NULL DEFAULT NULL,
     `language`        VARCHAR(10) NULL DEFAULT NULL,
     `is_guest`        TINYINT(1) NULL DEFAULT NULL COMMENT '0=logged in, 1=guest',
-    `session_hash`    VARCHAR(64) NULL DEFAULT NULL COMMENT 'SHA-256 of session ID; consent-required',
+    `session_hash`    VARCHAR(64) NULL DEFAULT NULL COMMENT 'Keyed hash of session ID, rotated daily; not linkable across days; consent-required',
     `created`         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
     KEY `idx_study_created`    (`study_id`, `created`),

--- a/admin/sql/updates/mysql/10.5.6-20260806.sql
+++ b/admin/sql/updates/mysql/10.5.6-20260806.sql
@@ -24,3 +24,21 @@ ALTER TABLE `#__bsms_studytopics`
 -- them.
 DELETE FROM `#__bsms_studytopics`
 WHERE `study_id` NOT IN (SELECT `id` FROM `#__bsms_studies`);
+
+-- #1611: session_hash is now a keyed digest rotated daily, so a visitor cannot
+-- be followed across days. Update the column comment to say so.
+ALTER TABLE `#__bsms_analytics_events`
+    MODIFY `session_hash` VARCHAR(64) NULL DEFAULT NULL
+    COMMENT 'Keyed hash of session ID, rotated daily; not linkable across days; consent-required';
+
+-- Re-key the existing history. Rows written before this release hold a bare,
+-- unsalted SHA-256 that is stable for all time, so one visitor could be traced
+-- across the whole table. Folding each row's own date into the digest gives
+-- those rows the same cross-day unlinkability new rows get.
+--
+-- Rows from the same visitor on the same day still collide, so
+-- COUNT(DISTINCT session_hash) is unchanged and no historical Sessions figure
+-- moves. NULL stays NULL because CONCAT() propagates it.
+UPDATE `#__bsms_analytics_events`
+SET `session_hash` = SHA2(CONCAT(`session_hash`, DATE(`created`)), 256)
+WHERE `session_hash` IS NOT NULL;

--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -145,13 +145,28 @@ class CwmanalyticsHelper
             // Campus: resolved from study or media record
             $locationId = self::resolveLocationId($studyId, $mediaId);
 
-            // Session hash (personal data — consent-required)
+            // Session hash (personal data — consent-required).
+            //
+            // Keyed and rotated daily, so the same visitor hashes differently
+            // on different days and cannot be followed across them. See
+            // deriveSessionHash(). If no site secret is available the hash is
+            // left NULL rather than falling back to an unkeyed digest --
+            // losing a row from the Sessions count is preferable to writing a
+            // permanently linkable identifier.
             $sessionHash = null;
 
             if ($consentOn) {
                 try {
-                    $sessionId   = $app->getSession()->getId();
-                    $sessionHash = hash('sha256', $sessionId);
+                    $sessionId = (string) $app->getSession()->getId();
+                    $secret    = (string) $app->get('secret');
+
+                    if ($sessionId !== '' && $secret !== '') {
+                        $sessionHash = self::deriveSessionHash(
+                            $sessionId,
+                            $secret,
+                            (new \DateTime('now', new \DateTimeZone('UTC')))->format('Y-m-d')
+                        );
+                    }
                 } catch (\Exception $e) {
                     $sessionHash = null;
                 }
@@ -372,6 +387,55 @@ class CwmanalyticsHelper
         }
 
         return ['device' => $device, 'browser' => $browser, 'os' => $os];
+    }
+
+    /**
+     * Domain-separation label for the session-hash key derivation.
+     *
+     * Keeps the derived analytics key distinct from any other use of the site
+     * secret, so it is not interchangeable with tokens minted elsewhere.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const string SESSION_HASH_CONTEXT = 'proclaim:analytics:session';
+
+    /**
+     * Derive the stored session identifier: keyed, and rotated daily.
+     *
+     * Previously this was a bare hash('sha256', $sessionId). That had two
+     * problems. It was unkeyed, so the digest was reproducible by anyone
+     * holding a candidate session ID; and it was stable forever, so a single
+     * visitor could be followed across the entire history of the table.
+     *
+     * Keying with the site secret removes the first. Folding the day into the
+     * key removes the second: the same visitor produces a different hash
+     * tomorrow, and no amount of access to the stored data reveals that the
+     * two rows belong to one person. Within a day the value is still stable,
+     * which is exactly what COUNT(DISTINCT session_hash) needs -- so the
+     * Sessions metric keeps working while cross-day tracking becomes
+     * impossible.
+     *
+     * This mirrors the rotating-salt approach Plausible and Fathom use, and is
+     * the basis on which they describe themselves as storing no personal data.
+     * Note the value remains pseudonymous *within* a single day and is still
+     * treated as consent-required.
+     *
+     * Pure by design -- the secret and day are arguments rather than globals
+     * so the rotation can be proven in a test without a request context.
+     *
+     * @param   string  $sessionId  Raw session identifier; never stored.
+     * @param   string  $secret     Site secret used as key material.
+     * @param   string  $day        Rotation bucket, 'Y-m-d' in UTC.
+     *
+     * @return  string  64-character hex digest.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function deriveSessionHash(string $sessionId, string $secret, string $day): string
+    {
+        $dailyKey = hash_hmac('sha256', self::SESSION_HASH_CONTEXT . ':' . $day, $secret);
+
+        return hash_hmac('sha256', $sessionId, $dailyKey);
     }
 
     /**

--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -149,7 +149,7 @@ class CwmanalyticsHelper
             //
             // Keyed and rotated daily, so the same visitor hashes differently
             // on different days and cannot be followed across them. See
-            // deriveSessionHash(). If no site secret is available the hash is
+            // hashSessionForDay(). If no site secret is available the hash is
             // left NULL rather than falling back to an unkeyed digest --
             // losing a row from the Sessions count is preferable to writing a
             // permanently linkable identifier.
@@ -161,7 +161,7 @@ class CwmanalyticsHelper
                     $secret    = (string) $app->get('secret');
 
                     if ($sessionId !== '' && $secret !== '') {
-                        $sessionHash = self::deriveSessionHash(
+                        $sessionHash = self::hashSessionForDay(
                             $sessionId,
                             $secret,
                             (new \DateTime('now', new \DateTimeZone('UTC')))->format('Y-m-d')
@@ -400,12 +400,25 @@ class CwmanalyticsHelper
     private const string SESSION_HASH_CONTEXT = 'proclaim:analytics:session';
 
     /**
-     * Derive the stored session identifier: keyed, and rotated daily.
+     * Fingerprint a visitor's session for one particular day.
+     *
+     * This is what gets stored in session_hash, and it exists for exactly one
+     * reason: to count how many distinct visits happened, without recording
+     * who made them. COUNT(DISTINCT session_hash) is the Sessions figure on
+     * the analytics dashboard.
+     *
+     * The fingerprint deliberately changes every day. Two rows from the same
+     * visitor on the same day share a value, so a day's visits still count as
+     * one session; two rows from different days do not, so nobody can join
+     * them up. The raw session ID is never stored, and the value cannot be
+     * turned back into one.
      *
      * Previously this was a bare hash('sha256', $sessionId). That had two
      * problems. It was unkeyed, so the digest was reproducible by anyone
-     * holding a candidate session ID; and it was stable forever, so a single
-     * visitor could be followed across the entire history of the table.
+     * holding a candidate session ID -- letting them confirm that a specific
+     * person had visited. And it was stable forever, so a single visitor could
+     * be followed across the entire history of the table; 188 of them were, on
+     * a real 82,565-row site.
      *
      * Keying with the site secret removes the first. Folding the day into the
      * key removes the second: the same visitor produces a different hash
@@ -431,7 +444,7 @@ class CwmanalyticsHelper
      *
      * @since   __DEPLOY_VERSION__
      */
-    public static function deriveSessionHash(string $sessionId, string $secret, string $day): string
+    public static function hashSessionForDay(string $sessionId, string $secret, string $day): string
     {
         $dailyKey = hash_hmac('sha256', self::SESSION_HASH_CONTEXT . ':' . $day, $secret);
 

--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -67,16 +67,9 @@ class CwmanalyticsHelper
      * Respects GDPR opt-out (DNT header + proclaim_analytics_optout cookie).
      * Classifies UA and referrer at log-time; raw signals never stored.
      *
-     * NOTE: no GeoIP classification happens here, despite what this docblock
-     * previously claimed. There is no GeoIP resolution anywhere in the
-     * codebase, and country_code is absent from this method's INSERT column
-     * list, so #__bsms_analytics_events.country_code is always NULL. The
-     * monthly rollup and CwmanalyticsModel::getBreakdown('country_code', ...)
-     * therefore have nothing to report. Deliberately left unimplemented rather
-     * than wired up here: GeoIP means a new dependency and a new privacy
-     * surface, against a schema that documents never storing the raw IP. No
-     * admin view currently renders a country breakdown, so nothing surfaces an
-     * empty widget. See #1571.
+     * NOTE: no GeoIP happens here -- country_code is absent from the INSERT and
+     * is always NULL. Unimplemented on purpose: it means a new dependency and
+     * privacy surface, and no admin view renders a country breakdown.
      *
      * @param   string  $type      Event type: page_view|play|download|outbound_click
      * @param   int     $studyId   Study (message) ID, 0 if media-only
@@ -146,13 +139,8 @@ class CwmanalyticsHelper
             $locationId = self::resolveLocationId($studyId, $mediaId);
 
             // Session hash (personal data — consent-required).
-            //
-            // Keyed and rotated daily, so the same visitor hashes differently
-            // on different days and cannot be followed across them. See
-            // hashSessionForDay(). If no site secret is available the hash is
-            // left NULL rather than falling back to an unkeyed digest --
-            // losing a row from the Sessions count is preferable to writing a
-            // permanently linkable identifier.
+            // Left NULL without a secret rather than falling back to an
+            // unkeyed digest, which would be permanently linkable.
             $sessionHash = null;
 
             if ($consentOn) {
@@ -188,13 +176,7 @@ class CwmanalyticsHelper
             }
 
             // Outbound click: repurpose destUrl as referrer_url column.
-            //
-            // Gated on $consentOn like every other write to this column. It
-            // previously sat outside the gate, so a visitor who had signalled
-            // GPC/DNT still had a destination URL and timestamp recorded --
-            // and since referrer_url is otherwise only written when the
-            // referrer mode is set to 'full', this was the one path that
-            // populated the column on a default install.
+            // Gated on $consentOn like every other write to this column.
             if ($consentOn && $type === 'outbound_click' && $destUrl !== '') {
                 $referrerUrl = substr($destUrl, 0, 2048);
             }
@@ -390,51 +372,24 @@ class CwmanalyticsHelper
     }
 
     /**
-     * Domain-separation label for the session-hash key derivation.
-     *
-     * Keeps the derived analytics key distinct from any other use of the site
-     * secret, so it is not interchangeable with tokens minted elsewhere.
+     * Domain-separation label, so the analytics key is not interchangeable
+     * with tokens minted elsewhere from the same site secret.
      *
      * @since  __DEPLOY_VERSION__
      */
     private const string SESSION_HASH_CONTEXT = 'proclaim:analytics:session';
 
     /**
-     * Fingerprint a visitor's session for one particular day.
+     * Fingerprint a visitor's session for one day.
      *
-     * This is what gets stored in session_hash, and it exists for exactly one
-     * reason: to count how many distinct visits happened, without recording
-     * who made them. COUNT(DISTINCT session_hash) is the Sessions figure on
-     * the analytics dashboard.
+     * Stored in session_hash so COUNT(DISTINCT session_hash) can report the
+     * Sessions figure. Keyed with the site secret so an outsider cannot
+     * recompute it from a guessed session ID, and rotated daily so the same
+     * visitor is not linkable across days. Stable within a day, which is all
+     * the count needs.
      *
-     * The fingerprint deliberately changes every day. Two rows from the same
-     * visitor on the same day share a value, so a day's visits still count as
-     * one session; two rows from different days do not, so nobody can join
-     * them up. The raw session ID is never stored, and the value cannot be
-     * turned back into one.
-     *
-     * Previously this was a bare hash('sha256', $sessionId). That had two
-     * problems. It was unkeyed, so the digest was reproducible by anyone
-     * holding a candidate session ID -- letting them confirm that a specific
-     * person had visited. And it was stable forever, so a single visitor could
-     * be followed across the entire history of the table; 188 of them were, on
-     * a real 82,565-row site.
-     *
-     * Keying with the site secret removes the first. Folding the day into the
-     * key removes the second: the same visitor produces a different hash
-     * tomorrow, and no amount of access to the stored data reveals that the
-     * two rows belong to one person. Within a day the value is still stable,
-     * which is exactly what COUNT(DISTINCT session_hash) needs -- so the
-     * Sessions metric keeps working while cross-day tracking becomes
-     * impossible.
-     *
-     * This mirrors the rotating-salt approach Plausible and Fathom use, and is
-     * the basis on which they describe themselves as storing no personal data.
-     * Note the value remains pseudonymous *within* a single day and is still
-     * treated as consent-required.
-     *
-     * Pure by design -- the secret and day are arguments rather than globals
-     * so the rotation can be proven in a test without a request context.
+     * Secret and day are arguments rather than globals so the rotation is
+     * testable without a request context.
      *
      * @param   string  $sessionId  Raw session identifier; never stored.
      * @param   string  $secret     Site secret used as key material.
@@ -452,16 +407,11 @@ class CwmanalyticsHelper
     }
 
     /**
-     * Name of the cookie a consent manager sets to suppress personal-data columns.
+     * Cookie a site's own consent manager sets to suppress the personal-data
+     * columns. Any non-empty value counts.
      *
-     * This is Proclaim's published integration contract, not a cookie Proclaim
-     * sets. Proclaim deliberately ships no consent banner: virtually every
-     * Joomla site already runs one, and a second would compete with it.
-     * Joomla core offers nothing to integrate with either -- plg_system_
-     * privacyconsent covers account-registration consent and has no concept of
-     * an anonymous visitor -- so a documented cookie is the integration point.
-     *
-     * Set it to any non-empty value when a visitor declines analytics.
+     * Proclaim ships no consent banner -- most Joomla sites already run one --
+     * so this is the published integration point, not a cookie Proclaim sets.
      *
      * @since  __DEPLOY_VERSION__
      */
@@ -470,22 +420,13 @@ class CwmanalyticsHelper
     /**
      * Check whether the current visitor has opted out of personal-data tracking.
      *
-     * Three signals are honoured, any one of which suppresses the
-     * consent-required columns:
+     * Any one of three signals suppresses the consent-required columns:
+     * Sec-GPC: 1, DNT: 1, or OPTOUT_COOKIE. DNT is kept for completeness but is
+     * effectively defunct, which is why GPC was added alongside it.
      *
-     *  - Sec-GPC: 1 -- Global Privacy Control. The live successor to DNT, sent
-     *    by Firefox, Brave and DuckDuckGo and recognised under CCPA/CPRA.
-     *  - DNT: 1 -- retained for completeness, but effectively defunct: the W3C
-     *    discontinued the specification, Safari and Firefox removed the
-     *    setting, and Chrome never sent it by default. Almost no visitor sends
-     *    this, which is why GPC was added alongside it.
-     *  - The OPTOUT_COOKIE, which the site's own consent manager sets.
-     *
-     * Note this governs the personal-data tier only. Proclaim itself stores
-     * nothing on the visitor's device -- the session identifier it hashes comes
-     * from Joomla's own strictly-necessary session cookie -- so the ePrivacy
-     * consent requirement that cookie banners exist to satisfy is not what is
-     * being answered here.
+     * Governs the personal-data tier only. Proclaim stores nothing on the
+     * visitor's device, so this is not answering the ePrivacy cookie-consent
+     * question. See #1613.
      *
      * @return  bool  True if opted out (skip personal-data columns).
      *
@@ -540,21 +481,14 @@ class CwmanalyticsHelper
     /**
      * Is this retention window safe to delete raw events against?
      *
-     * A window of zero or less puts the cutoff at -- or, when negative,
-     * *after* -- "now", which makes the purge DELETE match every row in
-     * the events table rather than only aged ones.
+     * A window of zero or less puts the cutoff at (or, when negative, after)
+     * "now", so the purge DELETE would match every row rather than only aged
+     * ones. A blank field in the Scheduler UI saves as "" and casts to 0, so
+     * this is reachable from ordinary configuration. Adding filter="int" to
+     * that field does NOT help -- it converts "" to exactly the lethal 0.
      *
-     * That is reachable from ordinary configuration, not just tampering.
-     * The task plugin reads `retention_days` from task params and casts it
-     * with `(int)`, and `?? 90` only defends against NULL: a blank field in
-     * the Scheduler UI saves as `""`, and `(int) "" === 0`. `min="7"` on
-     * the form field is a client-side rendering hint that is not enforced
-     * server-side. Note that adding `filter="int"` to that field does NOT
-     * help -- it converts `""` to exactly the lethal `0`.
-     *
-     * Kept pure and public so it can be exercised without touching the
-     * database. Testing the guard by calling rollupAndPurge() with a bad
-     * window means running the real DELETE if the guard is wrong.
+     * Pure and public so the guard can be tested without running the real
+     * DELETE.
      *
      * @param   int  $retentionDays  Proposed retention window in days.
      *

--- a/tests/integration/Admin/Helper/CwmanalyticsSessionHashTest.php
+++ b/tests/integration/Admin/Helper/CwmanalyticsSessionHashTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Integration tests for the daily-rotating session hash.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmanalyticsHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1611.
+ *
+ * session_hash was a bare hash('sha256', $sessionId): unkeyed, so the digest
+ * was reproducible by anyone holding a candidate session ID, and stable
+ * forever, so one visitor could be followed across the entire history of the
+ * table. Measured against 82,565 real events, it also linked two events in
+ * only 1.6% of sessions -- carrying the whole consent burden for almost no
+ * analytical return.
+ *
+ * It is now keyed with the site secret and rotated daily, mirroring the
+ * approach Plausible and Fathom use. Within a day the value is stable, so
+ * COUNT(DISTINCT session_hash) -- the Sessions KPI -- is unaffected; across
+ * days the same visitor is unlinkable.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmanalyticsHelper::class)]
+class CwmanalyticsSessionHashTest extends IntegrationTestCase
+{
+    private const string SESSION = 'abc123sessionidentifier';
+    private const string SECRET  = 'site-secret-value';
+
+    // -------------------------------------------------------------------------
+    // The rotation property
+    // -------------------------------------------------------------------------
+
+    #[TestDox('The same visitor on the same day produces a stable hash')]
+    public function testStableWithinADay(): void
+    {
+        $this->assertSame(
+            CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06'),
+            CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06'),
+            'Sessions counting depends on same-day stability'
+        );
+    }
+
+    /**
+     * The point of the change: history cannot be joined across days.
+     */
+    #[TestDox('The same visitor on a different day is unlinkable')]
+    public function testRotatesAcrossDays(): void
+    {
+        $day1 = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
+        $day2 = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-07');
+
+        $this->assertNotSame(
+            $day1,
+            $day2,
+            'A stable hash let one visitor be traced across the whole table — see #1611'
+        );
+    }
+
+    #[TestDox('Different visitors on the same day differ')]
+    public function testDistinctVisitorsDiffer(): void
+    {
+        $this->assertNotSame(
+            CwmanalyticsHelper::deriveSessionHash('session-one', self::SECRET, '2026-08-06'),
+            CwmanalyticsHelper::deriveSessionHash('session-two', self::SECRET, '2026-08-06')
+        );
+    }
+
+    #[TestDox('The digest is keyed, not a plain SHA-256 of the session id')]
+    public function testIsKeyed(): void
+    {
+        $derived = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
+
+        $this->assertNotSame(
+            hash('sha256', self::SESSION),
+            $derived,
+            'An unkeyed digest is reproducible by anyone holding a candidate session ID — see #1611'
+        );
+
+        // A different site secret must yield a different value, or the key is
+        // not actually participating.
+        $this->assertNotSame(
+            $derived,
+            CwmanalyticsHelper::deriveSessionHash(self::SESSION, 'another-secret', '2026-08-06'),
+            'The site secret must be load-bearing'
+        );
+    }
+
+    #[TestDox('The stored value never contains the raw session id')]
+    public function testRawSessionIdIsNotStored(): void
+    {
+        $derived = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
+
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $derived, 'Expected a hex sha256 digest');
+        $this->assertStringNotContainsString(self::SESSION, $derived);
+    }
+
+    /**
+     * An empty secret must not silently degrade to an unkeyed hash. logEvent()
+     * stores NULL in that case; this pins that the derivation itself still
+     * keys rather than collapsing to hash('sha256', $id).
+     */
+    #[TestDox('An empty secret does not collapse to an unkeyed digest')]
+    public function testEmptySecretDoesNotCollapseToPlainHash(): void
+    {
+        $this->assertNotSame(
+            hash('sha256', self::SESSION),
+            CwmanalyticsHelper::deriveSessionHash(self::SESSION, '', '2026-08-06')
+        );
+    }
+
+    #[TestDox('logEvent leaves the hash NULL when no site secret is available')]
+    public function testLogEventRefusesToWriteAnUnkeyedHash(): void
+    {
+        $ref   = new \ReflectionMethod(CwmanalyticsHelper::class, 'logEvent');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString(
+            "\$secret !== ''",
+            $body,
+            'Without a secret the hash must stay NULL rather than fall back to an unkeyed digest — see #1611'
+        );
+        $this->assertStringNotContainsString(
+            "hash('sha256', \$sessionId)",
+            $body,
+            'The bare unkeyed digest must not reappear'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // The migration must not move any historical Sessions figure
+    // -------------------------------------------------------------------------
+
+    /**
+     * The 10.5.6 migration re-keys existing rows with
+     * SHA2(CONCAT(session_hash, DATE(created)), 256) so old data gains the
+     * same cross-day unlinkability. That must leave COUNT(DISTINCT
+     * session_hash) untouched per day, or historical Sessions numbers would
+     * shift under administrators.
+     *
+     * Runs against a TEMPORARY table: it exists only for this connection and
+     * disappears with it, so there is no path from this test to real rows.
+     */
+    #[TestDox('Re-keying historical rows preserves the per-day Sessions count')]
+    public function testMigrationPreservesPerDaySessionCounts(): void
+    {
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        $db->setQuery(
+            'CREATE TEMPORARY TABLE cwm1611_rekey ('
+            . ' session_hash VARCHAR(64) NULL, created DATETIME NOT NULL)'
+        )->execute();
+
+        // Two visitors, each seen on two days, plus a repeat visit and a NULL.
+        $rows = [
+            ['aaa', '2026-08-06 09:00:00'],
+            ['aaa', '2026-08-06 11:00:00'], // same visitor, same day
+            ['aaa', '2026-08-07 09:00:00'], // same visitor, next day
+            ['bbb', '2026-08-06 10:00:00'],
+            [null,  '2026-08-06 12:00:00'],
+        ];
+
+        foreach ($rows as [$hash, $created]) {
+            $db->setQuery(
+                'INSERT INTO cwm1611_rekey (session_hash, created) VALUES ('
+                . ($hash === null ? 'NULL' : $db->quote($hash)) . ', ' . $db->quote($created) . ')'
+            )->execute();
+        }
+
+        $perDay = static fn (): array => $db->setQuery(
+            'SELECT DATE(created) d, COUNT(DISTINCT session_hash) n FROM cwm1611_rekey GROUP BY DATE(created) ORDER BY d'
+        )->loadAssocList('d', 'n');
+
+        $before = $perDay();
+
+        $db->setQuery(
+            'UPDATE cwm1611_rekey SET session_hash = SHA2(CONCAT(session_hash, DATE(created)), 256)'
+            . ' WHERE session_hash IS NOT NULL'
+        )->execute();
+
+        $this->assertSame($before, $perDay(), 'Historical Sessions figures must not move — see #1611');
+
+        // And the visitor must no longer be joinable across days.
+        $crossDay = (int) $db->setQuery(
+            'SELECT COUNT(*) FROM (SELECT session_hash FROM cwm1611_rekey WHERE session_hash IS NOT NULL'
+            . ' GROUP BY session_hash HAVING COUNT(DISTINCT DATE(created)) > 1) x'
+        )->loadResult();
+
+        $this->assertSame(0, $crossDay, 'No hash may span two days after re-keying');
+
+        // NULLs must survive as NULL rather than becoming a digest of "".
+        $this->assertSame(
+            1,
+            (int) $db->setQuery('SELECT COUNT(*) FROM cwm1611_rekey WHERE session_hash IS NULL')->loadResult(),
+            'CONCAT() propagates NULL; a NULL hash must not become a real one'
+        );
+
+        $db->setQuery('DROP TEMPORARY TABLE cwm1611_rekey')->execute();
+    }
+}

--- a/tests/integration/Admin/Helper/CwmanalyticsSessionHashTest.php
+++ b/tests/integration/Admin/Helper/CwmanalyticsSessionHashTest.php
@@ -49,8 +49,8 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
     public function testStableWithinADay(): void
     {
         $this->assertSame(
-            CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06'),
-            CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06'),
+            CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-06'),
+            CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-06'),
             'Sessions counting depends on same-day stability'
         );
     }
@@ -61,8 +61,8 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
     #[TestDox('The same visitor on a different day is unlinkable')]
     public function testRotatesAcrossDays(): void
     {
-        $day1 = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
-        $day2 = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-07');
+        $day1 = CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-06');
+        $day2 = CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-07');
 
         $this->assertNotSame(
             $day1,
@@ -75,15 +75,15 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
     public function testDistinctVisitorsDiffer(): void
     {
         $this->assertNotSame(
-            CwmanalyticsHelper::deriveSessionHash('session-one', self::SECRET, '2026-08-06'),
-            CwmanalyticsHelper::deriveSessionHash('session-two', self::SECRET, '2026-08-06')
+            CwmanalyticsHelper::hashSessionForDay('session-one', self::SECRET, '2026-08-06'),
+            CwmanalyticsHelper::hashSessionForDay('session-two', self::SECRET, '2026-08-06')
         );
     }
 
     #[TestDox('The digest is keyed, not a plain SHA-256 of the session id')]
     public function testIsKeyed(): void
     {
-        $derived = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
+        $derived = CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-06');
 
         $this->assertNotSame(
             hash('sha256', self::SESSION),
@@ -95,7 +95,7 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
         // not actually participating.
         $this->assertNotSame(
             $derived,
-            CwmanalyticsHelper::deriveSessionHash(self::SESSION, 'another-secret', '2026-08-06'),
+            CwmanalyticsHelper::hashSessionForDay(self::SESSION, 'another-secret', '2026-08-06'),
             'The site secret must be load-bearing'
         );
     }
@@ -103,7 +103,7 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
     #[TestDox('The stored value never contains the raw session id')]
     public function testRawSessionIdIsNotStored(): void
     {
-        $derived = CwmanalyticsHelper::deriveSessionHash(self::SESSION, self::SECRET, '2026-08-06');
+        $derived = CwmanalyticsHelper::hashSessionForDay(self::SESSION, self::SECRET, '2026-08-06');
 
         $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $derived, 'Expected a hex sha256 digest');
         $this->assertStringNotContainsString(self::SESSION, $derived);
@@ -119,7 +119,7 @@ class CwmanalyticsSessionHashTest extends IntegrationTestCase
     {
         $this->assertNotSame(
             hash('sha256', self::SESSION),
-            CwmanalyticsHelper::deriveSessionHash(self::SESSION, '', '2026-08-06')
+            CwmanalyticsHelper::hashSessionForDay(self::SESSION, '', '2026-08-06')
         );
     }
 


### PR DESCRIPTION
Fixes #1611

## The problem

```php
$sessionHash = hash('sha256', $sessionId);   // unkeyed, and stable forever
```

Two consequences:

1. **Unkeyed** — anyone holding a candidate session ID could reproduce the digest and confirm a visitor's presence.
2. **Stable forever** — one visitor could be followed across the entire history of the table. **Measured on a real 82,565-row site: 188 visitors were linkable across days.**

## The fix

Keyed with Joomla's site secret, with the UTC day folded into a domain-separated subkey:

```php
$dailyKey = hash_hmac('sha256', self::SESSION_HASH_CONTEXT . ':' . $day, $secret);
return hash_hmac('sha256', $sessionId, $dailyKey);
```

| | Before | After |
|---|---|---|
| Same visitor, same day | same hash | **same hash** (Sessions KPI unaffected) |
| Same visitor, next day | same hash | **different hash** (unlinkable) |
| Reproducible without the secret | yes | no |

Mirrors the rotating-salt approach Plausible and Fathom use — the basis on which they describe themselves as storing no personal data.

## No new configuration

@bcordis asked whether session keys are Joomla-driven. They are, and that made this cheaper than the option I originally quoted (which said "new param for the secret" — not needed):

- **Session ID** is Joomla's: `$app->getSession()->getId()`. Proclaim creates no session, sets no cookie, controls no expiry.
- **Key** is Joomla's: `$app->get('secret')`, generated at install by `UserHelper::genRandomPassword(16)` and already used by `Version.php`.
- **Rotation** comes from folding the date into the derivation, not from rotating anything stored — so there is nothing to schedule, manage or back up.

**Accuracy cost is nil in practice**: Joomla's default session lifetime is **15 minutes**, so sessions effectively never span a day boundary for the rotation to truncate. (This also explains the earlier finding that 98.4% of sessions hold a single event — that is genuine single-page sermon visits, not a broken identifier.)

## Fail-safe

Where no site secret is available the hash is left **NULL** rather than falling back to an unkeyed digest. Losing a row from the Sessions count is preferable to writing a permanently linkable identifier.

## Migration — validated against the real export

`10.5.6-20260806.sql` re-keys existing rows as `SHA2(CONCAT(session_hash, DATE(created)), 256)`, giving history the same cross-day unlinkability. Run against the production export:

| Check | Result |
|---|---|
| Days where the Sessions figure moved | **0** |
| Hashes linkable across days | **188 → 0** |
| NULL hashes preserved | 1,156 (exact — `CONCAT()` propagates NULL) |
| Digests still well-formed 64-hex | 81,409 (all) |

## Honest scope

This is a **large reduction in linkability, not anonymisation.** The value remains pseudonymous within a single day and is still consent-required. Per #1611's measurements, only aggregation reaches anonymity — expiring columns still left 67.9% of rows uniquely identifying at day resolution.

## Testing

8 new tests in `CwmanalyticsSessionHashTest`, including a behavioural check that the migration's re-key preserves per-day `COUNT(DISTINCT)` — run against a `TEMPORARY` table so there is no path from the test to real rows. Red-checked by reverting the derivation to the bare hash: three assertions fail.

Full suite **1536 tests / 6058 assertions** on PHP 8.5.7. Dev analytics tables verified unchanged before and after.

⚠️ CI may fail on `Set up job` — GitHub Actions is [under an active incident](https://www.githubstatus.com/). Locally verified on 8.3.31 / 8.5.3 / 8.5.7.