### PR TITLE
fix: survive valid-JSON-wrong-shape params in description building

### DIFF
--- a/admin/src/Helper/CwmdescriptionHelper.php
+++ b/admin/src/Helper/CwmdescriptionHelper.php
@@ -286,6 +286,35 @@ class CwmdescriptionHelper
     }
 
     /**
+     * Decode a params column into an array.
+     *
+     * The callers index into the result, so anything that is not an array --
+     * malformed JSON, but equally a valid scalar or list where an object was
+     * expected -- has to come back as an empty array rather than as something
+     * that warns on offset access or fails a return type further up.
+     *
+     * @param   mixed  $json  Raw params value
+     *
+     * @return  array  Decoded parameters, or an empty array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function decodeParams(mixed $json): array
+    {
+        if (!\is_string($json) || $json === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        return \is_array($decoded) ? $decoded : [];
+    }
+
+    /**
      * Get the description format template from a media file's server addon.
      *
      * Looks for a `description_format` or `yt_description_format` param
@@ -319,16 +348,19 @@ class CwmdescriptionHelper
             return '';
         }
 
-        try {
-            $decoded = json_decode($serverParams, true, 512, JSON_THROW_ON_ERROR) ?: [];
-        } catch (\JsonException) {
-            return '';
-        }
+        $decoded = self::decodeParams($serverParams);
 
         // Prefer the standardized key; fall back to legacy YouTube-specific key
-        return $decoded['description_format']
+        $format = $decoded['description_format']
             ?? $decoded['yt_description_format']
             ?? '';
+
+        // Valid JSON carrying the wrong shape -- an object or list where a
+        // template string belongs -- would otherwise fail this method's return
+        // type. That is a TypeError, which is an Error rather than an
+        // Exception, so the AJAX callers' catch(\Exception) does not see it and
+        // the request dies instead of falling back to no format.
+        return \is_string($format) ? $format : '';
     }
 
     /**
@@ -439,10 +471,12 @@ class CwmdescriptionHelper
 
             if ($params) {
                 try {
-                    $decoded  = json_decode($params, true, 512, JSON_THROW_ON_ERROR) ?: [];
-                    $chapters = $decoded['chapters'] ?? [];
+                    $chapters = self::decodeParams($params)['chapters'] ?? [];
 
-                    if (!empty($chapters)) {
+                    // is_array before the emptiness test: a non-empty string or
+                    // number here would satisfy !empty() and then fail this
+                    // method's array return type.
+                    if (\is_array($chapters) && $chapters !== []) {
                         return $chapters;
                     }
                 } catch (\JsonException) {
@@ -467,10 +501,9 @@ class CwmdescriptionHelper
             }
 
             try {
-                $decoded  = json_decode($paramsJson, true, 512, JSON_THROW_ON_ERROR) ?: [];
-                $chapters = $decoded['chapters'] ?? [];
+                $chapters = self::decodeParams($paramsJson)['chapters'] ?? [];
 
-                if (!empty($chapters)) {
+                if (\is_array($chapters) && $chapters !== []) {
                     return $chapters;
                 }
             } catch (\JsonException) {

--- a/tests/integration/Admin/Helper/CwmdescriptionParamsTest.php
+++ b/tests/integration/Admin/Helper/CwmdescriptionParamsTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * Integration tests for description building against malformed params data.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdescriptionHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1580.
+ *
+ * The JSON decodes here were wrapped in catch(\JsonException), so malformed
+ * syntax could not crash description building. Valid JSON carrying the wrong
+ * shape could: description_format as an object failed a string return type,
+ * and chapters as a string satisfied !empty() and then failed an array return
+ * type. Both are TypeErrors, which extend Error rather than Exception, so the
+ * AJAX callers' catch(\Exception) did not see them either -- the request died
+ * instead of falling back to no format and no chapters.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmdescriptionHelper::class)]
+class CwmdescriptionParamsTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    private int $rowsAtStart = 0;
+
+    private int $studyId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+        $this->rowsAtStart = $this->countMedia();
+
+        $study = (object) [
+            'published'  => 1,
+            'studytitle' => 'cwm1580 fixture',
+            'language'   => '*',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+    }
+
+    protected function tearDown(): void
+    {
+        $leaked = null;
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+                $after = $this->countMedia();
+
+                if ($after !== $this->rowsAtStart) {
+                    $leaked = \sprintf(
+                        'Test isolation broke: #__bsms_mediafiles went from %d to %d rows.',
+                        $this->rowsAtStart,
+                        $after
+                    );
+                }
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+
+        if ($leaked !== null) {
+            $this->fail($leaked);
+        }
+    }
+
+    /**
+     * @return  int  Rows in the media table.
+     */
+    private function countMedia(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__bsms_mediafiles'))
+        )->loadResult();
+    }
+
+    /**
+     * Insert a media file carrying the given params JSON.
+     *
+     * @param   string  $paramsJson  Raw params column value
+     *
+     * @return  int  Media id
+     */
+    private function insertMedia(string $paramsJson): int
+    {
+        $row = (object) [
+            'study_id'  => $this->studyId,
+            'published' => 1,
+            'params'    => $paramsJson,
+            'ordering'  => 0,
+            'language'  => '*',
+            'metadata'  => '',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $row, 'id');
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Shapes that are valid JSON but not what the code expects.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function malformedShapeProvider(): array
+    {
+        return [
+            'format as an object'   => ['{"description_format":{"nested":true}}'],
+            'format as a list'      => ['{"description_format":[1,2]}'],
+            'format as a number'    => ['{"description_format":42}'],
+            'format as a bool'      => ['{"description_format":true}'],
+            'chapters as a string'  => ['{"chapters":"not-an-array"}'],
+            'chapters as a number'  => ['{"chapters":5}'],
+            'whole doc is a list'   => ['[1,2,3]'],
+            'whole doc is a scalar' => ['5'],
+            'whole doc is a string' => ['"just a string"'],
+            'malformed syntax'      => ['{not valid json'],
+            'empty'                 => [''],
+        ];
+    }
+
+    /**
+     * The contract the surrounding try/catch machinery was written to provide:
+     * bad params data degrades description building, it does not crash it.
+     *
+     * @param   string  $paramsJson  Raw params value
+     */
+    #[DataProvider('malformedShapeProvider')]
+    #[TestDox('Chapters lookup survives valid JSON with the wrong shape')]
+    public function testChaptersLookupSurvivesBadShapes(string $paramsJson): void
+    {
+        $mediaId = $this->insertMedia($paramsJson);
+
+        $ref = new \ReflectionMethod(CwmdescriptionHelper::class, 'getChaptersForDescription');
+
+        try {
+            $result = $ref->invoke(null, $this->studyId, $mediaId);
+        } catch (\TypeError $e) {
+            $this->fail(
+                'A TypeError escapes the AJAX callers\' catch(\Exception) and kills the request — see #1580: '
+                . $e->getMessage()
+            );
+        }
+
+        $this->assertIsArray($result, 'Chapters must always come back as an array');
+    }
+
+    /**
+     * @param   string  $paramsJson  Raw params value
+     */
+    #[DataProvider('malformedShapeProvider')]
+    #[TestDox('Server description format survives valid JSON with the wrong shape')]
+    public function testServerFormatSurvivesBadShapes(string $paramsJson): void
+    {
+        $server = (object) ['published' => 1, 'params' => $paramsJson, 'type' => 'legacy', 'media' => ''];
+        $this->db->insertObject('#__bsms_servers', $server, 'id');
+        $serverId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $this->studyId,
+            'published' => 1,
+            'server_id' => $serverId,
+            'params'    => '{}',
+            'ordering'  => 0,
+            'language'  => '*',
+            'metadata'  => '',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+        $mediaId = (int) $this->db->insertid();
+
+        $ref = new \ReflectionMethod(CwmdescriptionHelper::class, 'getServerDescriptionFormat');
+
+        try {
+            $result = $ref->invoke(null, $mediaId);
+        } catch (\TypeError $e) {
+            $this->fail(
+                'A TypeError escapes the AJAX callers\' catch(\Exception) and kills the request — see #1580: '
+                . $e->getMessage()
+            );
+        }
+
+        $this->assertIsString($result, 'The format must always come back as a string');
+    }
+
+    // -------------------------------------------------------------------------
+    // The well-formed cases still have to work
+    // -------------------------------------------------------------------------
+
+    #[TestDox('A real chapters array is still returned')]
+    public function testWellFormedChaptersAreReturned(): void
+    {
+        $mediaId = $this->insertMedia('{"chapters":[{"time":"00:00","title":"Intro"}]}');
+
+        $ref    = new \ReflectionMethod(CwmdescriptionHelper::class, 'getChaptersForDescription');
+        $result = $ref->invoke(null, $this->studyId, $mediaId);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Intro', $result[0]['title']);
+    }
+
+    #[TestDox('A real description format string is still returned')]
+    public function testWellFormedFormatIsReturned(): void
+    {
+        $server = (object) ['published' => 1, 'params' => '{"description_format":"{title} — {teacher}"}', 'type' => 'legacy', 'media' => ''];
+        $this->db->insertObject('#__bsms_servers', $server, 'id');
+        $serverId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $this->studyId,
+            'published' => 1,
+            'server_id' => $serverId,
+            'params'    => '{}',
+            'ordering'  => 0,
+            'language'  => '*',
+            'metadata'  => '',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+
+        $ref = new \ReflectionMethod(CwmdescriptionHelper::class, 'getServerDescriptionFormat');
+
+        $this->assertSame('{title} — {teacher}', $ref->invoke(null, (int) $this->db->insertid()));
+    }
+
+    #[TestDox('The legacy yt_description_format key is still honoured')]
+    public function testLegacyFormatKeyStillWorks(): void
+    {
+        $server = (object) ['published' => 1, 'params' => '{"yt_description_format":"legacy {title}"}', 'type' => 'legacy', 'media' => ''];
+        $this->db->insertObject('#__bsms_servers', $server, 'id');
+        $serverId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $this->studyId,
+            'published' => 1,
+            'server_id' => $serverId,
+            'params'    => '{}',
+            'ordering'  => 0,
+            'language'  => '*',
+            'metadata'  => '',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+
+        $this->assertSame(
+            'legacy {title}',
+            (new \ReflectionMethod(CwmdescriptionHelper::class, 'getServerDescriptionFormat'))
+                ->invoke(null, (int) $this->db->insertid())
+        );
+    }
+}


### PR DESCRIPTION
The JSON decodes here were already wrapped in catch(\JsonException), so
malformed syntax could not crash description building. Valid JSON carrying the
wrong internal shape could, and did so past every guard in the file.

getServerDescriptionFormat() is declared : string and returned whatever sat
under description_format. A server params row holding an object or a list there
-- a hand-edited row, a partially-failed migration -- failed the return type.
getChaptersForDescription() is declared : array and tested !empty($chapters)
before returning them, so a non-empty string satisfied the test and then failed
the return type. Both raise TypeError, which extends Error rather than
Exception, so buildVideoDescription() did not catch it and neither did the AJAX
callers' catch(\Exception): the request died instead of falling back to no
format and no chapters, which is exactly what the surrounding try/catch
machinery was written to guarantee.

Both values are now type-checked before they are returned.

The three decode sites also went through one decodeParams(), which returns an
array or nothing. That covers a case neither finding mentions: valid JSON whose
top level is a scalar or a list. Indexing into that is not a TypeError but it
does emit an undefined-offset warning per call, and phpunit.xml sets
failOnWarning, so the tests would have failed on it even where the code
recovered.

Fixes #1580

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
