### PR TITLE
feat: create com_proclaim section assets, provably inert (#1653 phase 1)

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -41,6 +41,206 @@ class Cwmassets
      */
     public static int $parent_id = 0;
 
+    /**
+     * Cached `com_proclaim.<section>` asset IDs, keyed by section name.
+     *
+     * @var array<string, int>
+     * @since __DEPLOY_VERSION__
+     */
+    private static array $sectionIds = [];
+
+    /**
+     * Cached section names declared in admin/access.xml.
+     *
+     * @var list<string>|null
+     * @since __DEPLOY_VERSION__
+     */
+    private static ?array $declaredSections = null;
+
+    /**
+     * Forget cached section ids and the parsed access.xml.
+     *
+     * `sectionId()` memoises name -> id for the request. That is safe while
+     * assets only ever get created, but this class also repairs and removes
+     * them — `fixAllAssets()`, `cleanOrphanedAssets()`, `pruneEmptyAssetRows()`
+     * — after which a cached id points at a row that no longer exists, and
+     * `seedSections()` would report success without recreating anything.
+     *
+     * Call this after any operation that deletes asset rows.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function clearSectionCache(): void
+    {
+        self::$sectionIds       = [];
+        self::$declaredSections = null;
+    }
+
+    /**
+     * Section names admin/access.xml declares, excluding `component`.
+     *
+     * Read from the manifest rather than hardcoded so the list cannot drift
+     * from the file that defines the permissions UI.
+     *
+     * @return  list<string>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function declaredSections(): array
+    {
+        if (self::$declaredSections !== null) {
+            return self::$declaredSections;
+        }
+
+        self::$declaredSections = [];
+
+        // Resolved relative to this class rather than through JPATH_ADMINISTRATOR.
+        // Both layouts put access.xml two levels above src/Lib —
+        // administrator/components/com_proclaim/ when installed, admin/ in the
+        // repository — so the same expression works under test, where
+        // JPATH_ADMINISTRATOR points at the Joomla install rather than at us.
+        $file = \dirname(__DIR__, 2) . '/access.xml';
+
+        if (!is_file($file)) {
+            $file = JPATH_ADMINISTRATOR . '/components/com_proclaim/access.xml';
+        }
+
+        if (!is_file($file)) {
+            Log::add('access.xml not found; no section assets can be resolved', Log::ERROR, 'com_proclaim');
+
+            return self::$declaredSections;
+        }
+
+        $doc = new \DOMDocument();
+
+        if (!@$doc->load($file)) {
+            Log::add('access.xml is not parseable; no section assets can be resolved', Log::ERROR, 'com_proclaim');
+
+            return self::$declaredSections;
+        }
+
+        foreach ((new \DOMXPath($doc))->query('/access/section') as $section) {
+            $name = $section->getAttribute('name');
+
+            if ($name !== '' && $name !== 'component') {
+                self::$declaredSections[] = $name;
+            }
+        }
+
+        return self::$declaredSections;
+    }
+
+    /**
+     * Find or create the `com_proclaim.<section>` asset, returning its id.
+     *
+     * Created with **empty rules**, which is what makes this inert: an empty
+     * rule set inherits from `com_proclaim`, so every effective permission is
+     * the same answer the fallback already produced. Verified on a development
+     * database across 14 groups x 17 sections x 5 actions — 1190 cells, none
+     * changed (#1653).
+     *
+     * Written through `Table\Asset::setLocation()`/`store()` rather than a raw
+     * INSERT, so the nested set stays correct without a `rebuild()` pass. A
+     * present-but-broken `#__assets` row is a known cause of 404s in this
+     * component, which is why this path never hand-writes `lft`/`rgt`.
+     *
+     * ⚠️ A section asset resolving does NOT make item assets inherit through
+     * it. `Access::getAssetRules()` falls back from an unresolved name straight
+     * to the extension asset — everything before the first dot — so
+     * `com_proclaim.teacher.5` reaches `com_proclaim`, never
+     * `com_proclaim.teacher`. Section rules bite only where code asks for the
+     * section name explicitly, or where a real item asset is parented beneath
+     * it.
+     *
+     * @param   string  $section  Section name as declared in access.xml
+     *
+     * @return  int  Asset id, or 0 when the section is undeclared or creation failed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function sectionId(string $section): int
+    {
+        if (isset(self::$sectionIds[$section])) {
+            return self::$sectionIds[$section];
+        }
+
+        // Refuse to mint an asset for a name access.xml does not declare.
+        // Permissions set on such a section would govern nothing, and the row
+        // would be invisible to the UI that is supposed to manage it.
+        if (!\in_array($section, self::declaredSections(), true)) {
+            Log::add(
+                "Refusing to create asset for undeclared section '{$section}' — add it to access.xml first",
+                Log::WARNING,
+                'com_proclaim'
+            );
+
+            return 0;
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $name  = 'com_proclaim.' . $section;
+        $asset = new \Joomla\CMS\Table\Asset($db);
+
+        if ($asset->loadByName($name)) {
+            return self::$sectionIds[$section] = (int) $asset->id;
+        }
+
+        $parentId = self::parentId();
+
+        if ($parentId < 1) {
+            Log::add("Cannot create {$name}: com_proclaim asset is missing", Log::ERROR, 'com_proclaim');
+
+            return 0;
+        }
+
+        $asset->name  = $name;
+        $asset->title = $name;
+        $asset->rules = '{}';
+        $asset->setLocation($parentId, 'last-child');
+
+        if (!$asset->check() || !$asset->store()) {
+            // A concurrent request may have won the race — the unique index on
+            // `name` is the arbiter. Re-read before reporting failure so the
+            // loser returns the winner's id instead of 0.
+            $retry = new \Joomla\CMS\Table\Asset($db);
+
+            if ($retry->loadByName($name)) {
+                return self::$sectionIds[$section] = (int) $retry->id;
+            }
+
+            Log::add("Failed to create {$name}: " . $asset->getError(), Log::ERROR, 'com_proclaim');
+
+            return 0;
+        }
+
+        return self::$sectionIds[$section] = (int) $asset->id;
+    }
+
+    /**
+     * Create every section asset access.xml declares.
+     *
+     * Idempotent — existing rows are loaded, not duplicated — so it is safe to
+     * run on install and on every update.
+     *
+     * @return  int  Number of sections resolved (created or already present)
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function seedSections(): int
+    {
+        $resolved = 0;
+
+        foreach (self::declaredSections() as $section) {
+            if (self::sectionId($section) > 0) {
+                $resolved++;
+            }
+        }
+
+        return $resolved;
+    }
+
     // =========================================================================
     // Parent Asset Management
     // =========================================================================

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -13,6 +13,7 @@
 use CWM\Component\Proclaim\Administrator\Helper\CwmguidedtourHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
 use Joomla\CMS\Event\Cache\AfterPurgeEvent;
 use Joomla\CMS\Event\Model\AfterCleanCacheEvent;
@@ -643,6 +644,35 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @since   10.5.6
      */
+    /**
+     * Create the `com_proclaim.<section>` assets access.xml declares.
+     *
+     * Phase 1 of #1653. Every section is created with empty rules, which
+     * inherit from `com_proclaim` — so effective permissions are unchanged for
+     * every group, section and action. Measured on a development database:
+     * 1190 cells compared, none changed.
+     *
+     * Seeding on update as well as install matters because access.xml can gain
+     * a section in any release, and a section with no asset is a permission
+     * the UI can offer but nothing can store.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function seedSectionAssets(): void
+    {
+        try {
+            $resolved = Cwmassets::seedSections();
+
+            Log::add("Resolved {$resolved} Proclaim section asset(s)", Log::INFO, 'com_proclaim');
+        } catch (\Throwable $e) {
+            // Nothing reads these yet, so a failure costs no behaviour today —
+            // and must not take down an otherwise successful install.
+            Log::add('Could not seed section assets: ' . $e->getMessage(), Log::WARNING, 'com_proclaim');
+        }
+    }
+
     private function dropRedundantStudyTopicIndex(): void
     {
         if (!$this->tableExists('#__bsms_studytopics')) {
@@ -1537,6 +1567,11 @@ class com_proclaimInstallerScript extends InstallerScript
         // The analytics aggregate key cannot be reworked in SQL at all; this is
         // where it is brought to its intended columns. No-op when already correct.
         $this->reconcileAnalyticsAggregateIndex();
+
+        // Seeded on update as well as install: access.xml can gain a section in
+        // any release, and a section with no asset is a permission the UI can
+        // offer but nothing can store.
+        $this->seedSectionAssets();
 
         // Install subExtensions
         $this->installSubExtensions($parent);

--- a/tests/integration/Admin/Lib/CwmassetsSectionTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsSectionTest.php
@@ -1,0 +1,317 @@
+<?php
+
+/**
+ * Phase 1 of #1653: section assets must be provably inert.
+ *
+ * `Cwmassets::seedSections()` writes 17 rows into #__assets on every install
+ * and update. The whole claim is that it changes no effective permission for
+ * anyone, because empty rules inherit from `com_proclaim` — which is exactly
+ * the answer the fallback produced when the section did not resolve.
+ *
+ * "Should be inert" is not a property to take on trust when the subject is
+ * ACL, so this measures it: every user group x every declared section x every
+ * action, before and after, asserting the answers are identical.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Access\Access;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Asset;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsSectionTest extends IntegrationTestCase
+{
+    /**
+     * Actions every non-component section declares.
+     *
+     * @var list<string>
+     * @since __DEPLOY_VERSION__
+     */
+    private const ACTIONS = ['core.create', 'core.delete', 'core.edit', 'core.edit.state', 'core.edit.own'];
+
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * Section asset ids created by the test, removed again in tearDown.
+     *
+     * @var list<int>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $created = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if (!Cwmassets::declaredSections()) {
+            $this->markTestSkipped('access.xml is not readable from this install path.');
+        }
+    }
+
+    /**
+     * Remove only what this test created.
+     *
+     * Deliberately NOT a transaction rollback. `Table\Asset::store()` takes a
+     * table lock, and a lock is an implicit COMMIT in MySQL — so a
+     * transaction-wrapped asset test leaks its rows into the database instead
+     * of rolling them back. Delete explicitly, by the ids captured on the way
+     * in, so a pre-existing section asset is never removed.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->created as $id) {
+            $asset = new Asset($this->db);
+
+            if ($asset->load($id)) {
+                $asset->delete();
+            }
+        }
+
+        $this->created = [];
+
+        // The rows are gone, so the memoised ids are stale. Without this the
+        // next test's seedSections() returns cached ids for deleted rows and
+        // creates nothing — which showed up as a test that ran no assertions
+        // rather than as a failure.
+        Cwmassets::clearSectionCache();
+        Access::clearStatics();
+
+        parent::tearDown();
+    }
+
+
+    /**
+     * Note which sections this test is responsible for cleaning up.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    private function rememberCreated(array $before): void
+    {
+        foreach (Cwmassets::declaredSections() as $section) {
+            if (isset($before[$section])) {
+                continue;
+            }
+
+            $asset = new Asset($this->db);
+
+            if ($asset->loadByName('com_proclaim.' . $section)) {
+                $this->created[] = (int) $asset->id;
+            }
+        }
+    }
+
+    /**
+     * Section assets that already exist, so tearDown leaves them alone.
+     *
+     * @return  array<string, int>
+     * @since __DEPLOY_VERSION__
+     */
+    private function existingSections(): array
+    {
+        $found = [];
+
+        foreach (Cwmassets::declaredSections() as $section) {
+            $asset = new Asset($this->db);
+
+            if ($asset->loadByName('com_proclaim.' . $section)) {
+                $found[$section] = (int) $asset->id;
+            }
+        }
+
+        return $found;
+    }
+
+    #[TestDox('every section answers exactly what the component answers')]
+    public function testSectionsAnswerTheSameAsTheComponent(): void
+    {
+        // Seed FIRST, then measure. A before/after comparison in one process
+        // cannot work here: Access::getAssetId() memoises name -> id in a
+        // function-level `static $loaded`, which clearStatics() does not reset
+        // (it clears the class properties only). Once a name has resolved to
+        // "no asset", that miss is cached for the rest of the process, so
+        // assets created afterwards are invisible and the "after" matrix is
+        // identical no matter what rules were written. Measuring only after
+        // creation sidesteps the cache entirely.
+        //
+        // The property is the same one a before/after would show. Inert means
+        // a section returns what the fallback returned, and the fallback
+        // returned the component's answer -- so assert exactly that.
+        $existing = $this->existingSections();
+
+        Cwmassets::seedSections();
+        $this->rememberCreated($existing);
+
+        Access::clearStatics();
+
+        $groups = $this->db->setQuery(
+            $this->db->createQuery()->select('id')->from($this->db->quoteName('#__usergroups'))
+        )->loadColumn();
+
+        $divergent = [];
+        $compared  = 0;
+
+        foreach ($groups as $groupId) {
+            foreach (self::ACTIONS as $action) {
+                $component = Access::checkGroup((int) $groupId, $action, 'com_proclaim');
+
+                foreach (Cwmassets::declaredSections() as $section) {
+                    $compared++;
+                    $section_ = Access::checkGroup((int) $groupId, $action, 'com_proclaim.' . $section);
+
+                    if ($section_ !== $component) {
+                        $divergent[$groupId . '|' . $section . '|' . $action] =
+                            var_export($component, true) . ' -> ' . var_export($section_, true);
+                    }
+                }
+            }
+        }
+
+        $this->assertGreaterThan(0, $compared, 'Nothing was compared — the assertion would be vacuous.');
+        $this->assertSame(
+            [],
+            $divergent,
+            "A section asset answered differently from com_proclaim.\n"
+            . 'Section assets must carry empty rules so they inherit; a non-empty rule set '
+            . 'here silently re-permissions every existing site on update.'
+        );
+    }
+
+    #[TestDox('section assets are created with empty rules')]
+    public function testSectionAssetsCarryEmptyRules(): void
+    {
+        $existing = $this->existingSections();
+
+        Cwmassets::seedSections();
+        $this->rememberCreated($existing);
+
+        foreach ($this->created as $id) {
+            $asset = new Asset($this->db);
+            $asset->load($id);
+
+            $this->assertSame(
+                '{}',
+                (string) $asset->rules,
+                "Section asset {$asset->name} was created with rules other than '{}'. "
+                . 'Empty rules are what make seeding inert.'
+            );
+        }
+    }
+
+    #[TestDox('every declared section resolves to an asset, and the nested set stays valid')]
+    public function testSeedingCreatesEveryDeclaredSection(): void
+    {
+        $existing = $this->existingSections();
+
+        Cwmassets::seedSections();
+        $this->rememberCreated($existing);
+
+        foreach (Cwmassets::declaredSections() as $section) {
+            $this->assertGreaterThan(
+                0,
+                Cwmassets::sectionId($section),
+                "No asset for declared section '{$section}'."
+            );
+        }
+
+        // A broken #__assets row is a known 404 cause, so assert the tree the
+        // writes ran through is still coherent rather than just present.
+        $invalid = (int) $this->db->setQuery(
+            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('lft') . ' >= ' . $this->db->quoteName('rgt')
+        )->loadResult();
+
+        $this->assertSame(0, $invalid, 'Nested set corrupted: rows exist where lft >= rgt.');
+
+        $duplicates = (int) $this->db->setQuery(
+            'SELECT COUNT(*) FROM (SELECT ' . $this->db->quoteName('lft')
+            . ' FROM ' . $this->db->quoteName('#__assets')
+            . ' GROUP BY ' . $this->db->quoteName('lft') . ' HAVING COUNT(*) > 1) d'
+        )->loadResult();
+
+        $this->assertSame(0, $duplicates, 'Nested set corrupted: duplicate lft values.');
+    }
+
+    #[TestDox('seeding twice creates nothing the second time')]
+    public function testSeedingIsIdempotent(): void
+    {
+        $existing = $this->existingSections();
+
+        Cwmassets::seedSections();
+        $this->rememberCreated($existing);
+
+        $countAfterFirst = $this->countSectionAssets();
+
+        Cwmassets::seedSections();
+
+        $this->assertSame(
+            $countAfterFirst,
+            $this->countSectionAssets(),
+            'A second seed added rows — seedSections() must find existing assets, not duplicate them.'
+        );
+    }
+
+    #[TestDox('an undeclared section is refused rather than minted')]
+    public function testUndeclaredSectionIsRefused(): void
+    {
+        $this->assertSame(
+            0,
+            Cwmassets::sectionId('definitely_not_a_section'),
+            'An undeclared section produced an asset. Permissions on it would govern nothing, '
+            . 'and the row would be invisible to the UI meant to manage it.'
+        );
+
+        $asset = new Asset($this->db);
+
+        $this->assertFalse(
+            $asset->loadByName('com_proclaim.definitely_not_a_section'),
+            'An asset row was written for an undeclared section.'
+        );
+    }
+
+    /**
+     * How many `com_proclaim.<section>` assets exist right now.
+     *
+     * @return  int
+     * @since __DEPLOY_VERSION__
+     */
+    private function countSectionAssets(): int
+    {
+        $names = [];
+
+        foreach (Cwmassets::declaredSections() as $section) {
+            $names[] = $this->db->quote('com_proclaim.' . $section);
+        }
+
+        return (int) $this->db->setQuery(
+            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('name') . ' IN (' . implode(',', $names) . ')'
+        )->loadResult();
+    }
+}


### PR DESCRIPTION
> **Draft, stacked on #1669.** Targets the phase 0 branch so the diff shows only phase 1. Hold both until the section work is proven end to end.

Phase 1 of #1653: create the `com_proclaim.<section>` assets, and prove they change nothing.

## What it adds

- `Cwmassets::sectionId(string $section): int` — find or create, empty rules
- `Cwmassets::seedSections(): int` — every section `access.xml` declares
- `Cwmassets::clearSectionCache(): void`
- seeded from the component postflight on install **and** update
- `CwmassetsSectionTest` — an integration test that measures the neutrality claim

## Proof it is inert

Prototyped against j6-dev, a site with real groups and a non-trivial rule set (Campus A Managers carries explicit denies):

```
cells compared: 1190   (14 groups x 17 sections x 5 actions)
cells changed:  0
```

Nested set after creating all 17: `com_proclaim` `rgt` moved 1100 → 1134 — exactly +34, or 17 × 2 — with no rows where `lft >= rgt` and no duplicate `lft`. `Table\Asset::setLocation()`/`store()` kept the tree correct without a `rebuild()` pass. j6-dev was snapshotted and fully restored afterwards: 3 rows before, 3 after, nothing added or lost.

The reason it is inert is the empty rule set: `{}` inherits from `com_proclaim`, which is exactly the answer the fallback produced when the section did not resolve.

## Two things found while building the test

**`Access::getAssetId()` memoises misses for the whole process.** It keeps a function-level `static $loaded = []` (`Access.php:664`) that `clearStatics()` does **not** reset — `clearStatics()` clears the class properties only. Once a name resolves to "no asset", that miss is cached, so assets created later in the same process are invisible.

That makes a before/after matrix impossible inside one PHP process: the "after" pass returns the "before" answers no matter what rules were written. My first version of this test did exactly that and **passed under a mutation that denied `core.edit` to Managers** — a green test proving nothing. The j6-dev prototype avoided the trap only because each phase ran as a separate process.

The test now asserts the property directly instead: **every section answers exactly what `com_proclaim` answers**. That is what inert means, all lookups happen after creation, and no cache can hide it.

**The static id cache needed invalidation.** `Cwmassets` also *removes* asset rows (`fixAllAssets()`, `cleanOrphanedAssets()`, `pruneEmptyAssetRows()`), after which a memoised id points at a deleted row and `seedSections()` reports success having created nothing. This surfaced as a test that ran **zero assertions** rather than as a failure. `clearSectionCache()` fixes it, and it is a real bug in the repair paths, not only test scaffolding.

## Mutation-validated

| mutation | result |
|---|---|
| section assets get `{"core.edit":{"6":0}}` | **both** assertions fail — equivalence and empty-rules |
| unchanged | 10 tests, 59 assertions, OK |

The test also asserts the nested set stays valid, that seeding twice adds nothing, and that an undeclared section is refused rather than minted.

## ⚠️ This changes no behaviour, and cannot yet

There are currently **116** `authorise()` calls against bare `com_proclaim` and **zero** against `com_proclaim.<section>`. Until entity-scoped call sites ask the section question — the phase 1.5 proposed on #1653 — these 17 assets are consulted by nothing.

That is deliberate for this PR. It is also the reason not to ship phase 2's UI on top of this alone: an administrator would set permissions that govern nothing.

## Verification

```
composer test:unit                     1399 tests, 2995 assertions — OK
integration Helper + Lib + Table       365 tests, 3664 assertions — OK
php-cs-fixer                           0 of 1 fixable, all three files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
