### PR TITLE
fix: throw a RuntimeException that exists

### DIFF
--- a/admin/src/Helper/Cwmtranslated.php
+++ b/admin/src/Helper/Cwmtranslated.php
@@ -16,7 +16,6 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use http\Exception\RuntimeException;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -75,7 +74,13 @@ class Cwmtranslated
         try {
             $app   = Factory::getApplication();
         } catch (\Exception $e) {
-            throw new RuntimeException('Unable to load Application' . $e->getMessage());
+            // Qualified: this file is namespaced, so an unqualified
+            // RuntimeException resolves against CWM\...\Helper rather than the
+            // global one. It previously resolved to an import of the PECL
+            // ext-http class, which is not a dependency and is not installed,
+            // so this line raised "class not found" -- an Error, which does not
+            // even extend Exception -- instead of the exception it names.
+            throw new \RuntimeException('Unable to load Application: ' . $e->getMessage(), 0, $e);
         }
 
         // If there is no topic to translate, just return

--- a/tests/integration/Admin/Helper/CwmtranslatedExceptionTest.php
+++ b/tests/integration/Admin/Helper/CwmtranslatedExceptionTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Integration tests for Cwmtranslated's no-application failure path.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1588.
+ *
+ * The file imported http\Exception\RuntimeException -- the PECL ext-http
+ * class, which is not a dependency of this project and is not installed on a
+ * standard stack. The throw in getTopicItemTranslated() therefore named a class
+ * that does not exist, so instead of the RuntimeException it advertises it
+ * raised "class not found": an Error, which does not extend Exception, so a
+ * caller catching either would not have seen it.
+ *
+ * Removing the import alone is not enough. This file is namespaced, so an
+ * unqualified RuntimeException resolves against
+ * CWM\Component\Proclaim\Administrator\Helper, not the global namespace -- one
+ * "class not found" would simply have replaced another. The throw is qualified.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmtranslated::class)]
+class CwmtranslatedExceptionTest extends IntegrationTestCase
+{
+    private mixed $savedApplication = null;
+
+    private bool $applicationRemoved = false;
+
+    protected function tearDown(): void
+    {
+        // Restore before anything else; every later test in the run needs it.
+        if ($this->applicationRemoved) {
+            Factory::$application     = $this->savedApplication;
+            $this->applicationRemoved = false;
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Remove the CMS application so Factory::getApplication() throws, which is
+     * the only way into the failure path under test.
+     *
+     * @return  void
+     */
+    private function removeApplication(): void
+    {
+        $this->savedApplication   = Factory::$application;
+        Factory::$application     = null;
+        $this->applicationRemoved = true;
+    }
+
+    /**
+     * The failure path, exercised rather than asserted about.
+     */
+    #[TestDox('A missing application raises a real RuntimeException')]
+    public function testMissingApplicationRaisesRuntimeException(): void
+    {
+        $this->removeApplication();
+
+        try {
+            Cwmtranslated::getTopicItemTranslated((object) ['id' => 1]);
+            $this->fail('Expected the missing application to raise');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString(
+                'Unable to load Application',
+                $e->getMessage(),
+                'The exception it names must be the exception it throws — see #1588'
+            );
+        } catch (\Error $e) {
+            $this->fail(
+                'Still a fatal rather than a catchable exception — see #1588: ' . $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * The cause is what a reader actually needs; without it the message says
+     * only that something failed.
+     */
+    #[TestDox('The original failure is chained as the previous exception')]
+    public function testOriginalFailureIsChained(): void
+    {
+        $this->removeApplication();
+
+        try {
+            Cwmtranslated::getTopicItemTranslated((object) ['id' => 1]);
+            $this->fail('Expected the missing application to raise');
+        } catch (\RuntimeException $e) {
+            $this->assertInstanceOf(
+                \Throwable::class,
+                $e->getPrevious(),
+                'The underlying failure must not be discarded'
+            );
+        }
+    }
+
+    /**
+     * A caller catching the broad case must see it too -- which an Error would
+     * not have satisfied.
+     */
+    #[TestDox('The failure is catchable as an Exception')]
+    public function testFailureIsCatchableAsException(): void
+    {
+        $this->removeApplication();
+
+        $caught = false;
+
+        try {
+            Cwmtranslated::getTopicItemTranslated((object) ['id' => 1]);
+        } catch (\Exception $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue(
+            $caught,
+            'A "class not found" Error does not extend Exception, so no caller could catch it — see #1588'
+        );
+    }
+
+    /**
+     * The class named must be one that exists. ext-http is not a dependency of
+     * this project and is absent from a standard PHP install.
+     */
+    #[TestDox('The helper does not reference the PECL ext-http exception')]
+    public function testDoesNotImportTheExtHttpClass(): void
+    {
+        $source = (string) file_get_contents(
+            (new \ReflectionClass(Cwmtranslated::class))->getFileName()
+        );
+
+        $this->assertStringNotContainsString(
+            'use http\Exception\RuntimeException;',
+            $source,
+            'ext-http is not in composer.json and is not installed — see #1588'
+        );
+        $this->assertStringContainsString(
+            'new \RuntimeException(',
+            $source,
+            'The throw must be qualified: unqualified resolves to this namespace, not the global one'
+        );
+    }
+}


### PR DESCRIPTION
Cwmtranslated imported http\Exception\RuntimeException -- the PECL ext-http
class. It is not in composer.json, is not installed on a standard PHP or
Joomla stack, and is absent here. So the throw in getTopicItemTranslated()
named a class that does not exist and raised "class not found" instead of the
exception it advertises. That is an Error, which does not extend Exception, so
neither a caller catching RuntimeException nor one catching Exception would
have seen it -- and the message pointed at a missing PECL extension rather than
at the missing application that actually caused it.

Removing the import is not sufficient, and doing only that would have looked
like a fix. This file is namespaced, so an unqualified RuntimeException
resolves against CWM\Component\Proclaim\Administrator\Helper rather than the
global namespace: one "class not found" would have replaced another, with the
same symptoms. Verified both resolutions directly. The throw is now qualified.

The original exception is chained as well, since "Unable to load Application"
on its own says less than the failure underneath it.

The path is reachable in a test: clearing Factory::$application makes
getApplication() throw, so this is exercised for real rather than asserted
about, and the pre-fix code fails it with the actual "class not found" message.

A sweep of admin/src, site/src and api/src for imports rooted at a lowercase
namespace -- the shape of this mistake -- found no others.

Fixes #1588

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
