### PR TITLE
fix: retire update sites left registered against com_proclaim (#1666)

### DIFF
--- a/build/script.install.php
+++ b/build/script.install.php
@@ -114,7 +114,99 @@ return new class () implements InstallerScriptInterface {
         // Ensure the scripture links plugin is enabled
         $this->enablePlugin('scripturelinks', 'content');
 
+        // Retire update sites left registered against com_proclaim
+        $this->removeComponentUpdateSites();
+
         return true;
+    }
+
+    /**
+     * Retire update sites still registered against com_proclaim.
+     *
+     * Until 10.4.0 the component manifest carried its own <updateservers>, so
+     * every site installed before then holds an update site owned by
+     * com_proclaim. Joomla does not remove an update site when a manifest stops
+     * declaring one, so those rows outlive the change: a site with history ends
+     * up polling the stream twice and reporting Proclaim as a *component*
+     * update, while a fresh install polls once as a package.
+     *
+     * Some of those rows point at ARS stream id=2, which only ever served
+     * 9.2.x. A site carrying one polls a stream whose newest entry predates
+     * every 10.x release, so it can never be offered anything from it.
+     *
+     * Updates belong to the package in the bundled-package distribution model,
+     * so the package's own update site is the one to keep.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function removeComponentUpdateSites(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        try {
+            $sitesFor = function (string $element, string $type) use ($db): array {
+                $query = $db->createQuery()
+                    ->select($db->quoteName('se.update_site_id'))
+                    ->from($db->quoteName('#__update_sites_extensions', 'se'))
+                    ->join(
+                        'INNER',
+                        $db->quoteName('#__extensions', 'e'),
+                        $db->quoteName('e.extension_id') . ' = ' . $db->quoteName('se.extension_id')
+                    )
+                    ->where($db->quoteName('e.element') . ' = :element')
+                    ->where($db->quoteName('e.type') . ' = :type')
+                    ->bind(':element', $element)
+                    ->bind(':type', $type);
+
+                return array_map('intval', $db->setQuery($query)->loadColumn() ?: []);
+            };
+
+            $packageSites = $sitesFor('pkg_proclaim', 'package');
+
+            // Never leave a site with no way to hear about updates. If the
+            // package has not registered its own update site — a partial
+            // install, or a component-only site that has not taken the package
+            // yet — the component's row is the only channel there is, so it
+            // stays. The next successful package install runs this again.
+            if ($packageSites === []) {
+                return;
+            }
+
+            $stale = array_diff($sitesFor('com_proclaim', 'component'), $packageSites);
+
+            if ($stale === []) {
+                return;
+            }
+
+            $ids = implode(',', $stale);
+
+            // #__updates rows are keyed to the site and would otherwise be
+            // orphaned, leaving phantom entries on Extensions > Update.
+            foreach (['#__updates', '#__update_sites_extensions', '#__update_sites'] as $table) {
+                $db->setQuery(
+                    $db->createQuery()
+                        ->delete($db->quoteName($table))
+                        ->where($db->quoteName('update_site_id') . ' IN (' . $ids . ')')
+                )->execute();
+            }
+
+            Log::add(
+                'pkg_proclaim: retired ' . \count($stale) . ' com_proclaim update site(s); '
+                . 'the package now owns updates.',
+                Log::INFO,
+                'com_proclaim'
+            );
+        } catch (\Throwable $e) {
+            // Housekeeping. A site that keeps a duplicate update site still
+            // updates correctly, so this must never fail an install.
+            Log::add(
+                'pkg_proclaim: could not retire com_proclaim update sites: ' . $e->getMessage(),
+                Log::WARNING,
+                'com_proclaim'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Closes the "only the package should own updates" half of #1666.

## What was actually wrong

Until 10.4.0 `proclaim.xml` carried its own `<updateservers>`. **Joomla does not remove an update site when a manifest stops declaring one**, so every site installed before then still holds an update site owned by `com_proclaim`.

Measured across the dev sites:

| site | update sites for Proclaim | owned by |
|---|---|---|
| j5-dev | 2 | `com_proclaim`, `com_proclaim` |
| j6-dev | 1 | `com_proclaim` |
| j6-test (installed today) | 1 | `pkg_proclaim` |

That is the mechanism behind the *Component* row on Extensions → Update: on a site with history the update site belongs to the component, so the component entry in the stream is the one that matches. A fresh install polls once, as a package.

One of j5-dev's rows points at ARS stream **id=2**, which serves 9.2.x only — deliberately, since 9.2.x → 10.x is a migration rather than an in-place update. Once a site is on 10.x that stream can offer it nothing, so the row is pure noise.

## The change

`removeComponentUpdateSites()` in the package's postflight drops update sites owned by `com_proclaim`, leaving the package's own.

**Guarded so a site can never be left with no update channel.** If the package has not registered an update site — a partial install, or a component-only site that has not taken the package yet — the component row stays, and the next successful package install retries. A 9.2.x site never reaches this code at all: it migrates rather than installing the package.

It also deletes the matching `#__updates` rows, which are keyed to the update site and would otherwise leave phantom entries on Extensions → Update. Any failure is logged, never fatal — a site that keeps a duplicate update site still updates correctly, so this must not be able to fail an install.

## Verification

Seeded j6-test with a legacy component-owned site (pointing at id=2, mirroring j5-dev), then installed the package:

```
before:  site=489 pkg_proclaim (package)  id=1
         site=492 com_proclaim (component) id=2
after:   site=489 pkg_proclaim (package)  id=1
         total: 1
orphan update_sites_extensions: 0
orphan updates:                 0
```

And the guard, with the package channel removed:

```
package-owned sites: (none)
component-owned sites: 494
guard decision: RETURN EARLY — component site kept
```

`php -l` and `php-cs-fixer` clean.

## What this does not change

The stream still carries both a `com_proclaim` and a `pkg_proclaim` entry, and `com_proclaim` must stay first — see the discussion on #1666. This PR only stops sites from *polling twice*; it does not touch what the stream advertises, and it deliberately leaves the component entry working for sites that have not converted yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
