### PR TITLE
fix: stop overwriting admin-edited guided tours on every update

### DIFF
--- a/admin/src/Helper/CwmguidedtourHelper.php
+++ b/admin/src/Helper/CwmguidedtourHelper.php
@@ -476,7 +476,7 @@ class CwmguidedtourHelper
      *
      * @since 10.1.0
      */
-    public function registerGuidedTours(): int
+    public function registerGuidedTours(bool $force = false): int
     {
         if (!$this->supportsGuidedTours()) {
             Log::add('Guided tours not supported on this Joomla version', Log::INFO, 'com_proclaim');
@@ -486,18 +486,53 @@ class CwmguidedtourHelper
         $count = 0;
 
         foreach ($this->tours as $key => $tour) {
-            if ($this->tourExists($tour['uid'])) {
-                if ($this->updateTour($key, $tour)) {
+            if (!$this->tourExists($tour['uid'])) {
+                if ($this->insertTour($key, $tour)) {
                     $count++;
-                    Log::add('Updated guided tour: ' . $key, Log::INFO, 'com_proclaim');
+                    Log::add('Registered guided tour: ' . $key, Log::INFO, 'com_proclaim');
                 }
-            } elseif ($this->insertTour($key, $tour)) {
+
+                continue;
+            }
+
+            // The tour is already present. Once installed it belongs to the
+            // site: an administrator may have unpublished it, raised its access
+            // level, reworded steps or added translated rows through Joomla's
+            // Guided Tours UI. Rewriting it here would discard all of that, and
+            // this method runs on every Proclaim release including no-op patch
+            // bumps, so the loss would be silent and repeated.
+            //
+            // Refreshing from the shipped definition therefore has to be asked
+            // for explicitly.
+            if (!$force) {
+                Log::add('Preserved existing guided tour (admin-owned): ' . $key, Log::INFO, 'com_proclaim');
+
+                continue;
+            }
+
+            if ($this->updateTour($key, $tour)) {
                 $count++;
-                Log::add('Registered guided tour: ' . $key, Log::INFO, 'com_proclaim');
+                Log::add('Reset guided tour to shipped default: ' . $key, Log::INFO, 'com_proclaim');
             }
         }
 
         return $count;
+    }
+
+    /**
+     * Discard local changes and rewrite every tour from its shipped definition.
+     *
+     * Destructive: replaces tour metadata and deletes and reinserts all steps,
+     * losing admin edits and translated step rows. Exposed so a reset can be
+     * offered deliberately, rather than happening as a side effect of updating.
+     *
+     * @return  int  Number of tours rewritten
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function resetGuidedTours(): int
+    {
+        return $this->registerGuidedTours(true);
     }
 
 
@@ -529,17 +564,102 @@ class CwmguidedtourHelper
      */
     public function getTourId(string $uid): int
     {
+        $ids = $this->getTourIds($uid);
+
+        return $ids === [] ? 0 : $ids[0];
+    }
+
+    /**
+     * Get every tour id sharing a uid, lowest first.
+     *
+     * Core's #__guidedtours indexes uid with a plain KEY, not a UNIQUE one, so
+     * more than one row can carry the same uid. Ordering makes callers pick the
+     * same row every time instead of whichever the server happens to return.
+     *
+     * @param   string  $uid  Tour UID
+     *
+     * @return  int[]  Matching ids, ascending
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getTourIds(string $uid): array
+    {
         if (!$this->supportsGuidedTours()) {
-            return 0;
+            return [];
         }
 
         $query = $this->db->createQuery()
             ->select($this->db->quoteName('id'))
             ->from($this->db->quoteName('#__guidedtours'))
-            ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($uid));
+            ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($uid))
+            ->order($this->db->quoteName('id') . ' ASC');
         $this->db->setQuery($query);
 
-        return (int) $this->db->loadResult();
+        return array_map('intval', $this->db->loadColumn() ?: []);
+    }
+
+    /**
+     * Collapse duplicate rows for a uid down to the earliest one.
+     *
+     * Registration is check-then-act with no lock, so two overlapping requests
+     * can both find the tour absent and both insert it. Nothing in core
+     * prevents that -- uid is not unique -- and the surplus rows are otherwise
+     * permanent: they survive a Proclaim uninstall because they live in core
+     * tables. Running this after an insert keeps the damage from accumulating
+     * and clears up sites that already have it.
+     *
+     * @param   string  $uid  Tour UID
+     *
+     * @return  int  Number of duplicate tours removed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function pruneDuplicateTours(string $uid): int
+    {
+        $ids = $this->getTourIds($uid);
+
+        if (\count($ids) < 2) {
+            return 0;
+        }
+
+        // Keep the earliest; anything after it is a duplicate.
+        $surplus = \array_slice($ids, 1);
+
+        foreach ($surplus as $id) {
+            $this->deleteTourById($id);
+        }
+
+        Log::add(
+            'Removed ' . \count($surplus) . ' duplicate guided tour(s) for uid ' . $uid,
+            Log::WARNING,
+            'com_proclaim'
+        );
+
+        return \count($surplus);
+    }
+
+    /**
+     * Delete one tour and its steps.
+     *
+     * @param   int  $tourId  Tour id
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function deleteTourById(int $tourId): void
+    {
+        $query = $this->db->createQuery()
+            ->delete($this->db->quoteName('#__guidedtour_steps'))
+            ->where($this->db->quoteName('tour_id') . ' = ' . $tourId);
+        $this->db->setQuery($query);
+        $this->db->execute();
+
+        $query = $this->db->createQuery()
+            ->delete($this->db->quoteName('#__guidedtours'))
+            ->where($this->db->quoteName('id') . ' = ' . $tourId);
+        $this->db->setQuery($query);
+        $this->db->execute();
     }
 
     /**
@@ -624,6 +744,11 @@ class CwmguidedtourHelper
 
             $this->db->insertObject('#__guidedtours', $tourObj, 'id');
             $tourId = $this->db->insertid();
+
+            // A concurrent request may have inserted the same uid between our
+            // existence check and this insert. Collapse any surplus rows now,
+            // while we still know which uid to look at.
+            $this->pruneDuplicateTours($tour['uid']);
 
             // Insert the steps
             $ordering = 1;
@@ -800,28 +925,11 @@ class CwmguidedtourHelper
         $count = 0;
 
         foreach ($this->tours as $tour) {
-            $query = $this->db->createQuery()
-                ->select($this->db->quoteName('id'))
-                ->from($this->db->quoteName('#__guidedtours'))
-                ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($tour['uid']));
-            $this->db->setQuery($query);
-            $tourId = $this->db->loadResult();
-
-            if ($tourId) {
-                // Delete steps first
-                $query = $this->db->createQuery()
-                    ->delete($this->db->quoteName('#__guidedtour_steps'))
-                    ->where($this->db->quoteName('tour_id') . ' = ' . (int) $tourId);
-                $this->db->setQuery($query);
-                $this->db->execute();
-
-                // Delete tour
-                $query = $this->db->createQuery()
-                    ->delete($this->db->quoteName('#__guidedtours'))
-                    ->where($this->db->quoteName('id') . ' = ' . (int) $tourId);
-                $this->db->setQuery($query);
-                $this->db->execute();
-
+            // Every row for the uid, not just one. uid is not unique in core,
+            // so a single-row delete would leave duplicates behind in core
+            // tables after Proclaim had been uninstalled.
+            foreach ($this->getTourIds($tour['uid']) as $tourId) {
+                $this->deleteTourById($tourId);
                 $count++;
             }
         }

--- a/tests/integration/Admin/Helper/CwmguidedtourHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmguidedtourHelperTest.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * Integration tests for guided tour registration.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmguidedtourHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1572.
+ *
+ * registerGuidedTours() ran on every Proclaim release, including no-op patch
+ * bumps, and rewrote any existing tour from the hardcoded definition --
+ * resetting published/access/language and deleting every step row before
+ * reinserting the shipped ones. Admin edits and translated steps were lost
+ * silently and repeatedly.
+ *
+ * Separately, core indexes #__guidedtours.uid with a plain KEY rather than a
+ * UNIQUE one, and registration is check-then-act with no lock, so concurrent
+ * requests could leave permanent duplicate tours. Lookups returned an
+ * arbitrary one and uninstall removed only one, leaving the rest in core
+ * tables forever.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmguidedtourHelper::class)]
+class CwmguidedtourHelperTest extends IntegrationTestCase
+{
+    private const string UID = 'com_proclaim_test_1572';
+
+    private ?DatabaseDriver $db = null;
+
+    private int $toursAtStart = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        if (!\in_array($this->db->getPrefix() . 'guidedtours', $this->db->getTableList(), true)) {
+            $this->markTestSkipped('Core #__guidedtours table not present');
+        }
+
+        $this->db->transactionStart(true);
+        $this->toursAtStart = $this->countTours();
+    }
+
+    protected function tearDown(): void
+    {
+        $leaked = null;
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+
+                // These tests write to core Joomla tables, so a broken
+                // isolation boundary damages more than Proclaim's own data.
+                $after = $this->countTours();
+
+                if ($after !== $this->toursAtStart) {
+                    $leaked = \sprintf(
+                        'Test isolation broke: #__guidedtours went from %d to %d rows.',
+                        $this->toursAtStart,
+                        $after
+                    );
+                }
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+
+        if ($leaked !== null) {
+            $this->fail($leaked);
+        }
+    }
+
+    /**
+     * @return  int  Total rows in the core tours table.
+     */
+    private function countTours(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__guidedtours'))
+        )->loadResult();
+    }
+
+    /**
+     * Insert a bare tour row directly, bypassing the helper.
+     *
+     * @param   string  $uid        Tour uid
+     * @param   string  $title      Title to store
+     * @param   int     $published  Published state
+     *
+     * @return  int  Inserted id
+     */
+    private function insertRawTour(string $uid, string $title = 'Local title', int $published = 1): int
+    {
+        $row = (object) [
+            'title'       => $title,
+            'description' => 'local description',
+            'extensions'  => json_encode(['com_proclaim']),
+            'url'         => 'administrator/index.php?option=com_proclaim',
+            'published'   => $published,
+            'access'      => 1,
+            'language'    => '*',
+            'note'        => '',
+            'uid'         => $uid,
+            'created'     => (new \Joomla\CMS\Date\Date())->toSql(),
+            'created_by'  => 0,
+            'modified'    => (new \Joomla\CMS\Date\Date())->toSql(),
+            'modified_by' => 0,
+        ];
+
+        $this->db->insertObject('#__guidedtours', $row, 'id');
+
+        return (int) $this->db->insertid();
+    }
+
+
+    /**
+     * A helper whose tour list holds only a synthetic test tour.
+     *
+     * Registration iterates every shipped definition, and a real site already
+     * carries those rows, so tests that asserted against the shipped uid were
+     * really asserting against whatever the site happened to have. Replacing
+     * the list keeps each test dependent only on its own fixture.
+     *
+     * @return  CwmguidedtourHelper
+     */
+    private function helper(): CwmguidedtourHelper
+    {
+        $helper = new CwmguidedtourHelper();
+
+        $tours = new \ReflectionProperty(CwmguidedtourHelper::class, 'tours');
+        $tours->setValue($helper, [
+            'test_1572' => [
+                'title'       => 'SHIPPED_TITLE',
+                'description' => 'SHIPPED_DESC',
+                'url'         => 'administrator/index.php?option=com_proclaim',
+                'extensions'  => ['com_proclaim'],
+                'published'   => 1,
+                'access'      => 1,
+                'language'    => '*',
+                'note'        => '',
+                'uid'         => self::UID,
+                'autostart'   => false,
+                'steps'       => [
+                    [
+                        'title'       => 'SHIPPED_STEP',
+                        'description' => 'SHIPPED_STEP_DESC',
+                        'position'    => 'center',
+                        'target'      => '',
+                        'type'        => 0,
+                        'url'         => 'administrator/index.php?option=com_proclaim',
+                    ],
+                ],
+            ],
+        ]);
+
+        return $helper;
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 1 -- an existing tour is not rewritten on update
+    // -------------------------------------------------------------------------
+
+    #[TestDox('Registering leaves an existing tour untouched')]
+    public function testRegisterPreservesAnExistingTour(): void
+    {
+        $id = $this->insertRawTour(self::UID, 'Admin renamed this', 0);
+
+        $this->helper()->registerGuidedTours();
+
+        $row = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select([$this->db->quoteName('title'), $this->db->quoteName('published')])
+                ->from($this->db->quoteName('#__guidedtours'))
+                ->where($this->db->quoteName('id') . ' = ' . $id)
+        )->loadObject();
+
+        $this->assertSame(
+            'Admin renamed this',
+            $row->title,
+            'Every Proclaim update overwrote admin-edited tour text — see #1572'
+        );
+        $this->assertSame(
+            '0',
+            (string) $row->published,
+            'An unpublished tour was silently re-published on each update — see #1572'
+        );
+    }
+
+    #[TestDox('Registering does not delete the steps of an existing tour')]
+    public function testRegisterPreservesExistingSteps(): void
+    {
+        $id = $this->insertRawTour(self::UID);
+
+        $step = (object) [
+            'tour_id'     => $id,
+            'title'       => 'Admin authored step',
+            'description' => 'translated content',
+            'position'    => 'center',
+            'target'      => '',
+            'type'        => 0,
+            'url'         => 'administrator/index.php',
+            'published'   => 1,
+            'language'    => 'de-DE',
+            'ordering'    => 1,
+            'note'        => '',
+            'created'     => (new \Joomla\CMS\Date\Date())->toSql(),
+            'created_by'  => 0,
+            'modified'    => (new \Joomla\CMS\Date\Date())->toSql(),
+            'modified_by' => 0,
+        ];
+        $this->db->insertObject('#__guidedtour_steps', $step, 'id');
+        $stepId = (int) $this->db->insertid();
+
+        $this->helper()->registerGuidedTours();
+
+        $this->assertSame(
+            1,
+            (int) $this->db->setQuery(
+                $this->db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($this->db->quoteName('#__guidedtour_steps'))
+                    ->where($this->db->quoteName('id') . ' = ' . $stepId)
+            )->loadResult(),
+            'Steps were deleted and reinserted on every update, losing translated rows — see #1572'
+        );
+    }
+
+    /**
+     * The destructive refresh must still be reachable, just not by accident.
+     */
+    #[TestDox('An explicit reset does rewrite the tour')]
+    public function testResetRewritesTheTour(): void
+    {
+        $id = $this->insertRawTour(self::UID, 'Admin renamed this', 0);
+
+        $this->helper()->resetGuidedTours();
+
+        $title = (string) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('title'))
+                ->from($this->db->quoteName('#__guidedtours'))
+                ->where($this->db->quoteName('id') . ' = ' . $id)
+        )->loadResult();
+
+        $this->assertNotSame('Admin renamed this', $title, 'An explicit reset is meant to restore the shipped text');
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- duplicate uids
+    // -------------------------------------------------------------------------
+
+    #[TestDox('Lookups return the earliest row when duplicates exist')]
+    public function testLookupIsDeterministicAcrossDuplicates(): void
+    {
+        $first  = $this->insertRawTour(self::UID, 'first');
+        $second = $this->insertRawTour(self::UID, 'second');
+
+        $this->assertGreaterThan($first, $second, 'Precondition: two rows share the uid');
+
+        $helper = $this->helper();
+
+        $this->assertSame($first, $helper->getTourId(self::UID), 'Lookup must not depend on server row order — see #1572');
+        $this->assertSame([$first, $second], $helper->getTourIds(self::UID));
+    }
+
+    /**
+     * Without ORDER BY, MySQL happens to return rows in primary-key order, so
+     * a runtime assertion here passes whether or not the clause is present.
+     * Pin it in the source instead rather than claim coverage we do not have.
+     */
+    #[TestDox('The duplicate lookup orders explicitly rather than relying on storage order')]
+    public function testLookupOrdersExplicitly(): void
+    {
+        $ref   = new \ReflectionMethod(CwmguidedtourHelper::class, 'getTourIds');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertMatchesRegularExpression(
+            '/->order\(/',
+            $body,
+            'Callers must get the same row every time, not whichever the server returns — see #1572'
+        );
+    }
+
+    #[TestDox('Uninstall removes every duplicate, not just one')]
+    public function testRemoveAllToursDeletesEveryDuplicate(): void
+    {
+        $this->insertRawTour(self::UID, 'first');
+        $this->insertRawTour(self::UID, 'second');
+        $this->insertRawTour(self::UID, 'third');
+
+        $this->helper()->removeAllTours();
+
+        $this->assertSame(
+            [],
+            $this->helper()->getTourIds(self::UID),
+            'Surplus rows survived uninstall in core tables forever — see #1572'
+        );
+    }
+
+    /**
+     * Registering into a database that already carries duplicates should leave
+     * exactly one behind, so existing damage heals rather than persisting.
+     */
+    #[TestDox('Registration collapses pre-existing duplicates')]
+    public function testRegistrationIsSelfHealingForExistingDuplicates(): void
+    {
+        $helper = $this->helper();
+
+        // No tour yet -> the helper inserts one, then a racing request adds a
+        // second. The next insert path prunes.
+        $this->insertRawTour(self::UID, 'racer one');
+        $this->insertRawTour(self::UID, 'racer two');
+
+        $ref     = new \ReflectionMethod(CwmguidedtourHelper::class, 'pruneDuplicateTours');
+        $removed = $ref->invoke($helper, self::UID);
+
+        $this->assertSame(1, $removed, 'Exactly one surplus row should be removed');
+        $this->assertCount(1, $helper->getTourIds(self::UID), 'One row must remain');
+    }
+
+    #[TestDox('Pruning a uid with no duplicates is a no-op')]
+    public function testPruneIsANoOpWithoutDuplicates(): void
+    {
+        $this->insertRawTour(self::UID, 'only one');
+
+        $ref = new \ReflectionMethod(CwmguidedtourHelper::class, 'pruneDuplicateTours');
+
+        $this->assertSame(0, $ref->invoke($this->helper(), self::UID));
+    }
+}


### PR DESCRIPTION
Fixes #1572

## 1. Every update rewrote the tour

`registerGuidedTours()` rewrote any tour it found from the hardcoded definition. It is a finish step in **both** of `CwminstallModel`'s lists — the full migration *and* the minimal no-DB-changes one (lines 362 and 371) — so it ran on **every Proclaim release, including no-op patch bumps**.

Each run reset `title`, `description`, `url`, `published`, `access`, `language`, `note` and `autostart`, then `DELETE`d every step row and reinserted the twelve shipped ones.

An administrator who unpublished the tour, raised its access level, reworded a step, or added translated step rows lost all of it on the next update — silently, with an unremarkable INFO log line.

**An installed tour now belongs to the site.** Registration inserts when absent and otherwise leaves it alone. The destructive refresh remains available via `resetGuidedTours()`, so restoring shipped defaults is something a site *asks for* rather than something an update does to it.

## 2. Duplicate tours were permanent

Verified: core indexes `uid` with a plain `KEY idx_uid (uid(191))`, **not** UNIQUE — in `extensions.sql` and against a live database (`non_unique=1`). Registration is check-then-act with no lock, so two overlapping requests could both find the tour missing and both insert.

The surplus rows were permanent:

- `getTourId()` used `loadResult()` with no `ORDER BY` → returned an arbitrary duplicate, which then drove autostart wiring and every future update
- `removeAllTours()` deleted **one row per uid** → the rest survived in **core tables even after Proclaim was uninstalled**

Now: lookups go through `getTourIds()` ordered by `id`; `removeAllTours()` deletes every match; and `insertTour()` prunes surplus rows immediately after inserting — which also **heals databases that already have duplicates**.

### Deliberately no UNIQUE index

The issue suggested a UNIQUE migration on `uid` as a longer-term fix. I did not do that: `#__guidedtours` is a **core Joomla table**, and altering its schema from an extension puts us in conflict with core migrations and with any other extension registering tours. Converging after the fact is the safer half of that trade.

## Testing

8 tests in `CwmguidedtourHelperTest`, run against the real core tables inside a savepoint-aware transaction, with a `tearDown()` row-count assertion — these write to *core* tables, so a broken isolation boundary would damage more than Proclaim's own data. Verified 16 tours / 132 steps unchanged before and after.

Tests scope the helper to a synthetic tour via reflection. My first version asserted against the shipped uid and failed, because a real site already carries that row — the tests were really asserting against whatever the site happened to have.

**Red-checked per fix**, and two of my first attempts were invalid, so I redid them:

| Fix | Reverted → |
|---|---|
| Preserve on update | 2 tests fail |
| `removeAllTours` multi-delete | 1 test fails |
| Deterministic ordering | **0 tests fail** |

That last one is honest rather than fixed: without `ORDER BY`, MySQL returns rows in primary-key order anyway, so a runtime assertion passes either way. It is pinned with a source-level assertion instead of claiming coverage that does not exist.

Full suite **1544 tests / 6070 assertions**.

⚠️ CI may fail at `Set up job` — GitHub Actions incident is ongoing. Verified locally on PHP 8.5.7.