### PR TITLE
fix: make the media display batch apply a whole configuration (#1627)

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -1158,6 +1158,7 @@ JBS_CMN_SCHEMA_RESET = "Reset Schema from Item Data"
 ;; BAT Batch process
 JBS_BAT_DOWNLOAD_NOCHANGE = "- No Download Change -"
 JBS_BAT_MEDIATYPE_NOCHANGE = "- No Media Image Change -"
+JBS_BAT_MEDIATYPE_INVALID = "The selected media display setting could not be read. Please choose it again."
 JBS_BAT_MESSAGETYPE_DESC = "Choose a new message type for the batch process"
 JBS_BAT_MESSAGETYPE_NOCHANGE = "- Do Not Change Message Type -"
 JBS_BAT_MIMETYPE_DESC = "Choose a mimetype for the batch process"

--- a/admin/src/Field/MediaFileImagesField.php
+++ b/admin/src/Field/MediaFileImagesField.php
@@ -42,6 +42,26 @@ class MediaFileImagesField extends ListField
     protected $type = 'MediaFileImages';
 
     /**
+     * The params that together describe how a media file is displayed.
+     *
+     * Matches the set CwmadminModel::changeMediaImages() writes, so an option
+     * value round-trips through either consumer without losing a field.
+     *
+     * @var  string[]
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public const DISPLAY_KEYS = [
+        'media_use_button_icon',
+        'media_button_type',
+        'media_button_text',
+        'media_button_color',
+        'media_icon_type',
+        'media_custom_icon',
+        'media_image',
+    ];
+
+    /**
      * Method to get a list of options for a list input.
      *
      * @return   array  An array of HTMLHelper options.
@@ -50,6 +70,28 @@ class MediaFileImagesField extends ListField
      */
     #[\Override]
     protected function getOptions(): array
+    {
+        return array_merge(parent::getOptions(), self::buildDisplayOptions());
+    }
+
+    /**
+     * Build one option per distinct display configuration in use.
+     *
+     * Shared with Cwmhtml::mediaType(), which offers the same choices as a
+     * batch action, so the list a batch can apply and the list this field
+     * offers cannot drift apart.
+     *
+     * @param   bool  $withCounts  Append the site-wide number of media files
+     *                             using each configuration to its label. Off
+     *                             for the batch widget, where a global count
+     *                             next to a selection of rows misleads.
+     *
+     * @return  object[]  HTMLHelper select options; value is a JSON blob of the
+     *                    display params, text is a human-readable label.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function buildDisplayOptions(bool $withCounts = true): array
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery();
@@ -68,48 +110,49 @@ class MediaFileImagesField extends ListField
                 if ($media->params->get('media_use_button_icon') >= 1) {
                     switch ($media->params->get('media_use_button_icon')) {
                         case 1:
-                            $button             = $this->getButton($media);
+                            $button             = self::getButton($media);
                             $media->media_image = Text::_('JBS_MED_BUTTON') . ': ' . $button . ' - ' . Text::_(
                                 'JBS_MED_TEXT'
                             ) .
                                 ': ' . $media->params->get('media_button_text');
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                $this->buildOptionValueJson($media->params),
+                                self::buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
                         case 2:
-                            $button             = $this->getButton($media);
-                            $icon               = $this->getIcon($media);
+                            $button             = self::getButton($media);
+                            $icon               = self::getIcon($media);
                             $media->media_image = Text::_('JBS_MED_BUTTON') . ': ' . $button . ' - ' . Text::_(
                                 'JBS_MED_ICON'
                             ) . ': ' . $icon;
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                $this->buildOptionValueJson($media->params),
+                                self::buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
                         case 3:
-                            $icon               = $this->getIcon($media);
+                            $icon               = self::getIcon($media);
                             $media->media_image = Text::_('JBS_MED_ICON') . ': ' . $icon;
                             $options[]          = HTMLHelper::_(
                                 'select.option',
-                                $this->buildOptionValueJson($media->params),
+                                self::buildOptionValueJson($media->params),
                                 $media->media_image
                             );
                             break;
                     }
                 } else {
-                    $image              = $media->params->get('media_image');
-                    $totalcount         = \strlen($image);
+                    // media_image is unset on media files that predate the
+                    // display settings, so cast before measuring it.
+                    $image              = (string) ($media->params->get('media_image') ?? '');
                     $slash              = strrpos($image, '/');
-                    $imagecount         = $totalcount - $slash;
-                    $media->media_image = Text::_('JBS_MED_IMAGE') . ': ' . substr($image, $slash + 1, $imagecount);
+                    $media->media_image = Text::_('JBS_MED_IMAGE') . ': '
+                        . ($slash === false ? $image : substr($image, $slash + 1));
                     $options[]          = HTMLHelper::_(
                         'select.option',
-                        $this->buildOptionValueJson($media->params, $media->params->get('media_image')),
+                        self::buildOptionValueJson($media->params, $image),
                         $media->media_image
                     );
                 }
@@ -134,21 +177,28 @@ class MediaFileImagesField extends ListField
             }
         }
 
-        // Add the number of records from $count to the text of the drop down
-        foreach ($options as $k => $v) {
-            foreach ($count as $key => $value) {
-                if ($key == $v->text) {
-                    $options[$k]->text = $v->text . ' (' . $value . ')';
+        if ($withCounts) {
+            foreach ($options as $k => $v) {
+                foreach ($count as $key => $value) {
+                    if ($key == $v->text) {
+                        $options[$k]->text = $v->text . ' (' . $value . ')';
+                    }
                 }
             }
         }
 
-        return array_merge(parent::getOptions(), $options);
+        return array_values($options);
     }
 
     /**
      * Build the option value: a JSON blob of the media params this option
      * represents, re-applied to the target field on selection.
+     *
+     * Every key CwmadminModel::changeMediaImages() writes is included, so
+     * applying an option reproduces the configuration its label describes.
+     * Leaving media_button_color or media_custom_icon out would keep the
+     * target's existing colour or custom icon and produce something that does
+     * not match the option the administrator picked.
      *
      * @param   Registry  $params      The media file's params.
      * @param   string    $mediaImage  The media_image value to embed (empty for button/icon options).
@@ -157,15 +207,18 @@ class MediaFileImagesField extends ListField
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function buildOptionValueJson(Registry $params, string $mediaImage = ''): string
+    public static function buildOptionValueJson(Registry $params, string $mediaImage = ''): string
     {
-        return json_encode([
-            'media_use_button_icon' => (string) $params->get('media_use_button_icon'),
-            'media_button_type'     => (string) $params->get('media_button_type'),
-            'media_button_text'     => (string) $params->get('media_button_text'),
-            'media_icon_type'       => (string) $params->get('media_icon_type'),
-            'media_image'           => $mediaImage,
-        ]) ?: '{}';
+        $value = [];
+
+        foreach (self::DISPLAY_KEYS as $key) {
+            $value[$key] = (string) $params->get($key);
+        }
+
+        // Button/icon options carry no image; only the image mode sets one.
+        $value['media_image'] = $mediaImage;
+
+        return json_encode($value) ?: '{}';
     }
 
     /**
@@ -177,7 +230,7 @@ class MediaFileImagesField extends ListField
      *
      * @since 7.0
      */
-    public function getButton(object $media): ?string
+    public static function getButton(object $media): ?string
     {
         $button = null;
 
@@ -218,19 +271,23 @@ class MediaFileImagesField extends ListField
      *
      * @since 7.0
      */
-    public function getIcon(object $media): string
+    public static function getIcon(object $media): string
     {
         $MediaHelper = new Cwmmedia();
         $mimetypes   = $MediaHelper->getIcons();
 
-        if (
-            $media->params->get('media_icon_type') !== '1'
-            && !str_starts_with($media->params->get('media_icon_type'), 'fa')
-            && !empty($media->params->get('media_icon_type'))
-        ) {
-            return Text::_($mimetypes[$media->params->get('media_icon_type')]) ?? "";
+        $iconType = (string) ($media->params->get('media_icon_type') ?? '');
+
+        if ($iconType !== '1' && !str_starts_with($iconType, 'fa') && $iconType !== '') {
+            // An icon type with no entry in the map would otherwise raise an
+            // undefined-key warning and render an empty label.
+            return isset($mimetypes[$iconType]) ? Text::_($mimetypes[$iconType]) : $iconType;
         }
 
-        return $media->params->get('media_custom_icon');
+        // media_custom_icon is unset on any media file using a Font Awesome
+        // icon rather than a custom one, and the declared return type is
+        // string -- returning the null straight through fataled the whole
+        // Image Tools screen for those rows.
+        return (string) ($media->params->get('media_custom_icon') ?? '');
     }
 }

--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Administrator\Helper;
 
+use CWM\Component\Proclaim\Administrator\Field\MediaFileImagesField;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -143,7 +144,11 @@ class Cwmhtml
     }
 
     /**
-     * Display a batch widget for the player selector.
+     * Display a batch widget for the media display selector.
+     *
+     * Offers the same display configurations (image, button, or icon) as the
+     * Image Tools screen, applied to the selected media files rather than to
+     * every file sharing a configuration.
      *
      * @return  string  The necessary HTML for the widget.
      *
@@ -157,25 +162,40 @@ class Cwmhtml
             . '::' . Text::_('JBS_MED_IMAGE_DESC') . '">',
             Text::_('JBS_MED_SELECT_MEDIA_TYPE'),
             '</label>',
-            // Deliberately left with no options beyond "No change".
-            //
-            // The obvious completion is to populate this the way every sibling
-            // widget does, but the handler behind it is not ready for that:
-            // CwmmediafileModel::batchMediatype() writes (int) $value into the
-            // media_image param, and media_image holds an image path --
-            // "images/biblestudy/streamingvideo24.png" and the like on a real
-            // database, never a number. Offering options here would give
-            // administrators a one-click way to replace every selected file's
-            // image path with an integer.
-            //
-            // The empty select is what currently prevents that, so it stays
-            // until the handler is fixed. Tracked separately.
             '<select name="batch[mediaType]" class="form-select" id="batch-mediaType">',
             '<option value="">' . Text::_('JBS_BAT_MEDIATYPE_NOCHANGE') . '</option>',
+            // Counts are suppressed: they describe the whole site, which reads
+            // as though it described the current selection.
+            HTMLHelper::_('select.options', self::mediaTypeList(), 'value', 'text'),
             '</select>',
         ];
 
         return implode("\n", $lines);
+    }
+
+    /**
+     * The media display configurations a batch can apply.
+     *
+     * Delegates to the field that backs the Image Tools screen so the two
+     * offer the same choices and cannot drift apart.
+     *
+     * @return  object[]  Options whose value is a JSON blob of display params.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function mediaTypeList(): array
+    {
+        try {
+            return MediaFileImagesField::buildDisplayOptions(false);
+        } catch (\Exception $e) {
+            try {
+                Factory::getApplication()->enqueueMessage($e->getMessage(), 'warning');
+            } catch (\Exception) {
+                return [];
+            }
+
+            return [];
+        }
     }
 
     /**

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Administrator\Field\MediaFileImagesField;
 use CWM\Component\Proclaim\Administrator\Helper\CwmImageCleanup;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmplaylistSyncHelper;
@@ -903,9 +904,18 @@ class CwmmediafileModel extends AdminModel
     }
 
     /**
-     * Batch pop-up changes for a group of media files.
+     * Batch display changes (image, button or icon) for a group of media files.
      *
-     * @param   string  $value     The new value matching a client.
+     * $value is the JSON blob Cwmhtml::mediaType() offers, describing one whole
+     * display configuration. Applying it to a media file means writing every
+     * key in it: setting media_use_button_icon to "button" while leaving the
+     * previous button type and text behind would produce a configuration the
+     * administrator never chose.
+     *
+     * The same change Image Tools makes to every file sharing a configuration,
+     * scoped instead to the selected rows.
+     *
+     * @param   string  $value     JSON display configuration from the batch widget.
      * @param   array   $pks       An array of row IDs.
      * @param   array   $contexts  An array of item contexts.
      *
@@ -916,24 +926,57 @@ class CwmmediafileModel extends AdminModel
      */
     protected function batchMediatype($value, $pks, $contexts): bool
     {
-        // Set the variables
+        try {
+            $decoded = json_decode((string) $value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $decoded = null;
+        }
+
+        if (!\is_array($decoded)) {
+            $this->setError(Text::_('JBS_BAT_MEDIATYPE_INVALID'));
+
+            return false;
+        }
+
+        // $value arrives from the request, so take only the keys that describe
+        // a display configuration and ignore anything else the payload carries.
+        // These params are rendered into the page, so writing arbitrary keys
+        // from a hand-edited POST would be an injection surface.
+        $settings = [];
+
+        foreach (MediaFileImagesField::DISPLAY_KEYS as $key) {
+            if (\array_key_exists($key, $decoded) && \is_scalar($decoded[$key])) {
+                $settings[$key] = (string) $decoded[$key];
+            }
+        }
+
+        if ($settings === []) {
+            $this->setError(Text::_('JBS_BAT_MEDIATYPE_INVALID'));
+
+            return false;
+        }
+
         $user  = Factory::getApplication()->getIdentity();
         $table = $this->getTable();
 
         foreach ($pks as $pk) {
-            if ($user->authorise('core.edit', $contexts[$pk])) {
-                $table->reset();
-                $table->load($pk);
-                $reg = new Registry();
-                $reg->loadString($table->params);
-                $reg->set('media_image', (int)$value);
-                $table->params = $reg->toString();
-
-                if (!$table->store()) {
-                    throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
-                }
-            } else {
+            if (!$user->authorise('core.edit', $contexts[$pk])) {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
+            }
+
+            $table->reset();
+            $table->load($pk);
+            $reg = new Registry();
+            $reg->loadString($table->params);
+
+            foreach ($settings as $key => $setting) {
+                $reg->set($key, $setting);
+            }
+
+            $table->params = $reg->toString();
+
+            if (!$table->store()) {
+                throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
             }
         }
 

--- a/tests/integration/Admin/Helper/CwmhtmlBatchWidgetTest.php
+++ b/tests/integration/Admin/Helper/CwmhtmlBatchWidgetTest.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
 
+use CWM\Component\Proclaim\Administrator\Field\MediaFileImagesField;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhtml;
 use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -144,26 +145,57 @@ class CwmhtmlBatchWidgetTest extends IntegrationTestCase
     }
 
     // -------------------------------------------------------------------------
-    // The media-type widget stays inert on purpose
+    // The media-type widget offers whole display configurations
     // -------------------------------------------------------------------------
 
     /**
-     * Completing this widget the obvious way would expose a batch action that
-     * writes an integer into media_image, which holds an image path. The empty
-     * select is what prevents that, so it must not be "finished" without the
-     * handler being fixed first -- see #1627.
+     * This widget was deliberately left empty while batchMediatype() wrote an
+     * integer into media_image, which holds an image path -- offering options
+     * would have exposed a one-click way to corrupt every selected file. The
+     * handler now applies a whole display configuration, so the widget carries
+     * the same choices as the Image Tools screen. See #1627.
      */
-    #[TestDox('The media-type widget offers nothing until its handler is fixed')]
-    public function testMediaTypeWidgetStaysInert(): void
+    #[TestDox('The media-type widget offers display configurations, each a complete parameter set')]
+    public function testMediaTypeWidgetOffersDisplayConfigurations(): void
     {
         $html = Cwmhtml::mediaType();
 
-        preg_match_all('/<option /', $html, $matches);
+        preg_match_all('/<option value="([^"]*)"/', $html, $matches);
 
-        $this->assertCount(
+        $this->assertGreaterThan(
             1,
-            $matches[0],
-            'Only the "No change" sentinel: batchMediatype() would overwrite image paths with integers — see #1627'
+            \count($matches[1]),
+            'The widget must offer more than the "No change" sentinel now the handler is fixed'
         );
+
+        // The first option is the sentinel; every other value must decode to a
+        // configuration carrying each display key, or applying it would leave a
+        // media file in a state the chosen label does not describe.
+        foreach (\array_slice($matches[1], 1) as $value) {
+            $decoded = json_decode(html_entity_decode($value, ENT_QUOTES), true);
+
+            $this->assertIsArray($decoded, 'Each option value must be a display configuration');
+
+            foreach (MediaFileImagesField::DISPLAY_KEYS as $key) {
+                $this->assertArrayHasKey($key, $decoded, $key . ' missing from an option the batch can apply');
+            }
+        }
+    }
+
+    /**
+     * A count is appended to the Image Tools labels to show how many files share
+     * a configuration. In a batch modal that number describes the whole site
+     * rather than the rows the administrator picked, so it is left off there.
+     */
+    #[TestDox('The batch widget omits the site-wide usage counts the Image Tools field shows')]
+    public function testBatchWidgetOmitsSiteWideCounts(): void
+    {
+        foreach (MediaFileImagesField::buildDisplayOptions(false) as $option) {
+            $this->assertDoesNotMatchRegularExpression(
+                '/\(\d+\)$/',
+                $option->text,
+                'A site-wide count next to a selection of rows misleads: ' . $option->text
+            );
+        }
     }
 }

--- a/tests/integration/Admin/Model/CwmbatchMediatypeTest.php
+++ b/tests/integration/Admin/Model/CwmbatchMediatypeTest.php
@@ -1,0 +1,378 @@
+<?php
+
+/**
+ * Integration tests for the media-file display batch action.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Field\MediaFileImagesField;
+use CWM\Component\Proclaim\Administrator\Model\CwmmediafileModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\CMS\User\User;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1627.
+ *
+ * batchMediatype() wrote `(int) $value` into media_image, a param that holds an
+ * image path. The batch widget had no options, which was the only thing keeping
+ * that unreachable -- populating it would have given administrators a one-click
+ * way to replace every selected file's image path with an integer.
+ *
+ * The batch now carries a whole display configuration, the same payload the
+ * Image Tools screen applies, scoped to the selected rows.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmmediafileModel::class)]
+class CwmbatchMediatypeTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var  mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @var  int[]
+     */
+    private array $created = [];
+
+    /**
+     * @var  mixed
+     */
+    private mixed $savedIdentity = null;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        // batchMediatype() checks core.edit per row, and the console harness has
+        // no identity -- without one every test would error before reaching the
+        // behaviour under test.
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+
+        // core.edit has to actually pass, so borrow a Super User rather than
+        // inventing an id with no groups.
+        $db        = Factory::getContainer()->get(DatabaseDriver::class);
+        $superUser = (int) $db->setQuery(
+            'SELECT ' . $db->quoteName('user_id') . ' FROM ' . $db->quoteName('#__user_usergroup_map')
+            . ' WHERE ' . $db->quoteName('group_id') . ' = 8',
+            0,
+            1
+        )->loadResult();
+
+        if ($superUser === 0) {
+            $this->markTestSkipped('No Super User available to authorise the batch');
+        }
+
+        $app->loadIdentity(User::getInstance($superUser));
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+
+            try {
+                foreach ($this->created as $id) {
+                    $this->db->setQuery(
+                        'DELETE FROM ' . $this->db->quoteName('#__bsms_mediafiles')
+                        . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+                    )->execute();
+                }
+            } catch (\Throwable) {
+                // Best effort; the assertions have already run.
+            }
+
+            $this->created = [];
+        }
+
+        Factory::getApplication()->loadIdentity($this->savedIdentity);
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    #[TestDox('A batch writes the whole display configuration, not an integer into the image path')]
+    public function testBatchAppliesFullDisplayConfiguration(): void
+    {
+        $target = $this->insertMediafile([
+            'media_image'           => 'images/biblestudy/streamingvideo24.png',
+            'media_use_button_icon' => '0',
+        ]);
+
+        $value = json_encode([
+            'media_use_button_icon' => '1',
+            'media_button_type'     => 'btn-primary',
+            'media_button_text'     => 'Watch',
+            'media_button_color'    => '#ffffff',
+            'media_icon_type'       => '',
+            'media_custom_icon'     => '',
+            'media_image'           => '',
+        ]);
+
+        $this->runBatch($value, [$target]);
+
+        $params = $this->loadParams($target);
+
+        $this->assertSame('1', (string) $params->get('media_use_button_icon'));
+        $this->assertSame('btn-primary', (string) $params->get('media_button_type'));
+        $this->assertSame('Watch', (string) $params->get('media_button_text'));
+        $this->assertSame('#ffffff', (string) $params->get('media_button_color'));
+
+        // The bug: media_image previously became an integer.
+        $this->assertSame('', (string) $params->get('media_image'), 'media_image must hold a path, never a number');
+    }
+
+    #[TestDox('A batch leaves media files outside the selection untouched')]
+    public function testUnselectedRowsAreUntouched(): void
+    {
+        $original = [
+            'media_image'           => 'images/biblestudy/untouched.png',
+            'media_use_button_icon' => '0',
+        ];
+
+        $target     = $this->insertMediafile($original);
+        $bystander  = $this->insertMediafile($original);
+        $beforeJson = $this->loadRawParams($bystander);
+
+        $value = json_encode([
+            'media_use_button_icon' => '3',
+            'media_button_type'     => '',
+            'media_button_text'     => '',
+            'media_button_color'    => '',
+            'media_icon_type'       => 'fa-solid fa-video',
+            'media_custom_icon'     => '',
+            'media_image'           => '',
+        ]);
+
+        $this->runBatch($value, [$target]);
+
+        $this->assertSame(
+            '3',
+            (string) $this->loadParams($target)->get('media_use_button_icon'),
+            'The selected row should have been updated'
+        );
+        $this->assertSame(
+            $beforeJson,
+            $this->loadRawParams($bystander),
+            'A media file outside the selection must be byte-identical afterwards'
+        );
+    }
+
+    #[TestDox('A batch value carrying unknown keys writes only display params')]
+    public function testUnknownKeysAreIgnored(): void
+    {
+        $target = $this->insertMediafile(['media_image' => 'images/biblestudy/keep.png']);
+
+        // $value comes from the request, so a hand-edited payload can name
+        // anything. Only the display keys may reach the params.
+        $value = json_encode([
+            'media_use_button_icon' => '3',
+            'media_icon_type'       => 'fa-solid fa-video',
+            'filename'              => 'https://evil.example/pwned.mp4',
+            'player'                => '9',
+            'injected'              => '<script>alert(1)</script>',
+        ]);
+
+        $this->runBatch($value, [$target]);
+
+        $params = $this->loadParams($target);
+
+        $this->assertSame('3', (string) $params->get('media_use_button_icon'));
+        $this->assertNull($params->get('injected'), 'An unknown key must not be written');
+        $this->assertNotSame(
+            'https://evil.example/pwned.mp4',
+            (string) $params->get('filename'),
+            'A known-but-not-display param must not be overwritten'
+        );
+    }
+
+    #[TestDox('A malformed batch value is refused rather than written')]
+    public function testMalformedValueIsRefused(): void
+    {
+        $target     = $this->insertMediafile(['media_image' => 'images/biblestudy/intact.png']);
+        $beforeJson = $this->loadRawParams($target);
+
+        $model = $this->createModel();
+        $ok    = $this->invokeBatch($model, 'not json at all', [$target]);
+
+        $this->assertFalse($ok, 'A value that is not a display configuration must be refused');
+        $this->assertSame($beforeJson, $this->loadRawParams($target), 'Nothing may be written on refusal');
+    }
+
+    #[TestDox('The batch widget offers the same configurations as the Image Tools field')]
+    public function testWidgetOptionsMatchTheImageToolsField(): void
+    {
+        $this->insertMediafile([
+            'media_image'           => 'images/biblestudy/widget-fixture.png',
+            'media_use_button_icon' => '0',
+        ]);
+
+        $options = MediaFileImagesField::buildDisplayOptions(false);
+
+        $this->assertNotEmpty($options, 'The widget must offer the configurations in use');
+
+        foreach ($options as $option) {
+            $decoded = json_decode($option->value, true);
+
+            $this->assertIsArray($decoded, 'Every option value must be a display configuration');
+
+            foreach (MediaFileImagesField::DISPLAY_KEYS as $key) {
+                $this->assertArrayHasKey(
+                    $key,
+                    $decoded,
+                    $key . ' must be carried, or applying the option changes something it did not name'
+                );
+            }
+        }
+    }
+
+    /**
+     * @param   string  $value  JSON display configuration.
+     * @param   int[]   $pks    Selected media file IDs.
+     *
+     * @return  void
+     */
+    private function runBatch(string $value, array $pks): void
+    {
+        $this->assertTrue($this->invokeBatch($this->createModel(), $value, $pks));
+    }
+
+    /**
+     * @param   CwmmediafileModel  $model  Model under test.
+     * @param   string             $value  JSON display configuration.
+     * @param   int[]              $pks    Selected media file IDs.
+     *
+     * @return  bool
+     */
+    private function invokeBatch(CwmmediafileModel $model, string $value, array $pks): bool
+    {
+        $contexts = [];
+
+        foreach ($pks as $pk) {
+            $contexts[$pk] = 'com_proclaim.mediafile.' . $pk;
+        }
+
+        $method = new \ReflectionMethod(CwmmediafileModel::class, 'batchMediatype');
+
+        return (bool) $method->invoke($model, $value, $pks, $contexts);
+    }
+
+    /**
+     * @return  CwmmediafileModel
+     */
+    private function createModel(): CwmmediafileModel
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+        $factory->setFormFactory($container->get(FormFactoryInterface::class));
+
+        /** @var CwmmediafileModel $model */
+        $model = $factory->createModel('Cwmmediafile', 'Administrator', ['ignore_request' => true]);
+
+        $this->assertInstanceOf(CwmmediafileModel::class, $model);
+
+        return $model;
+    }
+
+    /**
+     * @param   int  $id  Media file ID.
+     *
+     * @return  Registry
+     */
+    private function loadParams(int $id): Registry
+    {
+        $reg = new Registry();
+        $reg->loadString($this->loadRawParams($id));
+
+        return $reg;
+    }
+
+    /**
+     * @param   int  $id  Media file ID.
+     *
+     * @return  string  The raw params JSON.
+     */
+    private function loadRawParams(int $id): string
+    {
+        return (string) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('params') . ' FROM ' . $this->db->quoteName('#__bsms_mediafiles')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+        )->loadResult();
+    }
+
+    /**
+     * @param   array  $params  Params to seed.
+     *
+     * @return  int  Media file ID.
+     */
+    private function insertMediafile(array $params): int
+    {
+        $reg = new Registry();
+
+        foreach ($params + ['filename' => 'https://example.test/fixture.mp4', 'player' => '1'] as $k => $v) {
+            $reg->set($k, $v);
+        }
+
+        $row = (object) [
+            'study_id'  => 0,
+            'server_id' => 0,
+            'published' => 1,
+            'access'    => 1,
+            'language'  => '*',
+            'params'    => $reg->toString(),
+            'mime_type' => 'video/mp4',
+            'metadata'  => '',
+        ];
+
+        $this->db->insertObject('#__bsms_mediafiles', $row);
+
+        $id              = (int) $this->db->insertid();
+        $this->created[] = $id;
+
+        return $id;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1627. `batchMediatype()` wrote `(int) $value` into `media_image`, a param that holds an image path — never a number on any real database. The batch widget had no options, and that was the *only* thing keeping the handler unreachable: populating it the obvious way would have handed administrators a one-click way to replace every selected file's image path with an integer.

## What the batch is for

The display configuration (image vs button vs icon) is already bulk-editable from **Image Tools**, which enumerates the configurations in use and writes the full parameter set for each. The batch differs in **scope** — the selected rows rather than every row sharing a configuration — which is the reason to have both.

So the batch now carries the same payload Image Tools applies, and the widget offers the same list. Concretely:

- `MediaFileImagesField::buildDisplayOptions()` is extracted from `getOptions()` and shared with `Cwmhtml::mediaType()`, so the list a batch can apply and the list Image Tools offers cannot drift apart.
- `batchMediatype()` decodes the option's JSON and writes every display key, instead of casting it to an integer.

## Two bugs found in the payload itself

**`buildOptionValueJson()` encoded five keys while `changeMediaImages()` writes seven** — `media_button_color` and `media_custom_icon` were missing. Applying an option would have left the target's existing button colour and custom icon in place, producing a configuration the chosen label does not describe. Both now derive from one `DISPLAY_KEYS` list, so they cannot diverge again.

**Three latent faults in the option builder**, surfaced by exercising it against real data. Each would fatal or corrupt the Image Tools screen for rows predating the display settings:

- `getIcon()` returned `null` against a `string` return type — a `TypeError` for any media file using a Font Awesome icon rather than a custom one.
- The image branch called `strlen()`, `strrpos()` and `substr()` on a null `media_image`.
- An icon type absent from the mimetype map raised an undefined-key warning and rendered an empty label.

## Input handling

`$value` arrives from the request, so the handler decodes with `JSON_THROW_ON_ERROR`, refuses anything that is not a display configuration, and writes **only** the named display keys — never `foreach ($decoded as $k => $v)`. These params render into the page, so a free-form key/value write from a hand-edited POST would be an injection surface, not just untidy.

The empty sentinel needs no special handling: core's `AdminModel::batch()` guards each command with `!empty($commands[$identifier])`.

## Smaller decisions

- The batch list **omits the usage counts** Image Tools appends. Those count the whole site, which beside a selection of five rows reads as though it described the selection.
- The long comment in `Cwmhtml::mediaType()` explaining why the widget was deliberately empty is gone — it would now be narrating a fixed bug (#1617).
- Milestoned `10.5.6` rather than `Backlog`, matching where the fix lands.

## Test plan

- [x] `tests/integration/Admin/Model/CwmbatchMediatypeTest.php` — 5 tests: the batch writes the whole configuration and leaves `media_image` a path; **rows outside the selection are byte-identical afterwards**; unknown keys in the payload are ignored while a real display key still applies; a malformed value is refused with nothing written; every widget option decodes to a complete configuration.
- [x] All 4 behavioural tests confirmed **red** against the original handler.
- [x] `CwmhtmlBatchWidgetTest::testMediaTypeWidgetStaysInert` — the guard #1589 installed to stop this widget being "finished" prematurely — replaced by its inverse now the handler is fixed, plus a test that the batch list carries no site-wide counts.
- [x] Full suite: `composer test` — 1738 tests, 6643 assertions, 0 skipped.
- [x] `composer lint` clean for every file in this diff.
- [x] This handler **mutates existing rows**, so deletion-based cleanup would not catch a runaway `WHERE`. Verified `#__bsms_mediafiles` row count and `MD5(GROUP_CONCAT(id, params))` are identical before and after three consecutive full-suite runs.

## Not covered

The batch has not been driven through the admin UI in a browser; coverage is at the model and widget level.
