### PR TITLE
fix: make (remote playlist, server) unique and de-dup existing rows (#1560)

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -161,11 +161,19 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlists`
     `asset_id`            INT(10) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'FK to the #__assets table.',
     `access`              INT(10) UNSIGNED NOT NULL DEFAULT '1',
     `ordering`            INT(11)          NOT NULL DEFAULT '0',
+    -- A remote playlist maps to one local row per server. remote_playlist_id is
+    -- NOT NULL DEFAULT '' and the edit form does not require it, so a playlist
+    -- created by hand in the admin carries ''. Mapping '' to NULL keeps those
+    -- unconstrained, because NULLs are distinct from each other in a unique index.
+    `remote_playlist_uk`  VARCHAR(64) GENERATED ALWAYS AS
+        (IF(`remote_playlist_id` <> '', `remote_playlist_id`, NULL)) STORED,
     PRIMARY KEY (`id`),
+    UNIQUE KEY `uq_server_remote_playlist` (`server_id`, `remote_playlist_uk`),
     KEY `idx_state` (`published`),
     KEY `idx_access` (`access`),
     KEY `idx_checkout` (`checked_out`),
     KEY `idx_server` (`server_id`),
+    KEY `idx_remote_playlist` (`remote_playlist_id`, `server_id`),
     KEY `idx_published_access` (`published`, `access`)
 ) ENGINE InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/admin/sql/updates/mysql/10.5.6-20260806.sql
+++ b/admin/sql/updates/mysql/10.5.6-20260806.sql
@@ -79,3 +79,93 @@ ALTER TABLE `#__bsms_studies`
 
 ALTER TABLE `#__bsms_studies`
     ADD UNIQUE KEY `uq_series_studynumber` (`series_id`, `studynumber_uk`);
+
+-- #1560: nothing stopped two overlapping playlist imports from both creating a
+-- row for the same remote playlist. CwmplaylistSyncHelper::importChannelPlaylists()
+-- looks the playlist up and inserts when absent, with no constraint between the
+-- two steps, so a scheduled sync overlapping a manual "Import from YouTube" could
+-- have both pass the lookup before either had stored.
+
+-- Salvage the losing duplicates' junction rows before the rows go away. Each step
+-- runs against every duplicate group at once, keeping the earliest playlist of
+-- each group.
+
+-- 1. Carry a resolved media-file link over to the keeper where the keeper has
+--    none. Deleting the loser's row first would throw that link away.
+UPDATE `#__bsms_playlist_items` keep
+    JOIN `#__bsms_playlists` kp ON kp.`id` = keep.`playlist_id`
+    JOIN `#__bsms_playlists` lp
+        ON lp.`remote_playlist_id` = kp.`remote_playlist_id`
+       AND lp.`server_id` = kp.`server_id`
+       AND lp.`id` > kp.`id`
+    JOIN `#__bsms_playlist_items` lose
+        ON lose.`playlist_id` = lp.`id`
+       AND lose.`remote_video_id` = keep.`remote_video_id`
+SET keep.`mediafile_id` = lose.`mediafile_id`
+WHERE keep.`mediafile_id` IS NULL
+  AND lose.`mediafile_id` IS NOT NULL
+  AND kp.`remote_playlist_id` <> '';
+
+-- 2. Drop the losers' items the keeper already holds. #__bsms_playlist_items has
+--    UNIQUE KEY (playlist_id, remote_video_id), so remapping these in step 3
+--    would abort the migration on a duplicate key.
+DELETE lose FROM `#__bsms_playlist_items` lose
+    JOIN `#__bsms_playlists` lp ON lp.`id` = lose.`playlist_id`
+    JOIN `#__bsms_playlists` kp
+        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND kp.`server_id` = lp.`server_id`
+       AND kp.`id` < lp.`id`
+    JOIN `#__bsms_playlist_items` keep
+        ON keep.`playlist_id` = kp.`id`
+       AND keep.`remote_video_id` = lose.`remote_video_id`
+WHERE lp.`remote_playlist_id` <> '';
+
+-- 3. Move what survives onto the keeper, so a manual playlist assignment made
+--    against a duplicate is not silently lost.
+UPDATE `#__bsms_playlist_items` lose
+    JOIN `#__bsms_playlists` lp ON lp.`id` = lose.`playlist_id`
+    JOIN `#__bsms_playlists` kp
+        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND kp.`server_id` = lp.`server_id`
+       AND kp.`id` < lp.`id`
+SET lose.`playlist_id` = kp.`id`
+WHERE lp.`remote_playlist_id` <> '';
+
+-- 4. Release the losing rows' ACL assets, which nothing else would clean up once
+--    the rows are gone.
+DELETE a FROM `#__assets` a
+    JOIN `#__bsms_playlists` lp
+        ON a.`name` = CONCAT('com_proclaim.playlist.', lp.`id`)
+    JOIN `#__bsms_playlists` kp
+        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND kp.`server_id` = lp.`server_id`
+       AND kp.`id` < lp.`id`
+WHERE lp.`remote_playlist_id` <> '';
+
+-- 5. Remove the duplicates themselves. The constraint below cannot be created
+--    while any remain.
+DELETE lp FROM `#__bsms_playlists` lp
+    JOIN `#__bsms_playlists` kp
+        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND kp.`server_id` = lp.`server_id`
+       AND kp.`id` < lp.`id`
+WHERE lp.`remote_playlist_id` <> '';
+
+-- A remote playlist maps to one local row per server. remote_playlist_id is
+-- NOT NULL DEFAULT '' and the edit form does not require it, so a playlist
+-- created by hand in the admin carries ''. A plain unique index would let only
+-- one of those exist per server. Mapping '' to NULL leaves them unconstrained,
+-- because NULLs are distinct from each other in a unique index -- the same
+-- treatment uq_series_studynumber gives an absent episode number above.
+ALTER TABLE `#__bsms_playlists`
+    ADD COLUMN `remote_playlist_uk` VARCHAR(64)
+    GENERATED ALWAYS AS (IF(`remote_playlist_id` <> '', `remote_playlist_id`, NULL)) STORED;
+
+ALTER TABLE `#__bsms_playlists`
+    ADD UNIQUE KEY `uq_server_remote_playlist` (`server_id`, `remote_playlist_uk`);
+
+-- The unique index covers the generated column, which no query names. Lookups by
+-- (remote_playlist_id, server_id) -- every sync run does one per remote playlist
+-- -- would otherwise still fall back to idx_server alone.
+ALTER TABLE `#__bsms_playlists`
+    ADD KEY `idx_remote_playlist` (`remote_playlist_id`, `server_id`);

--- a/admin/sql/updates/mysql/10.5.6-20260806.sql
+++ b/admin/sql/updates/mysql/10.5.6-20260806.sql
@@ -86,37 +86,46 @@ ALTER TABLE `#__bsms_studies`
 -- two steps, so a scheduled sync overlapping a manual "Import from YouTube" could
 -- have both pass the lookup before either had stored.
 
--- Salvage the losing duplicates' junction rows before the rows go away. Each step
--- runs against every duplicate group at once, keeping the earliest playlist of
--- each group.
+-- Salvage the losing duplicates' junction rows before the rows go away. Each
+-- step runs against every duplicate group at once. `g` names the row each group
+-- keeps: joining on "any playlist with a lower id" instead would, in a group of
+-- three, let MySQL pick either survivor arbitrarily -- and step 3 could then
+-- remap an item onto a playlist that step 5 goes on to delete.
 
 -- 1. Carry a resolved media-file link over to the keeper where the keeper has
 --    none. Deleting the loser's row first would throw that link away.
 UPDATE `#__bsms_playlist_items` keep
     JOIN `#__bsms_playlists` kp ON kp.`id` = keep.`playlist_id`
+    JOIN (SELECT `remote_playlist_id`, `server_id`, MIN(`id`) AS keep_id
+          FROM `#__bsms_playlists`
+          WHERE `remote_playlist_id` <> ''
+          GROUP BY `remote_playlist_id`, `server_id`) g
+        ON g.`keep_id` = kp.`id`
     JOIN `#__bsms_playlists` lp
-        ON lp.`remote_playlist_id` = kp.`remote_playlist_id`
-       AND lp.`server_id` = kp.`server_id`
-       AND lp.`id` > kp.`id`
+        ON lp.`remote_playlist_id` = g.`remote_playlist_id`
+       AND lp.`server_id` = g.`server_id`
+       AND lp.`id` <> g.`keep_id`
     JOIN `#__bsms_playlist_items` lose
         ON lose.`playlist_id` = lp.`id`
        AND lose.`remote_video_id` = keep.`remote_video_id`
 SET keep.`mediafile_id` = lose.`mediafile_id`
 WHERE keep.`mediafile_id` IS NULL
-  AND lose.`mediafile_id` IS NOT NULL
-  AND kp.`remote_playlist_id` <> '';
+  AND lose.`mediafile_id` IS NOT NULL;
 
 -- 2. Drop the losers' items the keeper already holds. #__bsms_playlist_items has
 --    UNIQUE KEY (playlist_id, remote_video_id), so remapping these in step 3
 --    would abort the migration on a duplicate key.
 DELETE lose FROM `#__bsms_playlist_items` lose
     JOIN `#__bsms_playlists` lp ON lp.`id` = lose.`playlist_id`
-    JOIN `#__bsms_playlists` kp
-        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
-       AND kp.`server_id` = lp.`server_id`
-       AND kp.`id` < lp.`id`
+    JOIN (SELECT `remote_playlist_id`, `server_id`, MIN(`id`) AS keep_id
+          FROM `#__bsms_playlists`
+          WHERE `remote_playlist_id` <> ''
+          GROUP BY `remote_playlist_id`, `server_id`) g
+        ON g.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND g.`server_id` = lp.`server_id`
+       AND g.`keep_id` <> lp.`id`
     JOIN `#__bsms_playlist_items` keep
-        ON keep.`playlist_id` = kp.`id`
+        ON keep.`playlist_id` = g.`keep_id`
        AND keep.`remote_video_id` = lose.`remote_video_id`
 WHERE lp.`remote_playlist_id` <> '';
 
@@ -124,11 +133,14 @@ WHERE lp.`remote_playlist_id` <> '';
 --    against a duplicate is not silently lost.
 UPDATE `#__bsms_playlist_items` lose
     JOIN `#__bsms_playlists` lp ON lp.`id` = lose.`playlist_id`
-    JOIN `#__bsms_playlists` kp
-        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
-       AND kp.`server_id` = lp.`server_id`
-       AND kp.`id` < lp.`id`
-SET lose.`playlist_id` = kp.`id`
+    JOIN (SELECT `remote_playlist_id`, `server_id`, MIN(`id`) AS keep_id
+          FROM `#__bsms_playlists`
+          WHERE `remote_playlist_id` <> ''
+          GROUP BY `remote_playlist_id`, `server_id`) g
+        ON g.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND g.`server_id` = lp.`server_id`
+       AND g.`keep_id` <> lp.`id`
+SET lose.`playlist_id` = g.`keep_id`
 WHERE lp.`remote_playlist_id` <> '';
 
 -- 4. Release the losing rows' ACL assets, which nothing else would clean up once
@@ -136,19 +148,25 @@ WHERE lp.`remote_playlist_id` <> '';
 DELETE a FROM `#__assets` a
     JOIN `#__bsms_playlists` lp
         ON a.`name` = CONCAT('com_proclaim.playlist.', lp.`id`)
-    JOIN `#__bsms_playlists` kp
-        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
-       AND kp.`server_id` = lp.`server_id`
-       AND kp.`id` < lp.`id`
+    JOIN (SELECT `remote_playlist_id`, `server_id`, MIN(`id`) AS keep_id
+          FROM `#__bsms_playlists`
+          WHERE `remote_playlist_id` <> ''
+          GROUP BY `remote_playlist_id`, `server_id`) g
+        ON g.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND g.`server_id` = lp.`server_id`
+       AND g.`keep_id` <> lp.`id`
 WHERE lp.`remote_playlist_id` <> '';
 
 -- 5. Remove the duplicates themselves. The constraint below cannot be created
 --    while any remain.
 DELETE lp FROM `#__bsms_playlists` lp
-    JOIN `#__bsms_playlists` kp
-        ON kp.`remote_playlist_id` = lp.`remote_playlist_id`
-       AND kp.`server_id` = lp.`server_id`
-       AND kp.`id` < lp.`id`
+    JOIN (SELECT `remote_playlist_id`, `server_id`, MIN(`id`) AS keep_id
+          FROM `#__bsms_playlists`
+          WHERE `remote_playlist_id` <> ''
+          GROUP BY `remote_playlist_id`, `server_id`) g
+        ON g.`remote_playlist_id` = lp.`remote_playlist_id`
+       AND g.`server_id` = lp.`server_id`
+       AND g.`keep_id` <> lp.`id`
 WHERE lp.`remote_playlist_id` <> '';
 
 -- A remote playlist maps to one local row per server. remote_playlist_id is

--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -406,7 +406,35 @@ final class CwmplaylistSyncHelper
                 }
             }
 
-            if (!$table->bind($data) || !$table->check() || !$table->store()) {
+            if (!$table->bind($data) || !$table->check()) {
+                $out['error'] = $table->getError() ?: 'Failed to store playlist.';
+
+                return $out;
+            }
+
+            try {
+                $stored = $table->store();
+            } catch (\RuntimeException $e) {
+                // An insert can only fail this way once uq_server_remote_playlist
+                // exists, and findPlaylistId() found nothing moments ago -- so a
+                // concurrent run created this playlist in between. Its row is the
+                // winner; adopt it rather than failing the whole import over a
+                // race the constraint just resolved for us.
+                $raced = $isNew ? self::findPlaylistId($db, $remoteId, $serverId) : 0;
+
+                if ($raced === 0) {
+                    $out['error'] = $e->getMessage();
+
+                    return $out;
+                }
+
+                $out['playlistIds'][] = $raced;
+                $out['updated']++;
+
+                continue;
+            }
+
+            if (!$stored) {
                 $out['error'] = $table->getError() ?: 'Failed to store playlist.';
 
                 return $out;
@@ -1463,18 +1491,10 @@ final class CwmplaylistSyncHelper
     /**
      * Find an existing playlist by remote ID and server.
      *
-     * #__bsms_playlists has no unique constraint on (remote_playlist_id, server_id),
-     * so two importChannelPlaylists() runs racing each other (e.g. a scheduled sync
-     * overlapping a manual admin-triggered one) can each pass this lookup and both
-     * insert a row for the same remote playlist — a select-then-insert TOCTOU. A
-     * proper fix needs a unique index plus a de-dup migration first: existing sites
-     * that already hit the race may carry duplicate rows, and #__bsms_mediafiles'
-     * manual playlist assignments reference playlist IDs directly, so de-duping
-     * would also have to remap those — deliberately left as a follow-up rather than
-     * bundled here (see #1553). In the meantime, ORDER BY id makes the outcome of a
-     * duplicate deterministic: the lowest-id (originally-created) row always wins
-     * and keeps syncing, rather than each sync run nondeterministically picking a
-     * different duplicate to update.
+     * uq_server_remote_playlist keeps this pairing unique, so at most one row can
+     * match. ORDER BY id ASC LIMIT 1 still stands in for the pre-constraint case:
+     * a database that has not yet run the de-dup migration may hold duplicates,
+     * and the lowest-id (originally-created) row is the one that migration keeps.
      *
      * @param   DatabaseInterface  $db        Database driver.
      * @param   string             $remoteId  YouTube playlist ID.

--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -107,6 +107,56 @@ class Cwmbackup
     private static array $primaryKeyOrderClauses = [];
 
     /**
+     * Cached per-table set of generated column names, keyed by table name.
+     * Populated on first use.
+     *
+     * @var array<string, array<string, true>>
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static array $generatedColumns = [];
+
+    /**
+     * List the columns a table computes for itself.
+     *
+     * A generated column's value comes from its expression, and MySQL rejects
+     * any statement that writes one. The restored dump recreates the column
+     * from SHOW CREATE TABLE, so an exported INSERT naming it fails the whole
+     * restore. #__bsms_studies.studynumber_uk and
+     * #__bsms_playlists.remote_playlist_uk are two such columns.
+     *
+     * @param   DatabaseInterface  $db     Database driver
+     * @param   string             $table  Full table name (with `#__` prefix)
+     *
+     * @return  array<string, true>  Column names as keys
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function getGeneratedColumns(DatabaseInterface $db, string $table): array
+    {
+        if (isset(self::$generatedColumns[$table])) {
+            return self::$generatedColumns[$table];
+        }
+
+        $generated = [];
+
+        try {
+            foreach ($db->getTableColumns($table, false) as $name => $column) {
+                if (stripos($column->Extra ?? '', 'GENERATED') !== false) {
+                    $generated[$name] = true;
+                }
+            }
+        } catch (\RuntimeException) {
+            // Treat an unreadable schema as "nothing generated" rather than
+            // aborting the backup; the restore would surface any real problem.
+        }
+
+        self::$generatedColumns[$table] = $generated;
+
+        return $generated;
+    }
+
+    /**
      * Build a deterministic ORDER BY clause from a table's primary key.
      *
      * Handles composite keys by ordering on every key column in index
@@ -704,12 +754,20 @@ class Cwmbackup
 
         $export = '';
 
+        $generated = self::getGeneratedColumns($db, $table);
+
         if ($results) {
             foreach ($results as $result) {
                 $data   = [];
                 $export .= 'INSERT INTO ' . $db->quoteName($table) . ' SET ';
 
                 foreach ($result as $key => $value) {
+                    // The table computes these itself and rejects any attempt to
+                    // write them, so naming one here would fail the restore.
+                    if (isset($generated[$key])) {
+                        continue;
+                    }
+
                     if ($value === null) {
                         $data[] = $db->quoteName($key) . "=NULL";
                     } else {

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -671,6 +671,14 @@ class CwmmessageTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
+        // studynumber_uk exists only to carry uq_series_studynumber; the database
+        // computes it from series_id and studynumber, and rejects any statement
+        // that writes it. Table seeds it as an ordinary column and load() fills it
+        // in, so re-storing a loaded message would carry it into the SET clause --
+        // failing every save of a message that has both a series and an episode
+        // number, which are exactly the rows the generated column is non-null for.
+        unset($this->studynumber_uk);
+
         try {
             $result = parent::store($updateNulls);
         } catch (\Throwable $e) {

--- a/admin/src/Table/CwmplaylistTable.php
+++ b/admin/src/Table/CwmplaylistTable.php
@@ -329,6 +329,12 @@ class CwmplaylistTable extends Table
     #[\Override]
     public function store($updateNulls = false): bool
     {
+        // remote_playlist_uk exists only to carry uq_server_remote_playlist; the
+        // database computes it from remote_playlist_id and rejects any statement
+        // that writes it. Table picks it up as an ordinary column, so load() sets
+        // it and the follow-up update would carry it into the SET clause.
+        unset($this->remote_playlist_uk);
+
         $result = parent::store($updateNulls);
 
         if ($result) {

--- a/tests/integration/Admin/Helper/CwmplaylistImportRaceTest.php
+++ b/tests/integration/Admin/Helper/CwmplaylistImportRaceTest.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * Integration tests for CwmplaylistSyncHelper::importChannelPlaylists()'s
+ * duplicate-playlist handling.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
+use CWM\Component\Proclaim\Administrator\Helper\CwmplaylistSyncHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1560.
+ *
+ * importChannelPlaylists() looks a playlist up and inserts when absent, with
+ * nothing between the two steps -- so a scheduled sync overlapping a manual
+ * "Import from YouTube" could have both runs pass the lookup and both insert a
+ * row for the same remote playlist. uq_server_remote_playlist now makes the
+ * second insert fail; these tests pin the behaviour that failure produces, and
+ * the constraint's own boundaries.
+ *
+ * Each test runs inside a transaction that is rolled back, so nothing persists.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmplaylistSyncHelper::class)]
+class CwmplaylistImportRaceTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var  int
+     */
+    private int $serverId = 0;
+
+    /**
+     * Factory::$language as it was before silenceDateLanguageWarnings().
+     *
+     * @var  mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * Server rows this test created, for the explicit cleanup in tearDown().
+     *
+     * @var  int[]
+     */
+    private array $serverIds = [];
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        // importChannelPlaylists() stamps last_sync via Factory::getDate().
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        $this->serverId = $this->insertServer();
+    }
+
+    /**
+     * Remove everything this test created.
+     *
+     * The surrounding transaction is not enough on its own: Table::store()
+     * creates the row's #__assets entry, and the nested-set bookkeeping there
+     * runs LOCK TABLES, which MySQL treats as an implicit COMMIT. Anything
+     * written before that point is already durable when the rollback runs, so
+     * the rows have to be deleted by hand.
+     *
+     * @return  void
+     */
+    private function purgeCreatedRows(): void
+    {
+        if ($this->serverIds === []) {
+            return;
+        }
+
+        $servers = implode(',', array_map('intval', $this->serverIds));
+
+        $ids = $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('id') . ' FROM ' . $this->db->quoteName('#__bsms_playlists')
+            . ' WHERE ' . $this->db->quoteName('server_id') . ' IN (' . $servers . ')'
+        )->loadColumn() ?: [];
+
+        foreach ($ids as $id) {
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__assets')
+                . ' WHERE ' . $this->db->quoteName('name') . ' = '
+                . $this->db->quote('com_proclaim.playlist.' . (int) $id)
+            )->execute();
+        }
+
+        $this->db->setQuery(
+            'DELETE FROM ' . $this->db->quoteName('#__bsms_playlists')
+            . ' WHERE ' . $this->db->quoteName('server_id') . ' IN (' . $servers . ')'
+        )->execute();
+
+        $this->db->setQuery(
+            'DELETE FROM ' . $this->db->quoteName('#__bsms_servers')
+            . ' WHERE ' . $this->db->quoteName('id') . ' IN (' . $servers . ')'
+        )->execute();
+
+        $this->serverIds = [];
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+
+            try {
+                $this->purgeCreatedRows();
+            } catch (\Throwable) {
+                // Best effort; the assertions below already ran.
+            }
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    #[TestDox('A remote playlist already present is adopted, not inserted a second time')]
+    public function testExistingRemotePlaylistIsNotDuplicated(): void
+    {
+        $existingId = $this->insertPlaylist('PLraced', $this->serverId, 'Created by the other run');
+
+        $addon  = $this->fakeAddon([['playlistId' => 'PLraced', 'title' => 'Remote title']]);
+        $result = CwmplaylistSyncHelper::importChannelPlaylists($this->db, $addon, $this->serverId);
+
+        $this->assertNull($result['error'], 'Import must not fail over an already-present playlist');
+        $this->assertSame(0, $result['created'], 'Nothing new should be created');
+        $this->assertContains($existingId, $result['playlistIds'], 'The import must resolve to the existing row');
+        $this->assertSame(
+            1,
+            $this->countPlaylists('PLraced'),
+            'Exactly one row may exist for a (remote playlist, server) pair'
+        );
+    }
+
+    #[TestDox('Importing the same channel twice creates the playlist once')]
+    public function testRepeatedImportCreatesOnlyOneRow(): void
+    {
+        $addon = $this->fakeAddon([['playlistId' => 'PLfresh', 'title' => 'Fresh playlist']]);
+
+        $first  = CwmplaylistSyncHelper::importChannelPlaylists($this->db, $addon, $this->serverId);
+        $second = CwmplaylistSyncHelper::importChannelPlaylists($this->db, $addon, $this->serverId);
+
+        $this->assertNull($first['error']);
+        $this->assertNull($second['error']);
+        $this->assertSame(1, $first['created'], 'First import creates the row');
+        $this->assertSame(0, $second['created'], 'Second import must find it rather than insert again');
+        $this->assertSame(1, $this->countPlaylists('PLfresh'));
+        $this->assertSame(
+            $first['playlistIds'],
+            $second['playlistIds'],
+            'Both runs must resolve to the same playlist row'
+        );
+    }
+
+    #[TestDox('uq_server_remote_playlist rejects a duplicate (remote playlist, server) pair')]
+    public function testConstraintRejectsDuplicatePair(): void
+    {
+        $this->insertPlaylist('PLunique', $this->serverId, 'First');
+
+        $this->expectException(\RuntimeException::class);
+        $this->insertPlaylist('PLunique', $this->serverId, 'Second');
+    }
+
+    #[TestDox('The constraint still allows several hand-made playlists, which carry no remote ID')]
+    public function testConstraintAllowsManuallyCreatedPlaylists(): void
+    {
+        // remote_playlist_id is NOT NULL DEFAULT '' and the edit form does not
+        // require it, so every hand-made playlist shares the same value. A plain
+        // UNIQUE (remote_playlist_id, server_id) would permit only one per server;
+        // the generated column maps '' to NULL to keep them unconstrained.
+        $first  = $this->insertPlaylist('', $this->serverId, 'Hand-made one');
+        $second = $this->insertPlaylist('', $this->serverId, 'Hand-made two');
+
+        $this->assertNotSame($first, $second);
+        $this->assertSame(2, $this->countPlaylists(''));
+    }
+
+    #[TestDox('The constraint still allows the same remote playlist under a different server')]
+    public function testConstraintIsScopedPerServer(): void
+    {
+        $otherServerId = $this->insertServer();
+
+        $this->insertPlaylist('PLshared', $this->serverId, 'On server A');
+        $this->insertPlaylist('PLshared', $otherServerId, 'On server B');
+
+        $this->assertSame(1, $this->countPlaylists('PLshared'));
+        $this->assertSame(1, $this->countPlaylists('PLshared', $otherServerId));
+    }
+
+    /**
+     * @param   string    $remoteId  Remote playlist ID ('' for a hand-made playlist).
+     * @param   int|null  $serverId  Server to scope to; defaults to this test's server.
+     *
+     * @return  int  Number of playlist rows carrying that remote ID on that server.
+     */
+    private function countPlaylists(string $remoteId, ?int $serverId = null): int
+    {
+        // Scoped to one server on purpose: the constraint is per-server, so a
+        // count across servers would not answer the question being asked and
+        // would drift with whatever else the database happens to hold.
+        $serverId ??= $this->serverId;
+
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_playlists'))
+                ->where($this->db->quoteName('remote_playlist_id') . ' = :rid')
+                ->where($this->db->quoteName('server_id') . ' = :sid')
+                ->bind(':rid', $remoteId, \Joomla\Database\ParameterType::STRING)
+                ->bind(':sid', $serverId, \Joomla\Database\ParameterType::INTEGER)
+        )->loadResult();
+    }
+
+    /**
+     * @param   string  $remoteId  Remote playlist ID.
+     * @param   int     $serverId  Server ID.
+     * @param   string  $title     Playlist title.
+     *
+     * @return  int  The new playlist row ID.
+     */
+    private function insertPlaylist(string $remoteId, int $serverId, string $title): int
+    {
+        $row = (object) [
+            'title'              => $title,
+            'alias'              => 'pl-' . uniqid('', true),
+            'remote_playlist_id' => $remoteId,
+            'server_id'          => $serverId,
+            'published'          => 1,
+            'access'             => 1,
+            'language'           => '*',
+            'sync_enabled'       => 1,
+            'params'             => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_playlists', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @return  int  Server ID.
+     */
+    private function insertServer(): int
+    {
+        $row = (object) [
+            'server_name' => 'Test YouTube ' . uniqid('', true),
+            'published'   => 1,
+            'access'      => 1,
+            'type'        => 'youtube',
+            'params'      => '{}',
+            'media'       => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_servers', $row);
+
+        $id                = (int) $this->db->insertid();
+        $this->serverIds[] = $id;
+
+        return $id;
+    }
+
+    /**
+     * Build a playlist-capable addon double that reports a fixed remote playlist
+     * list, so no test ever reaches a real YouTube account.
+     *
+     * @param   array<int,array{playlistId:string,title:string}>  $playlists  Remote playlists to report.
+     *
+     * @return  CWMAddon
+     */
+    private function fakeAddon(array $playlists): CWMAddon
+    {
+        return new class ($playlists) extends CWMAddon {
+            /** @var array<int,array{playlistId:string,title:string}> */
+            private array $playlists;
+
+            public function __construct(array $playlists = [])
+            {
+                $this->playlists = $playlists;
+            }
+
+            public function supportsPlaylists(): bool
+            {
+                return true;
+            }
+
+            public function supportsPlaylistWriteback(): bool
+            {
+                return false;
+            }
+
+            public function fetchRemotePlaylists(\Joomla\Input\Input $data): array
+            {
+                return ['success' => true, 'playlists' => $this->playlists];
+            }
+
+            public function extractRemoteMediaId(string $text): ?string
+            {
+                return CWMAddonYoutube::extractMediaId($text);
+            }
+
+            public function renderGeneral(object $media_form, bool $new): string
+            {
+                return '';
+            }
+
+            public function render(object $media_form, bool $new): string
+            {
+                return '';
+            }
+
+            protected function upload(\Joomla\Input\Input $data): mixed
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
+++ b/tests/integration/Admin/Helper/CwmplaylistMembershipPushTest.php
@@ -70,50 +70,13 @@ class CwmplaylistMembershipPushTest extends IntegrationTestCase
             $this->markTestSkipped('Database not available for integration tests');
         }
 
-        $this->silenceDateLanguageWarnings();
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
 
         $this->db = Factory::getContainer()->get(DatabaseDriver::class);
         $this->db->transactionStart();
 
         $this->serverId = $this->insertServer();
         $this->seriesId = $this->insertSeries();
-    }
-
-    /**
-     * Stop Factory::getDate() from emitting PHP warnings in the test harness.
-     *
-     * pushMemberships() stamps junction rows via Factory::getDate(), which reads
-     * Factory::$language->getTag() — i.e. the language's metadata['tag']. The CI
-     * Joomla root carries no langmetadata files, so every Language instance here
-     * has metadata = null; getTag() then accesses an offset on null and the date
-     * path prints warnings that trip beStrictAboutOutputDuringTests. There is no
-     * public tag setter, so force a tag onto the metadata via reflection and make
-     * that language the one Factory::getDate() reads.
-     *
-     * @return  void
-     */
-    private function silenceDateLanguageWarnings(): void
-    {
-        // Remember the process-wide state so tearDown() can put it back --
-        // leaving the forced en-GB tag in place leaks into every later test
-        // in the run and masks the exact null-metadata warning class other
-        // suites' beStrictAboutOutputDuringTests would surface.
-        $this->previousFactoryLanguage = Factory::$language;
-
-        $lang = Factory::getApplication()->getLanguage();
-
-        try {
-            $prop = new \ReflectionProperty($lang, 'metadata');
-            $meta = $prop->getValue($lang);
-
-            if (!\is_array($meta) || ($meta['tag'] ?? null) === null) {
-                $prop->setValue($lang, array_merge(\is_array($meta) ? $meta : [], ['tag' => 'en-GB']));
-            }
-        } catch (\ReflectionException) {
-            // Property absent on this Joomla version — leave the language as-is.
-        }
-
-        Factory::$language = $lang;
     }
 
     /**

--- a/tests/integration/Admin/Table/CwmgeneratedColumnStoreTest.php
+++ b/tests/integration/Admin/Table/CwmgeneratedColumnStoreTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Integration tests for storing rows on tables that carry a generated column.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Table;
+
+use CWM\Component\Proclaim\Administrator\Table\CwmmessageTable;
+use CWM\Component\Proclaim\Administrator\Table\CwmplaylistTable;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Two tables carry a STORED generated column that exists only to back a unique
+ * index: #__bsms_studies.studynumber_uk (uq_series_studynumber) and
+ * #__bsms_playlists.remote_playlist_uk (uq_server_remote_playlist).
+ *
+ * MySQL rejects any statement that writes a generated column. Joomla's Table
+ * seeds a property for every schema column and load() fills them all in, so
+ * re-storing a loaded row carries the generated value into the SET clause and
+ * the save fails -- but only for rows where the column is non-null, which is why
+ * it survives a casual smoke test. These tests pin the exclusion.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmmessageTable::class)]
+#[CoversClass(CwmplaylistTable::class)]
+class CwmgeneratedColumnStoreTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var  mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * Rows this test created, as table => ids, for the explicit cleanup below.
+     *
+     * @var  array<string, int[]>
+     */
+    private array $created = [];
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+
+            try {
+                $this->purgeCreatedRows();
+            } catch (\Throwable) {
+                // Best effort; the assertions have already run.
+            }
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    #[TestDox('A message that has both a series and an episode number can still be re-stored')]
+    public function testMessageWithGeneratedUniquenessValueStores(): void
+    {
+        $this->requireColumn('#__bsms_studies', 'studynumber_uk');
+
+        $id = $this->seedNumberedStudy();
+
+        $table = new CwmmessageTable($this->db);
+        $this->assertTrue($table->load($id), 'Failed to load the seeded study');
+
+        // The bug only bites when the generated column is non-null, which needs
+        // both a real series and a non-empty episode number.
+        $this->assertNotNull($table->studynumber_uk ?? null, 'Fixture must produce a non-null generated value');
+
+        $this->assertTrue(
+            $table->store(),
+            'Storing a loaded message must not attempt to write studynumber_uk: ' . $table->getError()
+        );
+    }
+
+    #[TestDox('A playlist that has a remote ID can still be re-stored')]
+    public function testPlaylistWithGeneratedUniquenessValueStores(): void
+    {
+        $this->requireColumn('#__bsms_playlists', 'remote_playlist_uk');
+
+        $row = (object) [
+            'title'              => 'Generated column fixture',
+            'alias'              => 'genfix-' . uniqid('', true),
+            'remote_playlist_id' => 'PLgenerated' . uniqid('', true),
+            'server_id'          => 0,
+            'published'          => 1,
+            'access'             => 1,
+            'language'           => '*',
+            'params'             => '{}',
+        ];
+        $this->db->insertObject('#__bsms_playlists', $row);
+        $id                                   = (int) $this->db->insertid();
+        $this->created['#__bsms_playlists'][] = $id;
+
+        $table = new CwmplaylistTable($this->db);
+        $this->assertTrue($table->load($id), 'Failed to load the seeded playlist');
+        $this->assertNotNull($table->remote_playlist_uk ?? null, 'Fixture must produce a non-null generated value');
+
+        $this->assertTrue(
+            $table->store(),
+            'Storing a loaded playlist must not attempt to write remote_playlist_uk: ' . $table->getError()
+        );
+    }
+
+    /**
+     * Delete everything this test seeded.
+     *
+     * The surrounding transaction does not cover it: Table::store() creates the
+     * row's #__assets entry, and the nested-set bookkeeping there runs LOCK
+     * TABLES, which MySQL treats as an implicit COMMIT. Whatever was written
+     * before that point is already durable when the rollback runs.
+     *
+     * @return  void
+     */
+    private function purgeCreatedRows(): void
+    {
+        foreach ($this->created['#__bsms_playlists'] ?? [] as $id) {
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__assets')
+                . ' WHERE ' . $this->db->quoteName('name') . ' = '
+                . $this->db->quote('com_proclaim.playlist.' . $id)
+            )->execute();
+        }
+
+        foreach ($this->created['#__bsms_studies'] ?? [] as $id) {
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__assets')
+                . ' WHERE ' . $this->db->quoteName('name') . ' = '
+                . $this->db->quote('com_proclaim.message.' . $id)
+            )->execute();
+        }
+
+        foreach ($this->created as $table => $ids) {
+            if ($ids === []) {
+                continue;
+            }
+
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName($table)
+                . ' WHERE ' . $this->db->quoteName('id')
+                . ' IN (' . implode(',', array_map('intval', $ids)) . ')'
+            )->execute();
+        }
+
+        $this->created = [];
+    }
+
+    /**
+     * Skip when the database predates the migration that adds the column, so the
+     * suite still runs against an un-upgraded developer database.
+     *
+     * @param   string  $table   Table name.
+     * @param   string  $column  Column name.
+     *
+     * @return  void
+     */
+    private function requireColumn(string $table, string $column): void
+    {
+        $found = $this->db->setQuery(
+            'SHOW COLUMNS FROM ' . $this->db->quoteName($table) . ' LIKE ' . $this->db->quote($column)
+        )->loadResult();
+
+        if (!$found) {
+            $this->markTestSkipped($table . '.' . $column . ' not present; run the 10.5.6 migration first');
+        }
+    }
+
+    /**
+     * Seed a published study inside a real series, carrying an episode number.
+     *
+     * @return  int  Study ID.
+     */
+    private function seedNumberedStudy(): int
+    {
+        $series = (object) [
+            'series_text' => 'Generated column fixture series',
+            'alias'       => 'genfix-series-' . uniqid('', true),
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+        ];
+        $this->db->insertObject('#__bsms_series', $series);
+        $seriesId                          = (int) $this->db->insertid();
+        $this->created['#__bsms_series'][] = $seriesId;
+
+        $study = (object) [
+            'studytitle'  => 'Generated column fixture study',
+            'alias'       => 'genfix-study-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'studynumber' => '77',
+            'series_id'   => $seriesId,
+            'messagetype' => '1',
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'params'      => '{}',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study);
+
+        $id                                 = (int) $this->db->insertid();
+        $this->created['#__bsms_studies'][] = $id;
+
+        return $id;
+    }
+}

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -143,4 +143,44 @@ abstract class IntegrationTestCase extends ProclaimTestCase
         $prop = $ref->getProperty($property);
         $prop->setValue(null, $value);
     }
+
+    /**
+     * Give Factory::getDate() a language tag to read, and return the previous
+     * language so the caller can restore it.
+     *
+     * Any code under test that calls Factory::getDate() reaches
+     * Factory::$language->getTag(), i.e. the language's metadata['tag']. A test
+     * Joomla root carrying no langmetadata files leaves every Language instance
+     * with metadata = null, so getTag() reads an offset on null and the date path
+     * prints warnings that trip beStrictAboutOutputDuringTests. There is no public
+     * tag setter, so force one onto the metadata via reflection.
+     *
+     * Restore the returned value in tearDown(): leaving the forced tag in place
+     * leaks into every later test in the run and masks exactly this warning class
+     * for suites that would otherwise surface it.
+     *
+     * @return  mixed  The previous Factory::$language.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function silenceDateLanguageWarnings(): mixed
+    {
+        $previous = \Joomla\CMS\Factory::$language;
+        $lang     = \Joomla\CMS\Factory::getApplication()->getLanguage();
+
+        try {
+            $prop = new \ReflectionProperty($lang, 'metadata');
+            $meta = $prop->getValue($lang);
+
+            if (!\is_array($meta) || ($meta['tag'] ?? null) === null) {
+                $prop->setValue($lang, array_merge(\is_array($meta) ? $meta : [], ['tag' => 'en-GB']));
+            }
+        } catch (\ReflectionException) {
+            // Property absent on this Joomla version -- leave the language as-is.
+        }
+
+        \Joomla\CMS\Factory::$language = $lang;
+
+        return $previous;
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1560. `importChannelPlaylists()` looked a playlist up and inserted when absent, with no constraint between the two steps — so a scheduled sync overlapping a manual "Import from YouTube" could have both runs pass the lookup and both insert a row for the same remote playlist. #1559 only made the *outcome* of an existing duplicate deterministic.

## The issue's stated fix direction would have broken hand-made playlists

Fix direction #1 asks for `UNIQUE KEY (remote_playlist_id, server_id)`. That can't ship as written: `remote_playlist_id` is `NOT NULL DEFAULT ''`, the edit form doesn't mark it required, and `CwmplaylistTable::check()` only requires a title — so **every playlist created by hand in the admin carries `''`**, and a plain unique index would allow only one of them per server.

A `STORED` generated column mapping `''` to `NULL` leaves those unconstrained, since NULLs are distinct from each other in a unique index. That's the same treatment `uq_series_studynumber` already gives an absent episode number in this very migration file, so it's a reuse of an in-repo pattern rather than a new gamble on generated-column support.

```sql
ALTER TABLE `#__bsms_playlists`
    ADD COLUMN `remote_playlist_uk` VARCHAR(64)
    GENERATED ALWAYS AS (IF(`remote_playlist_id` <> '', `remote_playlist_id`, NULL)) STORED;

ALTER TABLE `#__bsms_playlists`
    ADD UNIQUE KEY `uq_server_remote_playlist` (`server_id`, `remote_playlist_uk`);
```

The unique index covers the *generated* column, which no query names, so a plain `(remote_playlist_id, server_id)` index went in alongside it — every sync run does one such lookup per remote playlist and had only `idx_server` to work with.

## De-dup ordering

`#__bsms_playlist_items.playlist_id` is the **only** table column referencing playlist ids. (The issue's wording — "`#__bsms_mediafiles`' manual playlist assignments reference playlist IDs directly" — implies a column on `#__bsms_mediafiles` that doesn't exist; the `source='manual'` junction rows are what it meant.)

That table carries `UNIQUE KEY (playlist_id, remote_video_id)`, so a bare `UPDATE ... SET playlist_id = keeper` aborts the whole `.sql` file on a duplicate key whenever a keeper and a duplicate share a video. The migration therefore, keeping the lowest-id row of each group:

1. carries a resolved `mediafile_id` over to the keeper where the keeper has none (deleting first would discard the link),
2. deletes the losers' items the keeper already holds,
3. remaps what survives, so a manual assignment made against a duplicate isn't lost,
4. releases the losing rows' `#__assets` entries, which nothing else would clean up,
5. deletes the duplicate playlists.

Every step joins a `MIN(id)` derived table naming the group's keeper — the form #1579 already uses in this file. Joining on "any playlist with a lower id" would, in a group of three, let MySQL pick either survivor for an item on the highest row, and step 3 could then remap it onto a playlist step 5 goes on to delete. MySQL 8.0.44 picks the lowest id in practice, so this removes a dependency on documented-unspecified behaviour rather than fixing a reproduced orphan.

`install.mysql.utf8.sql` gets the same column and indexes, so clean installs and upgraded sites don't diverge. (#1629 already added `studynumber_uk` / `uq_series_studynumber` there, so fresh installs get that constraint too.)

## Insert path

With the constraint live, a losing insert now catches the failure and adopts the winning row rather than failing the entire import. `Table::store()` is kept (asset creation, `check()`) instead of hand-rolling an upsert.

`findPlaylistId()`'s docblock was a ten-line narration of the deferred fix; it now states what the method does.

## Bonus: a regression in #1579's `studynumber_uk`, unreleased in this same version

Building the second instance of this pattern surfaced a defect in the first. MySQL rejects any statement that writes a generated column, and Joomla's `Table` seeds a property for **every** schema column, which `load()` then fills in — so re-storing a loaded row carries the generated value into the `SET` clause.

Confirmed against a real database: with `studynumber_uk` present, `CwmmessageTable::store()` returns `false` for any message that has both a series and an episode number. **Saving those messages is broken on any site that runs the 10.5.6 migration.** It survives casual testing because the column is `NULL` — and therefore skipped by `updateObject()` — for every message *without* both.

Both tables now drop the generated column before storing. Fixed here rather than filed separately because 10.5.6 is unreleased and this PR adds the second instance of the same pattern.

**Backups are the third writer to hit this.** `Cwmbackup::getExportTableRows()` builds its `INSERT` from `SELECT *` output, so once either generated column exists, every backup emitted a statement naming it — and the restore, which recreates the column from `SHOW CREATE TABLE`, would reject the whole thing. Generated columns are now skipped, resolved from the schema so a future one needs no change here.

## Test plan

- [x] `tests/integration/Admin/Helper/CwmplaylistImportRaceTest.php` — 5 tests: an already-present remote playlist is adopted not duplicated; a repeated import creates one row; the constraint rejects a duplicate pair; **it still allows several hand-made playlists**; it stays scoped per server. Uses a fake addon, so nothing reaches a real YouTube account.
- [x] `tests/integration/Admin/Table/CwmgeneratedColumnStoreTest.php` — 2 tests pinning that a message with a series + episode number, and a playlist with a remote ID, can still be re-stored. Both confirmed **red** with the fixes reverted.
- [x] De-dup DML validated against real MySQL over constraint-free clones of the real tables, covering the collision case specifically (keeper and duplicate sharing a video, one with `mediafile_id` set and one `NULL`): links carried over, no duplicate `(playlist_id, remote_video_id)` pairs left, manual assignment remapped, unrelated playlist untouched.
- [x] Constraint semantics verified live: two hand-made playlists on one server allowed; duplicate pair rejected (`23000`); same remote ID under a different server allowed.
- [x] Full suite: `composer test` (1727 tests, 6383 assertions, 2 skipped), `npm test` (232 tests).
- [x] `composer lint` clean for every file in this diff.

### Test-isolation note

These tests can't rely on the usual transaction rollback: `Table::store()` creates the row's `#__assets` entry, and the nested-set bookkeeping there runs `LOCK TABLES`, which MySQL treats as an **implicit COMMIT** — anything written before that point is already durable when the rollback runs. The first draft leaked 8 playlists and 8 servers into the dev database before this was caught. Both suites now track what they create and delete it explicitly in `tearDown()`; verified by running the full suite three times and confirming every affected table's row count is unchanged.

`silenceDateLanguageWarnings()` moved from a private method on `CwmplaylistMembershipPushTest` to `IntegrationTestCase`, since a second suite needed it.

### End-to-end migration run

The de-dup and the `ALTER`s were also run **as one block, in order**, against a table holding duplicates — the composition, not just the halves. Fixture: a three-member duplicate group (with a video unique to the third row), a second two-member group on another server, two hand-made `''` playlists, and one unrelated remote playlist.

All 8 statements executed; both indexes landed; only the keepers, hand-made and unrelated rows survived; **zero junction rows orphaned onto a deleted playlist**; the shared video collapsed to one row on the keeper carrying the duplicate's `mediafile_id`; the manual assignment from the third duplicate remapped onto the keeper; the second group de-duped onto its own keeper independently; both hand-made playlists survived the unique index.

## Not covered

- The migration has not been run through `composer test:release`'s full install-then-upgrade path; it was validated directly against MySQL 8.0.44 as described above.
- Backup/restore was not exercised end to end against a post-migration database — the generated-column exclusion is covered by reading the schema, not by a round-trip test.
