### PR TITLE
fix: the Getting Started podcast step could never appear (#1626)

### DIFF
--- a/admin/src/Helper/CwmsetupwizardHelper.php
+++ b/admin/src/Helper/CwmsetupwizardHelper.php
@@ -269,7 +269,7 @@ class CwmsetupwizardHelper
                 ];
             }
 
-            // Check if podcast is configured (if enabled)
+            // Check if a published podcast exists (Full/Multi-Campus)
             if ($style !== 'simple') {
                 $query = $db->createQuery()
                     ->select('COUNT(*)')
@@ -278,20 +278,19 @@ class CwmsetupwizardHelper
                 $db->setQuery($query);
                 $hasPodcast = (int) $db->loadResult() > 0;
 
-                // NOTE: enable_podcast is not persisted to either params
-                // store -- the setup wizard collects it, uses it to decide
-                // whether to create a podcast, and discards it. This condition
-                // is therefore never true and the item never appears. Left as
-                // found because making it appear is a product decision, not a
-                // correction; tracked separately.
-                if (!$hasPodcast && $params->get('enable_podcast', 0)) {
-                    $items[] = [
-                        'key'   => 'podcast_setup',
-                        'label' => 'JBS_CHECKLIST_PODCAST_SETUP',
-                        'done'  => false,
-                        'link'  => 'index.php?option=com_proclaim&task=cwmpodcast.add',
-                    ];
-                }
+                // Keyed off the podcast itself, like every other item here.
+                // This used to be gated on an `enable_podcast` param that is
+                // written nowhere -- the wizard collects it, uses it to decide
+                // whether to create a podcast, and discards it -- so the item
+                // could never appear. Persisting that answer would not have
+                // helped either: opting in makes the wizard create a published
+                // podcast, which satisfies this check immediately.
+                $items[] = [
+                    'key'   => 'podcast_setup',
+                    'label' => 'JBS_CHECKLIST_PODCAST_SETUP',
+                    'done'  => $hasPodcast,
+                    'link'  => 'index.php?option=com_proclaim&task=cwmpodcast.add',
+                ];
             }
 
             // Multi-Campus: check location wizard completed

--- a/tests/integration/Admin/Helper/CwmsetupwizardChecklistTest.php
+++ b/tests/integration/Admin/Helper/CwmsetupwizardChecklistTest.php
@@ -157,4 +157,67 @@ class CwmsetupwizardChecklistTest extends IntegrationTestCase
             $this->assertIsBool($item['done']);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // #1626 -- the podcast step could never appear
+    // -------------------------------------------------------------------------
+
+    /**
+     * The step was gated on an `enable_podcast` param written to neither params
+     * store, so the condition was always false. It is now keyed off the podcast
+     * itself, like every sibling item.
+     */
+    #[TestDox('The podcast step is not gated on a param that is stored nowhere')]
+    public function testPodcastStepIsNotGatedOnAnUnstoredParam(): void
+    {
+        $ref   = new \ReflectionMethod(CwmsetupwizardHelper::class, 'getChecklistItems');
+        $lines = file($ref->getFileName());
+        $body  = implode('', \array_slice($lines, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+
+        // Strip comments: the explanation of the old bug legitimately names it.
+        $code = preg_replace('#//[^\n]*#', '', $body);
+
+        $this->assertStringNotContainsString(
+            "get('enable_podcast'",
+            (string) $code,
+            'enable_podcast is persisted nowhere, so gating on it hides the step forever — see #1626'
+        );
+    }
+
+    /**
+     * Every other item is emitted unconditionally with a `done` flag, and the
+     * control panel counts "X of Y complete" over the whole list. An item that
+     * appears only while incomplete would shrink that denominator on completion.
+     */
+    #[TestDox('The podcast step reports done rather than disappearing when a podcast exists')]
+    public function testPodcastStepCarriesADoneFlag(): void
+    {
+        $items = CwmsetupwizardHelper::getChecklistItems();
+        $keys  = array_column($items, 'key');
+
+        // Simple-mode sites omit it by design, so only assert when it is present.
+        if (!\in_array('podcast_setup', $keys, true)) {
+            $this->assertNotContains('series_image', $keys, 'Non-simple styles must offer the podcast step');
+
+            return;
+        }
+
+        $podcast = $items[array_search('podcast_setup', $keys, true)];
+
+        $this->assertIsBool($podcast['done']);
+        $this->assertArrayHasKey('link', $podcast);
+
+        // Whether it is done must track the data, not a stored intention.
+        $db         = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseDriver::class);
+        $hasPodcast = (int) $db->setQuery(
+            'SELECT COUNT(*) FROM ' . $db->quoteName('#__bsms_podcast')
+            . ' WHERE ' . $db->quoteName('published') . ' = 1'
+        )->loadResult() > 0;
+
+        $this->assertSame(
+            $hasPodcast,
+            $podcast['done'],
+            'The step\'s done state must reflect whether a published podcast exists'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1626. The step was gated on `enable_podcast`, a value written to neither params store — the wizard collects it, uses it to decide whether to create a podcast, and discards it. Always false, so the item never appeared.

## Why the issue's preferred option would not have worked

Option 1 was "persist the wizard's answer and keep the current meaning: *you said you wanted a podcast, you have not made one yet*".

But **opting in makes the wizard create the podcast**, published:

```php
// CwmsetupwizardModel::save()
if (!empty($data['enable_podcast'])) {
    $podcastId = $this->createPodcastRecord($data);   // inserts with published => 1
}
```

and the checklist block's own guard is `!$hasPodcast && …` against `published = 1`. So with the flag persisted:

- opted in → podcast exists → `$hasPodcast` true → **step still hidden**
- opted out → flag false → **step still hidden**

The step could only ever appear if the admin opted in *and* that podcast was later deleted or unpublished. That is a "your podcast went missing" alert, not "set up your podcast" — the label would be wrong for the only case that could reach it.

## What this does instead

Keys it off the podcast itself, like every sibling item in the checklist, and emits it **unconditionally with a `done` flag** rather than only while incomplete.

That last part matters: the control panel computes

```php
$completedCount = count(array_filter($checklistItems, fn($item) => $item['done']));
$totalCount     = count($checklistItems);
```

so an item that disappeared on completion would shrink the denominator as it was satisfied. `first_message` and `series_image` are both emitted unconditionally with a `done` flag; the podcast step was the odd one out.

Existing sites get the step too, which persisting the wizard's answer could never have delivered.

## On the nag concern

The issue notes there is no per-item dismiss. There is a **whole-checklist** dismiss (`cwmsetupwizard.dismissChecklist` → `setup_checklist_dismissed`), and the panel auto-dismisses once every actionable item is done. An administrator who wants no podcast dismisses the checklist — the same way they would opt out of any other item they do not intend to complete. Worth stating plainly: for those sites the checklist will not auto-dismiss, since the podcast item never completes.

## Test plan

- [x] Two tests added to `CwmsetupwizardChecklistTest`:
  - the step is not gated on `enable_podcast` (comments stripped first, since the explanation of the old bug legitimately names it)
  - the step carries a `done` flag that tracks whether a published podcast actually exists, rather than vanishing
- [x] Both confirmed **red** against the original gate.
- [x] Full suite: `composer test` — 1765 tests, 6686 assertions, 0 skipped.
- [x] `composer lint` clean.

## Not covered

Not viewed in the control panel in a browser; coverage is at the helper level. The rendering path itself is unchanged — this only alters which items the helper returns.
