### PR TITLE
fix: read each page's own filters instead of the sermons list's

### DIFF
--- a/admin/src/Field/BookListField.php
+++ b/admin/src/Field/BookListField.php
@@ -82,7 +82,11 @@ class BookListField extends ListField
             ->group($db->quoteName('book.id'))
             ->order($db->quoteName('book.booknumber') . ' ASC');
 
-        CwmfilterHelper::applyCrossFilters($query, 'book');
+        CwmfilterHelper::applyCrossFilters(
+            $query,
+            'book',
+            CwmfilterHelper::contextFromForm($this->form)
+        );
 
         $db->setQuery($query);
         $books   = $db->loadObjectList() ?: [];

--- a/admin/src/Field/LocationListField.php
+++ b/admin/src/Field/LocationListField.php
@@ -81,7 +81,11 @@ class LocationListField extends ListField
                 ->whereIn($db->quoteName('s.access'), $groups)
                 ->order($db->quoteName('loc.location_text'));
 
-            CwmfilterHelper::applyCrossFilters($query, 'location');
+            CwmfilterHelper::applyCrossFilters(
+                $query,
+                'location',
+                CwmfilterHelper::contextFromForm($this->form)
+            );
 
             $db->setQuery($query);
             $rows    = $db->loadObjectList() ?: [];

--- a/admin/src/Field/MessageTypeListField.php
+++ b/admin/src/Field/MessageTypeListField.php
@@ -73,7 +73,11 @@ class MessageTypeListField extends ListField
                 ->whereIn($db->quoteName('s.published'), [1, 2])
                 ->whereIn($db->quoteName('s.access'), $groups);
 
-            CwmfilterHelper::applyCrossFilters($query, 'messagetype');
+            CwmfilterHelper::applyCrossFilters(
+                $query,
+                'messagetype',
+                CwmfilterHelper::contextFromForm($this->form)
+            );
         }
 
         $query->order($db->quoteName('mt.message_type'));

--- a/admin/src/Field/SeriesField.php
+++ b/admin/src/Field/SeriesField.php
@@ -74,7 +74,11 @@ class SeriesField extends ListField
                 ->whereIn($db->quoteName('s.access'), $groups)
                 ->whereIn($db->quoteName('se.access'), $groups);
 
-            CwmfilterHelper::applyCrossFilters($query, 'series');
+            CwmfilterHelper::applyCrossFilters(
+                $query,
+                'series',
+                CwmfilterHelper::contextFromForm($this->form)
+            );
         }
 
         $query->order($db->quoteName('se.series_text'));

--- a/admin/src/Field/TeacherListField.php
+++ b/admin/src/Field/TeacherListField.php
@@ -106,7 +106,11 @@ class TeacherListField extends ListField
                 ->whereIn($db->quoteName('s.published'), [1, 2])
                 ->whereIn($db->quoteName('s.access'), $groups);
 
-            CwmfilterHelper::applyCrossFilters($query, 'teacher');
+            CwmfilterHelper::applyCrossFilters(
+                $query,
+                'teacher',
+                CwmfilterHelper::contextFromForm($this->form)
+            );
         }
 
         $query->order($db->quoteName('t.teachername'));

--- a/admin/src/Field/TopicsListField.php
+++ b/admin/src/Field/TopicsListField.php
@@ -82,7 +82,11 @@ class TopicsListField extends ListField
             $groups = $user->getAuthorisedViewLevels();
             $query->whereIn($db->quoteName('s.access'), $groups);
 
-            CwmfilterHelper::applyCrossFilters($query, 'topic');
+            CwmfilterHelper::applyCrossFilters(
+                $query,
+                'topic',
+                CwmfilterHelper::contextFromForm($this->form)
+            );
         }
 
         $query->order($db->quoteName('t.topic_text') . ' ASC');

--- a/admin/src/Field/YearListField.php
+++ b/admin/src/Field/YearListField.php
@@ -75,7 +75,11 @@ class YearListField extends ListField
             ->whereIn($db->quoteName('s.access'), $groups)
             ->order($db->quoteName('value') . ' DESC');
 
-        CwmfilterHelper::applyCrossFilters($query, 'year');
+        CwmfilterHelper::applyCrossFilters(
+            $query,
+            'year',
+            CwmfilterHelper::contextFromForm($this->form)
+        );
 
         $db->setQuery($query);
         $years   = $db->loadObjectList() ?: [];

--- a/admin/src/Helper/CwmfilterHelper.php
+++ b/admin/src/Helper/CwmfilterHelper.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 
@@ -42,12 +43,42 @@ abstract class CwmfilterHelper
      *
      * @since   10.1.0
      */
-    private static function getFilterValue(string $name): mixed
+    private static function getFilterValue(string $name, string $context): mixed
     {
-        $app     = Factory::getApplication();
-        $context = 'com_proclaim.sermons.list';
+        return Factory::getApplication()->getUserStateFromRequest(
+            $context . '.filter.' . $name,
+            'filter_' . $name,
+            ''
+        );
+    }
 
-        return $app->getUserStateFromRequest($context . '.filter.' . $name, 'filter_' . $name, '');
+    /**
+     * Derive the list context a filter field belongs to, from its own form.
+     *
+     * ListModel::getFilterForm() names the form `{context}.filter`, so a field
+     * can recover the context of whatever page is rendering it. Without this
+     * every dropdown read and wrote one hardcoded context, which meant a filter
+     * set on one page silently constrained the dropdowns on another -- and
+     * submitting a filter on the second page wrote back into the first page's
+     * session key.
+     *
+     * @param   ?Form  $form  The form the field belongs to.
+     *
+     * @return  string  The list context, or the sermons list when it cannot be
+     *                  determined -- the previous behaviour, kept so a caller
+     *                  without a form is no worse off than before.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function contextFromForm(?Form $form): string
+    {
+        $name = $form?->getName() ?? '';
+
+        if ($name !== '' && str_ends_with($name, '.filter')) {
+            return substr($name, 0, -\strlen('.filter'));
+        }
+
+        return 'com_proclaim.sermons.list';
     }
 
     /**
@@ -59,18 +90,24 @@ abstract class CwmfilterHelper
      *
      * @param   QueryInterface  $query    The query to constrain
      * @param   string          $exclude  Filter name to skip (the caller's own filter)
+     * @param   string          $context  The list context whose filters apply. Callers
+     *                                    should pass contextFromForm($this->form);
+     *                                    an empty value keeps the historic
+     *                                    sermons-list behaviour.
      *
      * @return  void
      *
      * @since   10.1.0
      */
-    public static function applyCrossFilters(QueryInterface $query, string $exclude = ''): void
+    public static function applyCrossFilters(QueryInterface $query, string $exclude = '', string $context = ''): void
     {
+        $context = $context !== '' ? $context : 'com_proclaim.sermons.list';
+
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Teacher filter
         if ($exclude !== 'teacher') {
-            $teacher = (int) self::getFilterValue('teacher');
+            $teacher = (int) self::getFilterValue('teacher', $context);
 
             if ($teacher > 0) {
                 // Use junction table for multi-teacher support
@@ -85,7 +122,7 @@ abstract class CwmfilterHelper
 
         // Book filter
         if ($exclude !== 'book') {
-            $book = (int) self::getFilterValue('book');
+            $book = (int) self::getFilterValue('book', $context);
 
             if ($book > 0) {
                 $query->where(
@@ -97,7 +134,7 @@ abstract class CwmfilterHelper
 
         // Series filter
         if ($exclude !== 'series') {
-            $series = (int) self::getFilterValue('series');
+            $series = (int) self::getFilterValue('series', $context);
 
             if ($series > 0) {
                 $query->where($db->quoteName('s.series_id') . ' = ' . $series);
@@ -106,7 +143,7 @@ abstract class CwmfilterHelper
 
         // Message type filter
         if ($exclude !== 'messagetype') {
-            $messagetype = (int) self::getFilterValue('messageType');
+            $messagetype = (int) self::getFilterValue('messageType', $context);
 
             if ($messagetype > 0) {
                 $query->where($db->quoteName('s.messagetype') . ' = ' . $messagetype);
@@ -115,7 +152,7 @@ abstract class CwmfilterHelper
 
         // Year filter
         if ($exclude !== 'year') {
-            $year = (int) self::getFilterValue('year');
+            $year = (int) self::getFilterValue('year', $context);
 
             if ($year > 0) {
                 $query->where('YEAR(' . $db->quoteName('s.studydate') . ') = ' . $year);
@@ -124,7 +161,7 @@ abstract class CwmfilterHelper
 
         // Topic filter
         if ($exclude !== 'topic') {
-            $topic = (int) self::getFilterValue('topic');
+            $topic = (int) self::getFilterValue('topic', $context);
 
             if ($topic > 0) {
                 $query->join(
@@ -138,7 +175,7 @@ abstract class CwmfilterHelper
 
         // Location filter
         if ($exclude !== 'location') {
-            $location = (int) self::getFilterValue('location');
+            $location = (int) self::getFilterValue('location', $context);
 
             if ($location > 0) {
                 $query->where($db->quoteName('s.location_id') . ' = ' . $location);

--- a/tests/integration/Admin/Helper/CwmfilterContextTest.php
+++ b/tests/integration/Admin/Helper/CwmfilterContextTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Integration tests for filter-context isolation between list pages.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmfilterHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Form\Form;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1582.
+ *
+ * getFilterValue() hardcoded the sermons list context, but every *ListField
+ * calls applyCrossFilters() on whatever page is rendering it. A Book filter set
+ * on the Sermons list therefore constrained the Teacher dropdown on Series
+ * Displays -- a page whose form has no Book filter and no way to show one is
+ * active -- and submitting a filter there wrote back into the sermons list's
+ * session key.
+ *
+ * ListModel::getFilterForm() names the filter form `{context}.filter`, so a
+ * field can recover the context of the page it is on.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmfilterHelper::class)]
+class CwmfilterContextTest extends IntegrationTestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function formNameProvider(): array
+    {
+        return [
+            'sermons list'    => ['com_proclaim.sermons.list.filter', 'com_proclaim.sermons.list'],
+            'series displays' => ['com_proclaim.seriesdisplays.filter', 'com_proclaim.seriesdisplays'],
+            'admin messages'  => ['com_proclaim.messages.filter', 'com_proclaim.messages'],
+            'nested context'  => ['com_proclaim.a.b.c.filter', 'com_proclaim.a.b.c'],
+        ];
+    }
+
+    /**
+     * @param   string  $formName  The filter form's name
+     * @param   string  $expected  The context it should yield
+     */
+    #[DataProvider('formNameProvider')]
+    #[TestDox('The list context is recovered from the filter form name')]
+    public function testContextIsDerivedFromTheForm(string $formName, string $expected): void
+    {
+        $form = new Form($formName);
+
+        $this->assertSame(
+            $expected,
+            CwmfilterHelper::contextFromForm($form),
+            'Each page must read its own filters, not the sermons list — see #1582'
+        );
+    }
+
+    /**
+     * Two different pages must never resolve to the same context, which is
+     * precisely what the hardcoded value did.
+     */
+    #[TestDox('Different pages resolve to different contexts')]
+    public function testDifferentPagesDoNotShareAContext(): void
+    {
+        $sermons = CwmfilterHelper::contextFromForm(new Form('com_proclaim.sermons.list.filter'));
+        $series  = CwmfilterHelper::contextFromForm(new Form('com_proclaim.seriesdisplays.filter'));
+
+        $this->assertNotSame(
+            $sermons,
+            $series,
+            'A Book filter on one page silently constrained dropdowns on the other — see #1582'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: ?Form}>
+     */
+    public static function unresolvableProvider(): array
+    {
+        return [
+            'no form at all'       => [null],
+            'form without a name'  => [new Form('')],
+            'name is not a filter' => [new Form('com_proclaim.something')],
+        ];
+    }
+
+    /**
+     * Where the context cannot be determined the historic value is kept, so a
+     * caller without a form is no worse off than before rather than losing its
+     * filters entirely.
+     *
+     * @param   ?Form  $form  Form to resolve from
+     */
+    #[DataProvider('unresolvableProvider')]
+    #[TestDox('An unresolvable form falls back to the previous behaviour')]
+    public function testFallbackIsThePreviousBehaviour(?Form $form): void
+    {
+        $this->assertSame('com_proclaim.sermons.list', CwmfilterHelper::contextFromForm($form));
+    }
+
+    /**
+     * The helper is only useful if the dropdowns actually pass their context.
+     * A field that keeps calling the two-argument form silently keeps the bug.
+     */
+    #[TestDox('Every list field passes its own context')]
+    public function testEveryListFieldPassesItsContext(): void
+    {
+        $fields = [
+            'MessageTypeListField',
+            'TopicsListField',
+            'TeacherListField',
+            'BookListField',
+            'SeriesField',
+            'LocationListField',
+            'YearListField',
+        ];
+
+        foreach ($fields as $field) {
+            $source = (string) file_get_contents(JPATH_ROOT . '/admin/src/Field/' . $field . '.php');
+
+            $this->assertStringContainsString(
+                'CwmfilterHelper::contextFromForm($this->form)',
+                $source,
+                $field . ' must read the filters of the page it is on — see #1582'
+            );
+        }
+    }
+
+    /**
+     * applyCrossFilters() must accept a context; without the parameter the
+     * fields above would have nowhere to pass it.
+     */
+    #[TestDox('applyCrossFilters accepts a context argument')]
+    public function testApplyCrossFiltersAcceptsAContext(): void
+    {
+        $params = (new \ReflectionMethod(CwmfilterHelper::class, 'applyCrossFilters'))->getParameters();
+        $names  = array_map(static fn (\ReflectionParameter $p): string => $p->getName(), $params);
+
+        $this->assertContains('context', $names, 'The caller must be able to say which page it is — see #1582');
+    }
+}


### PR DESCRIPTION
getFilterValue() hardcoded com_proclaim.sermons.list, but every *ListField
calls applyCrossFilters() on whatever page happens to be rendering it. A Book
filter set on the Sermons list therefore constrained the Teacher dropdown on
Series Displays -- a page whose form has no Book filter and no way to show that
one is active, so the missing teachers look like missing data. It leaked both
ways: submitting a filter on the second page wrote back into the first page's
session key.

ListModel::getFilterForm() names the filter form `{context}.filter`, so a field
can recover the context of the page it is on from its own form. contextFromForm()
does that, and all seven list fields now pass it.

Where the context cannot be worked out -- no form, or a form whose name is not
a filter form -- the sermons list is still used. That is the previous behaviour
for every caller, so nothing that works today starts returning an unfiltered
list instead.

Fixes #1582

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
