### PR TITLE
fix(deps): raise the js-yaml override floor to the patched 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6575,9 +6575,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "serialize-javascript": "^7.0.3",
     "brace-expansion": "^5.0.6",
     "ws": "^8.21.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert 57 — **GHSA-5p4m-2wfm-xmqj**, quadratic CPU consumption resolving `!!omap`, affecting `>= 4.0.0, < 4.3.1`. Rated **high** by GitHub.

## The change

Two lines: raise the existing `js-yaml` override from `^4.2.0` to `^4.3.1`, and refresh the lockfile 4.3.0 → 4.3.1.

The override already permitted the fix — `^4.2.0` admits 4.3.1 — the lock simply had not been refreshed since 4.3.1 published. Raising the floor makes the patched version a documented minimum instead of something a future resolve could quietly drop below.

## Exposure was minimal, and the "high" rating overstates it here

- **Development scope only.** `js-yaml` is a transitive devDependency of `jest`, six levels down via `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config`. Confirmed absent from the shipped package: `pkg_proclaim-10.5.6.zip` contains no `node_modules` and no `js-yaml`.
- **The vulnerable path is unreachable in this repo.** `load-nyc-config` parses YAML only when reading an nyc config file (`.nycrc`, `.nycrc.yml`, …). None exist here, so the `!!omap` resolution never runs.

Worth fixing anyway because it is two lines and it silences an alert that has been appearing on every push.

## One thing checked along the way

The override is a bigger jump than it looks: `@istanbuljs/load-nyc-config` declares `js-yaml ^3.13.1`, so forcing `^4.x` moves it two majors past its own requirement — and js-yaml 4 removed `safeLoad`.

It is fine. `load-nyc-config/index.js:80` calls `require('js-yaml').load(...)`, not `safeLoad`, so the API it uses still exists. Noting it because the mismatch looks alarming in `npm ls` and would otherwise be rediscovered later.

## Verification

```
npm audit                 found 0 vulnerabilities
npm test                  17 suites, 232 tests passed
js-yaml in lockfile       4.3.1 (dev)
```

Diff is 4 lines across `package.json` and `package-lock.json` — no other dependency moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
