### PR TITLE
fix: make scripture reference saving atomic

### DIFF
--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -244,8 +244,7 @@ class CwmcsvimportHelper
             $scriptures = self::parseScriptures($rowData['scripture']);
 
             if (!empty($scriptures)) {
-                CwmscriptureHelper::saveScriptures($studyId, $scriptures);
-                CwmscriptureHelper::syncLegacyColumns($studyId, $scriptures);
+                CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
             }
         }
 
@@ -342,8 +341,7 @@ class CwmcsvimportHelper
             $scriptures = self::parseScriptures($rowData['scripture']);
 
             if (!empty($scriptures)) {
-                CwmscriptureHelper::saveScriptures($studyId, $scriptures);
-                CwmscriptureHelper::syncLegacyColumns($studyId, $scriptures);
+                CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
             }
         }
 

--- a/admin/src/Helper/CwmscriptureHelper.php
+++ b/admin/src/Helper/CwmscriptureHelper.php
@@ -160,6 +160,88 @@ class CwmscriptureHelper extends ScriptureHelper
 
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
+        // The delete and the inserts are one unit. Without that, an insert
+        // failing partway through leaves the study with its old references
+        // gone and only some of the new ones written, which nothing later
+        // reconciles.
+        //
+        // Savepoint-aware so this can nest inside a caller's transaction:
+        // MysqliDriver::transactionStart() calls begin_transaction()
+        // unconditionally otherwise, and MySQL implicitly commits any
+        // transaction already open when it does.
+        $db->transactionStart(true);
+
+        try {
+            self::writeScriptures($db, $studyId, $scriptures);
+            $db->transactionCommit(true);
+        } catch (\Throwable $e) {
+            try {
+                $db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Nothing to roll back.
+            }
+
+            // The cache was cleared before the write; clear it again so a
+            // reader after the rollback re-reads the restored rows.
+            self::resetScriptureCache($studyId);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Save references and refresh the legacy flat columns as one unit.
+     *
+     * #__bsms_studies carries a flattened copy of the first two references.
+     * Writing the junction table and that copy separately lets them diverge if
+     * the second write never happens, and the divergence is permanent -- the
+     * flat columns keep describing the previous reference set until some later
+     * save happens to succeed. Callers that maintain both should use this.
+     *
+     * @param   int                   $studyId     Study primary key
+     * @param   ScriptureReference[]  $scriptures  References to save
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function saveScripturesAndSync(int $studyId, array $scriptures): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart(true);
+
+        try {
+            self::resetScriptureCache($studyId);
+            self::writeScriptures($db, $studyId, $scriptures);
+            self::syncLegacyColumns($studyId, $scriptures);
+            $db->transactionCommit(true);
+        } catch (\Throwable $e) {
+            try {
+                $db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Nothing to roll back.
+            }
+
+            self::resetScriptureCache($studyId);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Replace a study's reference rows. Caller owns the transaction.
+     *
+     * @param   DatabaseInterface     $db          Database driver
+     * @param   int                   $studyId     Study primary key
+     * @param   ScriptureReference[]  $scriptures  References to write
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function writeScriptures(DatabaseInterface $db, int $studyId, array $scriptures): void
+    {
         $query = $db->createQuery()
             ->delete($db->quoteName('#__bsms_study_scriptures'))
             ->where($db->quoteName('study_id') . ' = ' . $studyId);

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -582,8 +582,7 @@ class CwmmessageModel extends AdminModel
             $ordering++;
         }
 
-        CwmscriptureHelper::saveScriptures($studyId, $scriptures);
-        CwmscriptureHelper::syncLegacyColumns($studyId, $scriptures);
+        CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
     }
 
     /**

--- a/tests/integration/Admin/Helper/CwmscriptureSaveTest.php
+++ b/tests/integration/Admin/Helper/CwmscriptureSaveTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Integration tests for atomic scripture reference saving.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1573.
+ *
+ * saveScriptures() deleted a study's references and then inserted the new set
+ * one row at a time with nothing wrapping the two. An insert failing partway
+ * through left the old references gone and only some of the new ones written.
+ *
+ * Callers paired it with syncLegacyColumns(), which copies the first two
+ * references into flat columns on #__bsms_studies. That second call never ran
+ * when the first threw, so the flat columns kept describing the previous
+ * reference set -- a divergence nothing reconciles until a later save happens
+ * to succeed.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmscriptureHelper::class)]
+class CwmscriptureSaveTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    private int $studyId = 0;
+
+    private int $rowsAtStart = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        $this->rowsAtStart = $this->countAllReferences();
+
+        // A study of our own, so no real content is touched.
+        $study = (object) [
+            'published'     => 0,
+            'studytitle'    => 'cwm1573 fixture',
+            'booknumber'    => 1,
+            'chapter_begin' => 1,
+            'verse_begin'   => 1,
+            'chapter_end'   => 1,
+            'verse_end'     => 1,
+            'bible_version' => 'kjv',
+            'language'      => '*',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+    }
+
+    protected function tearDown(): void
+    {
+        $leaked = null;
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+
+                $after = $this->countAllReferences();
+
+                if ($after !== $this->rowsAtStart) {
+                    $leaked = \sprintf(
+                        'Test isolation broke: #__bsms_study_scriptures went from %d to %d rows.',
+                        $this->rowsAtStart,
+                        $after
+                    );
+                }
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+
+        if ($leaked !== null) {
+            $this->fail($leaked);
+        }
+    }
+
+    /**
+     * @return  int  Total rows in the junction table.
+     */
+    private function countAllReferences(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__bsms_study_scriptures'))
+        )->loadResult();
+    }
+
+    /**
+     * @return  int  Reference rows for the fixture study.
+     */
+    private function countReferences(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_study_scriptures'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+
+    /**
+     * @return  int  booknumber currently on the flat columns.
+     */
+    private function legacyBookNumber(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('booknumber'))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+
+    /**
+     * Build a reference object shaped like ScriptureReference.
+     *
+     * @param   int   $book   Book number
+     * @param   mixed $verse  verse_begin value; a non-numeric value makes the
+     *                        INSERT fail, which is how a mid-loop failure is
+     *                        provoked without mocking the driver.
+     *
+     * @return  object
+     */
+    private function ref(int $book, mixed $verse = 1): object
+    {
+        return (object) [
+            'booknumber'    => $book,
+            'chapterBegin'  => 1,
+            'verseBegin'    => $verse,
+            'chapterEnd'    => 1,
+            'verseEnd'      => 2,
+            'bibleVersion'  => 'kjv',
+            'referenceText' => 'Book ' . $book . ' 1:1-2',
+        ];
+    }
+
+    #[TestDox('A successful save replaces the reference set')]
+    public function testSuccessfulSaveReplacesReferences(): void
+    {
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(1), $this->ref(2)]);
+        $this->assertSame(2, $this->countReferences());
+
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(5)]);
+        $this->assertSame(1, $this->countReferences(), 'The previous set must be replaced, not appended to');
+    }
+
+    /**
+     * The core guarantee: a failure partway through must leave the study with
+     * the references it had, not a half-written set.
+     */
+    #[TestDox('A failure mid-loop leaves the original references intact')]
+    public function testFailedSaveRollsBackToTheOriginalReferences(): void
+    {
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(1), $this->ref(2), $this->ref(3)]);
+        $this->assertSame(3, $this->countReferences(), 'Precondition');
+
+        // Second reference carries a value the column will not accept, so the
+        // loop throws after the first insert has already been written.
+        try {
+            CwmscriptureHelper::saveScriptures(
+                $this->studyId,
+                [$this->ref(7), $this->ref(8, 'not-a-number'), $this->ref(9)]
+            );
+            $this->fail('Expected the invalid reference to raise');
+        } catch (\Throwable) {
+            // Expected — the contract is that callers still see the failure.
+        }
+
+        $this->assertSame(
+            3,
+            $this->countReferences(),
+            'The delete committed independently of the inserts, losing the old references — see #1573'
+        );
+
+        $books = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('booknumber'))
+                ->from($this->db->quoteName('#__bsms_study_scriptures'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+                ->order($this->db->quoteName('ordering'))
+        )->loadColumn();
+
+        $this->assertSame(['1', '2', '3'], array_map('strval', $books), 'The original set must be exactly restored');
+    }
+
+    #[TestDox('The exception still reaches the caller after rollback')]
+    public function testFailureStillPropagates(): void
+    {
+        $this->expectException(\Throwable::class);
+
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(1, 'not-a-number')]);
+    }
+
+    // -------------------------------------------------------------------------
+    // The junction table and the flat columns must not diverge
+    // -------------------------------------------------------------------------
+
+    #[TestDox('Saving with sync updates both the references and the flat columns')]
+    public function testSaveAndSyncWritesBoth(): void
+    {
+        CwmscriptureHelper::saveScripturesAndSync($this->studyId, [$this->ref(42)]);
+
+        $this->assertSame(1, $this->countReferences());
+        $this->assertSame(42, $this->legacyBookNumber(), 'The flat columns must reflect the saved reference');
+    }
+
+    /**
+     * The divergence this issue is really about: references written, flat
+     * columns left describing the previous set.
+     */
+    #[TestDox('A failed save leaves references and flat columns consistent')]
+    public function testFailedSaveAndSyncLeavesNoDivergence(): void
+    {
+        CwmscriptureHelper::saveScripturesAndSync($this->studyId, [$this->ref(11)]);
+        $this->assertSame(11, $this->legacyBookNumber(), 'Precondition');
+
+        try {
+            CwmscriptureHelper::saveScripturesAndSync(
+                $this->studyId,
+                [$this->ref(20), $this->ref(21, 'not-a-number')]
+            );
+            $this->fail('Expected the invalid reference to raise');
+        } catch (\Throwable) {
+            // Expected.
+        }
+
+        $this->assertSame(
+            11,
+            $this->legacyBookNumber(),
+            'Flat columns must not describe a reference set that was never written — see #1573'
+        );
+
+        // Assert the surviving reference, not just how many there are: a bare
+        // count of 1 is satisfied both by the restored reference and by a
+        // single orphaned row from the failed write, which are opposite
+        // outcomes.
+        $books = array_map('intval', $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('booknumber'))
+                ->from($this->db->quoteName('#__bsms_study_scriptures'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+        )->loadColumn());
+
+        $this->assertSame(
+            [11],
+            $books,
+            'The junction table must still hold the reference the flat columns describe — see #1573'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1573

## The reference set could be left half-written

`saveScriptures()` deleted a study's reference rows and then inserted the new set one at a time, with nothing wrapping the two:

```php
$db->execute();                    // DELETE all rows for the study
foreach ($scriptures as $i => $ref) {
    $db->execute();                // INSERT, one at a time
}
```

An insert failing partway through — a bad value, a deadlock, a dropped connection — left the study with its **previous references already deleted and only some of the new ones written**. Nothing reconciled that afterwards.

Confirmed `#__bsms_study_scriptures` is InnoDB, so a transaction is viable.

The exception still reaches the caller, so upstream error handling is unchanged. What changes is that the rows are back the way they were when it does.

## And a second half: the flat columns diverged

`#__bsms_studies` carries a flattened copy of the first two references. All three call sites called the two operations separately:

```php
CwmscriptureHelper::saveScriptures($studyId, $scriptures);
CwmscriptureHelper::syncLegacyColumns($studyId, $scriptures);
```

When the first threw, the second never ran — so the flat columns went on describing the **previous** reference set while the junction table held something else. Permanent, until some later save happened to succeed.

`saveScripturesAndSync()` now writes both in one transaction, and all three call sites (`CwmmessageModel`, and both CSV import paths) use it.

## Savepoint-aware, deliberately

`MysqliDriver::transactionStart()` calls `begin_transaction()` unconditionally without the flag, and **MySQL implicitly commits any transaction already open** when it does — so a bare call here would commit a caller's transaction out from under it. No caller opens one today, but saving a study is exactly the kind of operation that grows one later. (This is not hypothetical; the same mistake destroyed 74 rows in a developer database earlier in this sweep.)

## Testing

5 tests that provoke a **real** mid-loop failure — an invalid value on the second reference — rather than mocking the driver or asserting on source text.

Both failure paths red-checked by reverting the transactions:

| Test | Reverted → |
|---|---|
| Original references restored | `Failed asserting that 1 is identical to 3` |
| No divergence after failure | `Failed asserting that two arrays are identical` |

⚠️ The second of those was initially a **weak assertion I had to strengthen**: `assertSame(1, countReferences())` passed in both states, because post-fix the single row is the restored reference and pre-fix it is an orphan from the failed write — same count, opposite meaning. It now asserts the surviving `booknumber`.

Fixture creates its own study, runs inside a savepoint-aware transaction, and `tearDown()` asserts the junction table row count is restored. Verified 827 studies / 441 references unchanged before and after.

Full suite **1533 tests / 6056 assertions**.

⚠️ CI may fail at `Set up job` — the GitHub Actions incident is ongoing. Verified locally on PHP 8.5.7.