### PR TITLE
fix: stop two JSON fallbacks failing quietly (#1558 tier B)

### DIFF
--- a/admin/src/Helper/CwmlocationHelper.php
+++ b/admin/src/Helper/CwmlocationHelper.php
@@ -45,6 +45,20 @@ class CwmlocationHelper
     private static array $locationCache = [];
 
     /**
+     * Whether an unreadable location_group_mapping has already been reported
+     * this request.
+     *
+     * getGroupMapping() runs once per user per request from two call sites, so
+     * without this a corrupt param would write the same line to the log
+     * repeatedly on a busy site.
+     *
+     * @var    bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private static bool $mappingWarned = false;
+
+    /**
      * Return the location IDs visible to a user.
      *
      * Super admins receive an empty array (meaning: no filter, see everything).
@@ -544,7 +558,9 @@ class CwmlocationHelper
         if (\is_string($raw)) {
             try {
                 $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
-            } catch (\JsonException) {
+            } catch (\JsonException $e) {
+                self::reportUnreadableMapping($e);
+
                 return [];
             }
 
@@ -555,12 +571,48 @@ class CwmlocationHelper
         if ($raw instanceof \stdClass) {
             try {
                 return json_decode(json_encode($raw, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR) ?: [];
-            } catch (\JsonException) {
+            } catch (\JsonException $e) {
+                self::reportUnreadableMapping($e);
+
                 return [];
             }
         }
 
         return \is_array($raw) ? $raw : [];
+    }
+
+    /**
+     * Record that location_group_mapping could not be read.
+     *
+     * The empty array this accompanies is deliberately unchanged. An empty
+     * mapping is also the legitimate "campuses not configured yet" state, and
+     * getUserLocations() treats every unmapped location as unrestricted — so an
+     * unreadable param silently opens every campus to every user rather than
+     * closing them. Failing closed instead is not an option: it would lock out
+     * every site that has never configured campuses, which is most of them, and
+     * the two cases cannot be told apart by value.
+     *
+     * What can be fixed is the silence.
+     *
+     * @param   \JsonException  $e  The decode failure.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function reportUnreadableMapping(\JsonException $e): void
+    {
+        if (self::$mappingWarned) {
+            return;
+        }
+
+        self::$mappingWarned = true;
+
+        CwmlogHelper::error(
+            'The location_group_mapping component parameter could not be read, so campus filtering is '
+            . 'inactive and every location is visible to every user. Re-save Proclaim\'s Location '
+            . 'Management options to rebuild it. ' . $e->getMessage()
+        );
     }
 
     /**

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -997,12 +997,20 @@ class CwmmigrationHelper
     /**
      * Persist the group→location mappings array in component parameters.
      *
-     * Merges with existing mappings so repeated calls are safe.
+     * Merges with existing mappings so repeated calls are safe, and adds only
+     * keys the stored mapping does not already hold — an administrator's manual
+     * entries always win. If the stored mapping cannot be read, nothing is
+     * written at all, because merging into an empty array would silently drop
+     * those entries.
+     *
+     * Only the location_group_mapping key is touched; every other component
+     * parameter is left as it stands.
      *
      * @param   array<int, int[]>  $mappings  locationId → [groupId, ...]
      *
      * @return  void
      *
+     * @throws  \RuntimeException  If the component params row cannot be written.
      * @since   10.1.0
      */
     public static function createGroupLocationMappings(array $mappings): void
@@ -1013,8 +1021,19 @@ class CwmmigrationHelper
         if (\is_string($existing)) {
             try {
                 $existing = json_decode($existing, true, 512, JSON_THROW_ON_ERROR) ?: [];
-            } catch (\JsonException) {
-                $existing = [];
+            } catch (\JsonException $e) {
+                // Refuse rather than merge into an empty array. The loop below
+                // only adds keys it cannot already see, so starting from []
+                // would write back a mapping containing none of the entries an
+                // administrator had configured by hand -- destroying exactly
+                // what the comment below promises to preserve.
+                CwmlogHelper::error(
+                    'Cannot merge migrated group-to-location mappings: the existing '
+                    . 'location_group_mapping parameter could not be read, and overwriting it would '
+                    . 'discard any mappings configured by hand. No changes made. ' . $e->getMessage()
+                );
+
+                return;
             }
         }
 
@@ -1027,14 +1046,19 @@ class CwmmigrationHelper
             }
         }
 
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery()
-            ->update($db->quoteName('#__extensions'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote(json_encode($existing, JSON_THROW_ON_ERROR)))
-            ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
-            ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
-        $db->setQuery($query);
-        $db->execute();
+        // Write through Cwmparams, which merges into the stored params Registry
+        // and clears the _system cache.
+        //
+        // This previously ran its own UPDATE that set #__extensions.params to
+        // json_encode($existing) -- the mapping array alone, as the whole params
+        // column. Every other Proclaim setting on the site was replaced by it,
+        // and because the write bypassed ComponentHelper's cache the damage was
+        // invisible until the next request. Scenario 2A of
+        // migrateAccessToLocations() is the only caller, so a multi-campus
+        // migration wiped the component's configuration as a side effect.
+        Cwmparams::setCompParams(
+            ['location_group_mapping' => json_encode($existing, JSON_THROW_ON_ERROR)]
+        );
     }
 
     /**

--- a/tests/unit/Admin/Helper/SilentJsonFallbackTest.php
+++ b/tests/unit/Admin/Helper/SilentJsonFallbackTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * Tests for the two JSON fallbacks whose silence had consequences.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression tests for #1558, tier B.
+ *
+ * Twenty-one `catch (\JsonException)` blocks across `Helper/` swallow the error
+ * and substitute a fallback. Most are right to: nine are cache reads where a
+ * corrupt entry is a miss, and logging every one would bury the signal. Two
+ * were not.
+ *
+ * `CwmlocationHelper::getGroupMapping()` returns `[]`, which
+ * `getUserLocations()` reads as "no locations are restricted" — so an
+ * unreadable parameter opened every campus to every user without a word
+ * anywhere. The fallback is still `[]`, because that is also the legitimate
+ * "campuses not configured" state and failing closed would lock out every site
+ * that has never used them. Only the silence was fixable.
+ *
+ * `CwmmigrationHelper::createGroupLocationMappings()` was worse in two ways at
+ * once, and the second was found only by reading the code around the first.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmlocationHelper::class)]
+#[CoversClass(CwmmigrationHelper::class)]
+class SilentJsonFallbackTest extends ProclaimTestCase
+{
+    /**
+     * Invoke the private getGroupMapping() against a params Registry.
+     *
+     * @param   mixed  $stored  Whatever is sitting in location_group_mapping.
+     *
+     * @return  array
+     */
+    private function mappingFor(mixed $stored): array
+    {
+        $method = new \ReflectionMethod(CwmlocationHelper::class, 'getGroupMapping');
+
+        return $method->invoke(null, new Registry(['location_group_mapping' => $stored]));
+    }
+
+    /**
+     * Clear the once-per-request warning latch between cases.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $flag = new \ReflectionProperty(CwmlocationHelper::class, 'mappingWarned');
+        $flag->setValue(null, false);
+    }
+
+    #[TestDox('A readable mapping is returned as-is')]
+    public function testReadableMappingSurvives(): void
+    {
+        $this->assertSame(
+            ['4' => [11, 12]],
+            $this->mappingFor('{"4":[11,12]}')
+        );
+    }
+
+    #[TestDox('An unreadable mapping still returns [], because [] also means "not configured"')]
+    public function testUnreadableMappingStillReturnsEmpty(): void
+    {
+        // The value, not the logging, is the contract here. Failing closed would
+        // lock out every site that has never configured campuses — which cannot
+        // be told apart from this case by return value alone.
+        $this->assertSame([], $this->mappingFor('{"4":[11,12'));
+    }
+
+    #[TestDox('An empty mapping is indistinguishable from a corrupt one by value alone')]
+    public function testEmptyAndCorruptAgreeOnValue(): void
+    {
+        // Pinned deliberately: it is the reason the fix had to be logging rather
+        // than a different fallback. If these ever diverge, the fail-open
+        // reasoning in getGroupMapping()'s docblock needs revisiting.
+        $this->assertSame($this->mappingFor('{}'), $this->mappingFor('not json at all'));
+    }
+
+    #[TestDox('The warning latch fires once per request, not once per lookup')]
+    public function testWarningIsLatched(): void
+    {
+        $flag = new \ReflectionProperty(CwmlocationHelper::class, 'mappingWarned');
+
+        $this->assertFalse($flag->getValue(), 'setUp() should have cleared the latch');
+
+        $this->mappingFor('{"4":[11,12');
+        $this->assertTrue($flag->getValue(), 'A corrupt mapping must set the latch');
+
+        // getUserLocations() has two call sites and runs per user per request;
+        // without the latch a corrupt parameter would repeat the same line.
+        $this->mappingFor('{"4":[11,12');
+        $this->assertTrue($flag->getValue());
+    }
+
+    #[TestDox('A readable mapping never sets the warning latch')]
+    public function testReadableMappingDoesNotWarn(): void
+    {
+        $this->mappingFor('{"4":[11,12]}');
+
+        $flag = new \ReflectionProperty(CwmlocationHelper::class, 'mappingWarned');
+
+        $this->assertFalse($flag->getValue(), 'Valid JSON must not report a failure');
+    }
+
+    #[TestDox('createGroupLocationMappings writes only its own key, never the whole params blob')]
+    public function testMigrationWritesOnlyItsOwnParam(): void
+    {
+        // The defect this pins is not the JSON handling it was filed for.
+        //
+        // The method used to run its own UPDATE setting #__extensions.params to
+        // json_encode($existing) — the mapping array alone, as the entire params
+        // column. Every other Proclaim setting was replaced by it. Because the
+        // write bypassed ComponentHelper's cache, nothing looked wrong until the
+        // next request. migrateAccessToLocations() scenario 2A is the only
+        // caller, so a multi-campus migration wiped the component configuration
+        // as a side effect.
+        //
+        // Asserted on the source rather than by running it: the write path needs
+        // a live #__extensions row and a cache controller, and what matters is
+        // structural — that the raw UPDATE is gone and the merging writer is
+        // used instead.
+        $source = (string) file_get_contents(
+            \dirname(__DIR__, 4) . '/admin/src/Helper/CwmmigrationHelper.php'
+        );
+
+        $body = $this->methodBody($source, 'createGroupLocationMappings');
+
+        $this->assertNotSame('', $body, 'Could not isolate createGroupLocationMappings()');
+
+        $this->assertStringNotContainsString(
+            '#__extensions',
+            $body,
+            'This method must not write #__extensions directly — that is what replaced the whole '
+            . 'params column with the mapping array.'
+        );
+
+        $this->assertStringContainsString(
+            'Cwmparams::setCompParams(',
+            $body,
+            'Params must be written through Cwmparams::setCompParams(), which merges into the stored '
+            . 'Registry and clears the _system cache.'
+        );
+    }
+
+    #[TestDox('createGroupLocationMappings refuses to merge when the stored mapping is unreadable')]
+    public function testMigrationRefusesToMergeIntoNothing(): void
+    {
+        $source = (string) file_get_contents(
+            \dirname(__DIR__, 4) . '/admin/src/Helper/CwmmigrationHelper.php'
+        );
+
+        $body = $this->methodBody($source, 'createGroupLocationMappings');
+
+        // The merge loop only adds keys it cannot already see, so starting from
+        // [] writes back a mapping holding none of the administrator's manual
+        // entries — precisely what the loop's own comment promises to preserve.
+        $this->assertMatchesRegularExpression(
+            '/catch \(\\\\JsonException [^)]*\)\s*\{[^}]*return;/s',
+            $body,
+            'An unreadable stored mapping must abort, not fall through to the merge with $existing = []'
+        );
+
+        $this->assertStringNotContainsString(
+            '$existing = [];',
+            $body,
+            'Resetting $existing to [] on a decode failure is the data-loss path this test exists to stop'
+        );
+    }
+
+    /**
+     * Extract one method's body by brace matching, with comments removed.
+     *
+     * Comments have to go: both assertions below look for the absence of a
+     * string, and the code they guard is explained by a comment that names the
+     * very thing being asserted absent.
+     *
+     * @param   string  $source  File contents.
+     * @param   string  $name    Method name.
+     *
+     * @return  string
+     */
+    private function methodBody(string $source, string $name): string
+    {
+        $source = $this->stripComments($source);
+
+        $start = strpos($source, 'function ' . $name . '(');
+
+        if ($start === false) {
+            return '';
+        }
+
+        $open = strpos($source, '{', $start);
+
+        if ($open === false) {
+            return '';
+        }
+
+        $depth  = 0;
+        $length = \strlen($source);
+
+        for ($i = $open; $i < $length; $i++) {
+            if ($source[$i] === '{') {
+                $depth++;
+            } elseif ($source[$i] === '}') {
+                $depth--;
+
+                if ($depth === 0) {
+                    return substr($source, $open, $i - $open + 1);
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Replace every comment with a space, leaving code and line structure intact.
+     *
+     * @param   string  $source  PHP source.
+     *
+     * @return  string
+     */
+    private function stripComments(string $source): string
+    {
+        $out = '';
+
+        foreach (token_get_all($source) as $token) {
+            if (\is_array($token) && \in_array($token[0], [\T_COMMENT, \T_DOC_COMMENT], true)) {
+                // Keep the newlines so brace matching still lines up with the file.
+                $out .= str_repeat("\n", substr_count($token[1], "\n"));
+
+                continue;
+            }
+
+            $out .= \is_array($token) ? $token[1] : $token;
+        }
+
+        return $out;
+    }
+}


### PR DESCRIPTION
Closes #1558. Tier A shipped in #1657.

Twenty-one `catch (\JsonException)` blocks in `Helper/` swallow the error and substitute a fallback. **Most are right to** — nine are `CwmyoutubeFileCache` reads where a corrupt entry is a cache miss, and logging each would bury the signal. Two were not.

## 1. Campus filtering failed open

`CwmlocationHelper::getGroupMapping()` returned `[]`, which `getUserLocations()` reads as *"no location is restricted"* — `getUnrestrictedLocations([])` yields every published location. An unreadable `location_group_mapping` therefore **showed every campus to every user**, silently, while campus filtering appeared to be working.

**The fallback is deliberately still `[]`.** That value is also the legitimate "campuses not configured yet" state, and the two cannot be distinguished by return value — failing closed would lock out every site that has never used campuses, which is most of them. Only the silence was fixable.

A latch keeps it to one log entry per request; `getGroupMapping()` has two call sites and runs per user, so a corrupt parameter would otherwise repeat the same line all day.

## 2. A multi-campus migration wiped the component configuration

`createGroupLocationMappings()` was wrong twice, and the second was found only by reading the code around the first.

**The filed bug:** on a decode failure it reset `$existing = []` and carried on into a merge loop that adds only keys it cannot already see — writing back a mapping containing none of the administrator's manual entries, which is exactly what that loop's own comment promises to preserve. It now refuses and logs.

**The bug found while fixing it:** it then ran its own UPDATE —

```php
->set($db->quoteName('params') . ' = ' . $db->quote(json_encode($existing, JSON_THROW_ON_ERROR)))
```

`$existing` is the mapping array. That statement set `#__extensions.params` — **the entire component params column** — to it. Every other Proclaim setting on the site was replaced. Because the write bypassed `ComponentHelper`'s cache, nothing looked wrong until the next request.

`migrateAccessToLocations()` scenario 2A is the only caller, so **a multi-campus migration destroyed the component's configuration as a side effect.**

It now writes through `Cwmparams::setCompParams()`, which merges into the stored Registry and clears the `_system` cache — the same hardened path `CwmlicenseController` uses, and whose docblock documents this precise cache-staleness failure.

## Test

`SilentJsonFallbackTest` — 7 tests. Beyond the obvious ones, it pins that a corrupt and an empty mapping **agree on value**, because that equivalence is the reason the fix had to be logging rather than a different fallback. If they ever diverge, the reasoning needs revisiting.

The migration assertions read the method's source with **comments stripped** — both check for the absence of a string that the explanatory comments necessarily mention.

Mutation-checked both ways: restoring the raw `#__extensions` UPDATE, and restoring `$existing = []`, each turn it red.

## Verification

- `composer test:unit` — **1396 tests, 2990 assertions, green** (1389 → 1396)
- `composer lint` — clean for this change; 3 remaining failures are pre-existing in the `lib_cwmscripture` submodule, identical count on clean `development`

## Risk

No schema change. The campus fallback value is unchanged, so behaviour on every existing site is identical — corruption now speaks instead of passing silently. The migration path changes from destroying params to preserving them.