### PR TITLE
fix: batch list methods return arrays, and each widget labels itself

### DIFF
--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -40,7 +40,7 @@ class Cwmhtml
     {
         // Create the batch selector to change the player on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-linkType" class="hasTip" title="' . Text::_(
+            '<label id="batch-linkType-lbl" for="batch-linkType" class="hasTip" title="' . Text::_(
                 'JBS_MED_SHOW_DOWNLOAD_ICON'
             )
             . '::' . Text::_('JBS_MED_SHOW_DOWNLOAD_ICON_DESC') . '">',
@@ -106,7 +106,7 @@ class Cwmhtml
     {
         // Create the batch selector to change the popup on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-popup" class="hasTip" title="' . Text::_('JBS_MED_INTERNAL_POPUP')
+            '<label id="batch-popup-lbl" for="batch-popup" class="hasTip" title="' . Text::_('JBS_MED_INTERNAL_POPUP')
             . '::' . Text::_('JBS_MED_INTERNAL_POPUP_DESC') . '">',
             Text::_('JBS_MED_POPUP'),
             '</label>',
@@ -153,10 +153,23 @@ class Cwmhtml
     {
         // Create the batch selector to change the mediaType on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-mediaType" class="hasTip" title="' . Text::_('JBS_CMN_IMAGE')
+            '<label id="batch-mediaType-lbl" for="batch-mediaType" class="hasTip" title="' . Text::_('JBS_CMN_IMAGE')
             . '::' . Text::_('JBS_MED_IMAGE_DESC') . '">',
             Text::_('JBS_MED_SELECT_MEDIA_TYPE'),
             '</label>',
+            // Deliberately left with no options beyond "No change".
+            //
+            // The obvious completion is to populate this the way every sibling
+            // widget does, but the handler behind it is not ready for that:
+            // CwmmediafileModel::batchMediatype() writes (int) $value into the
+            // media_image param, and media_image holds an image path --
+            // "images/biblestudy/streamingvideo24.png" and the like on a real
+            // database, never a number. Offering options here would give
+            // administrators a one-click way to replace every selected file's
+            // image path with an integer.
+            //
+            // The empty select is what currently prevents that, so it stays
+            // until the handler is fixed. Tracked separately.
             '<select name="batch[mediaType]" class="form-select" id="batch-mediaType">',
             '<option value="">' . Text::_('JBS_BAT_MEDIATYPE_NOCHANGE') . '</option>',
             '</select>',
@@ -176,7 +189,7 @@ class Cwmhtml
     {
         // Create the batch selector to change the teacher on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-teacher" class="hasTip" title="' .
+            '<label id="batch-teacher-lbl" for="batch-teacher" class="hasTip" title="' .
             Text::_('JBS_CMN_TEACHER') . '::' . Text::_('JBS_BAT_TEACHER_DESC') . '">',
             Text::_('JBS_CMN_TEACHER'),
             '</label>',
@@ -196,9 +209,8 @@ class Cwmhtml
      *
      * @since    1.6
      */
-    public static function teacherList(): ?array
+    public static function teacherList(): array
     {
-        $options = null;
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->createQuery();
 
@@ -210,7 +222,7 @@ class Cwmhtml
         $db->setQuery($query);
 
         try {
-            $options = $db->loadObjectList();
+            return $db->loadObjectList() ?: [];
         } catch (\Exception $e) {
             try {
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
@@ -219,7 +231,11 @@ class Cwmhtml
             }
         }
 
-        return $options;
+        // Never null. HTMLHelper::_('select.options', ...) foreach()es this
+        // straight away and core has no null guard, so a failed query used to
+        // emit a TypeError warning into the middle of the batch dialog's markup.
+        // locationList() already did this correctly.
+        return [];
     }
 
     /**
@@ -233,7 +249,7 @@ class Cwmhtml
     {
         // Create the batch selector to change the message type on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-messageType" class="hasTip" title="' .
+            '<label id="batch-messageType-lbl" for="batch-messageType" class="hasTip" title="' .
             Text::_('JBS_CMN_MESSAGETYPE') . '::' . Text::_('JBS_BAT_MESSAGETYPE_DESC') . '">',
             Text::_('JBS_CMN_MESSAGETYPE'),
             '</label>',
@@ -253,9 +269,8 @@ class Cwmhtml
      *
      * @since    1.6
      */
-    public static function messageTypeList(): ?array
+    public static function messageTypeList(): array
     {
-        $options = null;
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->createQuery();
 
@@ -267,7 +282,7 @@ class Cwmhtml
         $db->setQuery($query);
 
         try {
-            $options = $db->loadObjectList();
+            return $db->loadObjectList() ?: [];
         } catch (\Exception $e) {
             try {
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
@@ -276,7 +291,11 @@ class Cwmhtml
             }
         }
 
-        return $options;
+        // Never null. HTMLHelper::_('select.options', ...) foreach()es this
+        // straight away and core has no null guard, so a failed query used to
+        // emit a TypeError warning into the middle of the batch dialog's markup.
+        // locationList() already did this correctly.
+        return [];
     }
 
     /**
@@ -290,7 +309,7 @@ class Cwmhtml
     {
         // Create the batch selector to change the series on a selection list.
         $lines = [
-            '<label id="batch-client-lbl" for="batch-series" class="hasTip" title="' .
+            '<label id="batch-series-lbl" for="batch-series" class="hasTip" title="' .
             Text::_('JBS_CMN_SERIES') . '::' . Text::_('JBS_BAT_SERIES_DESC') . '">',
             Text::_('JBS_CMN_SERIES'),
             '</label>',
@@ -310,9 +329,8 @@ class Cwmhtml
      *
      * @since    1.6
      */
-    public static function seriesList(): ?array
+    public static function seriesList(): array
     {
-        $options = null;
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->createQuery();
 
@@ -324,7 +342,7 @@ class Cwmhtml
         $db->setQuery($query);
 
         try {
-            $options = $db->loadObjectList();
+            return $db->loadObjectList() ?: [];
         } catch (\Exception $e) {
             try {
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
@@ -333,7 +351,11 @@ class Cwmhtml
             }
         }
 
-        return $options;
+        // Never null. HTMLHelper::_('select.options', ...) foreach()es this
+        // straight away and core has no null guard, so a failed query used to
+        // emit a TypeError warning into the middle of the batch dialog's markup.
+        // locationList() already did this correctly.
+        return [];
     }
 
     /**

--- a/tests/integration/Admin/Helper/CwmhtmlBatchWidgetTest.php
+++ b/tests/integration/Admin/Helper/CwmhtmlBatchWidgetTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Integration tests for the batch widget helpers.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmhtml;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1589.
+ *
+ * teacherList(), messageTypeList() and seriesList() initialised $options to
+ * null, assigned it only inside the try, and had no return in the catch -- so a
+ * failed query returned null. That null goes straight into
+ * HTMLHelper::_('select.options', ...), which foreach()es it with no null
+ * guard, so the batch dialog's markup got a TypeError warning written into the
+ * middle of it wherever display_errors is on. locationList() already returned
+ * [] on the same path.
+ *
+ * Six widgets also shared id="batch-client-lbl". Several appear on the same
+ * page -- the Messages batch body renders teacher(), series() and
+ * messageType() together -- which is invalid HTML, a duplicate-id
+ * accessibility failure, and makes any getElementById() lookup ambiguous.
+ * location(), added later, already used a unique id.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmhtml::class)]
+class CwmhtmlBatchWidgetTest extends IntegrationTestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function listMethodProvider(): array
+    {
+        return [
+            'teacherList'     => ['teacherList'],
+            'messageTypeList' => ['messageTypeList'],
+            'seriesList'      => ['seriesList'],
+            'locationList'    => ['locationList'],
+        ];
+    }
+
+    /**
+     * @param   string  $method  List method name
+     */
+    #[DataProvider('listMethodProvider')]
+    #[TestDox('A list method always returns an array, never null')]
+    public function testListMethodsReturnArrays(string $method): void
+    {
+        $this->assertIsArray(
+            Cwmhtml::$method(),
+            $method . '() returning null corrupts the batch dialog markup — see #1589'
+        );
+    }
+
+    /**
+     * The declared type is the contract callers rely on; leaving it nullable
+     * invites the same bug back.
+     *
+     * @param   string  $method  List method name
+     */
+    #[DataProvider('listMethodProvider')]
+    #[TestDox('A list method does not declare a nullable return')]
+    public function testListMethodsAreNotNullable(string $method): void
+    {
+        $type = (new \ReflectionMethod(Cwmhtml::class, $method))->getReturnType();
+
+        $this->assertNotNull($type, $method . '() must declare a return type');
+        $this->assertSame('array', (string) $type, $method . '() must return array, not ?array — see #1589');
+    }
+
+    // -------------------------------------------------------------------------
+    // Duplicate label ids
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function widgetProvider(): array
+    {
+        return [
+            'linkType'    => ['linkType'],
+            'popup'       => ['popup'],
+            'mediaType'   => ['mediaType'],
+            'teacher'     => ['teacher'],
+            'messageType' => ['messageType'],
+            'series'      => ['series'],
+            'location'    => ['location'],
+        ];
+    }
+
+    /**
+     * @param   string  $widget  Widget method name
+     */
+    #[DataProvider('widgetProvider')]
+    #[TestDox('A batch widget carries its own label id')]
+    public function testWidgetLabelIdIsUnique(string $widget): void
+    {
+        $html = Cwmhtml::$widget();
+
+        $this->assertStringNotContainsString(
+            'id="batch-client-lbl"',
+            $html,
+            $widget . '() shared one id with five other widgets — see #1589'
+        );
+        $this->assertStringContainsString(
+            'id="batch-' . $widget . '-lbl"',
+            $html,
+            $widget . '() must label itself distinctly'
+        );
+    }
+
+    /**
+     * The failure this prevents: several of these render into one page.
+     */
+    #[TestDox('Widgets rendered together produce no duplicate ids')]
+    public function testWidgetsCombineWithoutDuplicateIds(): void
+    {
+        // What admin/tmpl/cwmmessages/default_batch_body.php combines.
+        $html = Cwmhtml::teacher() . Cwmhtml::series() . Cwmhtml::messageType();
+
+        preg_match_all('/id="([^"]+)"/', $html, $matches);
+
+        $ids = $matches[1];
+
+        $this->assertSame(
+            \count($ids),
+            \count(array_unique($ids)),
+            'Duplicate ids on one page are invalid HTML and fail the accessibility scan — see #1589: '
+            . implode(', ', array_diff_assoc($ids, array_unique($ids)))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // The media-type widget stays inert on purpose
+    // -------------------------------------------------------------------------
+
+    /**
+     * Completing this widget the obvious way would expose a batch action that
+     * writes an integer into media_image, which holds an image path. The empty
+     * select is what prevents that, so it must not be "finished" without the
+     * handler being fixed first -- see #1627.
+     */
+    #[TestDox('The media-type widget offers nothing until its handler is fixed')]
+    public function testMediaTypeWidgetStaysInert(): void
+    {
+        $html = Cwmhtml::mediaType();
+
+        preg_match_all('/<option /', $html, $matches);
+
+        $this->assertCount(
+            1,
+            $matches[0],
+            'Only the "No change" sentinel: batchMediatype() would overwrite image paths with integers — see #1627'
+        );
+    }
+}


### PR DESCRIPTION
teacherList(), messageTypeList() and seriesList() set $options to null,
assigned it only inside the try, and had no return in the catch -- so a failed
query returned null. That null goes straight into HTMLHelper::_(
'select.options', ...), which foreach()es it with no null guard, so wherever
display_errors is on a TypeError warning was written into the middle of the
batch dialog's markup. locationList() already handled the same path correctly;
these three now match it, and their return types say array rather than ?array
so the next reader is not invited to reintroduce it.

Six widgets shared id="batch-client-lbl". The Messages batch body renders
teacher(), series() and messageType() together, so that is three elements with
one id on a page: invalid HTML, a duplicate-id accessibility failure, and any
getElementById() lookup resolving to whichever came first. Each now labels
itself, following location(), which was added later and already did.

The third finding is deliberately not fixed. It proposes populating
mediaType(), which is the only batch widget with no options -- but
CwmmediafileModel::batchMediatype() writes (int) $value into the media_image
param, and media_image holds an image path. Sampling 200 media rows on a real
database returns 116 empty strings and 84 paths such as
images/biblestudy/streamingvideo24.png; never a number. Adding options would
hand administrators a one-click way to replace every selected file's image path
with an integer, so the empty select is currently the only thing preventing
that. It stays, with a comment saying why, and the handler is tracked in #1627.
A test pins the widget as inert so it is not "finished" by accident.

Fixes #1589

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
