### PR TITLE
fix: make action logging actually fail open

### DIFF
--- a/admin/src/Helper/CwmactionlogHelper.php
+++ b/admin/src/Helper/CwmactionlogHelper.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 
 /**
@@ -71,14 +72,41 @@ class CwmactionlogHelper
                 'origin'      => Text::_(self::originLabel($app)),
             ], $extra);
 
-            /** @var ActionlogModel $model */
+            /** @var ?ActionlogModel $model */
             $model = $app->bootComponent('com_actionlogs')
                 ->getMVCFactory()
                 ->createModel('Actionlog', 'Administrator', ['ignore_request' => true]);
 
+            // createModel() returns null or false when the model cannot be
+            // resolved -- com_actionlogs enabled in #__extensions but its files
+            // missing after a partial removal or a failed update, for instance.
+            // Calling addLog() on that is an Error, not an Exception, so the
+            // catch below would not have stopped it before.
+            if (!$model instanceof ActionlogModel) {
+                return;
+            }
+
             $model->addLog([$message], $messageKey, 'com_proclaim', $user->id);
-        } catch (\Exception $e) {
-            // Silently fail — action logging should never break the main workflow
+        } catch (\Throwable $e) {
+            // Never break the main workflow. Throwable rather than Exception:
+            // the failures actually available here -- a method call on a
+            // null model, a type error out of the factory -- are Errors, which
+            // do not extend Exception, so the original catch documented a
+            // guarantee it did not provide.
+            //
+            // Recorded rather than swallowed outright, so a site that has
+            // stopped logging actions can find out why. The logging of the
+            // failure is itself guarded: it must not become the thing that
+            // breaks the save.
+            try {
+                Log::add(
+                    'Action log entry could not be written: ' . $e->getMessage(),
+                    Log::WARNING,
+                    'com_proclaim'
+                );
+            } catch (\Throwable) {
+                // Nothing further to do.
+            }
         }
     }
 

--- a/tests/integration/Admin/Helper/CwmactionlogFailOpenTest.php
+++ b/tests/integration/Admin/Helper/CwmactionlogFailOpenTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Integration tests for the action log's fail-open contract.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\User\User;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1583.
+ *
+ * The helper documents itself as never breaking the main workflow, and caught
+ * \Exception to achieve that. The failures actually reachable here are Errors:
+ * createModel() returns null or false when the model cannot be resolved, and
+ * calling addLog() on that raises Error, which does not extend Exception. A
+ * routine message save became a fatal.
+ *
+ * Note the issue described this as bootComponent() returning null. It cannot --
+ * core declares ComponentInterface, not ?ComponentInterface, and falls back to
+ * LegacyComponent when a component's files are absent. The reachable path is
+ * the model, not the component, and it is reachable on a working install:
+ * createModel() returns null in this very test harness.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmactionlogHelper::class)]
+class CwmactionlogFailOpenTest extends IntegrationTestCase
+{
+    private mixed $savedIdentity = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // log() returns early when there is no logged-in user, and the harness
+        // has none -- without an identity these tests would pass whether or not
+        // the model path is reachable at all.
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+
+        $user           = new User();
+        $user->id       = 42;
+        $user->username = 'cwm1583';
+        $app->loadIdentity($user);
+    }
+
+    protected function tearDown(): void
+    {
+        Factory::getApplication()->loadIdentity($this->savedIdentity);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The contract, exercised rather than asserted about: in this harness
+     * createModel('Actionlog') resolves to null, which is exactly the shape
+     * that used to escape. Calling log() must return quietly.
+     */
+    #[TestDox('Logging never propagates a failure to the caller')]
+    public function testLogNeverThrows(): void
+    {
+        try {
+            CwmactionlogHelper::log(
+                'COM_PROCLAIM_ACTION_LOG_TEST',
+                'cwm1583 fixture',
+                'message',
+                1,
+                ['extra' => 'value']
+            );
+        } catch (\Throwable $e) {
+            $this->fail(
+                'Action logging must never break the main workflow — see #1583: '
+                . \get_class($e) . ': ' . $e->getMessage()
+            );
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[TestDox('Logging survives an empty extras array and a zero id')]
+    public function testLogSurvivesEdgeInputs(): void
+    {
+        try {
+            CwmactionlogHelper::log('COM_PROCLAIM_ACTION_LOG_TEST', '', 'message', 0);
+        } catch (\Throwable $e) {
+            $this->fail('Unexpected failure: ' . \get_class($e) . ': ' . $e->getMessage());
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * An Error is what actually escapes, so catching Exception alone leaves the
+     * documented guarantee unmet.
+     */
+    #[TestDox('The catch covers Throwable, not just Exception')]
+    public function testCatchCoversThrowable(): void
+    {
+        $ref   = new \ReflectionMethod(CwmactionlogHelper::class, 'log');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString(
+            'catch (\Throwable $e)',
+            $body,
+            'createModel() returning null raises an Error, which catch(\Exception) does not see — see #1583'
+        );
+        $this->assertStringNotContainsString(
+            'catch (\Exception $e)',
+            $body,
+            'The Exception-only catch documented a guarantee it did not provide'
+        );
+    }
+
+    /**
+     * Better to not make the call than to catch the Error it would raise.
+     */
+    #[TestDox('An unresolvable model is checked before it is used')]
+    public function testModelIsCheckedBeforeUse(): void
+    {
+        $ref   = new \ReflectionMethod(CwmactionlogHelper::class, 'log');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $guardAt = strpos($body, 'instanceof ActionlogModel');
+        $callAt  = strpos($body, '$model->addLog(');
+
+        $this->assertNotFalse($guardAt, 'createModel() can return null or false — check it — see #1583');
+        $this->assertNotFalse($callAt, 'Expected the addLog() call to still be present');
+        $this->assertLessThan($callAt, $guardAt, 'The check must come before the call');
+    }
+
+    /**
+     * A site whose action logging has silently stopped should be able to find
+     * out why, and the reporting must not itself become the failure.
+     */
+    #[TestDox('A failure is recorded, and the recording is itself guarded')]
+    public function testFailureIsRecordedSafely(): void
+    {
+        $ref   = new \ReflectionMethod(CwmactionlogHelper::class, 'log');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        $this->assertStringContainsString('Log::add(', $body, 'Swallowing the failure entirely hides a broken audit trail');
+
+        // The Log::add call must sit inside its own try/catch, after the outer
+        // catch — logging the failure must not be able to raise a new one.
+        $outerCatchAt = strpos($body, 'catch (\Throwable $e)');
+        $logAt        = strpos($body, 'Log::add(');
+        $innerCatchAt = strpos($body, 'catch (\Throwable)', $logAt);
+
+        $this->assertNotFalse($innerCatchAt, 'The logging of a failure must itself be guarded — see #1583');
+        $this->assertLessThan($logAt, $outerCatchAt);
+    }
+}


### PR DESCRIPTION
The helper documents itself as never breaking the main workflow and caught
\Exception to achieve that. The failure actually available here is an Error:
createModel('Actionlog') returns null when the model cannot be resolved, and
calling addLog() on null does not extend Exception, so the catch never saw it
and a routine message save became a fatal. Reproduced end to end -- with an
identity loaded, the pre-fix code raises "Call to a member function addLog() on
null" straight out of log().

The catch now covers Throwable, and the model is checked before it is used, so
the common case is prevented rather than caught.

The failure is also recorded now instead of being swallowed outright: a site
whose audit trail has quietly stopped should be able to find out why. That
logging sits in its own try/catch, because the one thing it must not do is
become the failure it is reporting.

Two corrections to the issue's analysis, kept here because the next reader will
otherwise repeat the same reasoning. bootComponent() cannot return null --
core declares ComponentInterface, not ?ComponentInterface, and falls back to a
LegacyComponent when a component's files are missing. And the path does not
need a corrupted install to reach: createModel() returns null in the test
harness on a working system, which is what made the end-to-end test possible.

Fixes #1583

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
