### PR TITLE
test: complete the release gate for 10.5.6 and stop reset-testsite leaking rows

### DIFF
--- a/build/reset-testsite.php
+++ b/build/reset-testsite.php
@@ -114,6 +114,45 @@ foreach ($installs as $install) {
 
     echo '  removed ' . \count($ids) . " extension row(s) + their #__schemas rows\n";
 
+    // 2b. Module instances and their menu assignments. Removing the
+    //     #__extensions row leaves every published instance behind, and a
+    //     reinstall adds four more -- a test site cycled through the harness
+    //     accumulated 304 of them, which is enough to make the Modules screen
+    //     useless and to mask a genuine duplicate-instance bug.
+    $modules     = $prefix . 'modules';
+    $modulesMenu = $prefix . 'modules_menu';
+
+    $moduleIds = [];
+    $res       = $db->query("SELECT id FROM `{$modules}` WHERE module LIKE '%proclaim%'");
+
+    if ($res instanceof mysqli_result) {
+        while ($row = $res->fetch_row()) {
+            $moduleIds[] = (int) $row[0];
+        }
+    }
+
+    if ($moduleIds !== []) {
+        $moduleList = implode(',', $moduleIds);
+        $db->query("DELETE FROM `{$modulesMenu}` WHERE moduleid IN ({$moduleList})");
+        $db->query("DELETE FROM `{$modules}` WHERE id IN ({$moduleList})");
+    }
+
+    echo '  removed ' . \count($moduleIds) . " module instance(s) + menu assignments\n";
+
+    // 2c. Action-log registration. The install seeds #__action_logs_extensions
+    //     and #__action_log_config, uninstall removes neither, and nothing
+    //     de-duplicates on reinstall -- the same test site held 112 and 560
+    //     rows respectively where it should hold 1 and 13.
+    $logExt = $prefix . 'action_logs_extensions';
+    $logCfg = $prefix . 'action_log_config';
+
+    $db->query("DELETE FROM `{$logExt}` WHERE extension LIKE '%proclaim%'");
+    $logExtRows = $db->affected_rows;
+    $db->query("DELETE FROM `{$logCfg}` WHERE type_alias LIKE '%proclaim%'");
+    $logCfgRows = $db->affected_rows;
+
+    echo "  removed {$logExtRows} action-log extension row(s) + {$logCfgRows} action-log config row(s)\n";
+
     // 3. Clean up assets + categories owned by the component (best-effort).
     $assets = $prefix . 'assets';
     $cats   = $prefix . 'categories';
@@ -163,6 +202,7 @@ foreach ($installs as $install) {
         'plugins/content/scripturelinks',
         'plugins/task/cwmscripture',
         'administrator/manifests/packages/proclaim',
+        'administrator/manifests/packages/cwmscripture',
     ];
 
     $removed  = 0;
@@ -208,6 +248,8 @@ foreach ($installs as $install) {
     $globs = [
         'administrator/manifests/libraries/cwmscripture.xml',
         'administrator/manifests/packages/pkg_proclaim.xml',
+        'administrator/manifests/packages/pkg_cwmscripture.xml',
+        'administrator/logs/*proclaim*',
         'administrator/language/*/*proclaim*',
         'administrator/language/*/*cwmscripture*',
         'administrator/language/*/*scripturelinks*',

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -127,7 +127,7 @@ $EXPECTATIONS = [
     '10.5.6' => [
         'columns' => [
             // #1579 — uq_series_studynumber
-            '#__bsms_studies'   => ['studynumber_uk'],
+            '#__bsms_studies' => ['studynumber_uk'],
             // #1560 — uq_server_remote_playlist
             '#__bsms_playlists' => ['remote_playlist_uk'],
         ],

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -109,6 +109,35 @@ $EXPECTATIONS = [
         ],
         'schemaMin' => '10.5.3',
     ],
+    /*
+     * 10.5.6-20260807.sql carries four uniqueness/cleanup migrations.
+     *
+     * Both new columns are STORED generated columns that exist only to back a
+     * unique index: MySQL treats '' as a value, so a plain unique index would
+     * have collided across every unnumbered message and every hand-made
+     * playlist. Mapping the empty case to NULL leaves those rows
+     * unconstrained. Asserting the column and the index together is what
+     * catches half the pair being dropped.
+     *
+     * The DML halves are not asserted here: #1622's orphan cleanup, #1612's
+     * referrer rewrite and #1611's session_hash re-key all need a damaged-row
+     * fixture seeded before the upgrade, which this gate has no vocabulary for
+     * (same limitation noted on 10.4.1 above).
+     */
+    '10.5.6' => [
+        'columns' => [
+            // #1579 — uq_series_studynumber
+            '#__bsms_studies'   => ['studynumber_uk'],
+            // #1560 — uq_server_remote_playlist
+            '#__bsms_playlists' => ['remote_playlist_uk'],
+        ],
+        'indexes' => [
+            '#__bsms_studytopics' => ['uq_study_topic'],
+            '#__bsms_studies'     => ['uq_series_studynumber'],
+            '#__bsms_playlists'   => ['uq_server_remote_playlist', 'idx_remote_playlist'],
+        ],
+        'schemaMin' => '10.5.6',
+    ],
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two fixes to the release gate, found by running `composer test:release` against 10.5.6 for the first time.

## 1. 10.5.6 had no expectations entry

`verify-migrations.php` is keyed by version and deliberately **fails** when a release ships migration SQL nobody described — a good design, and 10.5.6 tripped it. Added the entry.

It asserts each generated column together with the unique index it exists to back, because half the pair going missing is the failure worth catching:

| | |
|---|---|
| `#__bsms_studies` | `studynumber_uk` + `uq_series_studynumber` |
| `#__bsms_playlists` | `remote_playlist_uk` + `uq_server_remote_playlist` + `idx_remote_playlist` |
| `#__bsms_studytopics` | `uq_study_topic` |
| `#__schemas` | ≥ `10.5.6` |

The DML halves are **not** asserted — #1622's orphan cleanup, #1612's referrer rewrite and #1611's `session_hash` re-key each need a damaged-row fixture seeded before the upgrade, which this gate has no vocabulary for. Same limitation already recorded on the 10.4.1 entry.

With this in place, all 10.5.6 assertions pass on **both** the clean-install and upgrade paths. Passing on clean install matters independently: it proves `install.mysql.utf8.sql` carries the generated columns and indexes, rather than drifting behind the update SQL.

## 2. reset-testsite left three categories behind

A test site cycled through the harness accumulated them install after install. Measured on j6-test before the fix:

| table | rows | of which Proclaim's | should be |
|---|---|---|---|
| `#__modules` | 377 | **304** | 0 |
| `#__action_logs_extensions` | 133 | **112** | 0 |
| `#__action_log_config` | 583 | **560** | 0 |

Removing the `#__extensions` row leaves every published module instance behind, and a reinstall adds four more. The action-log registration rows are seeded on install, removed by no uninstall, and de-duplicated by nothing on reinstall.

This matters beyond tidiness: 300 stale instances make the Modules screen unusable and would **mask a genuine duplicate-instance bug**, which is the kind of thing this harness exists to catch.

Also now removed: the orphaned scripture package manifest (`administrator/manifests/packages/pkg_cwmscripture.xml` and its directory — the on-disk sweep listed `proclaim` but not `cwmscripture`), and the component's stray log file.

Deletion is scoped: only module instances whose `module` is a Proclaim one, and `modules_menu` rows orphaned from *other* extensions are deliberately left alone.

## Test plan

- [x] `php build/verify-migrations.php` — fails with a clear "ships migration SQL but has no expectations entry" message before the addition, passes after.
- [x] `composer test:install` — **PASSED** (7/7), run three times.
- [x] `composer test:upgrade` — all 10.5.6 migration assertions **PASSED** (steps 1–9).
- [x] Reset verified as a round trip: install seeds the rows (4 modules, 1 + 5 action-log rows), reset returns all three tables to their Joomla baseline (73 / 21 / 23), and the site **installs cleanly again** afterwards.
- [x] `composer lint` clean.

## Known failure, not addressed here

`composer test:upgrade` still fails at step 12, on the scripture library's uninstall probe: after removing `pkg_proclaim`, the four scripture tables remain and `#__bsms_scripture_consumers` still lists two uninstalled extensions.

That is a real defect in `lib_cwmscripture` v1.1.8, reproduced twice — including on a database reset to a genuine clean slate, so it is not an artefact of accumulated state. `dropTablesIfOrphaned()`'s `isPackageUninstall()` guard is correct in intent (it is what stops the upgrade path destroying downloaded Bibles) but cannot distinguish an upgrade from a final package removal, and its docblock resolves that by pointing at "a later standalone uninstall" that cannot happen once the library itself is gone.

Filed as **Joomla-Bible-Study/lib_cwmscripture#37**, with the note that if the library's behaviour is deemed correct then step 11's expectation here needs to change instead.

Nothing in this PR touches scripture.
