### PR TITLE
fix: Cwmhelper fatal on null params, missed streaming skip, CLI warning

### DIFF
--- a/admin/src/Helper/Cwmhelper.php
+++ b/admin/src/Helper/Cwmhelper.php
@@ -78,15 +78,6 @@ class Cwmhelper
             return 0;
         }
 
-        // Skip streaming platforms — file size is meaningless for embedded players
-        $host = (string) parse_url($url, PHP_URL_HOST);
-
-        foreach (self::$streamingHosts as $streamHost) {
-            if (str_contains($host, $streamHost)) {
-                return 0;
-            }
-        }
-
         // Removes a bad url problem in some DB's
         if (substr_count($url, '/http')) {
             $url = ltrim($url, '/');
@@ -97,6 +88,19 @@ class Cwmhelper
                 $url = 'https:' . $url;
             } else {
                 $url = 'https://' . $url;
+            }
+        }
+
+        // Skip streaming platforms — file size is meaningless for embedded
+        // players. This has to come after the normalisation above:
+        // parse_url() only reports a host when the value carries a scheme, so
+        // a stored "youtube.com/watch?v=..." yields no host and the skip never
+        // fires, sending a real HEAD request to a streaming platform instead.
+        $host = (string) parse_url($url, PHP_URL_HOST);
+
+        foreach (self::$streamingHosts as $streamHost) {
+            if (str_contains($host, $streamHost)) {
+                return 0;
             }
         }
 
@@ -182,27 +186,29 @@ class Cwmhelper
     /**
      * Media Build URL Fix up for '/' and protocol.
      *
-     * @param   string    $spath        Server Path
-     * @param   string    $path         File
-     * @param   Registry  $params       Parameters.
-     * @param   bool      $setProtocol  True add protocol els no
-     * @param   bool      $local        Local server
-     * @param   bool      $podcast      True if from a precast
+     * @param   string     $spath        Server Path
+     * @param   string     $path         File
+     * @param   ?Registry  $params       Parameters. Only read when $setProtocol
+     *                                   is true; site callers pass null.
+     * @param   bool       $setProtocol  True add protocol els no
+     * @param   bool       $local        Unused. Retained because callers pass
+     *                                   $podcast positionally after it.
+     * @param   bool       $podcast      True if from a precast
      *
-     * @return string Completed path.
+     * @return string Completed path, or an empty string when $path is empty.
      *
      * @since 9.0.3
      */
     public static function mediaBuildUrl(
         $spath,
         $path,
-        Registry $params,
+        ?Registry $params = null,
         bool $setProtocol = false,
         bool $local = false,
         bool $podcast = false
     ): string {
         if (empty($path)) {
-            return false;
+            return '';
         }
 
         if ($spath) {
@@ -212,13 +218,7 @@ class Cwmhelper
         }
 
         $path     = ltrim($path, '/');
-        $host     = $_SERVER['HTTP_HOST'];
         $protocol = Uri::root();
-
-        // To see if the server is local
-        if (str_contains($spath, $host)) {
-            $local = true;
-        }
 
         if (substr_count($path, 'http://') && $podcast) {
             return str_replace('http://', "", $path);
@@ -237,7 +237,7 @@ class Cwmhelper
                 return $protocol . $path;
             }
 
-            $protocol = $params->get('protocol', 'https://');
+            $protocol = $params?->get('protocol', 'https://') ?? 'https://';
 
             if ((substr_count($spath, '://') || substr_count($spath, '//')) && !empty($spath)) {
                 if (substr_count($spath, '//')) {

--- a/tests/integration/Admin/Helper/CwmhelperUrlTest.php
+++ b/tests/integration/Admin/Helper/CwmhelperUrlTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * Integration tests for Cwmhelper URL building and remote size lookups.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1576.
+ *
+ * 1. mediaBuildUrl() declared a non-nullable Registry, but Cwmmedia::
+ *    getAVmediacode() passes null for it whenever a record uses the legacy
+ *    inline player. Object type declarations are never weak-coerced, so that
+ *    was a TypeError -- a fatal instead of a rendered video.
+ *
+ * 2. getRemoteFileSize() computed the host for its streaming-platform skip
+ *    before normalising the URL's scheme. parse_url() reports no host for a
+ *    schemeless value, so the skip never fired for exactly the stored shape the
+ *    normalisation below it exists to repair, and a real HEAD request went out
+ *    to the streaming platform.
+ *
+ * 3. mediaBuildUrl() read $_SERVER['HTTP_HOST'] unguarded. The podcast feed
+ *    rebuild runs from the CLI scheduler, where that key does not exist, so
+ *    every media file emitted a warning. The value fed a block whose result was
+ *    discarded.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmhelper::class)]
+class CwmhelperUrlTest extends IntegrationTestCase
+{
+    /** @var mixed */
+    private mixed $savedHost = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->savedHost = $_SERVER['HTTP_HOST'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedHost === null) {
+            unset($_SERVER['HTTP_HOST']);
+        } else {
+            $_SERVER['HTTP_HOST'] = $this->savedHost;
+        }
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 1 -- the null a live caller passes
+    // -------------------------------------------------------------------------
+
+    #[TestDox('mediaBuildUrl accepts the null params its site caller passes')]
+    public function testNullParamsIsAccepted(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'example.org';
+
+        // Exactly the call Cwmmedia::getAVmediacode() makes for the legacy
+        // inline player.
+        $result = Cwmhelper::mediaBuildUrl('media/sermons', 'talk.mp4', null);
+
+        $this->assertSame(
+            'media/sermons/talk.mp4',
+            $result,
+            'A live caller passes null here; a non-nullable Registry made that a fatal — see #1576'
+        );
+    }
+
+    #[TestDox('mediaBuildUrl still works when params are supplied')]
+    public function testRegistryParamsStillHonoured(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'example.org';
+
+        $params = new Registry();
+        $params->set('protocol', 'https://');
+
+        $this->assertSame(
+            'https://cdn.example.org/talk.mp4',
+            Cwmhelper::mediaBuildUrl('cdn.example.org', 'talk.mp4', $params, true)
+        );
+    }
+
+    /**
+     * With no Registry the protocol has to fall back rather than dereference
+     * null, since $setProtocol is what reaches that branch.
+     */
+    #[TestDox('A null Registry falls back to a default protocol')]
+    public function testNullParamsFallsBackToDefaultProtocol(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'example.org';
+
+        $this->assertSame(
+            'https://cdn.example.org/talk.mp4',
+            Cwmhelper::mediaBuildUrl('cdn.example.org', 'talk.mp4', null, true)
+        );
+    }
+
+    #[TestDox('An empty path yields an empty string, not false')]
+    public function testEmptyPathReturnsAString(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'example.org';
+
+        $this->assertSame('', Cwmhelper::mediaBuildUrl('media', '', null));
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 3 -- no HTTP request means no HTTP_HOST
+    // -------------------------------------------------------------------------
+
+    /**
+     * The podcast feed rebuild runs under the CLI scheduler, where there is no
+     * request at all. A warning per media file is noise in the task log, and
+     * phpunit.xml's failOnWarning would turn it into a failure here.
+     */
+    #[TestDox('mediaBuildUrl works with no HTTP_HOST, as under the CLI scheduler')]
+    public function testWorksWithoutHttpHost(): void
+    {
+        unset($_SERVER['HTTP_HOST']);
+
+        $this->assertSame(
+            'media/sermons/talk.mp4',
+            Cwmhelper::mediaBuildUrl('media/sermons', 'talk.mp4', null),
+            'The scheduled podcast rebuild has no request context — see #1576'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- the streaming skip has to see a normalised URL
+    // -------------------------------------------------------------------------
+
+    /**
+     * Clear the per-request file-size cache.
+     *
+     * @return  void
+     */
+    private function clearFileSizeCache(): void
+    {
+        $prop = new \ReflectionProperty(Cwmhelper::class, 'fileSizeCache');
+        $prop->setValue(null, []);
+    }
+
+    /**
+     * @return  array<string, int>  Current contents of the cache.
+     */
+    private function fileSizeCache(): array
+    {
+        $prop = new \ReflectionProperty(Cwmhelper::class, 'fileSizeCache');
+
+        return (array) $prop->getValue();
+    }
+
+    /**
+     * A schemeless stored URL is the shape the normalisation in this method
+     * exists to repair, so it is precisely the case the skip must handle.
+     *
+     * Asserting only that 0 comes back proves nothing: a HEAD request that
+     * fails also returns 0. The cache is the discriminator -- it is written
+     * only once a lookup has been attempted, so an empty cache means the URL
+     * was recognised and no request went out.
+     *
+     * @param   string  $url  Stored URL
+     */
+    #[DataProvider('streamingUrlProvider')]
+    #[TestDox('Streaming platforms are skipped without a request, scheme or not')]
+    public function testStreamingHostsAreSkipped(string $url): void
+    {
+        $this->clearFileSizeCache();
+
+        $this->assertSame(0, Cwmhelper::getRemoteFileSize($url));
+        $this->assertSame(
+            [],
+            $this->fileSizeCache(),
+            'The host was read before the scheme was normalised, so the skip never fired and a real '
+            . 'HEAD request went out to the streaming platform — see #1576'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function streamingUrlProvider(): array
+    {
+        return [
+            'youtube with scheme'       => ['https://www.youtube.com/watch?v=abc123'],
+            'youtube schemeless'        => ['youtube.com/watch?v=abc123'],
+            'youtube protocol-relative' => ['//www.youtube.com/watch?v=abc123'],
+            'youtu.be schemeless'       => ['youtu.be/abc123'],
+            'vimeo schemeless'          => ['vimeo.com/123456'],
+        ];
+    }
+
+    #[TestDox('An empty URL is not looked up')]
+    public function testEmptyUrlReturnsZero(): void
+    {
+        $this->assertSame(0, Cwmhelper::getRemoteFileSize(''));
+    }
+}


### PR DESCRIPTION
Fixes #1576

All three findings verified empirically before changing anything.

## 1. Fatal on a live call path

`mediaBuildUrl()` declared `Registry $params` — non-nullable, no default. `Cwmmedia::getAVmediacode()` passes literal `null` whenever a record uses the legacy inline player:

```php
Cwmhelper::mediaBuildUrl($media->spath, $media->filename, null)
```

**Object type declarations are never weak-coerced**, confirmed:

```
f(): Argument #1 ($p) must be of type ArrayObject, null given
```

So that is a fatal page instead of a rendered video for any site still using that player. Now `?Registry $params = null`, with the single dereference — reached only when `$setProtocol` is true — falling back to the same default it would have read.

## 2. The streaming skip never fired for schemeless URLs

`getRemoteFileSize()` skips streaming platforms because a file size is meaningless for an embedded player. But it computed the host from the **raw** URL, above the block that normalises a missing scheme:

| stored value | `parse_url(…, PHP_URL_HOST)` |
|---|---|
| `https://youtube.com/watch?v=abc` | `youtube.com` |
| `//youtube.com/x` | `youtube.com` |
| `youtube.com/watch?v=abc` | **NULL** |

So for a schemeless value the skip compared against `""`, never fired, and the function **made a real HEAD request to the streaming platform** — precisely the value shape the normalisation below it exists to repair ("Removes a bad url problem in some DB's"). Host is now read after normalisation.

## 3. Warning per media file under the CLI scheduler

`$_SERVER['HTTP_HOST']` was read unguarded. The podcast feed rebuild runs from Joomla's CLI scheduler, where no request exists — `E_WARNING: Undefined array key "HTTP_HOST"` for every media file processed.

The value fed a comparison whose only effect was reassigning `$local`, **which is never read again**. So the block is removed rather than guarded. `$local` stays in the signature because callers pass `$podcast` positionally after it; the docblock now says so explicitly rather than leaving a mystery parameter.

## Bonus

`if (empty($path)) { return false; }` in a method declared `: string`. In weak mode that was already silently becoming `""` — now the source says what actually happens.

## Testing

11 tests, all three findings red-checked:

| Fix | Reverted → |
|---|---|
| Nullable params | 4 tests fail |
| Host after normalisation | 3 tests fail — **exactly the schemeless cases** |
| HTTP_HOST guard | 1 test fails |

⚠️ **The streaming test needed strengthening.** My first version asserted only `=== 0`, which passes either way — a *failed* HEAD request also returns 0. It now asserts the private `$fileSizeCache` is untouched, which is written only once a lookup has been attempted. That makes an empty cache proof no request went out, and it means the passing test performs no network I/O. The reverted run genuinely hit the network; the fixed one does not.

Full suite **1539 tests / 6061 assertions** on PHP 8.5.7.

⚠️ CI may fail at `Set up job` — GitHub Actions incident ongoing.