### PR TITLE
docs: finish the behaviour-first docblock sweep for this repo (#1617)

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -334,10 +334,9 @@ abstract class CWMAddon
      *
      * xhr() is a generic dispatcher: it takes a `handler` name straight from
      * the request and invokes it on the resolved addon, passing the request
-     * Input. It previously gated only on method_exists(), which made every
-     * public method on every addon callable by name -- including
-     * state-changing ones such as createLiveEvent()/cancelLiveEvent(), and
-     * with no permission check at all (see #1599).
+     * Input. Gating on method_exists() alone would make every public method on
+     * every addon callable by name -- including state-changing ones such as
+     * createLiveEvent()/cancelLiveEvent() -- with no permission check.
      *
      * Returning an empty list here means an addon exposes nothing: an addon
      * must opt each handler in explicitly. This mirrors getAjaxActions(),

--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -2117,26 +2117,17 @@ class CwmadminController extends FormController
      *
      * 'mediatype' is a MIME type string (e.g. "video/mp4") -- the value of the
      * `mtFrom` MimeType field (see admin/forms/admin.xml), exactly what the
-     * non-AJAX CwmadminModel::playerByMediaType() also matches against. The
-     * previous version read it via getInt(), which strips non-digit
-     * characters (Joomla's INT filter), silently turning "video/mp4" into 4
-     * and "video/x-ms-wmv" into 0 -- neither is a usable value. It then
-     * compared that against 'media_image', a key that only exists inside the
-     * JSON params blob, not a real column on #__bsms_mediafiles, so every
-     * request that got past the mangled-value check still threw a DB error.
-     * See #1492.
+     * non-AJAX CwmadminModel::playerByMediaType() also matches against. It must
+     * be read as a string: getInt() applies Joomla's INT filter, which strips
+     * non-digit characters and turns "video/mp4" into 4 and "video/x-ms-wmv"
+     * into 0. Nor is it a column on #__bsms_mediafiles -- 'media_image' lives
+     * inside the JSON params blob, so matching against it as a column errors.
      *
-     * Deliberately left in the controller (not extracted to the Model) as
-     * part of #1443 -- the query itself was broken independent of where it
-     * lived, so moving it first would have just relocated the bug.
-     *
-     * Matching mirrors playerByMediaType()'s working logic (mime_type match,
-     * falling back to filename extension) without its dead-code bug (that
-     * method resets $from = '' at the top of every loop iteration, so its
-     * 'http'/'mediacode' branches can never fire). This version does not
-     * support the 'http'/'mediacode' sentinel values either -- that behavior
-     * was already non-functional in the method it mirrors, and reproducing
-     * it correctly is out of scope for this fix.
+     * Matching mirrors playerByMediaType()'s mime_type match falling back to
+     * filename extension, but not its dead code: that method resets $from = ''
+     * at the top of every loop iteration, so its 'http'/'mediacode' branches
+     * can never fire. This version does not support those sentinel values
+     * either.
      *
      * Unlike playerByMediaType(), this does not filter to published = 1 --
      * the point of a bulk "fix the player on files still using the wrong

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -152,11 +152,10 @@ class CwmmediafileController extends FormController
 
         // Every UI that reaches this endpoint is a form field rendered on an
         // edit/create screen (PlaylistPickerField, the Youtube/Vimeo/Wistia
-        // browse buttons), so require the matching permission. Previously the
-        // only gate was the CSRF token, which any authenticated backend user
-        // with com_proclaim access already has -- letting them invoke
-        // state-changing addon methods they were never granted rights to.
-        // See #1599.
+        // browse buttons), so require the matching permission. A CSRF token
+        // alone is not a gate here: any authenticated backend user with
+        // com_proclaim access already has one, and could otherwise invoke
+        // state-changing addon methods they hold no rights to.
         $user = $app->getIdentity();
 
         if (!$user || (!$user->authorise('core.edit', 'com_proclaim') && !$user->authorise('core.create', 'com_proclaim'))) {

--- a/admin/src/Controller/Trait/CwmJsonResponseTrait.php
+++ b/admin/src/Controller/Trait/CwmJsonResponseTrait.php
@@ -20,14 +20,13 @@ use Joomla\CMS\Log\Log;
 /**
  * Send a uniform {success, message, data} JSON response and terminate.
  *
- * Consolidates 5 previously byte-identical-envelope, independently
- * maintained sendJsonResponse() implementations (CwmassetsController,
+ * The single implementation shared by CwmassetsController,
  * CwmlocationwizardController, CwmsetupwizardController,
- * CwmanalyticsController, CwmbackupController) into one. This is the
- * CwmbackupController implementation, which was the most complete of the
- * five: it captures and logs stray output (PHP notices/warnings that would
- * otherwise corrupt the JSON body), guards header calls with headers_sent(),
- * and exits immediately rather than routing through Joomla's shutdown
+ * CwmanalyticsController and CwmbackupController, which each need the same
+ * envelope. It captures and logs stray output -- PHP notices and warnings that
+ * would otherwise corrupt the JSON body -- guards header calls with
+ * headers_sent(), and exits immediately rather than routing through Joomla's
+ * shutdown
  * processing.
  *
  * Only the plumbing was unified — every consuming controller already

--- a/admin/src/Extension/ProclaimComponent.php
+++ b/admin/src/Extension/ProclaimComponent.php
@@ -126,19 +126,19 @@ class ProclaimComponent extends MVCComponent implements
     {
         // Define the legacy BIBLESTUDY_* path constants before anything else runs.
         //
-        // These previously only existed if admin/api.php had been included, which
-        // never happens in the API application — code reachable from the API saw
-        // them as undefined and fatalled (see #1428). Defining them here means
-        // every application (administrator, site, API) gets them for real.
+        // Defined here rather than in admin/api.php, which the API application
+        // never includes — code reachable from the API would otherwise see them
+        // as undefined and fatal. boot() runs in every application, so
+        // administrator, site and API all get them.
         CwmproclaimHelper::defineLegacyPathConstants();
 
         // Load Proclaim's language files before anything else runs.
         //
-        // This previously only happened via admin/api.php, which is not included
-        // in the API application, so language strings were never loaded in that
-        // context (see #1431). Language::load() is idempotent, so this and
-        // admin/api.php's own calls (for paths that reach it without booting the
-        // component) do not double-load anything.
+        // Loaded here rather than only via admin/api.php, which the API
+        // application does not include — language strings would otherwise never
+        // load in that context. Language::load() is idempotent, so this and
+        // admin/api.php's own calls, for paths that reach it without booting the
+        // component, do not double-load anything.
         Factory::getApplication()->getLanguage()->load('com_proclaim', BIBLESTUDY_PATH_ADMIN, 'en-GB', true);
         Factory::getApplication()->getLanguage()->load('com_proclaim', BIBLESTUDY_PATH_ADMIN, null, true);
 
@@ -146,10 +146,10 @@ class ProclaimComponent extends MVCComponent implements
         //
         // Log::addLogEntry() only dispatches to loggers matching an entry's
         // category, so a Log::add() against an unregistered category is built and
-        // silently discarded. Proclaim makes ~160 such calls and previously
-        // registered nothing, so none of them reached a file. Doing it here means
-        // every code path dispatched through the component logs for real, whether
-        // it runs in the administrator, the site or the API.
+        // silently discarded. Proclaim makes ~160 such calls, so the categories
+        // have to be registered before any of them run. Doing it here covers
+        // every code path dispatched through the component, in the administrator,
+        // the site and the API alike.
         CwmlogHelper::register();
 
         // Check PHP version requirement

--- a/admin/src/Field/FeedLanguageField.php
+++ b/admin/src/Field/FeedLanguageField.php
@@ -27,7 +27,7 @@ use Joomla\CMS\Language\Text;
  * languages *installed in Joomla*, and the two are different concepts: RSS
  * <language> describes the audio, while a content language describes what
  * translations the CMS serves. Joomla ships en-GB and does not install en-US,
- * so every US church published en-GB and had no way to correct it (#1411).
+ * so a US church using the content languages could not select its own.
  *
  * The list is the codes podcast directories actually act on, not the full
  * RFC 5646 registry — Apple and Spotify use this for language and territory

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -232,11 +232,11 @@ class CwmdbHelper
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // DatabaseDriver::execute() returns true or throws -- it never returns
-        // false -- so the old `if (!$db->execute())` branch was unreachable and
-        // every real SQL failure escaped as an uncaught exception instead of the
-        // false this method's contract promises. CwmadminController::copyTables()
-        // calls this three times per table with no try/catch and relies on a
-        // false return to abort cleanly. See #1566.
+        // false -- so a `if (!$db->execute())` check is unreachable and every
+        // real SQL failure escapes as an uncaught exception instead of the false
+        // this method's contract promises. CwmadminController::copyTables()
+        // calls this three times per table with no try/catch and relies on that
+        // false return to abort cleanly.
         //
         // setQuery() is inside the try on purpose: the MySQLi driver prepares
         // the statement eagerly, so a bad table name or syntax error -- the

--- a/admin/src/Helper/Cwmparams.php
+++ b/admin/src/Helper/Cwmparams.php
@@ -71,10 +71,9 @@ class Cwmparams
     public static function getAdmin(): object
     {
         if (!isset(self::$admin)) {
-            // $app stays null when there is no application (CLI, early
-            // bootstrap). The previous version left it *undefined* on that
-            // path, so the enqueueMessage() below raised a second error while
-            // reporting the first.
+            // Initialised before the try: with no application (CLI, early
+            // bootstrap) $app is never assigned, and the enqueueMessage() below
+            // would then raise a second error while reporting the first.
             $app = null;
 
             try {
@@ -307,7 +306,8 @@ class Cwmparams
                 ->clean();
         } catch (\Throwable) {
             // A cache backend that cannot be cleared must not fail the save. The
-            // value is committed; the worst case is the old behaviour.
+            // value is committed either way; the worst case is that readers see
+            // the stale cached copy until it expires.
         }
     }
 }

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -583,8 +583,8 @@ class Cwmassets
      * points at a missing row) and the only thing we could create would
      * be an empty-rules placeholder, we leave it alone — permission
      * checks fall through to the `com_proclaim` parent asset, which is
-     * what we want. The old behavior accumulated thousands of empty rows
-     * that slowed down `Access::preload('com_proclaim')` for no benefit.
+     * what we want. Creating them instead accumulates thousands of empty rows
+     * that slow `Access::preload('com_proclaim')` down for no benefit.
      *
      * What it still does:
      *   - Relink a record to an existing, real-rules asset row by name.

--- a/modules/site/mod_proclaim_youtube/src/Helper/YoutubeHelper.php
+++ b/modules/site/mod_proclaim_youtube/src/Helper/YoutubeHelper.php
@@ -206,9 +206,10 @@ class YoutubeHelper implements DatabaseAwareInterface
         }
 
         // Cache the result (including null) to prevent repeated API calls.
-        // Use the full cache_time for null results too — the old 60s TTL caused
-        // ~200 quota units/minute when no stream was active (search.list x 2 per miss).
-        // Live transitions are detected by JS polling (getStatusAjax), not page loads.
+        // Null results get the full cache_time as well: a short TTL costs about
+        // 200 quota units a minute while no stream is active, at search.list x 2
+        // per miss. Live transitions are picked up by JS polling
+        // (getStatusAjax), not by page loads.
         $cacheData = $video ?? ['_noVideo' => true];
 
         // Primary: file-based cache (always works, even with Joomla caching off)

--- a/plugins/task/proclaim/src/Extension/Proclaim.php
+++ b/plugins/task/proclaim/src/Extension/Proclaim.php
@@ -395,9 +395,10 @@ final class Proclaim extends CMSPlugin implements SubscriberInterface
 
         try {
             if ($enableRollup || $enablePurge) {
-                // enable_purge was previously computed and then ignored --
-                // rollupAndPurge() deleted unconditionally, so an admin who
-                // explicitly set "Purge: No" still lost their raw events.
+                // $enablePurge is passed through, not just computed:
+                // rollupAndPurge() must not delete unless the administrator
+                // asked for it. Analytics history is kept indefinitely by
+                // default.
                 $result = CwmanalyticsHelper::rollupAndPurge($retentionDays, $enablePurge);
                 $this->logTask(
                     Text::sprintf(

--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -377,9 +377,9 @@ class CwmsermonController extends FormController
      * Method override to check if you can edit an existing record.
      *
      * Mirrors the admin-side CwmmessageController::allowEdit() for the same
-     * underlying #__bsms_studies table/asset scope (com_proclaim.message.*) —
-     * this override used to unconditionally return true, letting any caller
-     * edit any sermon regardless of ACL. See #1437.
+     * underlying #__bsms_studies table and asset scope (com_proclaim.message.*).
+     * Without the check, the inherited behaviour lets any caller edit any
+     * sermon regardless of ACL.
      *
      * @param   array   $data  An array of input data.
      * @param   string  $key   The name of the key for the primary key.

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -2478,8 +2478,8 @@ class Cwmlisting
                 break;
 
             case 4:
-                // Legacy "Link to Details with ToolTip" — downgrade to plain details link.
-                // The old hasTip tooltip was removed; scripture verse popovers replace it.
+                // Legacy "Link to Details with ToolTip" — downgrade to a plain
+                // details link. Scripture verse popovers cover this now.
                 $link = Route::_(
                     Cwmhelperroute::getArticleRoute($row->slug) . '&t=' . $params->get('detailstemplateid')
                 );


### PR DESCRIPTION
## Summary

Second and final batch for this repository, following #1650. 13 files across `Extension`, `Controller`, `Addons`, `Field`, `Helper`, `Lib`, `site` and the task plugin.

**Comments only** — verified: filtering the diff to non-comment, non-blank changed lines returns nothing.

**The component now reports zero genuine instances.**

## Same rule as the first batch

Kept the properties a reader could otherwise break:

- `Log::add()` against an unregistered category is built and silently discarded, so the categories must be registered in `boot()` — which runs in every application
- `DatabaseDriver::execute()` returns true or throws and never returns false, so a `if (!$db->execute())` check is unreachable — and `copyTables()` calls this three times per table with no try/catch, relying on that false return
- `xhr()` takes a handler name straight from the request, so gating on `method_exists()` alone would make every public addon method callable, including `createLiveEvent()`

Removed the accounts of how each came to be written that way.

## The flagged list was not the boundary

A broader sweep caught several the changelog-phrase pattern missed entirely:

- `"The previous version read it via getInt()"` — `CwmadminController`
- `"The old behavior accumulated thousands of empty rows"` — `Cwmassets`
- `"this override used to unconditionally return true"` — `CwmsermonController`
- `"the old 60s TTL caused ~200 quota units/minute"` — `YoutubeHelper`

Worth recording: the pattern is a starting point for finding these, not a definition of them.

## What is left matching, and why it stays

Every remaining match is a false positive of the kind noted on the issue:

| match | why it stays |
|---|---|
| `"Check the session for previously entered form data"` (×3) | describes behaviour |
| `"Remove previously seeded rows before re-inserting"` | describes rows |
| `"delisted previously-published ones"` | describes what Apple did to episodes |
| `"used to derive/append/track/bucket"` | ordinary verb usage |
| `"the old bare-ID folder"`, `"the old Bible Study component"` | real domain references |
| every `@deprecated` tag | supposed to say what replaced it |

## Test plan

- [x] `composer test` — 1775 tests, 6698 assertions, unchanged across both batches.
- [x] `composer lint` clean.
- [x] Diff verified comments-only.
- [x] The source-grepping structural tests (`CwmthumbnailSafetyTest`, `CwmanalyticsRollupTest`, `CwmmediafileXhrDispatchTest`) match code, not comments — green throughout.

## Still outstanding for #1617

The two submodules — `Joomla-Bible-Study/CWMScriptureLinks` and `Joomla-Bible-Study/lib_cwmscripture` — are separate repositories and need their own PRs there. A quick count puts them at roughly a dozen lines between them, several in `script.php` explaining the library's uninstall guards, where the reasoning genuinely earns its place and only the framing needs changing.

The issue should stay open until those land.
