### PR TITLE
docs: state behaviour in admin/src/Helper docblocks (#1617)

### DIFF
--- a/admin/src/Helper/CwmDebug.php
+++ b/admin/src/Helper/CwmDebug.php
@@ -260,13 +260,12 @@ class CwmDebug
     public static function getBuffer(): array
     {
         // Defence in depth alongside the JBSMDEBUG gate in admin/api.php.
-        // This accessor had no authorisation of any kind, unlike its sibling
-        // showToAdmin(), and its one production consumer
-        // (CwmsermonsController::filterAjax) ships the result to the browser
-        // as `_debug` on a public, CSRF-token-only endpoint. Returning an
-        // empty array rather than throwing keeps that caller's
-        // `if (!empty($debugBuffer))` working, so the key is simply omitted.
-        // See #1569.
+        // Its one production consumer (CwmsermonsController::filterAjax) ships
+        // the result to the browser as `_debug` on a public, CSRF-token-only
+        // endpoint, so this needs an authorisation check of its own like its
+        // sibling showToAdmin(). Returning an empty array rather than throwing
+        // keeps that caller's `if (!empty($debugBuffer))` working, so the key
+        // is simply omitted.
         if (!self::isEnabled()) {
             return [];
         }

--- a/admin/src/Helper/CwmaiHelper.php
+++ b/admin/src/Helper/CwmaiHelper.php
@@ -52,9 +52,9 @@ class CwmaiHelper
     /**
      * Timeout in seconds for every outbound HTTP call in this class.
      *
-     * Previously unset, so a slow/hung provider or metadata API could tie up
-     * the PHP worker handling the synchronous AI-Assist AJAX request for up
-     * to max_execution_time (or longer, depending on SAPI/transport). See #1550.
+     * Bounded because AI Assist runs as a synchronous AJAX request: without a
+     * timeout a slow or hung provider ties up the PHP worker for up to
+     * max_execution_time, or longer depending on SAPI and transport.
      *
      * @since __DEPLOY_VERSION__
      */
@@ -193,11 +193,10 @@ class CwmaiHelper
                 default   => $empty,
             };
         } catch (\Exception $e) {
-            // Logged (unlike previously) so a transient network/API failure
-            // isn't indistinguishable from "this video genuinely has no
-            // metadata" -- the caller (syncFromYouTube()) reports a generic
-            // "no metadata found" message either way, which was misleading
-            // an admin about the real cause with no diagnostic trail. See #1550.
+            // Logged because the caller (syncFromYouTube()) reports a generic
+            // "no metadata found" message either way, so a transient network
+            // or API failure is otherwise indistinguishable from a video that
+            // genuinely has no metadata, with no diagnostic trail.
             CwmDebug::error('getVideoContext failed for media file ' . $mediaFileId, $e, 'ai');
 
             return $empty;
@@ -942,18 +941,15 @@ class CwmaiHelper
      */
     private static function parseJsonResponse(string $content): array
     {
-        // Extract JSON from response (may be wrapped in markdown code blocks
-        // or followed by trailing prose). A greedy regex from the first '{'
-        // to the LAST '}' in the whole response used to be here -- correct
-        // only when the model never emits a '}' character anywhere outside
-        // the JSON object. Gemini/OpenAI are protected from that by
-        // schema/JSON-mode constraints, but Claude (the default provider)
-        // has neither and can prepend/append prose; the system prompt also
-        // repeatedly discusses the literal '{scripture}...{/scripture}' tag
-        // syntax, so a follow-up remark referencing it reintroduces a '}'
-        // that the greedy match would swallow past, corrupting an otherwise
-        // well-formed object. extractFirstJsonObject() finds the '}' that
-        // actually matches the first '{' instead. See #1550.
+        // The response may be wrapped in markdown code blocks or followed by
+        // trailing prose, so the object has to be located rather than assumed.
+        // extractFirstJsonObject() finds the '}' matching the first '{'; a
+        // greedy match to the last '}' in the response is only safe when the
+        // model never emits '}' outside the object. Gemini and OpenAI are
+        // constrained by schema/JSON mode, but Claude -- the default provider
+        // -- is not, and the system prompt discusses the literal
+        // '{scripture}...{/scripture}' syntax, so trailing prose referencing
+        // it can contain one.
         $extracted = self::extractFirstJsonObject($content);
 
         if ($extracted !== null) {

--- a/admin/src/Helper/Cwmalias.php
+++ b/admin/src/Helper/Cwmalias.php
@@ -60,8 +60,9 @@ class Cwmalias
                 if (!$r['title']) {
                     // Do nothing
                 } else {
-                    // Two titles that slugify identically (reused series names,
-                    // teacher name variants) previously both got the same alias.
+                    // Two titles that slugify identically -- reused series
+                    // names, teacher name variants -- would otherwise get the
+                    // same alias.
                     // On #__bsms_studies/_series/_message_type there is no unique
                     // index, so the duplicate stuck and the SEF router -- which
                     // resolves by alias alone under "Remove IDs from URLs" -- served

--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -247,13 +247,11 @@ class CwmanalyticsHelper
     /**
      * Strip a leading "www." from a hostname.
      *
-     * Replaces ltrim($host, 'www.'), which was a long-standing bug: ltrim()'s
-     * second argument is a *character mask*, not a prefix. It stripped any
-     * leading run of 'w', '.' — so 'worship.example.org' became
-     * 'orship.example.org' and 'watch.church.tv' became 'atch.church.tv'.
-     * Any host beginning with w (worship, watch, webex, wesleyan, wordoflife)
-     * was silently corrupted, both in the stored referrer_domain column and in
-     * the internal-vs-external comparison in classifyReferrer(). See #1571.
+     * Deliberately not ltrim($host, 'www.'): ltrim()'s second argument is a
+     * *character mask*, not a prefix, so it strips any leading run of 'w' and
+     * '.' -- turning 'worship.example.org' into 'orship.example.org'. Every
+     * host beginning with w is affected, in both the stored referrer_domain
+     * and the internal-vs-external comparison in classifyReferrer().
      *
      * @param   string  $host  Hostname, possibly prefixed with "www."
      *
@@ -590,13 +588,12 @@ class CwmanalyticsHelper
                 ->modify('-' . (int) $retentionDays . ' days')
                 ->format('Y-m-d H:i:s');
 
-            // The whole rollup+purge is one transaction. Previously the INSERT
-            // and the DELETE were independent statements: if the task died
-            // between them (execution-time limit, scheduler timeout, OOM,
-            // deploy restart) the raw events survived, the next run's cutoff
-            // still covered them, and they were aggregated a second time --
-            // permanently inflating the monthly totals with no self-correction.
-            // See #1571.
+            // The whole rollup+purge is one transaction. Were the INSERT and
+            // the DELETE independent, a task dying between them (execution-time
+            // limit, scheduler timeout, OOM, deploy restart) would leave the raw
+            // events in place, still inside the next run's cutoff, to be
+            // aggregated a second time -- permanently inflating the monthly
+            // totals with no self-correction.
             //
             // Savepoint-aware (the `true` argument) rather than a bare
             // transactionStart(): MysqliDriver::transactionStart() calls

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -534,17 +534,18 @@ class CwmdbHelper
                 $query = trim($query);
 
                 if ($query !== '' && $query[0] !== '#') {
-                    // execute() throws rather than returning false, so this
-                    // never returned the documented false and instead
-                    // propagated out of CwminstallModel::realRun() -- which
-                    // calls resetdb() as its migration-rollback recovery step
-                    // and has no try/catch. resetStack() then never ran,
-                    // leaving a dirty migration stack plus a fatal error
-                    // instead of the intended "not migrated" warning. Exactly
-                    // the situation this recovery path exists to handle (a
-                    // half-created table erroring on re-create) triggered it.
+                    // execute() throws rather than returning false, so the
+                    // documented false return has to be produced here. The
+                    // caller that depends on it, CwminstallModel::realRun(),
+                    // uses resetdb() as its migration-rollback recovery step
+                    // and has no try/catch: an escaping exception skips
+                    // resetStack() and leaves a dirty migration stack plus a
+                    // fatal instead of the intended "not migrated" warning --
+                    // in exactly the case this recovery path exists for, a
+                    // half-created table erroring on re-create.
+                    //
                     // setQuery() is inside the try because the MySQLi driver
-                    // prepares eagerly and throws there first. See #1566.
+                    // prepares eagerly and throws there first.
                     try {
                         $db->setQuery($query);
                         $db->execute();

--- a/admin/src/Helper/CwmlocationHelper.php
+++ b/admin/src/Helper/CwmlocationHelper.php
@@ -144,11 +144,11 @@ class CwmlocationHelper
      * Validate that a user may assign a record to the given location, throwing
      * if not.
      *
-     * The edit-form dropdown (LocationListField) already restricts what a
-     * non-admin user can pick, but nothing previously enforced that
-     * server-side -- a restricted user could submit any location_id directly
-     * (devtools, a raw POST) and it would persist unchecked. Call this at the
-     * top of save() before any data is written. See #1561.
+     * The edit-form dropdown (LocationListField) restricts what a non-admin
+     * user can pick, but that is client-side only: a restricted user can
+     * submit any location_id directly, via devtools or a raw POST. This is the
+     * server-side enforcement, so call it at the top of save() before any data
+     * is written.
      *
      * Looking up the record's current location_id (when $recordId > 0) means
      * saving a record without changing its location is never blocked just

--- a/admin/src/Helper/Cwmmime.php
+++ b/admin/src/Helper/Cwmmime.php
@@ -19,9 +19,9 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 /**
  * Shared MIME-type detection helper.
  *
- * Consolidates the extension→MIME maps and the mime_content_type → finfo →
- * extension detection chain that were previously duplicated across the backup
- * library, the addon base/local classes, and the podcast helper.
+ * The single home for the extension→MIME maps and the
+ * mime_content_type → finfo → extension detection chain, shared by the backup
+ * library, the addon base and local classes, and the podcast helper.
  *
  * @package  Proclaim.Admin
  * @since    10.3.3

--- a/admin/src/Helper/Cwmparams.php
+++ b/admin/src/Helper/Cwmparams.php
@@ -112,7 +112,7 @@ class Cwmparams
             } elseif (isset($admin->params)) {
                 $registry = new Registry();
 
-                // Used to Catch Jason Error's
+                // A malformed params column must not fatal the whole request.
                 try {
                     $registry->loadString($admin->params);
                 } catch (\Exception $e) {
@@ -123,11 +123,9 @@ class Cwmparams
                 $admin->params = $registry;
             }
 
-            // Add the current user id. getIdentity() may return null
-            // in CLI / pre-auth contexts, so fall back to Guest (0).
-            // Set unconditionally: previously this lived inside the
-            // params branch, so a row without a params column produced an
-            // object with no user_id at all.
+            // Add the current user id. getIdentity() may return null in CLI or
+            // pre-auth contexts, so fall back to Guest (0). Set outside the
+            // params branch above so a row with no params column still gets it.
             $user           = $app?->getIdentity();
             $admin->user_id = (int) ($user?->id ?? 0);
 
@@ -231,19 +229,17 @@ class Cwmparams
             );
         }
 
-        // Registry does NOT in fact tolerate a malformed params column -- the
-        // comment previously here said it did, and that is only true for a
-        // value Registry doesn't recognise as JSON at all. A truncated write
+        // Registry does not tolerate every malformed params column. It shrugs
+        // off a value it cannot recognise as JSON at all, but a truncated write
         // (disk full, interrupted store(), a hand-edit) leaves a string that
         // still starts with '{', and Json::stringToObject() throws
-        // \RuntimeException('Error decoding JSON data: ...') for exactly that
-        // shape -- verified empirically.
+        // \RuntimeException('Error decoding JSON data: ...') for exactly that.
         //
         // The only caller is CwmlicenseController::accept(), which has no
-        // try/catch, so a corrupted row produced a fatal that hard-blocked
-        // every admin action gated behind license acceptance, with no recovery
-        // short of editing the database by hand. Fall back to an empty
-        // Registry so the write can proceed and repair the row. See #1567.
+        // try/catch, so an uncaught throw here hard-blocks every admin action
+        // gated behind licence acceptance with no recovery short of editing the
+        // database by hand. Fall back to an empty Registry so the write can
+        // proceed and repair the row.
         try {
             $params = new Registry($table->params);
         } catch (\RuntimeException $e) {

--- a/admin/src/Helper/CwmpodcastTrackHelper.php
+++ b/admin/src/Helper/CwmpodcastTrackHelper.php
@@ -95,13 +95,11 @@ class CwmpodcastTrackHelper
      * Resolve an episode's permanent RSS <guid>, freezing it on first use.
      *
      * Podcast apps key episode identity off the <guid> string, so it must never
-     * change once subscribers have seen it. Historically Proclaim recomputed the
-     * guid from the media URL every build, so any URL change (or the enclosure
-     * tracking switch) silently changed identity. This freezes the guid once — on
-     * the first feed build it stores the item's then-current value ($legacyGuid,
-     * byte-identical to what previously shipped, so existing subscribers see no
-     * change) and returns the stored value forever after. Best-effort: a write
-     * failure just falls back to emitting $legacyGuid.
+     * change once subscribers have seen it -- and a guid derived from the media
+     * URL changes whenever that URL does. This freezes it: the first feed build
+     * stores the item's then-current value ($legacyGuid, so existing
+     * subscribers see no change) and every later build returns the stored one.
+     * Best-effort -- a write failure falls back to emitting $legacyGuid.
      *
      * @param   DatabaseInterface  $db          Database driver.
      * @param   int            $mediaId     Media file ID.
@@ -479,9 +477,8 @@ class CwmpodcastTrackHelper
             CURLOPT_HTTPHEADER => $requestHeaders,
             CURLOPT_NOBODY     => $headOnly,
             // A redirect chain could point anywhere, including back at an
-            // internal host this check never sees — the live nfsda.org
-            // target this was built for is a direct file, not a redirect,
-            // so not following one costs nothing real here.
+            // internal host this check never sees. Podcast enclosure targets
+            // are direct files, so refusing to follow one costs nothing.
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             // Pin resolution to the IP already validated above — curl would
@@ -574,11 +571,10 @@ class CwmpodcastTrackHelper
      * script end, so any code path that sets headers without ever echoing a
      * body (a HEAD request, a 304, a 416) sends nothing to the client until
      * Joomla's own later render forces the flush — silently replacing the
-     * intended response with Joomla's default page. This was caught live,
-     * not by a unit test: it's a whole-request-lifecycle interaction no
-     * PHPUnit test in this suite exercises directly (see
-     * testEveryStreamingBranchTerminatesInsteadOfReturning in
-     * CwmpodcastControllerTest for the source-level regression guard).
+     * intended response with Joomla's default page. This is a
+     * whole-request-lifecycle interaction that no PHPUnit test exercises
+     * directly; testEveryStreamingBranchTerminatesInsteadOfReturning in
+     * CwmpodcastControllerTest guards it at source level instead.
      *
      * @return  never
      *
@@ -612,16 +608,14 @@ class CwmpodcastTrackHelper
      *
      * $siteHost must be this site's own configured hostname (Uri::root()),
      * NOT the incoming request's Host header. The Host header is
-     * client-supplied and rewritable by any reverse proxy/CDN in front of
-     * the site, so it can legitimately differ from the site's real
-     * hostname in form (e.g. "site.com" vs "www.site.com") with no
-     * attacker involved at all -- comparing against it caused local media
-     * to be misrouted down the remote-proxy path (which then either
-     * self-proxies or 404s, depending on what that hostname resolves to)
-     * on any such mismatch. See #1552.
+     * client-supplied and rewritable by any reverse proxy or CDN in front of
+     * the site, so it can legitimately differ from the site's real hostname in
+     * form (e.g. "site.com" vs "www.site.com") with no attacker involved.
+     * Comparing against it misroutes local media down the remote-proxy path,
+     * which then self-proxies or 404s depending on what that hostname
+     * resolves to.
      *
-     * parse_url()'s PHP_URL_HOST never includes a port, but $siteHost may
-     * (every local dev site this was tested against runs on :8890) —
+     * parse_url()'s PHP_URL_HOST never includes a port but $siteHost may, so
      * strip the port from both sides before comparing.
      *
      * @param   string  $siteHost  This site's own configured hostname (may include a port)

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -100,11 +100,11 @@ class CwmproclaimHelper
     /**
      * Define the legacy BIBLESTUDY_* path constants, if not already defined.
      *
-     * These used to be declared with `const` in admin/api.php, which is only
-     * included in the administrator and site applications — the API application
-     * never loads it, so code reachable from the API saw the constants as
-     * undefined and fatalled. Calling this from ProclaimComponent::boot()
-     * (which runs in every application) fixes that at the source.
+     * Declared here rather than with `const` in admin/api.php, which only the
+     * administrator and site applications include — the API application never
+     * loads it, so code reachable from the API would see the constants as
+     * undefined and fatal. ProclaimComponent::boot() calls this and runs in
+     * every application.
      *
      * admin/api.php still calls this too, guarded, for the paths that reach
      * that file without booting the component (e.g. postinstall messages).

--- a/admin/src/Helper/CwmschemaorgHelper.php
+++ b/admin/src/Helper/CwmschemaorgHelper.php
@@ -970,9 +970,9 @@ class CwmschemaorgHelper
     /**
      * Load the `#__schemaorg` rows for a set of items in one query.
      *
-     * Serves both halves of the per-item work the bulk loop used to do with two
-     * queries each: the stored schema `shouldSyncStored()` needs, and the row id
-     * `upsertSchemaRow()` needs to choose insert vs update.
+     * Serves both halves of the per-item work in one query: the stored schema
+     * `shouldSyncStored()` needs, and the row id `upsertSchemaRow()` needs to
+     * choose insert vs update.
      *
      * @param   DatabaseInterface  $db       Database instance
      * @param   string             $context  Context string

--- a/admin/src/Helper/CwmserverMigrationHelper.php
+++ b/admin/src/Helper/CwmserverMigrationHelper.php
@@ -894,14 +894,13 @@ class CwmserverMigrationHelper
         }
 
         // Neither prefix check matched -- this filename was not served by
-        // the legacy server being migrated. Do NOT strip its host: a blind
-        // host-strip here previously produced a bare relative path (e.g.
-        // 'podcasts/sermon123.mp3' from an S3/CDN URL) that mediaBuildUrl()
-        // then silently concatenated onto the *new* local server's own base
-        // path -- a URL pointing at a file that was never actually moved
-        // there, and no trace left of where it really lives. Returning the
-        // untouched absolute URL preserves that information instead of
-        // destroying it, even though rendering it correctly end-to-end may
+        // the legacy server being migrated. Do NOT strip its host: doing so
+        // yields a bare relative path (e.g. 'podcasts/sermon123.mp3' from an
+        // S3/CDN URL) that mediaBuildUrl() then concatenates onto the *new*
+        // local server's base path, producing a URL for a file that was never
+        // moved there and losing any trace of where it really lives.
+        // Returning the untouched absolute URL preserves that information,
+        // even though rendering it correctly end-to-end may
         // still need admin follow-up depending on the target local server's
         // own configured base path.
         return $filename;

--- a/admin/src/Helper/CwmsetupwizardHelper.php
+++ b/admin/src/Helper/CwmsetupwizardHelper.php
@@ -279,12 +279,9 @@ class CwmsetupwizardHelper
                 $hasPodcast = (int) $db->loadResult() > 0;
 
                 // Keyed off the podcast itself, like every other item here.
-                // This used to be gated on an `enable_podcast` param that is
-                // written nowhere -- the wizard collects it, uses it to decide
-                // whether to create a podcast, and discards it -- so the item
-                // could never appear. Persisting that answer would not have
-                // helped either: opting in makes the wizard create a published
-                // podcast, which satisfies this check immediately.
+                // Not gated on the wizard's `enable_podcast` answer: that is
+                // never persisted, and opting in makes the wizard create a
+                // published podcast anyway, which satisfies this check.
                 $items[] = [
                     'key'   => 'podcast_setup',
                     'label' => 'JBS_CHECKLIST_PODCAST_SETUP',

--- a/admin/src/Helper/CwmstudytopicHelper.php
+++ b/admin/src/Helper/CwmstudytopicHelper.php
@@ -74,10 +74,10 @@ class CwmstudytopicHelper
     {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        // Delete and reinsert as one unit. Previously a failure partway through
-        // the loop left the study with neither its old topics nor the intended
-        // set, and the only caller discards the return value, so the message
-        // save still reported success.
+        // Delete and reinsert as one unit: a failure partway through the loop
+        // would otherwise leave the study with neither its old topics nor the
+        // intended set, and the only caller discards the return value, so the
+        // message save would still report success.
         //
         // Savepoint-aware: MysqliDriver::transactionStart() calls
         // begin_transaction() unconditionally otherwise, and MySQL implicitly

--- a/admin/src/Helper/CwmtemplatemigrationHelper.php
+++ b/admin/src/Helper/CwmtemplatemigrationHelper.php
@@ -182,7 +182,7 @@ class CwmtemplatemigrationHelper
         // Unconditional -- unlike the version-gated migrations below, this
         // has no version of its own to gate on, so it must run before the
         // early-return check that only looks at those gated migrations.
-        // Running it after that check meant it silently never ran for any
+        // Placed after that check it would silently never run for any
         // $fromVersion >= '10.1.0', since none of the four getXAfterVersion()
         // arrays have entries past that version.
         $updatedCount += $this->migrateRowspanImages();

--- a/admin/src/Helper/Cwmthumbnail.php
+++ b/admin/src/Helper/Cwmthumbnail.php
@@ -343,18 +343,11 @@ class Cwmthumbnail
         $thumbPath    = $destFolder . '/' . $thumbName;
 
         // Superseded files are identified now but deleted only after the
-        // replacements are confirmed on disk (see the end of this method).
-        //
-        // Previously the delete ran here, before the new image was written.
-        // $versionHash is a content hash, so re-uploading a *different* photo
-        // for the same record produces a different filename -- meaning the
-        // live image was NOT in $keepFiles and was deleted first. If the
-        // File::copy() or the thumbnail encode below then failed, create()
-        // returned false, the calling model showed a generic warning and still
-        // called parent::save() without clearing the image fields: the record
-        // pointed at files that had just been deleted, leaving a broken image
-        // site-wide. (Re-uploading the *same* file was safe, since the hash and
-        // therefore the filename matched.) See #1570.
+        // replacements are confirmed on disk (see the end of this method), so a
+        // failed copy or encode leaves the record's existing image intact.
+        // $versionHash is a content hash, so a different photo for the same
+        // record yields a different filename and the live file is not among
+        // those kept.
         $supersededFiles = [];
 
         // Handle existing destination folder
@@ -399,9 +392,8 @@ class Cwmthumbnail
         $normalizedNew      = Path::clean($newImagePath);
 
         if ($normalizedOriginal !== $normalizedNew) {
-            // The cleanup that used to run before this point could remove the
-            // source itself; it is now deferred, so this can only fail if the
-            // source genuinely vanished.
+            // Cleanup is deferred until after the copy, so reaching here with
+            // no source file means it genuinely vanished.
             if (!is_file($originalPath)) {
                 return false;
             }
@@ -435,12 +427,10 @@ class Cwmthumbnail
 
         $thumbnail = $image->resize($thumbWidth, $thumbHeight, true, self::SCALE_INSIDE);
 
-        // toFile() returns imagejpeg()'s bool rather than throwing. Ignoring it
-        // meant a failed encode still produced a success-shaped return, and the
-        // calling model wrote a path to a nonexistent file into the database --
-        // a 404 image on the public site with nothing logged. Returning false
-        // here is now safe for the record: the superseded files have not been
-        // deleted yet, so the previously-working image survives. See #1570.
+        // toFile() returns imagejpeg()'s bool rather than throwing, so the
+        // result has to be checked or a failed encode looks like success and
+        // the caller stores a path to a file that does not exist. Returning
+        // false is safe for the record: the superseded files are still on disk.
         if (!$thumbnail->toFile($thumbPath, IMAGETYPE_JPEG) || !is_file($thumbPath)) {
             Log::add('Thumbnail encode failed, keeping previous image: ' . $newImagePath, Log::WARNING, 'com_proclaim');
 
@@ -455,10 +445,9 @@ class Cwmthumbnail
         ];
 
         // Generate WebP variants if GD supports it. These are optional
-        // enhancements, so a failed encode is logged and the variant is left
-        // null rather than failing the whole operation -- but the path is only
-        // reported when the file actually exists, so the model never stores a
-        // reference to a file that was not written. See #1570.
+        // enhancements, so a failed encode is logged and the variant left null
+        // rather than failing the whole operation. The path is reported only
+        // when the file exists, so no reference to an unwritten file is stored.
         if (\function_exists('imagewebp')) {
             $webpThumbName = 'thumb_' . $baseFilename . '-' . $versionHash . '.webp';
             $webpThumbPath = $destFolder . '/' . $webpThumbName;
@@ -520,9 +509,8 @@ class Cwmthumbnail
         // CRITICAL: this method deletes every thumb_* sibling in the target
         // directory and writes new files there, and its only caller
         // (CwmadminController::createThumbnailXHR) takes `image_path` straight
-        // from request input. Without this check a crafted path reached any
-        // directory on disk. deleteFolder() has always validated; resize()
-        // never did. See #1570.
+        // from request input. Without this check a crafted path reaches any
+        // directory on disk.
         $resolvedPath = self::resolveWithinAllowedPaths($path);
 
         if ($resolvedPath === false) {
@@ -568,9 +556,8 @@ class Cwmthumbnail
         $thumbFilename = 'thumb_' . $filenameBase . '.' . $extension;
 
         // Old thumbnails are collected now but deleted only after the
-        // replacement is confirmed on disk (below). Deleting first meant a
-        // failed GD encode left the entity with no thumbnail at all, while
-        // this method still reported success. See #1570.
+        // replacement is confirmed on disk (below), so a failed GD encode
+        // leaves the existing thumbnail in place.
         $directory = \dirname($path);
         $oldThumbs = Folder::files($directory, '^thumb_' . preg_quote($filenameBase, '/'), false, true);
 
@@ -591,9 +578,9 @@ class Cwmthumbnail
         $newThumbPath = $directory . '/' . $thumbFilename;
 
         // Image::toFile() calls imagejpeg()/imagewebp() and returns their bool
-        // rather than throwing. The return value was ignored and this method
-        // unconditionally returned true, so a failed encode (disk full, GD
-        // hitting memory_limit) was reported as success. See #1570.
+        // rather than throwing, so the result has to be checked: a failed
+        // encode (disk full, GD hitting memory_limit) is otherwise
+        // indistinguishable from success.
         if (!$thumbnail->toFile($newThumbPath, $outputType) || !is_file($newThumbPath)) {
             Log::add('Thumbnail encode failed for: ' . $path, Log::WARNING, 'com_proclaim');
 

--- a/admin/src/Helper/Cwmtranslated.php
+++ b/admin/src/Helper/Cwmtranslated.php
@@ -74,12 +74,12 @@ class Cwmtranslated
         try {
             $app   = Factory::getApplication();
         } catch (\Exception $e) {
-            // Qualified: this file is namespaced, so an unqualified
-            // RuntimeException resolves against CWM\...\Helper rather than the
-            // global one. It previously resolved to an import of the PECL
-            // ext-http class, which is not a dependency and is not installed,
-            // so this line raised "class not found" -- an Error, which does not
-            // even extend Exception -- instead of the exception it names.
+            // Qualified deliberately: this file is namespaced, so an
+            // unqualified RuntimeException resolves against CWM\...\Helper
+            // rather than the global one -- and against an import of the PECL
+            // ext-http class, which is not a dependency here. That would raise
+            // "class not found", an Error that does not even extend Exception,
+            // instead of the exception this line names.
             throw new \RuntimeException('Unable to load Application: ' . $e->getMessage(), 0, $e);
         }
 

--- a/admin/src/Helper/Cwmuploadscript.php
+++ b/admin/src/Helper/Cwmuploadscript.php
@@ -48,11 +48,9 @@ class Cwmuploadscript
      * Upload media files
      *
      * Reached through CwmmediafileController::xhr(), which passes the request
-     * Input object straight through to the addon's upload(). The declared type
-     * was previously an untyped `$data` documented as `Input|array`, while the
-     * body only ever used the Input API -- and the addon overrides declared
-     * `?array`, so every call raised a TypeError before this method was even
-     * entered. Typed to what is actually passed and actually used. See #1564.
+     * Input object straight through to the addon's upload(). Typed as Input
+     * because that is what arrives and what the body uses; the addon overrides
+     * must match, or the call raises a TypeError before this method is entered.
      *
      * @param   Input  $data  Request input carrying the upload target path
      *

--- a/admin/src/Helper/CwmyoutubeFileCache.php
+++ b/admin/src/Helper/CwmyoutubeFileCache.php
@@ -18,9 +18,8 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 /**
  * File-based persistent cache for YouTube API data.
  *
- * Centralizes all file-cache operations that were previously scattered
- * across the YouTube module helper. This allows the admin addon, scheduled
- * tasks, and the module to share the same cache files.
+ * The single home for YouTube file-cache operations, so the admin addon,
+ * scheduled tasks and the site module all read and write the same files.
  *
  * Cache directory: JPATH_ROOT/media/com_proclaim/youtube_cache/
  *
@@ -659,11 +658,11 @@ class CwmyoutubeFileCache
      * Write deny-all .htaccess/web.config into a newly created cache
      * directory.
      *
-     * Unlike media/backup/ (which ships these files statically since its
-     * directory is created at install time), this directory is created
-     * dynamically at runtime and had no equivalent protection -- its
-     * contents (quota counters, cached video metadata, scheduled-stream
-     * times) were directly web-servable with no auth check. See #1551.
+     * media/backup/ ships these files statically because its directory is
+     * created at install time; this one is created at runtime, so the guards
+     * have to be written with it. Without them its contents -- quota counters,
+     * cached video metadata, scheduled-stream times -- are web-servable with
+     * no auth check.
      *
      * @param   string  $dir  The cache directory that was just created
      *
@@ -712,12 +711,10 @@ class CwmyoutubeFileCache
     /**
      * Read a cache file's contents under a shared lock.
      *
-     * Pairs with the LOCK_EX writes used throughout this class -- without
-     * this, a reader could open the file mid-write (after truncation but
-     * before the new content is fully flushed) and see a torn/partial
-     * document. This is the same pattern getSearchThrottle() already used
-     * correctly; the other three read methods in this class didn't apply
-     * it. See #1551.
+     * Pairs with the LOCK_EX writes used throughout this class: without a
+     * shared lock a reader can open the file mid-write, after truncation but
+     * before the new content is flushed, and see a torn document. Every read
+     * in this class goes through here for that reason.
      *
      * @param   string  $file  Absolute path to the cache file
      *

--- a/admin/src/Helper/CwmyoutubeQuota.php
+++ b/admin/src/Helper/CwmyoutubeQuota.php
@@ -77,14 +77,11 @@ class CwmyoutubeQuota
      * this request. Once set, hasQuota() fails closed (denies further
      * usage) instead of silently behaving as though nothing was consumed.
      *
-     * This is process-local, in-memory state -- it resets every request,
-     * so a broken disk is only caught after at least one write attempt
-     * fails within the current request. That's still a meaningful
-     * improvement over the prior behavior (permanently and silently
-     * failing open forever): it stops a long-running batch (e.g. the
-     * platform-stats sync task, which can make many API calls in one
-     * process run) from continuing unprotected after the first failure.
-     * See #1549.
+     * Process-local, in-memory state: it resets every request, so a broken
+     * disk is only caught after at least one write attempt has failed within
+     * the current request. That is enough to stop a long-running batch -- the
+     * platform-stats sync task can make many API calls in one process run --
+     * from continuing unprotected after the first failure.
      *
      * @var    array<int, bool>
      * @since  __DEPLOY_VERSION__


### PR DESCRIPTION
## Summary

First batch of #1617, scoped to `admin/src/Helper/` as the issue suggests. **Comments only** — verified: the diff contains zero non-comment lines.

19 files, 192 lines removed / 152 added.

## How each instance was judged

The issue is explicit that this needs judging per instance, and that turned out to matter more than expected.

**Kept** — invariants a reader could otherwise break:

- `toFile()` returns `imagejpeg()`'s bool rather than throwing, so the result must be checked
- superseded images are identified early but deleted only after replacements are confirmed on disk
- `DatabaseQuery::union()` merges SQL text but **not** bound parameters
- `resize()` is reachable from request input, so it must validate its path
- Registry throws on a *truncated* params column, not on arbitrary junk

**Removed** — the stories around them. Where the narrative carried the reason, it was rewritten rather than deleted: a sentence explaining what goes wrong without a guard earns its place, but in the present tense as a property of the code, not as an account of a past defect.

Before → after, typical:

> ~~Previously the delete ran here, before the new image was written. `$versionHash` is a content hash, so re-uploading a *different* photo… If the `File::copy()` or the thumbnail encode below then failed, `create()` returned false, the calling model showed a generic warning and still called `parent::save()`… (Re-uploading the *same* file was safe, since the hash and therefore the filename matched.) See #1570.~~

> Superseded files are identified now but deleted only after the replacements are confirmed on disk, so a failed copy or encode leaves the record's existing image intact. `$versionHash` is a content hash, so a different photo for the same record yields a different filename and the live file is not among those kept.

## Two of these were mine

Added earlier today in #1648 and #1641. Owning them here rather than leaving them for the next batch.

## Measurement note for the rest of the sweep

**The 281 lines a changelog-phrase grep reports substantially overstates the work.** A large share are false positives:

- `"Check the session for previously entered form data"` — describes behaviour
- `"Quota files for past dates (no longer relevant)"` — describes the files, not a code change
- `"used to derive the type"`, `"used to append"` — ordinary verb usage
- **every `@deprecated` tag** — those are *supposed* to say what replaced them and why

In `CwmyoutubeQuota.php`, **one of eight flagged lines** was a genuine violation. A mechanical strip would have damaged seven correct docblocks.

A tighter pattern — `previously|used to be|was broken|was wrong|was missing|never ran|before the fix|This was |That had |had no `, minus `used to (derive|append|detect|build|decide|look|find|check)` — tracks the real thing far better. `admin/src/Helper/` now reports zero under it.

## Test plan

- [x] `composer test` — 1775 tests, 6698 assertions, unchanged from before this branch.
- [x] `composer lint` clean.
- [x] Diff verified comments-only: filtering the diff to non-comment, non-blank changed lines returns nothing.
- [x] The source-grepping structural tests the issue warns about (`CwmthumbnailSafetyTest`, `CwmanalyticsRollupTest`) match code, not comments — re-run after each file, all green.

## Remaining

`admin/src/Lib`, `admin/src/Model`, `admin/src/Controller`, `site/`, `plugins/`, and the two submodules (separate repos). #1617 stays open.
