### PR TITLE
fix: stop one corrupted thumbnail crashing the public podcast list

### DIFF
--- a/admin/src/Helper/Cwmimagelib.php
+++ b/admin/src/Helper/Cwmimagelib.php
@@ -25,6 +25,16 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 class Cwmimagelib
 {
     /**
+     * Largest source edge, in pixels, that will be decoded.
+     *
+     * Output is a 300x169 thumbnail, so anything approaching this is already
+     * far larger than needed.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public const int MAX_SOURCE_DIMENSION = 8000;
+
+    /**
      * Extension Name
      *
      * @var string
@@ -78,8 +88,11 @@ class Cwmimagelib
                 self::resizeImage($newFilePath, $origFilePath);
 
                 return $newFileName;
-            } catch (\Exception $e) {
-                // Fall back to original if resize fails
+            } catch (\Throwable $e) {
+                // Fall back to the original image. Throwable rather than
+                // Exception because GD raises TypeError -- an Error -- when
+                // handed a failed decode, and that would otherwise escape and
+                // take down every page rendering this list.
                 return $img;
             }
         }
@@ -109,8 +122,14 @@ class Cwmimagelib
         float $canv_width = 300,
         float $canv_height = 169
     ): void {
-        $info = getimagesize($originalFile);
-        $mime = $info['mime'];
+        $info = @getimagesize($originalFile);
+
+        if (!\is_array($info) || (int) ($info[0] ?? 0) < 1 || (int) ($info[1] ?? 0) < 1) {
+            throw new \RuntimeException('Could not read image dimensions from ' . $originalFile);
+        }
+
+        [$width, $height] = [(int) $info[0], (int) $info[1]];
+        $mime             = (string) ($info['mime'] ?? '');
 
         switch ($mime) {
             case 'image/jpeg':
@@ -135,8 +154,33 @@ class Cwmimagelib
                 throw new \RuntimeException('Unknown image type.');
         }
 
-        $img              = $image_create_func($originalFile);
-        [$width, $height] = getimagesize($originalFile);
+        // PNG and GIF compress well enough that a small file can declare huge
+        // dimensions, and decoding is what allocates the memory -- 20000x20000
+        // is roughly 1.6GB as RGBA. Exceeding memory_limit is a raw fatal, not
+        // a Throwable, so nothing downstream could catch it. The only place to
+        // stop it is before the decode.
+        if ($width > self::MAX_SOURCE_DIMENSION || $height > self::MAX_SOURCE_DIMENSION) {
+            throw new \RuntimeException(
+                \sprintf(
+                    'Refusing to decode %dx%d image %s: over the %dpx limit',
+                    $width,
+                    $height,
+                    $originalFile,
+                    self::MAX_SOURCE_DIMENSION
+                )
+            );
+        }
+
+        $img = @$image_create_func($originalFile);
+
+        // A file can satisfy getimagesize() and still fail to decode -- a
+        // truncated PNG reports its header dimensions correctly and then
+        // returns false here. Passing that false on to imagecopyresampled()
+        // raises a TypeError, which is an Error rather than an Exception and so
+        // escapes the caller's catch, taking the whole page down.
+        if (!$img instanceof \GdImage) {
+            throw new \RuntimeException('Could not decode image ' . $originalFile);
+        }
 
         // Scale to fit within canvas while preserving aspect ratio (letterbox)
         $scale     = min($canv_width / $width, $canv_height / $height);
@@ -146,6 +190,10 @@ class Cwmimagelib
         $dst_y     = (int) round(($canv_height - $newHeight) / 2);
 
         $tmp = imagecreatetruecolor((int) $canv_width, (int) $canv_height);
+
+        if (!$tmp instanceof \GdImage) {
+            throw new \RuntimeException('Could not allocate the target canvas');
+        }
 
         // Fill background with neutral grey matching the CSS placeholder colour
         $bg = imagecolorallocate($tmp, 233, 236, 239);

--- a/tests/integration/Admin/Helper/CwmimagelibResizeTest.php
+++ b/tests/integration/Admin/Helper/CwmimagelibResizeTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * Integration tests for podcast thumbnail resizing.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmimagelib;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1577.
+ *
+ * A PNG whose header is intact but whose data stream is truncated satisfies
+ * getimagesize() -- correct mime, correct dimensions -- and then fails to
+ * decode, with imagecreatefrompng() returning false. That false reached
+ * imagecopyresampled(), which type-hints GdImage and raises a TypeError.
+ * TypeError extends Error, not Exception, so the caller's catch(\Exception)
+ * never saw it and one bad thumbnail took down the whole public podcast list
+ * for every visitor.
+ *
+ * Decoding also happened before any dimension check, so a small file declaring
+ * huge dimensions could exhaust memory_limit -- a raw fatal that no catch can
+ * reach.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmimagelib::class)]
+class CwmimagelibResizeTest extends IntegrationTestCase
+{
+    private string $dir = '';
+
+    /** @var string[] */
+    private array $created = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\extension_loaded('gd')) {
+            $this->markTestSkipped('GD is not available');
+        }
+
+        $this->dir = JPATH_ROOT . '/images/biblestudy/cwm1577';
+
+        if (!is_dir($this->dir)) {
+            mkdir($this->dir, 0777, true);
+            $this->created[] = $this->dir;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        foreach ($this->created as $dir) {
+            @rmdir($dir);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Write a real PNG.
+     *
+     * @param   string  $path    Destination
+     * @param   int     $width   Width
+     * @param   int     $height  Height
+     *
+     * @return  void
+     */
+    private function writePng(string $path, int $width = 200, int $height = 150): void
+    {
+        $im = imagecreatetruecolor($width, $height);
+        imagefilledrectangle($im, 0, 0, $width, $height, imagecolorallocate($im, 10, 120, 200));
+        imagepng($im, $path);
+    }
+
+    /**
+     * Write a PNG whose header survives but whose data stream is cut short.
+     *
+     * @param   string  $path  Destination
+     *
+     * @return  void
+     */
+    private function writeTruncatedPng(string $path): void
+    {
+        $full = $this->dir . '/source-for-truncation.png';
+        $this->writePng($full);
+
+        $bytes = (string) file_get_contents($full);
+        file_put_contents($path, substr($bytes, 0, (int) (\strlen($bytes) * 0.6)));
+
+        @unlink($full);
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 1 -- a failed decode must not escape as an Error
+    // -------------------------------------------------------------------------
+
+    #[TestDox('A truncated image raises a catchable exception, not a TypeError')]
+    public function testTruncatedImageRaisesACatchableException(): void
+    {
+        $source = $this->dir . '/truncated.png';
+        $this->writeTruncatedPng($source);
+
+        // Precondition: this is the shape that fooled the old guard — the
+        // header reads fine, the decode does not.
+        $this->assertIsArray(@getimagesize($source), 'Precondition: the header still parses');
+        $this->assertFalse(@imagecreatefrompng($source), 'Precondition: the data does not decode');
+
+        $ref = new \ReflectionMethod(Cwmimagelib::class, 'resizeImage');
+
+        try {
+            $ref->invoke(null, $this->dir . '/out.png', $source);
+            $this->fail('Expected the failed decode to raise');
+        } catch (\TypeError $e) {
+            $this->fail(
+                'A TypeError escapes catch(\Exception) and takes the page down — see #1577: ' . $e->getMessage()
+            );
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('decode', $e->getMessage());
+        }
+    }
+
+    /**
+     * The behaviour the page actually depends on: one bad thumbnail falls back
+     * to the original rather than aborting the request.
+     */
+    #[TestDox('A corrupted thumbnail falls back to the original image')]
+    public function testCorruptedImageFallsBackToTheOriginal(): void
+    {
+        $relative = 'images/biblestudy/cwm1577/broken.png';
+        $this->writeTruncatedPng(JPATH_ROOT . '/' . $relative);
+
+        $result = Cwmimagelib::getSeriesPodcast($relative);
+
+        $this->assertSame(
+            $relative,
+            $result,
+            'One corrupted image crashed the whole public podcast list — see #1577'
+        );
+    }
+
+    #[TestDox('A valid image is resized and the resized path returned')]
+    public function testValidImageIsResized(): void
+    {
+        $relative = 'images/biblestudy/cwm1577/good.png';
+        $this->writePng(JPATH_ROOT . '/' . $relative, 800, 600);
+
+        $result = Cwmimagelib::getSeriesPodcast($relative);
+
+        $this->assertSame('images/biblestudy/cwm1577/good-fit.png', $result);
+        $this->assertFileExists(JPATH_ROOT . '/' . $result, 'The resized file should exist on disk');
+
+        [$w, $h] = getimagesize(JPATH_ROOT . '/' . $result);
+        $this->assertSame(300, $w, 'Canvas width');
+        $this->assertSame(169, $h, 'Canvas height');
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding 2 -- refuse oversized sources before decoding them
+    // -------------------------------------------------------------------------
+
+    /**
+     * Decoding is what allocates the memory, so the check has to happen first.
+     * Exceeding memory_limit is a raw fatal that no catch can reach.
+     */
+    #[TestDox('An image beyond the dimension cap is refused before decoding')]
+    public function testOversizedImageIsRefusedBeforeDecoding(): void
+    {
+        $source = $this->dir . '/huge.png';
+
+        // Declare huge dimensions in the header without allocating them: the
+        // guard reads getimagesize(), which trusts the header.
+        $this->writePng($source, 64, 64);
+        $bytes = (string) file_get_contents($source);
+        $over  = Cwmimagelib::MAX_SOURCE_DIMENSION + 1000;
+        // IHDR width/height are the 4-byte big-endian values at offsets 16 and 20.
+        $bytes = substr_replace($bytes, pack('N', $over), 16, 4);
+        $bytes = substr_replace($bytes, pack('N', $over), 20, 4);
+        file_put_contents($source, $bytes);
+
+        $reported = @getimagesize($source);
+        $this->assertSame($over, $reported[0] ?? 0, 'Precondition: the header advertises huge dimensions');
+
+        $ref = new \ReflectionMethod(Cwmimagelib::class, 'resizeImage');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/limit|Refusing/i');
+
+        $ref->invoke(null, $this->dir . '/out.png', $source);
+    }
+
+    #[TestDox('An unreadable file is refused rather than decoded')]
+    public function testUnreadableFileIsRefused(): void
+    {
+        $source = $this->dir . '/notanimage.png';
+        file_put_contents($source, 'this is not a PNG at all');
+
+        $ref = new \ReflectionMethod(Cwmimagelib::class, 'resizeImage');
+
+        $this->expectException(\RuntimeException::class);
+
+        $ref->invoke(null, $this->dir . '/out.png', $source);
+    }
+}


### PR DESCRIPTION
Fixes #1577

## 1. A failed decode took down the whole page

Reproduced end to end:

| step | result |
|---|---|
| `getimagesize()` on a truncated PNG | **passes** — `200x150 image/png` |
| `imagecreatefrompng()` on it | **`false`** |
| `imagecopyresampled($tmp, false, …)` | **`TypeError`** |
| caught by `catch (\Exception)`? | **no** — TypeError extends `Error` |

`getSeriesPodcast()` is called per item from `site/tmpl/cwmseriespodcastlist/default.php`, so **one corrupted thumbnail crashed the entire public page for every visitor** — instead of falling back to the original image, which is exactly what that catch existed to do.

The decode result is now checked and a `RuntimeException` raised, which the caller already handles. The catch is widened to `Throwable` as a backstop.

## 2. No dimension cap before decode

Decoding happened before anything looked at the dimensions — even though `getimagesize()` had already reported them. PNG and GIF compress well enough that a small file can declare enormous dimensions, and **it is the decode that allocates**: 20000×20000 is roughly 1.6GB as RGBA.

Exceeding `memory_limit` is a **raw fatal, not a Throwable**, so no catch anywhere could have recovered. Sources beyond **8000px** on either edge are now refused before decoding; output is a 300×169 thumbnail, so nothing legitimate comes close.

## Two more found while testing

- **`getimagesize()` was called twice**, and the first result indexed for `['mime']` with no check — a non-image file emitted `Trying to access array offset on false` before reaching the switch that would have rejected it. Now one guarded call feeding both the type switch and the dimension check.
- The decode is suppressed with `@`, since libpng writes its own warnings for a file we are about to reject deliberately. Without that, `phpunit.xml`'s `failOnWarning` would fail the suite on the very case being tested.

## Testing

5 tests using a genuinely truncated PNG and a header-patched oversized one, not mocks.

| Fix | Reverted → |
|---|---|
| Decode guard | 1 test fails |
| Dimension cap | 1 test fails |
| `Throwable` widening | **0 tests fail** |

That last row is stated rather than papered over: with the decode guard in place the throw is already a `RuntimeException`, which `catch (\Exception)` handles — so the widening is defence in depth against future Errors from GD, not something these tests exercise. It costs nothing and I have kept it, but it is not covered.

Full suite **1533 tests / 6057 assertions**; test images cleaned up, no residue in `images/`.

⚠️ CI may fail at `Set up job` — GitHub Actions incident ongoing. Verified locally on PHP 8.5.7.