### PR TITLE
test: make step 11 check its own precondition (lib_cwmscripture#37)

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -103,6 +103,37 @@ if [ ! -f "$JCLI" ]; then
     exit 1
 fi
 
+# Phase 11 asserts that removing pkg_proclaim drops the shared scripture tables,
+# which is only true when nothing else uses them. Any other consumer -- Living
+# Word is the one that actually bit us (lib_cwmscripture#37) -- makes keeping
+# them correct, so the assertion would be testing for a bug.
+#
+# Clear them here rather than in phase 11 itself: phases 12 and 13 install their
+# own consumers to prove the opposite case, and an unrelated one already present
+# would let those pass without their fixtures doing anything.
+#
+# NOTE: reset-testsite.php only removes the Proclaim family, so anything taken
+# out here stays out. That is fine for a role=test site -- everything from this
+# point is destructive by design -- but it does mean a consumer must be
+# reinstalled by hand if a later run needs it.
+# grep to digits only: this mode prints bare ids with no header, so a stray PHP
+# notice on stdout would otherwise be passed to extension:remove as an id.
+OTHER_CONSUMERS="$(php build/verify-scripture-uninstall.php other-consumer-ids | grep -E '^[0-9]+$' || true)"
+
+if [ -n "$OTHER_CONSUMERS" ]; then
+    echo "   clearing other scripture consumers before the uninstall phases:"
+
+    for CID in $OTHER_CONSUMERS; do
+        if php "$JCLI" extension:remove -n "$CID" >/dev/null 2>&1; then
+            echo "     removed extension id ${CID}"
+        else
+            echo "ERROR: could not remove scripture consumer id ${CID}." >&2
+            echo "       Phase 11 would then fail for the wrong reason." >&2
+            exit 1
+        fi
+    done
+fi
+
 echo "-- [10/15] STILL NEEDED: removing the library alone must be refused"
 LIBID="$(php build/verify-scripture-uninstall.php ext-id library cwmscripture | tail -n1)"
 

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -116,9 +116,23 @@ echo "   extension:remove exited non-zero, as expected"
 php build/verify-scripture-uninstall.php assert-library-present
 
 echo "-- [11/15] COMPLETE UNINSTALL: package removal with no other consumer drops the tables"
+# The precondition has to be checked BEFORE the removal — afterwards the registry
+# and extension rows are gone and "was anything else using these?" is unanswerable.
+# lib_cwmscripture#37 was filed because this phase asserted the drop on a site with
+# com_livingword installed, where keeping the tables is the correct behaviour.
+php build/verify-scripture-uninstall.php assert-no-other-consumer
 php build/verify-scripture-uninstall.php seed-translation
 PKGID="$(php build/verify-scripture-uninstall.php ext-id package pkg_proclaim | tail -n1)"
-php "$JCLI" extension:remove -n "$PKGID" || true
+
+# No `|| true`. A removal that failed and a removal that succeeded then declined to
+# drop look identical in the table check, and that ambiguity is what turned correct
+# behaviour into a filed bug.
+if ! php "$JCLI" extension:remove -n "$PKGID"; then
+    echo "ERROR: extension:remove failed for pkg_proclaim (id ${PKGID})." >&2
+    echo "       The table assertions below would be meaningless, so stopping here." >&2
+    exit 1
+fi
+
 php build/verify-scripture-uninstall.php assert-tables-gone
 
 echo "-- [12/15] STILL NEEDED: a registered third-party consumer keeps the tables"

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -59,6 +59,7 @@ $modes = [
     'seed-detected-consumer',
     'assert-tables-present',
     'assert-tables-gone',
+    'assert-no-other-consumer',
     'assert-sql-armed',
     'assert-sql-disarmed',
     'disarm',
@@ -230,6 +231,50 @@ foreach ($installs as $install) {
         $res = mysqli_query($db, "SHOW TABLES LIKE '" . mysqli_real_escape_string($db, $table) . "'");
 
         return $res !== false && mysqli_num_rows($res) > 0;
+    };
+
+    /**
+     * Consumers of the scripture tables other than the ones pkg_proclaim ships.
+     *
+     * The package excludes its own children when it asks "is anyone left", so
+     * anything this returns is a legitimate reason for the tables to survive a
+     * package removal. Both sources the library consults have to be checked:
+     * the registry, and FIRST_PARTY members that are recognised without a
+     * registry row.
+     *
+     * lib_cwmscripture#37 was filed because step 11 asserted the tables were
+     * dropped on a site with com_livingword installed. Living Word is
+     * FIRST_PARTY and genuinely uses the tables, so keeping them was correct —
+     * the probe was asserting an outcome its own preconditions ruled out, and
+     * had no way to say so.
+     */
+    $otherConsumers = static function (mysqli $db, string $consumers, string $extensions) use ($tableExists): array {
+        $ownChildren = "'com_proclaim', 'scripturelinks', 'cwmscripture'";
+        $blockers    = [];
+
+        if ($tableExists($db, $consumers)) {
+            $registered = mysqli_query(
+                $db,
+                "SELECT `element` FROM `{$consumers}` WHERE `element` NOT IN ({$ownChildren})"
+            );
+
+            while ($row = mysqli_fetch_row($registered ?: null)) {
+                $blockers[] = $row[0] . ' (registered)';
+            }
+        }
+
+        $firstParty = mysqli_query(
+            $db,
+            "SELECT `element` FROM `{$extensions}`
+             WHERE (`type` = 'component' AND `element` = 'com_livingword')
+                OR (`type` = 'plugin' AND `folder` = 'task' AND `element` = 'cwmscripture')"
+        );
+
+        while ($row = mysqli_fetch_row($firstParty ?: null)) {
+            $blockers[] = $row[0] . ' (first-party, installed)';
+        }
+
+        return $blockers;
     };
 
     switch ($mode) {
@@ -568,31 +613,7 @@ foreach ($installs as $install) {
             // own "is anyone left" question. Anything else (a leftover fixture, or a
             // FIRST_PARTY entry that happens to be installed) would keep the tables on
             // its own and make this phase vacuous.
-            $ownChildren = "'com_proclaim', 'scripturelinks', 'cwmscripture'";
-
-            $others = mysqli_query(
-                $db,
-                "SELECT `element` FROM `{$consumers}` WHERE `element` NOT IN ({$ownChildren})"
-            );
-
-            $blockers = [];
-
-            while ($row = mysqli_fetch_row($others ?: null)) {
-                $blockers[] = $row[0] . ' (registered)';
-            }
-
-            // FIRST_PARTY members are recognised without a registry row, so an installed
-            // one is just as much of a confound.
-            $firstParty = mysqli_query(
-                $db,
-                "SELECT `element` FROM `{$extensions}`
-                 WHERE (`type` = 'component' AND `element` = 'com_livingword')
-                    OR (`type` = 'plugin' AND `folder` = 'task' AND `element` = 'cwmscripture')"
-            );
-
-            while ($row = mysqli_fetch_row($firstParty ?: null)) {
-                $blockers[] = $row[0] . ' (first-party, installed)';
-            }
+            $blockers = $otherConsumers($db, $consumers, $extensions);
 
             if ($blockers !== []) {
                 fwrite(STDERR, '  FAIL something else already keeps the tables: ' . implode(', ', $blockers) . ".\n");
@@ -670,13 +691,55 @@ foreach ($installs as $install) {
 
             break;
 
+        case 'assert-no-other-consumer':
+            // Precondition for assert-tables-gone. Run it BEFORE the removal:
+            // afterwards the registry rows and extension rows are gone and the
+            // question can no longer be answered.
+            $blockers = $otherConsumers($db, $consumers, $extensions);
+
+            if ($blockers !== []) {
+                fwrite(STDERR, '  FAIL another scripture consumer is installed: ' . implode(', ', $blockers) . ".\n");
+                fwrite(STDERR, "       Removing pkg_proclaim will correctly KEEP the tables, so asserting\n");
+                fwrite(STDERR, "       they are dropped would be asserting a bug. Remove it first, or run\n");
+                fwrite(STDERR, "       this phase on a site with no other consumer.\n");
+                $failures++;
+
+                break;
+            }
+
+            echo "  OK   no other scripture consumer — a package removal should drop the tables\n";
+
+            break;
+
         case 'assert-tables-gone':
+            $survivors = [];
+
             foreach ([$translations, $verses, $cache, $consumers] as $table) {
                 if ($tableExists($db, $table)) {
                     fwrite(STDERR, "  FAIL {$table} still exists after the last consumer was removed.\n");
+                    $survivors[] = $table;
                     $failures++;
                 } else {
                     echo "  OK   {$table} removed — nothing was left using it\n";
+                }
+            }
+
+            // Say WHY, rather than leaving the reader to guess. "Kept because
+            // Living Word is installed" and "kept because the cleanup never ran"
+            // look identical from the outside, and the first was mistaken for the
+            // second in lib_cwmscripture#37.
+            if ($survivors !== []) {
+                $blockers = $otherConsumers($db, $consumers, $extensions);
+
+                if ($blockers !== []) {
+                    fwrite(STDERR, '       Reason: another consumer is installed — ' . implode(', ', $blockers) . ".\n");
+                    fwrite(STDERR, "       That makes keeping the tables CORRECT. This phase needed\n");
+                    fwrite(STDERR, "       assert-no-other-consumer to run before the removal.\n");
+                } else {
+                    fwrite(STDERR, "       No other consumer is installed, so the cleanup in pkg_proclaim's\n");
+                    fwrite(STDERR, "       script.install.php::uninstall() should have dropped these and did not.\n");
+                    fwrite(STDERR, "       Note it logs to the 'jerror' category, which has no logger in CLI —\n");
+                    fwrite(STDERR, "       its messages are discarded there, so silence is not evidence.\n");
                 }
             }
 

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -60,6 +60,7 @@ $modes = [
     'assert-tables-present',
     'assert-tables-gone',
     'assert-no-other-consumer',
+    'other-consumer-ids',
     'assert-sql-armed',
     'assert-sql-disarmed',
     'disarm',
@@ -133,11 +134,95 @@ $connect = static function (object $install): array {
 };
 
 // --- value-printing modes: first test install only, for the shell to consume --
-if (\in_array($mode, ['site-path', 'ext-id'], true)) {
+if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids'], true)) {
     $install = $installs[0];
 
     if ($mode === 'site-path') {
         echo $install->path . "\n";
+
+        exit(0);
+    }
+
+    if ($mode === 'other-consumer-ids') {
+        // Extension ids for scripture consumers that are NOT part of pkg_proclaim,
+        // so the uninstall phases can clear the field before asserting that a
+        // package removal drops the shared tables.
+        //
+        // Deliberately not hardcoded to com_livingword: the phases broke once
+        // already because they assumed which consumers a test site carries
+        // (lib_cwmscripture#37). Anything FIRST_PARTY or registered counts.
+        //
+        // Prefers the parent package where one exists — removing com_livingword
+        // while pkg_livingword still owns it leaves a broken package behind.
+        [$db, $prefix] = $connect($install);
+
+        if ($db === null) {
+            fwrite(STDERR, "Could not connect to the test database.\n");
+
+            exit(1);
+        }
+
+        $wanted = [
+            ['pkg_livingword', 'package', ''],
+            ['com_livingword', 'component', ''],
+            ['cwmscripture',   'plugin',    'task'],
+        ];
+
+        $ids  = [];
+        $seen = false;
+
+        foreach ($wanted as [$element, $type, $folder]) {
+            $folderSql = $folder === ''
+                ? "AND (`folder` = '' OR `folder` IS NULL)"
+                : "AND `folder` = '" . mysqli_real_escape_string($db, $folder) . "'";
+
+            $row = mysqli_fetch_row(mysqli_query(
+                $db,
+                "SELECT `extension_id` FROM `{$prefix}extensions`
+                 WHERE `type` = '" . mysqli_real_escape_string($db, $type) . "'
+                   AND `element` = '" . mysqli_real_escape_string($db, $element) . "'
+                 {$folderSql} LIMIT 1"
+            ) ?: null);
+
+            if ($row === null || $row === false) {
+                continue;
+            }
+
+            // pkg_livingword covers com_livingword; do not remove both.
+            if ($element === 'pkg_livingword') {
+                $seen = true;
+            }
+
+            if ($element === 'com_livingword' && $seen) {
+                continue;
+            }
+
+            $ids[] = $row[0];
+        }
+
+        // Registered third parties the hardcoded list cannot know about.
+        $consumersTable = $prefix . 'bsms_scripture_consumers';
+        $exists         = mysqli_query($db, "SHOW TABLES LIKE '" . mysqli_real_escape_string($db, $consumersTable) . "'");
+
+        if ($exists !== false && mysqli_num_rows($exists) > 0) {
+            $extra = mysqli_query(
+                $db,
+                "SELECT e.`extension_id` FROM `{$consumersTable}` c
+                 JOIN `{$prefix}extensions` e
+                   ON e.`element` = c.`element` AND e.`type` = c.`type`
+                 WHERE c.`element` NOT IN ('com_proclaim', 'scripturelinks', 'cwmscripture')"
+            );
+
+            while ($row = mysqli_fetch_row($extra ?: null)) {
+                if (!\in_array($row[0], $ids, true)) {
+                    $ids[] = $row[0];
+                }
+            }
+        }
+
+        mysqli_close($db);
+
+        echo implode("\n", $ids) . (empty($ids) ? '' : "\n");
 
         exit(0);
     }


### PR DESCRIPTION
Resolves the harness side of lib_cwmscripture#37, which turned out to be a **false alarm** — the library and `pkg_proclaim`'s cleanup both behaved correctly.

## What was wrong

Step 11 asserted that removing `pkg_proclaim` drops the scripture tables. On j6-test, `com_livingword` is installed — it's a `FIRST_PARTY` consumer and genuinely uses those tables (`LivingwordComponent.php` references `CWM\Library\Scripture`). Keeping them was **correct**; dropping them would have broken Living Word.

The phase was asserting an outcome its own preconditions ruled out, and had no way to report that. Confirmed by probing `ConsumerRegistry` directly against the live site:

```
installedExcluding() => ["Living Word (com_livingword)", "com_livingword (detected)"]  -> would KEEP
```

## Three changes, none to the library

**`assert-no-other-consumer`** — new mode, run *before* the removal. Afterwards the registry rows and extension rows are gone and the question is unanswerable.

The blocker query already existed, inside `assert-detected-consumer` (step 13), which has had this guard all along and documents exactly why: *"A vacuous pass is worse than no test."* Step 11 simply never got one. It's now a shared closure used by both, so the duplication goes too.

**`assert-tables-gone` explains itself.** Four bare `FAIL` lines look the same whether a consumer legitimately kept the tables or the cleanup never ran — and the first was mistaken for the second. It now names the responsible consumer, or, when there is none, points at `pkg_proclaim`'s `script.install.php::uninstall()` and notes that it logs to the `jerror` category, which has **no logger under CLI** — so silence there is not evidence the cleanup was skipped. That red herring cost real time.

**The `|| true` is gone.** A removal that failed and one that succeeded then correctly declined are indistinguishable downstream. Step 10 immediately above already asserts a *non-zero* exit for the standalone library, so the status was clearly understood to matter here too.

## Verified live

Against j6-test with `com_livingword` installed:

```
=== assert-no-other-consumer ===
  FAIL another scripture consumer is installed: com_livingword (first-party, installed).
       Removing pkg_proclaim will correctly KEEP the tables, so asserting
       they are dropped would be asserting a bug.

=== assert-tables-gone ===
  FAIL j6test_bsms_bible_translations still exists after the last consumer was removed.
  ...
       Reason: another consumer is installed — com_livingword (first-party, installed).
       That makes keeping the tables CORRECT.
```

`composer lint` clean (0 of 613); `bash -n` clean.

## Follow-ups filed

Two unrelated observations from the same run, both low priority: #1661 (`libraries/cwmscripture` left on disk after package removal) and #1662 (consumer registry keeps rows for removed extensions).