### PR TITLE
fix: keep the extension on filenames containing # or ?

### DIFF
--- a/admin/src/Helper/Cwmmime.php
+++ b/admin/src/Helper/Cwmmime.php
@@ -90,10 +90,38 @@ final class Cwmmime
      */
     public static function fromExtension(string $pathOrFilename): ?string
     {
-        $path      = parse_url($pathOrFilename, PHP_URL_PATH) ?: $pathOrFilename;
-        $extension = strtolower(pathinfo((string) $path, PATHINFO_EXTENSION));
+        return self::MAP[self::extensionOf($pathOrFilename)] ?? null;
+    }
 
-        return self::MAP[$extension] ?? null;
+    /**
+     * Extract the lower-cased extension from a filename, path or URL.
+     *
+     * parse_url() splits on '?' and '#' whether or not the value is a URL, so
+     * routing a bare filename through it loses everything after those
+     * characters -- "Sermon #12.mp4" becomes "Sermon " and the extension is
+     * gone. Filenames here are admin-entered and unsanitised, so a '#' in one
+     * is ordinary rather than hostile. A query or fragment is therefore only
+     * stripped when the value actually is a URL.
+     *
+     * Detected by '://' or a leading '//' rather than PHP_URL_SCHEME, because
+     * a Windows path like "C:\media\file #1.mp4" reports its drive letter as
+     * the scheme and would be misread as a URL.
+     *
+     * @param   string  $pathOrFilename  Filename, filesystem path or URL
+     *
+     * @return  string  Lower-cased extension, or an empty string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function extensionOf(string $pathOrFilename): string
+    {
+        $path = $pathOrFilename;
+
+        if (str_contains($pathOrFilename, '://') || str_starts_with($pathOrFilename, '//')) {
+            $path = parse_url($pathOrFilename, PHP_URL_PATH) ?: $pathOrFilename;
+        }
+
+        return strtolower(pathinfo((string) $path, PATHINFO_EXTENSION));
     }
 
     /**

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -941,8 +941,12 @@ class Cwmpodcast
             return null;
         }
 
-        $extPath   = parse_url($path, PHP_URL_PATH) ?: $path;
-        $extension = strtolower(pathinfo((string) $extPath, PATHINFO_EXTENSION));
+        // $path may be a bare filesystem path, not a URL. Cwmmime::extensionOf()
+        // only strips a query or fragment when the value really is a URL --
+        // parse_url() alone would turn "Sermon #12.mp4" into "Sermon " and lose
+        // the extension, and an enclosure URL without one is what Apple refuses
+        // to ingest (#1424).
+        $extension = Cwmmime::extensionOf($path);
 
         if ($extension === '') {
             return null;

--- a/tests/integration/Admin/Helper/CwmmimeExtensionTest.php
+++ b/tests/integration/Admin/Helper/CwmmimeExtensionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Integration tests for extension-based MIME detection.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1578.
+ *
+ * fromExtension() ran every value through parse_url(), which splits on '?' and
+ * '#' whether or not the value is a URL. A stored filename like
+ * "Sermon #12.mp4" became "Sermon ", the extension was lost, and detection
+ * returned null.
+ *
+ * Downstream that meant a video declared as audio/mpeg in the podcast feed's
+ * enclosure, application/octet-stream on download, and the MIME-contradiction
+ * check silently skipping exactly the files most likely to be wrong. An
+ * enclosure whose type or URL carries no usable extension is the same class of
+ * defect that caused the Apple Podcasts delisting in v10.5.4/10.5.5.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmmime::class)]
+class CwmmimeExtensionTest extends IntegrationTestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function extensionProvider(): array
+    {
+        return [
+            // The bug: '#' and '?' in an ordinary filename.
+            'hash in filename'       => ['Sermon #12.mp4', 'mp4'],
+            'hash mid-filename'      => ['Track #3 - Sermon.mp4', 'mp4'],
+            'question in filename'   => ['episode?12.mp3', 'mp3'],
+            'hash in a path'         => ['media/sermons/talk #2.m4v', 'm4v'],
+            'windows path with hash' => ['C:\\media\\file #1.mp4', 'mp4'],
+
+            // URLs still have their query and fragment stripped.
+            'url with query'        => ['https://cdn.example.org/a/b.mp4?v=1', 'mp4'],
+            'url with fragment'     => ['https://cdn.example.org/a/b.mp3#t=30', 'mp3'],
+            'protocol-relative url' => ['//cdn.example.org/v.m4v#t=1', 'm4v'],
+
+            // Unremarkable cases.
+            'plain filename'      => ['normal.mp4', 'mp4'],
+            'uppercase extension' => ['SERMON.MP3', 'mp3'],
+            'no extension'        => ['sermon', ''],
+        ];
+    }
+
+    #[DataProvider('extensionProvider')]
+    #[TestDox('The extension survives characters parse_url() would treat as delimiters')]
+    public function testExtensionOf(string $input, string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            Cwmmime::extensionOf($input),
+            'parse_url() split a bare filename on # or ? and lost the extension — see #1578'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: ?string}>
+     */
+    public static function mimeProvider(): array
+    {
+        return [
+            'hash in filename'     => ['Sermon #12.mp4', 'video/mp4'],
+            'question in filename' => ['episode?12.mp3', 'audio/mpeg'],
+            'hash in a path'       => ['media/talk #2.m4v', 'video/mp4'],
+            'url with query'       => ['https://cdn.example.org/a/b.mp4?v=1', 'video/mp4'],
+            'plain filename'       => ['normal.mp3', 'audio/mpeg'],
+            'unknown extension'    => ['notes.xyz', null],
+        ];
+    }
+
+    /**
+     * The consequence that matters: a video whose name contains '#' was
+     * reported as having no detectable type, and the podcast enclosure then
+     * fell back to a hardcoded audio/mpeg.
+     *
+     * @param   string   $input     Filename or URL
+     * @param   ?string  $expected  Expected MIME type
+     */
+    #[DataProvider('mimeProvider')]
+    #[TestDox('MIME detection works for filenames containing # or ?')]
+    public function testFromExtension(string $input, ?string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            Cwmmime::fromExtension($input),
+            'A video declared as audio/mpeg in an enclosure is what got episodes delisted — see #1578'
+        );
+    }
+
+    /**
+     * The tracked enclosure URL is built from an extension and returns null
+     * without one, which is precisely what Apple refuses to ingest. It must
+     * derive that extension the same way.
+     */
+    #[TestDox('The tracked enclosure builder uses the shared extension helper')]
+    public function testEnclosureBuilderUsesTheSharedHelper(): void
+    {
+        $source = file_get_contents(JPATH_ROOT . '/site/src/Helper/Cwmpodcast.php');
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString(
+            'Cwmmime::extensionOf($path)',
+            $source,
+            'buildTrackedEnclosureUrl() must not re-derive the extension with bare parse_url() — see #1578'
+        );
+    }
+}


### PR DESCRIPTION
fromExtension() ran every value through parse_url() before reading the
extension. parse_url() splits on '?' and '#' whether or not the value is a URL,
so a stored filename like "Sermon #12.mp4" became "Sermon " and the extension
was gone. Filenames are admin-entered and unsanitised, so a '#' in one is
ordinary rather than hostile.

Detection then returned null, and the callers all have a fallback that is worse
than the truth: the podcast enclosure falls back to a hardcoded audio/mpeg, so
a video is declared as audio; downloads fall back to
application/octet-stream; and mimeTypeContradictsFile() skips the check
entirely, which quietly excuses exactly the files most likely to have a wrong
stored type. An enclosure that misdeclares its media is the same class of
defect behind the Apple Podcasts delisting in 10.5.4/10.5.5.

The query and fragment are now stripped only when the value really is a URL.
That is decided by '://' or a leading '//' rather than by PHP_URL_SCHEME,
because a Windows path such as "C:\media\file #1.mp4" reports its drive letter
as the scheme and would be misread as a URL.

The logic moved into a public extensionOf(), because the same derivation is
done in Cwmpodcast::buildTrackedEnclosureUrl(), which returns null when it
cannot find an extension -- and a tracked enclosure URL with no extension is
precisely what Apple would not ingest (#1424). That call site now shares the
helper.

Two other uses of the pattern were checked and left alone. Cwmpodcast line 596
resolves its value to an absolute URL immediately above, and
CwmpodcastTrackHelper::resolveLocalPath() works on served URLs where a literal
'#' is percent-encoded and stripping a real fragment is correct.

Fixes #1578

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
