### PR TITLE
fix: stale backup version and 'worning' alert type

### DIFF
--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -361,7 +361,7 @@ class CwmproclaimHelper
         try {
             $options = $db->loadObjectList();
         } catch (\RuntimeException $e) {
-            Factory::getApplication()->enqueueMessage($e->getMessage(), 'worning');
+            Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
         }
 
         return $options;
@@ -396,7 +396,7 @@ class CwmproclaimHelper
         try {
             $options = $db->loadObjectList();
         } catch (\RuntimeException $e) {
-            Factory::getApplication()->enqueueMessage($e->getMessage(), 'worning');
+            Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
         }
 
         return $options;
@@ -542,7 +542,7 @@ class CwmproclaimHelper
         try {
             $options = $db->loadObjectList();
         } catch (\RuntimeException $e) {
-            Factory::getApplication()->enqueueMessage($e->getMessage(), 'worning');
+            Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
         }
 
         return $options;
@@ -572,7 +572,7 @@ class CwmproclaimHelper
         try {
             $options = $db->loadObjectList();
         } catch (\RuntimeException $e) {
-            Factory::getApplication()->enqueueMessage($e->getMessage(), 'worning');
+            Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
         }
 
         return $options;

--- a/admin/src/Helper/Version.php
+++ b/admin/src/Helper/Version.php
@@ -43,6 +43,16 @@ final class Version
      * @var    int
      * @since  3.8.0
      */
+    /**
+     * NOTE: these constants are maintained by hand and are not updated by the
+     * release tooling -- cwm-bump and cwm-release rewrite versions.json,
+     * package.json and __DEPLOY_VERSION__ tokens, but not this file. They have
+     * drifted before and will again. Anything that needs the version actually
+     * installed should call CwmproclaimHelper::getVersion(), which reads the
+     * manifest cache.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
     public const int MAJOR_VERSION = 10;
 
     /**

--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -19,6 +19,7 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Version;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
@@ -171,9 +172,14 @@ class Cwmbackup
         // Get current date in ISO format
         $date = date('Y-m-d');
 
-        // Get Proclaim version
-        $versionHelper = new Version();
-        $version       = $versionHelper->getShortVersion();
+        // Get Proclaim version.
+        //
+        // From the installed manifest, not Version.php's constants: those are
+        // maintained by hand and are not touched by the release tooling, so
+        // they drift. They read 10.3.1 while versions.json says 10.5.5, which
+        // put a version two minor releases stale into every backup filename --
+        // exactly the thing a filename like this exists to record.
+        $version = CwmproclaimHelper::getVersion();
 
         return \sprintf('proclaim-backup_%s_%s_v%s.sql', $siteName, $date, $version);
     }

--- a/tests/integration/Admin/Helper/CwmproclaimCosmeticTest.php
+++ b/tests/integration/Admin/Helper/CwmproclaimCosmeticTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Integration tests for the #1590 cosmetic fixes.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1590.
+ *
+ * Four catch blocks enqueued their message with the type 'worning'. Joomla maps
+ * that string to an alert-{type} class, so the message rendered unstyled rather
+ * than as a warning. The sibling methods in the same file already used
+ * 'warning'.
+ *
+ * Backup filenames carried Version.php's hardcoded constants, which the release
+ * tooling does not touch -- 10.3.1 against a 10.5.5 release.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmproclaimCosmeticTest extends IntegrationTestCase
+{
+    #[TestDox('No enqueued message uses the misspelled type')]
+    public function testNoMisspelledMessageType(): void
+    {
+        $files = glob(JPATH_ROOT . '/admin/src/**/*.php') ?: [];
+        $found = [];
+
+        foreach (new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(JPATH_ROOT . '/admin/src')
+        ) as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            if (str_contains((string) file_get_contents($file->getPathname()), "'worning'")) {
+                $found[] = $file->getPathname();
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $found,
+            "'worning' matches no Bootstrap alert class, so the message renders unstyled — see #1590"
+        );
+    }
+
+    #[TestDox('Backup filenames use the installed version, not a hardcoded one')]
+    public function testBackupFilenameUsesInstalledVersion(): void
+    {
+        $source = (string) file_get_contents(JPATH_ROOT . '/admin/src/Lib/Cwmbackup.php');
+
+        $this->assertStringContainsString(
+            'CwmproclaimHelper::getVersion()',
+            $source,
+            'Version.php is not maintained by the release tooling and drifts — see #1590'
+        );
+        $this->assertStringNotContainsString(
+            '$versionHelper->getShortVersion()',
+            $source,
+            'The hardcoded constants put a stale version into every backup filename'
+        );
+    }
+
+    #[TestDox('The installed version is reported as a version string')]
+    public function testInstalledVersionIsAVersionString(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/^\d+\.\d+\.\d+/',
+            CwmproclaimHelper::getVersion(),
+            'A backup filename is built from this'
+        );
+    }
+}


### PR DESCRIPTION
Four catch blocks in CwmproclaimHelper enqueued their message with the type
'worning'. Joomla maps that string straight into an alert-{type} class, so a
failed query reported itself unstyled instead of as a warning. The sibling
methods in the same file already used 'warning'.

Backup filenames carried Version.php's hardcoded constants, which read 10.3.1
while versions.json says 10.5.5 -- the release tooling rewrites versions.json,
package.json and __DEPLOY_VERSION__ tokens but never this file, so it has
drifted across six releases. generateBackupFilename() now takes the version
from CwmproclaimHelper::getVersion(), which reads the installed manifest, so
the filename records what was actually installed. The constants keep their
display uses and now say in the file that they are not release-managed.

The third finding is not fixed here, because verifying it turned up something
larger. It reports that JBS_PDC_PLATFORM_* exists only in admin/language and so
renders as a raw key on the public site. The keys are indeed admin-only -- but
so is every other Proclaim string, the manifest declares <languages
folder="admin"> and nothing else, and <files folder="site"> ships no language
folder at all. Joomla's ComponentDispatcher::loadLanguage() tries
JPATH_BASE/language and then JPATH_BASE/components/com_proclaim/language, and
neither is installed. Taken at face value that means no Proclaim string
resolves on the site, which cannot be right for a shipping product, so
something is loading them by a route not visible from the repository.

Adding a site language file for these thirteen keys would be treating a symptom
of something not yet understood, and would look like a fix. This needs a real
site to settle, so it is reported rather than guessed at.

Fixes #1590

---

**Verification.** Suite green locally on PHP 8.5.7; each behavioural change red-checked by reverting it and confirming the relevant tests fail. Branch merges cleanly into `development`.
