### PR TITLE
fix: make teacher associations atomic

### DIFF
--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -235,8 +235,7 @@ class CwmcsvimportHelper
                 static fn (int $id) => ['teacher_id' => $id],
                 $teacherIds
             );
-            CwmstudyteacherHelper::saveTeachers($studyId, $teacherEntries);
-            CwmstudyteacherHelper::syncLegacyColumn($studyId, $teacherEntries);
+            CwmstudyteacherHelper::saveTeachersAndSync($studyId, $teacherEntries);
         }
 
         // Save scriptures
@@ -333,8 +332,7 @@ class CwmcsvimportHelper
                 static fn (int $id) => ['teacher_id' => $id],
                 $teacherIds
             );
-            CwmstudyteacherHelper::saveTeachers($studyId, $teacherEntries);
-            CwmstudyteacherHelper::syncLegacyColumn($studyId, $teacherEntries);
+            CwmstudyteacherHelper::saveTeachersAndSync($studyId, $teacherEntries);
         }
 
         // Update scriptures if provided

--- a/admin/src/Helper/CwmstudyteacherHelper.php
+++ b/admin/src/Helper/CwmstudyteacherHelper.php
@@ -174,7 +174,84 @@ class CwmstudyteacherHelper
 
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        // Delete existing
+        // The delete and the inserts are one unit. CwmmessageModel::save()
+        // commits the study row before calling this, so a failure partway
+        // through the loop left the study saved but its teacher list
+        // truncated, with the administrator seeing a fatal as though nothing
+        // had been written.
+        //
+        // Savepoint-aware: MysqliDriver::transactionStart() calls
+        // begin_transaction() unconditionally otherwise, and MySQL implicitly
+        // commits any transaction already open when it does.
+        $db->transactionStart(true);
+
+        try {
+            self::writeTeachers($db, $studyId, $teachers);
+            $db->transactionCommit(true);
+        } catch (\Throwable $e) {
+            try {
+                $db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Nothing to roll back.
+            }
+
+            self::resetCache($studyId);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Save the junction rows and the legacy teacher_id column as one unit.
+     *
+     * #__bsms_studies.teacher_id holds the primary teacher, duplicated from the
+     * junction table. Writing the two separately lets them diverge when the
+     * second write never happens, and nothing reconciles that afterwards.
+     *
+     * @param   int      $studyId   Study primary key
+     * @param   array[]  $teachers  Teacher entries to save
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function saveTeachersAndSync(int $studyId, array $teachers): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart(true);
+
+        try {
+            self::resetCache($studyId);
+            self::writeTeachers($db, $studyId, $teachers);
+            self::syncLegacyColumn($studyId, $teachers);
+            $db->transactionCommit(true);
+        } catch (\Throwable $e) {
+            try {
+                $db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Nothing to roll back.
+            }
+
+            self::resetCache($studyId);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Replace a study's teacher rows. Caller owns the transaction.
+     *
+     * @param   DatabaseInterface  $db        Database driver
+     * @param   int                $studyId   Study primary key
+     * @param   array[]            $teachers  Teacher entries to write
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function writeTeachers(DatabaseInterface $db, int $studyId, array $teachers): void
+    {
         $query = $db->createQuery()
             ->delete($db->quoteName('#__bsms_study_teachers'))
             ->where($db->quoteName('study_id') . ' = ' . $studyId);
@@ -184,7 +261,7 @@ class CwmstudyteacherHelper
         // Insert new (skip duplicates and empty entries)
         $seen = [];
 
-        foreach ($teachers as $i => $entry) {
+        foreach ($teachers as $entry) {
             $teacherId = (int) ($entry['teacher_id'] ?? 0);
 
             if ($teacherId <= 0 || isset($seen[$teacherId])) {

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -603,8 +603,7 @@ class CwmmessageModel extends AdminModel
             return;
         }
 
-        CwmstudyteacherHelper::saveTeachers($studyId, $teachersData);
-        CwmstudyteacherHelper::syncLegacyColumn($studyId, $teachersData);
+        CwmstudyteacherHelper::saveTeachersAndSync($studyId, $teachersData);
 
         // schemaorg's onContentAfterSave fires inside parent::save(), before the
         // junction is written here, so the auto-built schema has no author.

--- a/tests/integration/Admin/Helper/CwmstudyteacherSaveTest.php
+++ b/tests/integration/Admin/Helper/CwmstudyteacherSaveTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Integration tests for atomic study/teacher association saving.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1575.
+ *
+ * saveTeachers() deleted a study's teacher rows then inserted the new set one
+ * at a time with nothing wrapping the two. CwmmessageModel::save() commits the
+ * study row before calling it, so a failure partway through left the study
+ * saved but its teacher list truncated, while the administrator saw a fatal as
+ * though the save had not happened.
+ *
+ * #__bsms_studies.teacher_id duplicates the primary teacher, and callers wrote
+ * it in a separate statement that never ran when the first threw -- the same
+ * divergence fixed for scripture references in #1573.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmstudyteacherHelper::class)]
+class CwmstudyteacherSaveTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    private int $studyId = 0;
+
+    private int $rowsAtStart = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        $this->rowsAtStart = $this->countAllRows();
+
+        $study = (object) [
+            'published'  => 0,
+            'studytitle' => 'cwm1575 fixture',
+            'language'   => '*',
+            'teacher_id' => 0,
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+    }
+
+    protected function tearDown(): void
+    {
+        $leaked = null;
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+                $after = $this->countAllRows();
+
+                if ($after !== $this->rowsAtStart) {
+                    $leaked = \sprintf(
+                        'Test isolation broke: #__bsms_study_teachers went from %d to %d rows.',
+                        $this->rowsAtStart,
+                        $after
+                    );
+                }
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+
+        if ($leaked !== null) {
+            $this->fail($leaked);
+        }
+    }
+
+    /**
+     * @return  int  Total rows in the junction table.
+     */
+    private function countAllRows(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__bsms_study_teachers'))
+        )->loadResult();
+    }
+
+    /**
+     * @return  int[]  teacher_ids associated with the fixture study, in order.
+     */
+    private function teacherIds(): array
+    {
+        return array_map('intval', $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('teacher_id'))
+                ->from($this->db->quoteName('#__bsms_study_teachers'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+                ->order($this->db->quoteName('ordering'))
+        )->loadColumn());
+    }
+
+    /**
+     * @return  int  The legacy primary-teacher column.
+     */
+    private function legacyTeacherId(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('teacher_id'))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+
+    /**
+     * @param   int[]  $ids  Teacher ids
+     *
+     * @return  array[]  Entries shaped as saveTeachers() expects
+     */
+    private function entries(array $ids): array
+    {
+        return array_map(static fn (int $id): array => ['teacher_id' => $id], $ids);
+    }
+
+    #[TestDox('A successful save replaces the teacher list')]
+    public function testSuccessfulSaveReplacesTeachers(): void
+    {
+        CwmstudyteacherHelper::saveTeachers($this->studyId, $this->entries([4, 5]));
+        $this->assertSame([4, 5], $this->teacherIds());
+
+        CwmstudyteacherHelper::saveTeachers($this->studyId, $this->entries([9]));
+        $this->assertSame([9], $this->teacherIds(), 'The previous list must be replaced, not appended to');
+    }
+
+    #[TestDox('Duplicate and empty entries are skipped')]
+    public function testInputIsNormalised(): void
+    {
+        CwmstudyteacherHelper::saveTeachers($this->studyId, $this->entries([7, 7, 0, 8]));
+        $this->assertSame([7, 8], $this->teacherIds());
+    }
+
+    /**
+     * The guarantee that was missing: the study row is already committed by the
+     * time this runs, so a half-written teacher list is not recoverable.
+     */
+    #[TestDox('A failure mid-loop leaves the original teacher list intact')]
+    public function testFailedSaveRollsBack(): void
+    {
+        CwmstudyteacherHelper::saveTeachers($this->studyId, $this->entries([11, 12, 13]));
+        $this->assertSame([11, 12, 13], $this->teacherIds(), 'Precondition');
+
+        // teacher_id is an INT column; a value beyond its range makes the
+        // second insert fail after the first has been written.
+        try {
+            CwmstudyteacherHelper::saveTeachers(
+                $this->studyId,
+                [['teacher_id' => 21], ['teacher_id' => 999999999999999], ['teacher_id' => 23]]
+            );
+            $this->fail('Expected the out-of-range teacher id to raise');
+        } catch (\Throwable) {
+            // Expected — callers still see the failure.
+        }
+
+        $this->assertSame(
+            [11, 12, 13],
+            $this->teacherIds(),
+            'The delete committed independently of the inserts, truncating the teacher list — see #1575'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // The junction table and the legacy column must not diverge
+    // -------------------------------------------------------------------------
+
+    #[TestDox('Saving with sync updates both the junction rows and the legacy column')]
+    public function testSaveAndSyncWritesBoth(): void
+    {
+        CwmstudyteacherHelper::saveTeachersAndSync($this->studyId, $this->entries([42, 43]));
+
+        $this->assertSame([42, 43], $this->teacherIds());
+        $this->assertSame(42, $this->legacyTeacherId(), 'The first teacher is the primary');
+    }
+
+    #[TestDox('A failed save leaves the junction rows and the legacy column consistent')]
+    public function testFailedSaveAndSyncLeavesNoDivergence(): void
+    {
+        CwmstudyteacherHelper::saveTeachersAndSync($this->studyId, $this->entries([11]));
+        $this->assertSame(11, $this->legacyTeacherId(), 'Precondition');
+
+        try {
+            CwmstudyteacherHelper::saveTeachersAndSync(
+                $this->studyId,
+                [['teacher_id' => 20], ['teacher_id' => 999999999999999]]
+            );
+            $this->fail('Expected the out-of-range teacher id to raise');
+        } catch (\Throwable) {
+            // Expected.
+        }
+
+        $this->assertSame(
+            11,
+            $this->legacyTeacherId(),
+            'The legacy column must not describe a teacher list that was never written — see #1575'
+        );
+
+        // Assert which teacher survived, not merely how many: a count of one is
+        // satisfied both by the restored row and by an orphan from the failed
+        // write, which are opposite outcomes.
+        $this->assertSame(
+            [11],
+            $this->teacherIds(),
+            'The junction table must still hold the teacher the legacy column names — see #1575'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1575

## The reported half

`saveTeachers()` deleted a study's teacher rows then inserted the new set one at a time, unwrapped. `CwmmessageModel::save()` **commits the study row first**, so a transient failure partway through left the study saved with its teacher list truncated — while the administrator saw a fatal as though nothing had been written.

Now one unit. The exception still reaches the caller, so upstream error handling is unchanged.

## A second half the issue did not mention

Three of the four call sites follow `saveTeachers()` with `syncLegacyColumn()`, which copies the primary teacher into `#__bsms_studies.teacher_id`:

```php
CwmstudyteacherHelper::saveTeachers($studyId, $teacherEntries);
CwmstudyteacherHelper::syncLegacyColumn($studyId, $teacherEntries);
```

When the first threw, the second never ran — leaving that column naming a teacher the junction table no longer held. `saveTeachersAndSync()` writes both in one transaction.

**This is the same divergence fixed for scripture references in #1573.** The two helpers were built to the same shape and carried the same defect, so it is worth assuming the pattern repeats wherever a junction table shadows a flat column.

The fourth call site — batch teacher assignment — sets `teacher_id` through the table before calling `saveTeachers()`, so it is already consistent and is left alone.

## Not a problem here, unlike #1574

`#__bsms_study_teachers` already carries a **UNIQUE** key on `(study_id, teacher_id)` — verified `non_unique=0` on a live database, with **zero** duplicate pairs. So this table has none of the duplication `#__bsms_studytopics` accumulated. No migration needed.

## Testing

5 tests provoking a real mid-loop failure via an out-of-range teacher id. Both failure paths red-checked by disabling the transactions:

| Test | Reverted → |
|---|---|
| Original list restored | fails |
| No legacy-column divergence | fails |

The divergence test asserts **which** teacher survived, not just how many — a count of one is satisfied both by the restored row and by an orphan from the failed write, which are opposite outcomes. (Same trap I had to fix in #1619.)

Full suite **1533 tests / 6055 assertions**; 827 studies / 826 junction rows verified unchanged.

## Also noted for triage

The issue flags a related bug in different files, which I have **not** fixed here and will file separately: `CwmteacherModel::canDelete()` enqueues a "cannot delete" message when studies reference the teacher, then **falls through to `return authorise('core.delete')`** — so the block is cosmetic and deletion proceeds. `CwmteacherTable::delete()` has no cascade cleanup of `#__bsms_study_teachers`, unlike `CwmmessageTable::delete()` on the study side.

⚠️ CI may fail at `Set up job` — GitHub Actions incident ongoing. Verified locally on PHP 8.5.7.