### PR TITLE
fix: validate the whole body of an uploaded WebVTT file

### DIFF
--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -664,8 +664,10 @@ class CwmmediafileController extends FormController
             return;
         }
 
-        // Sniff the first 64 bytes to confirm WEBVTT, SBV, or SRT magic —
-        // defends against a renamed binary slipping past the extension whitelist.
+        // Sniff the first 64 bytes to route the file to the right converter.
+        // This is a format hint, not a safety check: it says what the file
+        // claims to be, not what the rest of it contains. VTT is validated in
+        // full below, before anything is kept.
         $head     = file_get_contents($userfile['tmp_name'], false, null, 0, 64);
         $detected = $head === false ? null : $validator->detectFormat($head);
 
@@ -677,6 +679,29 @@ class CwmmediafileController extends FormController
             Factory::getApplication()->close();
 
             return;
+        }
+
+        // SRT and SBV are parsed and re-serialised below, so only structurally
+        // valid cues survive them. VTT is stored byte-for-byte, so the same
+        // assurance has to come from reading it here: past byte 64 the sniff
+        // above knows nothing, and "WEBVTT" followed by arbitrary bytes would
+        // otherwise be kept verbatim and served from a public URL.
+        //
+        // Validated rather than rewritten -- rewriting would strip NOTE, STYLE
+        // and REGION blocks, cue settings and speaker tags from files that
+        // legitimately carry them.
+        if ($detected === 'vtt') {
+            $body = file_get_contents($userfile['tmp_name']);
+
+            if ($body === false || !$validator->isStructurallyVtt($body)) {
+                echo json_encode([
+                    'success' => false,
+                    'error'   => Text::_($body === false ? 'JBS_MED_VTT_UPLOAD_FAILED' : 'JBS_MED_VTT_INVALID_CONTENT'),
+                ]);
+                Factory::getApplication()->close();
+
+                return;
+            }
         }
 
         $destDir = JPATH_ROOT . '/media/com_proclaim/captions';

--- a/admin/src/Helper/CwmcaptionValidator.php
+++ b/admin/src/Helper/CwmcaptionValidator.php
@@ -170,6 +170,76 @@ class CwmcaptionValidator
     }
 
     /**
+     * Check that an entire WebVTT body is structurally WebVTT.
+     *
+     * detectFormat() only sniffs the first bytes, which is all it can do with a
+     * 64-byte head. That is enough to route a file but says nothing about the
+     * rest of it: `WEBVTT\n\n` followed by two megabytes of anything satisfies
+     * the prefix test. Since a VTT upload is stored byte-for-byte and served
+     * from a public URL, the whole body has to be checked before it is kept.
+     *
+     * This validates rather than rewrites. Parsing and re-serialising through
+     * parseVttCues() would also reject junk, but that method deliberately drops
+     * NOTE, STYLE and REGION blocks, cue identifiers, cue settings and inline
+     * tags such as <v Speaker> -- fine when converting to a format that cannot
+     * express them, and destructive when applied to a caption file the user
+     * authored. Valid files are stored exactly as uploaded.
+     *
+     * @param   string  $body  Full caption file contents.
+     *
+     * @return  bool  True when every block is a header, comment, style,
+     *                region, or a cue with a parseable timestamp line.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function isStructurallyVtt(string $body): bool
+    {
+        $body = ltrim($body, "\xEF\xBB\xBF");
+        $body = str_replace(["\r\n", "\r"], "\n", $body);
+        $body = trim($body);
+
+        if (!preg_match('/^WEBVTT(\s|$)/', $body)) {
+            return false;
+        }
+
+        $blocks = preg_split('/\n\s*\n/', $body) ?: [];
+
+        foreach ($blocks as $index => $block) {
+            $block = trim($block);
+
+            if ($block === '') {
+                continue;
+            }
+
+            // The header block, and the metadata blocks WebVTT allows.
+            if ($index === 0 && preg_match('/^WEBVTT(\s|$)/', $block)) {
+                continue;
+            }
+
+            if (preg_match('/^(NOTE|STYLE|REGION)(\s|$)/', $block)) {
+                continue;
+            }
+
+            // Anything else has to be a cue: an optional identifier line
+            // followed by a timestamp line.
+            $lines = explode("\n", $block);
+
+            if (!str_contains($lines[0], '-->') && \count($lines) > 1) {
+                array_shift($lines);
+            }
+
+            if (!preg_match(
+                '/^((?:\d{2,}:)?\d{2}:\d{2}\.\d{3})\s*-->\s*((?:\d{2,}:)?\d{2}:\d{2}\.\d{3})/',
+                $lines[0]
+            )) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Convert a YouTube SBV caption body to WebVTT.
      *
      * SBV cues are `H:MM:SS.mmm,H:MM:SS.mmm` on one line, followed by

--- a/tests/unit/Admin/Helper/CwmcaptionVttStructureTest.php
+++ b/tests/unit/Admin/Helper/CwmcaptionVttStructureTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Unit tests for whole-body WebVTT structure validation.
+ *
+ * @package    Proclaim.Test
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcaptionValidator;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1581.
+ *
+ * detectFormat() reads 64 bytes, so its VTT test is a six-character prefix
+ * check. Uploads detected as VTT were then moved into place byte-for-byte and
+ * served from a public URL, so "WEBVTT" followed by up to two megabytes of
+ * anything was stored verbatim. SRT and SBV never had that gap: both are parsed
+ * and re-serialised on the way in, so only valid cues survive.
+ *
+ * The body is now validated in full. Validated rather than normalised: the
+ * existing parseVttCues() drops NOTE, STYLE and REGION blocks, cue identifiers,
+ * cue settings and inline tags, which is correct when converting to a format
+ * that cannot express them and destructive when applied to a file the user
+ * authored.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmcaptionValidator::class)]
+class CwmcaptionVttStructureTest extends ProclaimTestCase
+{
+    private CwmcaptionValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = new CwmcaptionValidator();
+    }
+
+    /**
+     * Files that must be accepted, including every WebVTT feature the
+     * lossy converter would have discarded.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function validProvider(): array
+    {
+        return [
+            'minimal header only' => ["WEBVTT"],
+            'single cue'          => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000\nHello"],
+            'short timestamps'    => ["WEBVTT\n\n00:01.000 --> 00:04.000\nHello"],
+            'cue identifier'      => ["WEBVTT\n\nintro\n00:00:01.000 --> 00:00:04.000\nHello"],
+            'cue settings'        => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000 line:0 align:middle\nHello"],
+            'speaker tag'         => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000\n<v Pastor>Welcome</v>"],
+            'NOTE block'          => ["WEBVTT\n\nNOTE this is a comment\n\n00:00:01.000 --> 00:00:04.000\nHi"],
+            'STYLE block'         => ["WEBVTT\n\nSTYLE\n::cue { color: yellow }\n\n00:00:01.000 --> 00:00:04.000\nHi"],
+            'REGION block'        => ["WEBVTT\n\nREGION\nid:fred width:40%\n\n00:00:01.000 --> 00:00:04.000\nHi"],
+            'header metadata'     => ["WEBVTT - Some Title\n\n00:00:01.000 --> 00:00:04.000\nHi"],
+            'crlf line endings'   => ["WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nHello"],
+            'BOM prefix'          => ["\xEF\xBB\xBFWEBVTT\n\n00:00:01.000 --> 00:00:04.000\nHello"],
+            'multiple cues'       => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000\nOne\n\n00:00:05.000 --> 00:00:09.000\nTwo"],
+            'multi-line cue text' => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000\nLine one\nLine two"],
+            'hours over 99'       => ["WEBVTT\n\n100:00:01.000 --> 100:00:04.000\nHi"],
+        ];
+    }
+
+    /**
+     * A valid caption file must still be accepted and stored unchanged.
+     *
+     * @param   string  $body  Caption file contents
+     */
+    #[DataProvider('validProvider')]
+    #[TestDox('A structurally valid WebVTT file is accepted')]
+    public function testValidBodiesAreAccepted(string $body): void
+    {
+        $this->assertTrue(
+            $this->validator->isStructurallyVtt($body),
+            'Rejecting a legitimate caption feature would be worse than the hole being closed — see #1581'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidProvider(): array
+    {
+        return [
+            // The reported hole: the prefix passes, the rest is anything.
+            'header then arbitrary text'  => ["WEBVTT\n\nthis is not a cue at all"],
+            'header then html'            => ["WEBVTT\n\n<html><body>phishing</body></html>"],
+            'header then php'             => ["WEBVTT\n\n<?php echo 'x'; ?>"],
+            'header then binary-ish'      => ["WEBVTT\n\n\x00\x01\x02\x03 payload"],
+            'header then a second header' => ["WEBVTT\n\nWEBVTT junk"],
+            'valid cue then junk'         => ["WEBVTT\n\n00:00:01.000 --> 00:00:04.000\nHi\n\nnot a cue"],
+            // Not VTT at all.
+            'no header'            => ["00:00:01.000 --> 00:00:04.000\nHello"],
+            'empty'                => [''],
+            'plain text'           => ['just some text'],
+            'header glued to text' => ['WEBVTTjunk'],
+            // Malformed timestamps.
+            'missing milliseconds' => ["WEBVTT\n\n00:00:01 --> 00:00:04\nHi"],
+            'arrow only'           => ["WEBVTT\n\n--> \nHi"],
+        ];
+    }
+
+    /**
+     * @param   string  $body  Caption file contents
+     */
+    #[DataProvider('invalidProvider')]
+    #[TestDox('Content past the header that is not WebVTT is rejected')]
+    public function testInvalidBodiesAreRejected(string $body): void
+    {
+        $this->assertFalse(
+            $this->validator->isStructurallyVtt($body),
+            'A six-byte prefix check let arbitrary content reach a public URL — see #1581'
+        );
+    }
+
+    /**
+     * The specific upload described in the issue: a valid-looking header
+     * followed by a payload well past the 64 bytes detectFormat() reads.
+     */
+    #[TestDox('A large payload hidden past the sniff window is rejected')]
+    public function testPayloadBeyondTheSniffWindowIsRejected(): void
+    {
+        $body = "WEBVTT\n\n" . str_repeat('A', 200000);
+
+        $this->assertSame(
+            'vtt',
+            $this->validator->detectFormat(substr($body, 0, 64)),
+            'Precondition: the sniff still routes this as VTT — that is all it can do'
+        );
+        $this->assertFalse(
+            $this->validator->isStructurallyVtt($body),
+            'The whole body must be checked, not just the head — see #1581'
+        );
+    }
+
+    /**
+     * The upload path must actually call the validator; detecting the format
+     * is not the same as trusting the file.
+     */
+    #[TestDox('The upload endpoint validates the whole body before storing')]
+    public function testUploadPathValidatesBeforeStoring(): void
+    {
+        $source = (string) file_get_contents(
+            \dirname(__DIR__, 4) . '/admin/src/Controller/CwmmediafileController.php'
+        );
+
+        $this->assertStringContainsString(
+            'isStructurallyVtt($body)',
+            $source,
+            'move_uploaded_file() stores the file unread — the body must be checked first — see #1581'
+        );
+
+        $validateAt = strpos($source, 'isStructurallyVtt($body)');
+        $moveAt     = strpos($source, "'vtt' => move_uploaded_file");
+
+        $this->assertNotFalse($moveAt, 'Expected the VTT store branch to still be present');
+        $this->assertLessThan($moveAt, $validateAt, 'Validation must happen before the file is moved into place');
+    }
+}


### PR DESCRIPTION
detectFormat() reads 64 bytes, so its VTT branch is a six-character prefix
test. That is all a sniff of that size can be, but the upload path treated it
as more: a file detected as VTT was handed to move_uploaded_file() and stored
byte-for-byte, then served from a public URL. "WEBVTT" followed by up to two
megabytes of anything satisfied the test and was kept verbatim, which made the
captions directory a general-purpose file host for anyone who could reach the
endpoint.

SRT and SBV never had that gap. Both are parsed and re-serialised on the way
in, so only blocks with a valid timestamp line survive. VTT is now checked in
full before anything is kept.

Checked rather than rewritten. Routing uploads through parseVttCues() and
re-serialising would also reject junk, and it was the obvious symmetry to
reach for, but that method deliberately discards NOTE, STYLE and REGION blocks,
cue identifiers, cue settings such as line:0 align:middle, and inline tags like
<v Speaker>. Dropping those is correct when converting to a format that cannot
express them and destructive when applied to a file someone authored, so
isStructurallyVtt() validates the structure and leaves valid files exactly as
uploaded.

The check runs where the format is decided rather than inside the store, so a
file that fails it is reported as invalid content instead of as a failed
upload.

Also drops the claim that the sniff "defends against a renamed binary slipping
past the extension whitelist". Against a deliberate upload it never did, and
leaving the comment there invites the next reader to trust it.

Fixes #1581

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
