### PR TITLE
fix: correct two ACL asset names, and bind the rest to access.xml (#1653 phase 0)

### DIFF
--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -423,7 +423,7 @@ class CwmserverModel extends AdminModel
     {
         return Factory::getApplication()->getIdentity()->authorise(
             'core.delete',
-            'com_proclaim.cwmserver.' . (int)$record->id
+            'com_proclaim.server.' . (int)$record->id
         );
     }
 
@@ -444,7 +444,7 @@ class CwmserverModel extends AdminModel
 
         // Check for existing server record
         if (!empty($record->id)) {
-            return $user->authorise('core.edit.state', 'com_proclaim.cwmserver.' . (int)$record->id);
+            return $user->authorise('core.edit.state', 'com_proclaim.server.' . (int)$record->id);
         }
 
         return parent::canEditState($record);

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -153,9 +153,9 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
-                            $canEdit            = $user->authorise('core.edit', 'com_proclaim.cwmserver.' . $item->id);
-                            $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.cwmserver.' . $item->id);
-                            $canChange          = $user->authorise('core.edit.state', 'com_proclaim.cwmserver.' . $item->id);
+                            $canEdit            = $user->authorise('core.edit', 'com_proclaim.server.' . $item->id);
+                            $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.server.' . $item->id);
+                            $canChange          = $user->authorise('core.edit.state', 'com_proclaim.server.' . $item->id);
                             ?>
                             <tr class="row<?php
                             echo $i % 2; ?>">

--- a/admin/tmpl/cwmtemplatecodes/default.php
+++ b/admin/tmpl/cwmtemplatecodes/default.php
@@ -99,7 +99,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplatecodes'); ?>" method
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
                             $canCreate          = $user->authorise('core.create');
-                            $canEdit            = $user->authorise('core.edit', 'com_proclaim.templatcode.' . $item->id);
+                            $canEdit            = $user->authorise('core.edit', 'com_proclaim.templatecode.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.templatecode.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.templatecode.' . $item->id);
                             ?>

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * ACL asset names are a contract with admin/access.xml, and nothing enforces it.
+ *
+ * `Access::getAssetRules()` walks up to the parent asset when a name does not
+ * resolve, so a misspelled or undeclared section never errors -- it silently
+ * inherits the component's rules and looks correct. Every section check today
+ * resolves to `com_proclaim` anyway, because no section assets exist, which
+ * hides the mistake completely.
+ *
+ * That is exactly how five wrong names reached production (#1653): a class
+ * prefix leaking into an asset name (`com_proclaim.cwmserver` against declared
+ * `server`), a dropped letter (`templatcode`), an underscore that access.xml
+ * does not use (`message_type`), and a section written but never declared.
+ *
+ * The moment section assets exist, the correct names start honouring section
+ * rules and the wrong ones keep falling back -- so the feature looks broken
+ * rather than the names looking wrong. This test reads both sides and asserts
+ * they agree, before that divergence can happen.
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Assets;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Binds every ACL asset name in the codebase to a section in admin/access.xml.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class AssetNameContractTest extends TestCase
+{
+    /**
+     * Sections written to #__assets that access.xml does not declare.
+     *
+     * These are real mismatches, deliberately not fixed here. Unlike the names
+     * that live only in code, each of these has already been persisted as an
+     * #__assets row on every existing site, so correcting them means renaming
+     * live rows through Joomla's nested set rather than editing a string --
+     * see #1653 items 3-5.
+     *
+     * This list must only ever shrink. Adding to it means shipping a section
+     * whose permissions govern nothing.
+     *
+     * @var array<string, string>
+     * @since __DEPLOY_VERSION__
+     */
+    private const KNOWN_UNDECLARED = [
+        'message_type' => 'CwmmessagetypeTable writes message_type; access.xml declares messagetype (#1653)',
+        'cwmadmin'     => 'CwmadminTable writes cwmadmin; access.xml declares admin (#1653)',
+        'studytopics'  => 'CwmstudytopicsTable writes an asset for a section access.xml never declares (#1653)',
+    ];
+
+    /**
+     * Section names declared in admin/access.xml.
+     *
+     * @return  list<string>
+     * @since __DEPLOY_VERSION__
+     */
+    private static function declaredSections(): array
+    {
+        $doc = new \DOMDocument();
+        $doc->load(self::root() . '/admin/access.xml');
+
+        $names = [];
+
+        foreach ((new \DOMXPath($doc))->query('/access/section') as $section) {
+            $names[] = $section->getAttribute('name');
+        }
+
+        return $names;
+    }
+
+    /**
+     * Repository root.
+     *
+     * @return  string
+     * @since __DEPLOY_VERSION__
+     */
+    private static function root(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+
+    /**
+     * Every PHP file that could carry an asset name.
+     *
+     * @return  list<string>
+     * @since __DEPLOY_VERSION__
+     */
+    private static function sourceFiles(): array
+    {
+        $files = [];
+
+        foreach (['admin/src', 'site/src', 'api/src', 'admin/tmpl', 'site/tmpl'] as $dir) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(self::root() . '/' . $dir, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->getExtension() === 'php') {
+                    $files[] = $file->getPathname();
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    #[TestDox('every section passed to authorise() is declared in access.xml')]
+    public function testAuthoriseTargetsAreDeclaredSections(): void
+    {
+        $declared = self::declaredSections();
+        $offences = [];
+
+        foreach (self::sourceFiles() as $file) {
+            $code = (string) file_get_contents($file);
+
+            // Only authorise() calls. loadForm('com_proclaim.server.<type>'),
+            // setUserState() and $typeAlias share the prefix but are unrelated
+            // namespaces -- renaming those would break forms and UCM types.
+            preg_match_all(
+                '/authorise\(\s*[\'"][^\'"]+[\'"]\s*,\s*[\'"]com_proclaim\.([a-z_]+)/i',
+                $code,
+                $matches,
+                PREG_SET_ORDER
+            );
+
+            foreach ($matches as $match) {
+                if (!\in_array($match[1], $declared, true)) {
+                    $offences[] = str_replace(self::root() . '/', '', $file) . ' -> com_proclaim.' . $match[1];
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            array_values(array_unique($offences)),
+            "authorise() named a section admin/access.xml does not declare.\n"
+            . "The check silently inherits the component's rules, so it looks correct until\n"
+            . "section assets exist. Declare the section, or correct the name."
+        );
+    }
+
+    #[TestDox('every asset name written by a Table is declared in access.xml')]
+    public function testTableAssetNamesAreDeclaredSections(): void
+    {
+        $declared = self::declaredSections();
+        $offences = [];
+
+        foreach (glob(self::root() . '/admin/src/Table/*.php') as $file) {
+            $code = (string) file_get_contents($file);
+
+            if (!preg_match('/function\s+_getAssetName\b(.+?)\n    }/s', $code, $body)) {
+                continue;
+            }
+
+            if (!preg_match('/[\'"]com_proclaim\.([a-z_]+)/i', $body[1], $match)) {
+                continue;
+            }
+
+            $section = $match[1];
+
+            if (\in_array($section, $declared, true) || isset(self::KNOWN_UNDECLARED[$section])) {
+                continue;
+            }
+
+            $offences[] = basename($file) . ' -> com_proclaim.' . $section;
+        }
+
+        $this->assertSame(
+            [],
+            $offences,
+            "A Table writes an #__assets row for a section admin/access.xml does not declare.\n"
+            . 'Permissions set on that section would govern nothing.'
+        );
+    }
+
+    #[TestDox('the known-undeclared list only shrinks')]
+    public function testKnownUndeclaredEntriesStillApply(): void
+    {
+        $declared = self::declaredSections();
+
+        foreach (self::KNOWN_UNDECLARED as $section => $why) {
+            $this->assertNotContains(
+                $section,
+                $declared,
+                "'{$section}' is now declared in access.xml, so it no longer belongs in "
+                . 'KNOWN_UNDECLARED. Remove the entry: ' . $why
+            );
+        }
+    }
+}


### PR DESCRIPTION
> **Draft on purpose — hold this open.** Phase 0 of #1653 is behaviour-neutral by design, which also means it cannot be proven by observing the admin: every path it touches resolves identically before and after. It is worth sitting in a branch while the rest of the permissions work is designed, so it can be validated as part of a full working system rather than merged on the strength of a unit test.

Phase 0 of the per-section permissions plan in #1653: make every ACL asset name agree with `admin/access.xml` while the mismatches are still harmless.

## Why it has to be first

No section assets exist yet, so every `com_proclaim.<section>` lookup misses and `Access::getAssetRules()` inherits the component's rules. A wrong name is therefore indistinguishable from a right one today.

That changes the moment phase 1 creates section assets: the correct names start honouring section rules and the wrong ones keep falling back to the component. Servers and template codes would quietly ignore permissions everything else obeys — and it would read as "the new feature is broken" rather than "these names were always wrong".

## What changed

Two names, both code-only, nothing persisted:

| where | was | now |
|---|---|---|
| `CwmserverModel.php:426, 447` | `com_proclaim.cwmserver.<id>` | `com_proclaim.server.<id>` |
| `admin/tmpl/cwmservers/default.php:156-158` | `com_proclaim.cwmserver.<id>` | `com_proclaim.server.<id>` |
| `admin/tmpl/cwmtemplatecodes/default.php:102` | `com_proclaim.templatcode.<id>` | `com_proclaim.templatecode.<id>` |

`CwmserverTable::_getAssetName()` has always written `com_proclaim.server`, so nothing ever created the name those five calls were checking.

## Deliberately not changed

`loadForm('com_proclaim.cwmserver')` at `CwmserverModel:387`, and `loadForm('com_proclaim.server.' . $type)` at `:360`.

Form names share the prefix but are a **separate namespace** — they key the form registry and reach `onContentPrepareForm` listeners. Renaming them would break form loading while looking like a tidy-up. The audit in #1653 originally listed line 387 as one of the three `cwmserver` sites; it is not an ACL name.

## Not fixed here, and why

Three mismatches remain: `message_type`, `cwmadmin`, `studytopics`. Unlike the two above, each is already **persisted as an `#__assets` row on every existing site**, so correcting them means renaming live rows through Joomla's nested set — a migration, and its own change. Per the ACL-drift notes, a present-but-broken assets row is a known cause of 404s, so that is not something to fold into a string edit.

They are recorded in `AssetNameContractTest::KNOWN_UNDECLARED` with the reason, and a third test asserts the list only ever shrinks.

## The contract test

`tests/unit/Assets/AssetNameContractTest.php` binds both sides:

- every section passed to `authorise()` across `admin/src`, `site/src`, `api/src`, `admin/tmpl`, `site/tmpl` must be declared in `access.xml`
- every name written by a `Table::_getAssetName()` must be declared, or be a known outstanding row
- the known-outstanding list may only shrink

**Validated by mutation, not assumed:**

| mutation | result |
|---|---|
| reintroduce `templatcode` | test fails, naming the file |
| reintroduce `cwmserver` in an `authorise()` | test fails, naming the file |
| leave `loadForm('com_proclaim.cwmserver')` in place | test passes — no over-reach into form names |

That last row is the one that matters: it proves the test targets ACL names specifically rather than every string with the prefix.

## Verification

```
composer test:unit    1399 tests, 2995 assertions — OK
php-cs-fixer          0 of 1 fixable, both files
```

## What phase 1 still needs before this is provably right

This makes the names consistent; it does not prove the permissions work, because nothing yet reads section assets. The before/after that would prove it — effective permission per action × section × group, unchanged across the migration — only becomes possible once phase 1 creates the assets. That is the argument for holding this branch rather than merging it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
