### PR TITLE
fix: count only submitted content as awaiting review, gate every cpanel tile

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -1315,8 +1315,8 @@ JBS_CPL_SCHEMA_OUT_OF_SYNC = "Database Schema Out of Sync"
 JBS_CPL_SCHEMA_OUT_OF_SYNC_DESC = "Your database schema (version %s) is behind the current code (version %s). Some features may not work correctly until the database is updated."
 JBS_CPL_SCHEMA_FIX_BUTTON = "Fix Database"
 JBS_CPL_PENDING_REVIEW_TITLE = "Content Awaiting Review"
-JBS_CPL_PENDING_REVIEW_DESC_N_1 = "%d study is unpublished and awaiting editorial review. Content submitted through the API by users without publishing rights is saved unpublished until approved."
-JBS_CPL_PENDING_REVIEW_DESC_N_MORE = "%d studies are unpublished and awaiting editorial review. Content submitted through the API by users without publishing rights is saved unpublished until approved."
+JBS_CPL_PENDING_REVIEW_DESC_N_1 = "%d study was submitted for review and is not yet published."
+JBS_CPL_PENDING_REVIEW_DESC_N_MORE = "%d studies were submitted for review and are not yet published."
 JBS_CPL_PENDING_REVIEW_BUTTON = "Review Unpublished Studies"
 
 ;; IBM Install, Backup, Migrate

--- a/admin/src/Helper/CwmcountHelper.php
+++ b/admin/src/Helper/CwmcountHelper.php
@@ -83,6 +83,51 @@ class CwmcountHelper
     }
 
     /**
+     * Count studies the API force-unpublished pending editorial review.
+     *
+     * Deliberately narrower than "unpublished": an administrator unpublishing
+     * a draft or retiring an old sermon also leaves published = 0, so counting
+     * that alone reports content nobody submitted and never reaches zero on a
+     * site that unpublishes routinely.
+     *
+     * Matched on the params key rather than its value, and with LIKE rather
+     * than a JSON function: params is a longtext that not every row holds valid
+     * JSON in, and MySQL's JSON_EXTRACT errors on those instead of skipping
+     * them. The key is written only by AbstractWritableController and removed
+     * when the record is published.
+     *
+     * @param   string|null  $locationMode  Location filtering mode (null, 'location', 'study', 'access')
+     *
+     * @return  int
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function getPendingReviewCount(?string $locationMode = 'location'): int
+    {
+        $suffix = self::buildCacheKeySuffix($locationMode);
+        $key    = '#__bsms_studies:pendingreview' . $suffix;
+
+        if (isset(self::$cache[$key])) {
+            return self::$cache[$key];
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__bsms_studies', 't'))
+            ->where($db->quoteName('t.published') . ' = 0')
+            ->where($db->quoteName('t.params') . ' LIKE ' . $db->quote('%"pending_review"%'));
+
+        self::applyLocationFilter($query, $db, $locationMode);
+
+        $db->setQuery($query);
+
+        self::$cache[$key] = (int) $db->loadResult();
+
+        return self::$cache[$key];
+    }
+
+    /**
      * Count total rows in the given table (all states except trashed).
      *
      * Results are cached per request.

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -655,6 +655,90 @@ class CwmmessageTable extends Table
     }
 
     /**
+     * Publish or unpublish rows, clearing the pending-review mark on publish.
+     *
+     * The control panel counts records the API force-unpublished and marked
+     * awaiting review. Publishing one answers the review, so the mark is
+     * removed rather than left to reappear in the count if the record is ever
+     * unpublished again for an unrelated reason.
+     *
+     * @param   mixed  $pks     Primary keys, or null for the instance's own.
+     * @param   int    $state   The publishing state.
+     * @param   int    $userId  The user performing the change.
+     *
+     * @return  bool  True on success.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[\Override]
+    public function publish($pks = null, $state = 1, $userId = 0): bool
+    {
+        if (!parent::publish($pks, $state, $userId)) {
+            return false;
+        }
+
+        if ((int) $state === 1) {
+            $this->clearPendingReview($pks ?? $this->id);
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove the pending-review mark from the given records' params.
+     *
+     * Best-effort: the publish itself has already succeeded, so a failure here
+     * must not turn a completed state change into an error. The only cost is a
+     * stale mark, which shows up again if the record is unpublished later.
+     *
+     * @param   mixed  $pks  Primary key, or an array of them.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function clearPendingReview(mixed $pks): void
+    {
+        $ids = array_values(array_filter(array_map('intval', (array) $pks)));
+
+        if ($ids === []) {
+            return;
+        }
+
+        try {
+            $db    = $this->getDatabase();
+            $query = $db->createQuery()
+                ->select($db->quoteName(['id', 'params']))
+                ->from($db->quoteName('#__bsms_studies'))
+                ->whereIn($db->quoteName('id'), $ids)
+                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%"pending_review"%'));
+
+            foreach ($db->setQuery($query)->loadObjectList() ?: [] as $row) {
+                $params = new Registry($row->params);
+
+                if (!$params->exists('pending_review')) {
+                    continue;
+                }
+
+                $params->remove('pending_review');
+
+                $db->setQuery(
+                    $db->createQuery()
+                        ->update($db->quoteName('#__bsms_studies'))
+                        ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
+                        ->where($db->quoteName('id') . ' = ' . (int) $row->id)
+                )->execute();
+            }
+        } catch (\RuntimeException $e) {
+            Log::add(
+                'Could not clear the pending-review mark: ' . $e->getMessage(),
+                Log::WARNING,
+                'com_proclaim'
+            );
+        }
+    }
+
+    /**
      * Method to store a row in the database from the JTable instance properties.
      * If a primary key value is set the row with that primary key value will be
      * updated with the instance property values.  If no primary key value is set

--- a/admin/src/View/Cwmcpanel/HtmlView.php
+++ b/admin/src/View/Cwmcpanel/HtmlView.php
@@ -48,11 +48,12 @@ class HtmlView extends BaseHtmlView
     public string $total_messages;
 
     /**
-     * Count of studies awaiting editorial review (unpublished).
+     * Count of studies submitted through the API and awaiting review.
      *
      * Surfaced as a dashboard notice for users who can publish, so content
-     * submitted via the API by non-editors (forced to published=0) does not
-     * sit unnoticed. 0 when the current user lacks core.edit.state.
+     * submitted by non-editors does not sit unnoticed. Counts only records the
+     * API marked, not everything unpublished -- a draft or a retired sermon is
+     * not awaiting anything. 0 when the current user lacks core.edit.state.
      *
      * @var    int
      * @since  10.3.3
@@ -118,7 +119,7 @@ class HtmlView extends BaseHtmlView
         $user = Factory::getApplication()->getIdentity();
 
         if ($user && $user->authorise('core.edit.state', 'com_proclaim')) {
-            $this->pendingReview = CwmcountHelper::getCountByState('#__bsms_studies', 0, 'location');
+            $this->pendingReview = CwmcountHelper::getPendingReviewCount('location');
         }
 
         // Display the template

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -22,6 +22,7 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmsetupwizardHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmupgradeHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -116,23 +117,6 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
             <?php
             endif; ?>
 
-            <?php if (\Joomla\CMS\Component\ComponentHelper::isEnabled('com_actionlogs')) : ?>
-            <div class="col-12">
-                <div class="card mb-3">
-                    <div class="card-body">
-                        <h3 class="card-title">
-                            <span class="icon-list-2" aria-hidden="true"></span>
-                            <?php echo Text::_('JBS_CPANEL_ACTIONLOG_TITLE'); ?>
-                        </h3>
-                        <p><?php echo Text::_('JBS_CPANEL_ACTIONLOG_DESC'); ?></p>
-                        <a href="<?php echo Route::_('index.php?option=com_actionlogs&view=actionlogs&filter[extension]=com_proclaim'); ?>"
-                           class="btn btn-primary btn-large">
-                            <?php echo Text::_('JBS_CPANEL_ACTIONLOG_LINK'); ?>
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <?php endif; ?>
         <?php
             if ($simple->mode === 1 && $simple->display === 1) {
                 ?>
@@ -266,22 +250,21 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
             </div>
         <?php endif; ?>
         <?php
-            // Content awaiting editorial review (unpublished studies) — shown to publishers only
+            // Submitted through the API and awaiting review — publishers only.
             if ($this->pendingReview > 0) :
         ?>
             <div class="col-12">
-                <div class="alert alert-info">
+                <div class="alert alert-info d-flex align-items-center gap-2 py-2">
                     <span class="icon-pencil-2" aria-hidden="true"></span>
-                    <strong><?php echo Text::_('JBS_CPL_PENDING_REVIEW_TITLE'); ?></strong>
-                    <p class="mb-1">
+                    <span class="flex-grow-1">
                         <?php echo Text::plural('JBS_CPL_PENDING_REVIEW_DESC_N', $this->pendingReview); ?>
-                    </p>
+                    </span>
                     <?php // btn-primary, not btn-info: inside an .alert Atum's link
                           // colour overrides the button text and lands dark-on-blue
                           // at 1.68:1. The PIM alert above uses btn-primary and
                           // passes; match it. ?>
                     <a href="<?php echo Route::_('index.php?option=com_proclaim&view=cwmmessages&filter[published]=0'); ?>"
-                       class="btn btn-primary btn-sm">
+                       class="btn btn-primary btn-sm flex-shrink-0">
                         <?php echo Text::_('JBS_CPL_PENDING_REVIEW_BUTTON'); ?>
                     </a>
                 </div>
@@ -350,7 +333,20 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
             <h2 class="text-center">
                 <?php echo Text::_('JBS_CPL_MENUE_LINKS'); ?>
             </h2>
-            <?php $isAdmin = $cpanelUser->authorise('core.admin'); ?>
+            <?php
+            $isAdmin = $cpanelUser->authorise('core.admin');
+
+            // One rule for every tile: show a destination only to someone who
+            // could do something once they arrive. access.xml defines a section
+            // per entity, so each tile asks about its own -- previously a few
+            // were gated on core.admin (Super User only, hiding them from
+            // legitimate managers) and the rest on nothing at all, which sent
+            // users to a 403 the component dispatcher raises.
+            $canSee = static fn (string $section): bool =>
+                $cpanelUser->authorise('core.edit', 'com_proclaim.' . $section)
+                || $cpanelUser->authorise('core.create', 'com_proclaim.' . $section)
+                || $cpanelUser->authorise('core.edit.own', 'com_proclaim.' . $section);
+            ?>
             <div class="container">
                 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-3 justify-content-center">
                     <?php if ($isAdmin) : ?>
@@ -362,6 +358,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
+                    <?php if ($canSee('message')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmmessages'); ?>"
                            title="<?php echo Text::_('JBS_CMN_STUDIES'); ?>" class="cpanel-btn">
@@ -369,6 +366,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_STUDIES'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php if ($canSee('mediafile')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmmediafiles'); ?>"
                            title="<?php echo Text::_('JBS_CMN_MEDIA_FILES'); ?>" class="cpanel-btn">
@@ -376,6 +375,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_MEDIA_FILES'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php if ($canSee('teacher')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmteachers'); ?>"
                            title="<?php echo Text::_('JBS_CMN_TEACHERS'); ?>" class="cpanel-btn">
@@ -383,6 +384,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_TEACHERS'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php if ($canSee('serie')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmseries'); ?>"
                            title="<?php echo Text::_('JBS_CMN_SERIES'); ?>" class="cpanel-btn">
@@ -390,7 +393,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_SERIES'); ?></span>
                         </a>
                     </div>
-                    <?php if (!$simple->mode && $isAdmin) : ?>
+                    <?php endif; ?>
+                    <?php if (!$simple->mode && $canSee('messagetype')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmmessagetypes'); ?>"
                            title="<?php echo Text::_('JBS_CMN_MESSAGETYPES'); ?>" class="cpanel-btn">
@@ -399,7 +403,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if ($isAdmin) : ?>
+                    <?php if ($canSee('location')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmlocations'); ?>"
                            title="<?php echo Text::_('JBS_CMN_LOCATIONS'); ?>" class="cpanel-btn">
@@ -408,7 +412,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if (!$simple->mode && $isAdmin) : ?>
+                    <?php if (!$simple->mode && $canSee('topic')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmtopics'); ?>"
                            title="<?php echo Text::_('JBS_CMN_TOPICS'); ?>" class="cpanel-btn">
@@ -416,6 +420,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_TOPICS'); ?></span>
                         </a>
                     </div>
+                    <?php if ($canSee('comment')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmcomments'); ?>"
                            title="<?php echo Text::_('JBS_CMN_COMMENTS'); ?>" class="cpanel-btn">
@@ -424,7 +429,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if ($isAdmin) : ?>
+                    <?php endif; ?>
+                    <?php if ($canSee('server')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmservers'); ?>"
                            title="<?php echo Text::_('JBS_CMN_SERVERS'); ?>" class="cpanel-btn">
@@ -433,6 +439,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
+                    <?php if ($canSee('podcast')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmpodcasts'); ?>"
                            title="<?php echo Text::_('JBS_CMN_PODCASTS'); ?>" class="cpanel-btn">
@@ -440,6 +447,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_PODCASTS'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php if ($cpanelUser->authorise('core.manage', 'com_proclaim')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmanalytics'); ?>"
                            title="<?php echo Text::_('JBS_ANA_ANALYTICS'); ?>" class="cpanel-btn">
@@ -447,7 +456,9 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_ANA_ANALYTICS'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
                     <?php if (!$simple->mode) : ?>
+                    <?php if ($canSee('template')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmtemplates'); ?>"
                            title="<?php echo Text::_('JBS_CMN_TEMPLATES'); ?>" class="cpanel-btn">
@@ -455,6 +466,8 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_TEMPLATES'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php if ($canSee('templatecode')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmtemplatecodes'); ?>"
                            title="<?php echo Text::_('JBS_CMN_TEMPLATECODE'); ?>" class="cpanel-btn">
@@ -462,6 +475,22 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                             <span><?php echo Text::_('JBS_CMN_TEMPLATECODE'); ?></span>
                         </a>
                     </div>
+                    <?php endif; ?>
+                    <?php
+                    // The action log lives in com_actionlogs, so the permission
+                    // that matters is that component's -- the dispatcher refuses
+                    // anyone without core.manage on it, and a Proclaim-only
+                    // editor has no reason to hold that.
+                    if (ComponentHelper::isEnabled('com_actionlogs')
+                        && $cpanelUser->authorise('core.manage', 'com_actionlogs')) : ?>
+                    <div class="col">
+                        <a href="<?php echo Route::_('index.php?option=com_actionlogs&view=actionlogs&filter[extension]=com_proclaim'); ?>"
+                           title="<?php echo Text::_('JBS_CPANEL_ACTIONLOG_TITLE'); ?>" class="cpanel-btn">
+                            <i class="icon-list-2 fa-3x"></i>
+                            <span><?php echo Text::_('JBS_CPANEL_ACTIONLOG_TITLE'); ?></span>
+                        </a>
+                    </div>
+                    <?php endif; ?>
                     <?php endif; ?>
                 </div>
             </div>

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -346,6 +346,13 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                 $cpanelUser->authorise('core.edit', 'com_proclaim.' . $section)
                 || $cpanelUser->authorise('core.create', 'com_proclaim.' . $section)
                 || $cpanelUser->authorise('core.edit.own', 'com_proclaim.' . $section);
+
+            // Message types, topics, templates, template files and the action
+            // log configure how Proclaim works rather than what it holds.
+            // Simple mode hides them, and anyone below Super User gets that same
+            // reduced set whatever the site setting says -- a manager runs the
+            // content, an administrator configures the component.
+            $advanced = !$simple->mode && $isAdmin;
             ?>
             <div class="container">
                 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-3 justify-content-center">
@@ -394,7 +401,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if (!$simple->mode && $canSee('messagetype')) : ?>
+                    <?php if ($advanced && $canSee('messagetype')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmmessagetypes'); ?>"
                            title="<?php echo Text::_('JBS_CMN_MESSAGETYPES'); ?>" class="cpanel-btn">
@@ -412,7 +419,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if (!$simple->mode && $canSee('topic')) : ?>
+                    <?php if ($advanced && $canSee('topic')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmtopics'); ?>"
                            title="<?php echo Text::_('JBS_CMN_TOPICS'); ?>" class="cpanel-btn">
@@ -457,7 +464,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
                         </a>
                     </div>
                     <?php endif; ?>
-                    <?php if (!$simple->mode) : ?>
+                    <?php if ($advanced) : ?>
                     <?php if ($canSee('template')) : ?>
                     <div class="col">
                         <a href="<?php echo Route::_('index.php?option=com_proclaim&amp;view=cwmtemplates'); ?>"

--- a/api/src/Controller/AbstractWritableController.php
+++ b/api/src/Controller/AbstractWritableController.php
@@ -42,6 +42,16 @@ use Joomla\CMS\MVC\Controller\ApiController;
 abstract class AbstractWritableController extends ApiController
 {
     /**
+     * Params key marking a record the API force-unpublished pending review.
+     *
+     * Read by the control panel's review count, and cleared when the record is
+     * published.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public const string PENDING_REVIEW_KEY = 'pending_review';
+
+    /**
      * Entity type for the action log, e.g. 'topic'. Must have a matching
      * COM_PROCLAIM_ACTION_LOG_TYPE_* language key. Empty disables logging.
      *
@@ -251,9 +261,16 @@ abstract class AbstractWritableController extends ApiController
             unset($data['created_by']);
         }
 
-        // Restrict published state — users without core.edit.state default to unpublished
+        // Restrict published state — users without core.edit.state default to
+        // unpublished, and the record is marked as awaiting review.
+        //
+        // The mark is what separates a submission from an administrator
+        // deliberately unpublishing something. Both leave published = 0, so
+        // counting that alone reports drafts and retired sermons as pending
+        // review and never reaches zero on a site that unpublishes routinely.
         if (!$user->authorise('core.edit.state', 'com_proclaim')) {
             $data['published'] = 0;
+            $data['params']    = self::markPendingReview($data['params'] ?? null);
         }
 
         return $data;
@@ -303,5 +320,37 @@ abstract class AbstractWritableController extends ApiController
 
             return $fallback;
         }
+    }
+
+    /**
+     * Flag a params payload as awaiting editorial review.
+     *
+     * Accepts the shapes params arrives in from the API -- a JSON string, an
+     * array, or absent -- and returns an array, which the models bind and
+     * Registry encodes.
+     *
+     * @param   mixed  $params  Existing params, if any
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected static function markPendingReview(mixed $params): array
+    {
+        if (\is_string($params) && $params !== '') {
+            try {
+                $params = json_decode($params, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                $params = [];
+            }
+        }
+
+        if (!\is_array($params)) {
+            $params = [];
+        }
+
+        $params[self::PENDING_REVIEW_KEY] = 1;
+
+        return $params;
     }
 }

--- a/tests/integration/Admin/Helper/CwmpendingReviewTest.php
+++ b/tests/integration/Admin/Helper/CwmpendingReviewTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Integration tests for the control panel's pending-review count.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcountHelper;
+use CWM\Component\Proclaim\Administrator\Table\CwmmessageTable;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The control panel used to count every study with published = 0 and call them
+ * "awaiting editorial review". An administrator unpublishing a draft or retiring
+ * an old sermon leaves exactly the same state, so the notice reported content
+ * nobody had submitted and could never reach zero on a site that unpublishes
+ * routinely.
+ *
+ * The API now marks what it force-unpublishes, and only marked records count.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmcountHelper::class)]
+class CwmpendingReviewTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var  int[]
+     */
+    private array $created = [];
+
+    /**
+     * @var  mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        // Table::publish() stamps via Factory::getDate().
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        // The helper caches per request, and these tests change what it counts.
+        $this->resetStaticCache(CwmcountHelper::class, 'cache');
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+
+            try {
+                $this->purge();
+            } catch (\Throwable) {
+                // Best effort; the assertions have already run.
+            }
+        }
+
+        $this->resetStaticCache(CwmcountHelper::class, 'cache');
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    #[TestDox('A study unpublished without being submitted is not counted as awaiting review')]
+    public function testPlainlyUnpublishedStudyIsNotCounted(): void
+    {
+        $before = $this->pendingCount();
+
+        // A draft, or a sermon an administrator retired. Same published = 0 as a
+        // submission, which is exactly why the old count was wrong.
+        $this->insertStudy(0, '{}');
+
+        $this->assertSame($before, $this->pendingCount(), 'Unpublished alone must not mean awaiting review');
+    }
+
+    #[TestDox('A study the API marked and force-unpublished is counted')]
+    public function testMarkedStudyIsCounted(): void
+    {
+        $before = $this->pendingCount();
+
+        $this->insertStudy(0, '{"pending_review":1}');
+
+        $this->assertSame($before + 1, $this->pendingCount());
+    }
+
+    #[TestDox('A marked study that has been published is not counted')]
+    public function testMarkedButPublishedStudyIsNotCounted(): void
+    {
+        $before = $this->pendingCount();
+
+        $this->insertStudy(1, '{"pending_review":1}');
+
+        $this->assertSame($before, $this->pendingCount(), 'Publishing answers the review');
+    }
+
+    #[TestDox('Publishing a marked study clears the mark, so it cannot return to the count')]
+    public function testPublishingClearsTheMark(): void
+    {
+        $id = $this->insertStudy(0, '{"pending_review":1,"keepme":"yes"}');
+
+        $table = new CwmmessageTable($this->db);
+        $this->assertTrue($table->publish([$id], 1), 'Publish should succeed');
+
+        $params = (string) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('params') . ' FROM ' . $this->db->quoteName('#__bsms_studies')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+        )->loadResult();
+
+        $this->assertStringNotContainsString('pending_review', $params, 'The mark must be cleared on publish');
+        $this->assertStringContainsString('keepme', $params, 'Other params must survive');
+    }
+
+    #[TestDox('Unpublishing does not add a mark, so ordinary unpublishing stays uncounted')]
+    public function testUnpublishingDoesNotMark(): void
+    {
+        $id = $this->insertStudy(1, '{}');
+
+        $table = new CwmmessageTable($this->db);
+        $table->publish([$id], 0);
+
+        $params = (string) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('params') . ' FROM ' . $this->db->quoteName('#__bsms_studies')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+        )->loadResult();
+
+        $this->assertStringNotContainsString('pending_review', $params);
+    }
+
+    /**
+     * @return  int
+     */
+    private function pendingCount(): int
+    {
+        $this->resetStaticCache(CwmcountHelper::class, 'cache');
+
+        return CwmcountHelper::getPendingReviewCount(null);
+    }
+
+    /**
+     * @return  void
+     */
+    private function purge(): void
+    {
+        foreach ($this->created as $id) {
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__assets')
+                . ' WHERE ' . $this->db->quoteName('name') . ' = '
+                . $this->db->quote('com_proclaim.message.' . $id)
+            )->execute();
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__bsms_studies')
+                . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+            )->execute();
+        }
+
+        $this->created = [];
+    }
+
+    /**
+     * @param   int     $published  Published state.
+     * @param   string  $params     Params JSON.
+     *
+     * @return  int  Study ID.
+     */
+    private function insertStudy(int $published, string $params): int
+    {
+        $row = (object) [
+            'studytitle'  => 'Pending review fixture ' . uniqid('', true),
+            'alias'       => 'pending-' . uniqid('', true),
+            'studydate'   => '2026-01-15 10:00:00',
+            'messagetype' => '1',
+            'booknumber'  => 101,
+            'published'   => $published,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'params'      => $params,
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+
+        $id              = (int) $this->db->insertid();
+        $this->created[] = $id;
+
+        return $id;
+    }
+}


### PR DESCRIPTION
## Content Awaiting Review was counting the wrong thing

The panel reported every study with `published = 0` as "awaiting editorial review". But the API records **nothing** to distinguish a submission from an administrator unpublishing a draft or retiring an old sermon — both leave identical state:

```php
// AbstractWritableController, before
if (!$user->authorise('core.edit.state', 'com_proclaim')) {
    $data['published'] = 0;      // and nothing else
}
```

So on any site that unpublishes routinely, the notice showed a permanent nonzero count it could never clear. Measured on a development site: **3 unpublished studies, none of them submitted** — the panel claimed all three were awaiting review.

### Fix

The API now marks what it force-unpublishes (`params.pending_review`), and the count reads only marked records. Publishing **clears** the mark, so it cannot reappear if the record is unpublished later for an unrelated reason.

Existing unpublished content is deliberately **not** back-filled: there is no way to tell which of it was ever submitted, and guessing would preserve the bug. On the development site the count correctly drops from 3 to 0.

Matched with `LIKE` on the key rather than a JSON function — `params` is a `longtext` that not every row holds valid JSON in, and MySQL's `JSON_EXTRACT` errors on those rather than skipping them.

## Every tile is now gated the same way

Gating was inconsistent:

- a few tiles used `core.admin` — **Super User only**, hiding Message Types, Locations and Servers from managers who could legitimately use them
- the rest had **no check at all**, so a Proclaim-only editor saw destinations that answer with the 403 `ComponentDispatcher` raises

`access.xml` already defines a section per entity, so each tile now asks about its own:

```php
$canSee = static fn (string $section): bool =>
    $cpanelUser->authorise('core.edit',     'com_proclaim.' . $section)
    || $cpanelUser->authorise('core.create',   'com_proclaim.' . $section)
    || $cpanelUser->authorise('core.edit.own', 'com_proclaim.' . $section);
```

Administration keeps `core.admin`; Analytics uses `core.manage` on the component, having no section of its own.

### Important caveat: this is not yet granular

**No section assets exist.** `#__assets` holds `com_proclaim` and per-item rows only, so `Access::getAssetRules()` falls back to the extension asset for `com_proclaim.<section>`. Verified empirically — an invented section name returns the same answer as the component:

```
com_proclaim             edit=true
com_proclaim.teacher     edit=true
com_proclaim.nonsense    edit=true      <- no such section
[non-super user]         edit=false for both
```

So every section currently resolves to the component's own rules, which is what an administrator can actually set today. The gate is **correctly shaped** and forward-compatible — it becomes genuinely per-section the moment section assets and a UI to set them exist — but it does not add granularity by itself. It is still an improvement on gating some tiles at `core.admin` and the rest at nothing.

## Manager-level users get the simple-mode tile set

Message types, topics, templates, template files and the action log configure how Proclaim *works* rather than what it *holds*. Simple mode already hid them; anyone below Super User now gets that same reduced set whatever the site setting says.

```php
$advanced = !$simple->mode && $isAdmin;
```

A manager runs the content; an administrator configures the component.

## The action log moved into the grid

It was a full-width card with a heading, paragraph and large button, gated on nothing but whether `com_actionlogs` was enabled. It is now a tile alongside the others, gated on **`core.manage` for `com_actionlogs`** — the permission that component's own dispatcher enforces, and one a Proclaim-only editor has no reason to hold. Previously such a user saw the button and got a 403.

The review notice is a single line rather than a heading/paragraph/button block. Together that reclaims most of the vertical space above the menu grid.

## Test plan

- [x] `tests/integration/Admin/Helper/CwmpendingReviewTest.php` — 5 tests: a plainly unpublished study is **not** counted; a marked one is; a marked-but-published one is not; publishing clears the mark while preserving other params; unpublishing does not add one.
- [x] Confirmed **red** against the old query: `Failed asserting that 4 is identical to 3`.
- [x] Full suite: `composer test` — 1780 tests, 6705 assertions.
- [x] `composer lint` clean.

## Not covered

The control panel has not been rendered in a browser under a non-Super-User account, so the gating is verified at the permission-expression level rather than by logging in as a restricted user. Worth a spot check before release — the failure mode of a wrong gate is a tile disappearing for someone who should see it.
