### PR TITLE
fix: bound outbound HTTP requests that could hang a worker indefinitely

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -37,6 +37,18 @@ use Joomla\Registry\Registry;
 abstract class CWMAddon
 {
     /**
+     * Seconds to wait on an addon API request before giving up.
+     *
+     * Joomla's curl transport only sets CURLOPT_TIMEOUT when one is given, so
+     * omitting it means no timeout at all. These calls run inside admin
+     * requests -- connection tests, description sync, stats -- so a
+     * unresponsive provider would hold a PHP worker open indefinitely.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected const int HTTP_TIMEOUT = 20;
+
+    /**
      * Addon configuration
      *
      * @var     bool|null|\SimpleXMLElement
@@ -1006,7 +1018,8 @@ abstract class CWMAddon
         string $url,
         array $headers = [],
         ?string $body = null,
-        string $label = ''
+        string $label = '',
+        int $timeout = self::HTTP_TIMEOUT
     ): Response {
         $http    = (new HttpFactory())->getHttp();
         $verb    = strtoupper($method);
@@ -1015,11 +1028,11 @@ abstract class CWMAddon
 
         try {
             $response = match ($verb) {
-                'GET'    => $http->get($url, $headers),
-                'DELETE' => $http->delete($url, $headers),
-                'POST'   => $http->post($url, (string) $body, $headers),
-                'PUT'    => $http->put($url, (string) $body, $headers),
-                'PATCH'  => $http->patch($url, (string) $body, $headers),
+                'GET'    => $http->get($url, $headers, $timeout),
+                'DELETE' => $http->delete($url, $headers, $timeout),
+                'POST'   => $http->post($url, (string) $body, $headers, $timeout),
+                'PUT'    => $http->put($url, (string) $body, $headers, $timeout),
+                'PATCH'  => $http->patch($url, (string) $body, $headers, $timeout),
                 default  => throw new \InvalidArgumentException('Unsupported HTTP method: ' . $verb),
             };
         } catch (\Exception $e) {

--- a/admin/src/Helper/CwmpodcastIndexHelper.php
+++ b/admin/src/Helper/CwmpodcastIndexHelper.php
@@ -37,6 +37,18 @@ use Joomla\Http\Response;
 class CwmpodcastIndexHelper
 {
     /**
+     * Seconds to wait on a Podcast Index request before giving up.
+     *
+     * Joomla's curl transport only sets CURLOPT_TIMEOUT when one is given, so
+     * omitting it means no timeout at all. submitFeed() runs synchronously
+     * inside an admin AJAX request, so an unresponsive api.podcastindex.org
+     * would hold a PHP worker open indefinitely.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const int HTTP_TIMEOUT = 20;
+
+    /**
      * API base URL
      *
      * @var string
@@ -113,7 +125,7 @@ class CwmpodcastIndexHelper
         $startNs = CwmDebug::isEnabled() ? hrtime(true) : null;
 
         try {
-            $response = $http->get($url, $this->getAuthHeaders());
+            $response = $http->get($url, $this->getAuthHeaders(), self::HTTP_TIMEOUT);
         } catch (\Exception $e) {
             CwmDebug::error('Podcast Index ' . $label . ' request failed', $e, 'api');
 

--- a/tests/unit/Admin/Helper/CwmHttpTimeoutTest.php
+++ b/tests/unit/Admin/Helper/CwmHttpTimeoutTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Unit tests asserting outbound HTTP calls carry a timeout.
+ *
+ * @package    Proclaim.Test
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1587.
+ *
+ * Joomla's curl transport sets CURLOPT_TIMEOUT only when one is supplied
+ * (`if (isset($timeout))` in Transport/Curl.php), so a call that omits the
+ * argument gets no timeout at all. These requests run synchronously inside
+ * admin requests, so an unresponsive provider holds a PHP worker open with no
+ * bound from this code.
+ *
+ * The issue named CwmpodcastIndexHelper::apiGet(). A sweep found the same
+ * omission in CWMAddon::apiRequest(), which is the shared HTTP path for every
+ * server addon -- eighteen call sites across Vimeo, Wistia and Resi.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmHttpTimeoutTest extends ProclaimTestCase
+{
+    /**
+     * Files that make outbound HTTP calls through Joomla's HttpFactory.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function httpCallerProvider(): array
+    {
+        return [
+            'podcast index' => ['admin/src/Helper/CwmpodcastIndexHelper.php'],
+            'addon base'    => ['admin/src/Addons/CWMAddon.php'],
+            'ai helper'     => ['admin/src/Helper/CwmaiHelper.php'],
+        ];
+    }
+
+    /**
+     * Every HTTP verb call in these files must pass something in the timeout
+     * position -- a constant, or a variable carrying one.
+     *
+     * @param   string  $relative  Repo-relative file path
+     */
+    #[DataProvider('httpCallerProvider')]
+    #[TestDox('Every outbound HTTP call passes a timeout')]
+    public function testEveryHttpCallHasATimeout(string $relative): void
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 4) . '/' . $relative);
+
+        // Normalise multi-line calls onto one line so the argument list can be
+        // inspected whole; several of these span four or five lines.
+        $flat = preg_replace('/\s+/', ' ', $source);
+
+        preg_match_all(
+            '/\$http->(get|post|put|patch|delete)\((.*?)\);/',
+            (string) $flat,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $this->assertNotEmpty($matches, 'Expected to find HTTP calls in ' . $relative);
+
+        foreach ($matches as $call) {
+            [$whole, $verb, $args] = $call;
+
+            $this->assertMatchesRegularExpression(
+                '/(TIMEOUT|\$timeout|,\s*\d+\s*$)/',
+                $args,
+                $verb . '() in ' . $relative . ' has no timeout — curl then waits forever — see #1587: '
+                . substr($whole, 0, 90)
+            );
+        }
+    }
+
+    /**
+     * The value has to be a sane bound, not a placeholder.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function timeoutConstantProvider(): array
+    {
+        return [
+            'podcast index' => ['admin/src/Helper/CwmpodcastIndexHelper.php', 'HTTP_TIMEOUT'],
+            'addon base'    => ['admin/src/Addons/CWMAddon.php', 'HTTP_TIMEOUT'],
+        ];
+    }
+
+    /**
+     * @param   string  $relative  Repo-relative file path
+     * @param   string  $constant  Constant name
+     */
+    #[DataProvider('timeoutConstantProvider')]
+    #[TestDox('The timeout constant is declared and bounded')]
+    public function testTimeoutConstantIsSane(string $relative, string $constant): void
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 4) . '/' . $relative);
+
+        $this->assertMatchesRegularExpression(
+            '/const int ' . $constant . ' = (\d+);/',
+            $source,
+            $constant . ' must be declared in ' . $relative
+        );
+
+        preg_match('/const int ' . $constant . ' = (\d+);/', $source, $m);
+        $seconds = (int) ($m[1] ?? 0);
+
+        $this->assertGreaterThan(0, $seconds, 'A zero timeout means no timeout in curl');
+        $this->assertLessThanOrEqual(
+            60,
+            $seconds,
+            'A minute is already long for a synchronous admin request'
+        );
+    }
+
+    /**
+     * The addon helper is shared, so a caller with a slower provider needs to
+     * be able to raise the bound without abandoning it.
+     */
+    #[TestDox('The addon HTTP helper lets callers override the timeout')]
+    public function testAddonRequestTimeoutIsOverridable(): void
+    {
+        $params = (new \ReflectionMethod(
+            \CWM\Component\Proclaim\Administrator\Addons\CWMAddon::class,
+            'apiRequest'
+        ))->getParameters();
+
+        $names = array_map(static fn (\ReflectionParameter $p): string => $p->getName(), $params);
+
+        $this->assertContains('timeout', $names, 'A shared helper must not force one bound on every provider');
+
+        $timeout = $params[array_search('timeout', $names, true)];
+
+        $this->assertTrue($timeout->isDefaultValueAvailable(), 'Existing call sites must keep working unchanged');
+        $this->assertSame(20, $timeout->getDefaultValue());
+    }
+}


### PR DESCRIPTION
Joomla's curl transport sets CURLOPT_TIMEOUT only when one is supplied --
`if (isset($timeout))` in Transport/Curl.php -- so omitting the argument means
no timeout at all, not a default one. CwmpodcastIndexHelper::apiGet() omitted
it, and submitFeed() runs synchronously inside an admin AJAX request, so a slow
or partitioned api.podcastindex.org held a PHP worker open with no bound from
this code.

Sweeping the rest of the repository for the same omission found it again in
CWMAddon::apiRequest(), on all five verbs. That is the shared HTTP path for
every server addon: eighteen call sites across Vimeo, Wistia and Resi, covering
connection tests, description sync, stats and search, all of them reached from
admin requests. It is the larger exposure of the two and was not in the issue.

Both now pass twenty seconds, matching what CwmaiHelper already does on every
one of its calls -- this file was the outlier rather than the pattern.
apiRequest() takes the value as an optional trailing argument so a provider
that genuinely needs longer can ask for it without going back to no bound at
all, and every existing call site is unchanged.

The test asserts the property across all three HTTP-making files rather than
the two lines changed, so a future call added without a timeout fails. It
flattens whitespace first: several of these calls span four or five lines, and
a line-based check would have missed them -- which is how the original sweep
nearly produced a false negative.

Fixes #1587

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
