### PR TITLE
fix: unregister the package's own consumers on uninstall (#1662)

### DIFF
--- a/build/script.install.php
+++ b/build/script.install.php
@@ -298,20 +298,43 @@ return new class () implements InstallerScriptInterface {
             }
 
             // Everything this package removes; anything left is someone else's.
-            $remaining = ConsumerRegistry::installedExcluding([
+            $members = [
                 ['element' => 'com_proclaim',   'type' => 'component', 'folder' => ''],
                 ['element' => 'scripturelinks', 'type' => 'plugin',    'folder' => 'content'],
-            ]);
+            ];
+
+            $remaining = ConsumerRegistry::installedExcluding($members);
 
             if ($remaining !== []) {
+                // Another consumer keeps the tables — so the registry survives
+                // too, still naming the two extensions this uninstall is about
+                // to take away. installedExcluding() does prune stale rows, but
+                // it runs here, and InstallerAdapter::uninstall() calls the
+                // manifest script BEFORE removeExtensionFiles(): the children
+                // are still installed at this moment, so it correctly leaves
+                // them alone. Nothing runs afterwards to reconsider.
+                //
+                // Left behind, a reinstall inherits a registry describing the
+                // previous installation, and anything reading the table
+                // directly rather than through installedExcluding() sees
+                // extensions that do not exist. That is what sent
+                // lib_cwmscripture#37 down the wrong path to begin with.
+                foreach ($members as $member) {
+                    ConsumerRegistry::unregister($member['element'], $member['type'], $member['folder']);
+                }
+
                 Log::add(
-                    'pkg_proclaim: scripture tables still used by ' . implode(', ', $remaining) . ' — keeping them.',
+                    'pkg_proclaim: scripture tables still used by ' . implode(', ', $remaining)
+                    . ' — keeping them, and unregistered this package\'s own consumers.',
                     Log::INFO,
                     'jerror'
                 );
 
                 return;
             }
+
+            // The other branch needs no pruning: the consumers table itself is
+            // among the tables dropped below.
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
 

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -175,6 +175,9 @@ php build/verify-scripture-uninstall.php seed-translation
 PKGID="$(php build/verify-scripture-uninstall.php ext-id package pkg_proclaim | tail -n1)"
 php "$JCLI" extension:remove -n "$PKGID" || true
 php build/verify-scripture-uninstall.php assert-tables-present
+# Only meaningful in this phase: the registry survives here because the tables
+# were kept, so it is the one place a stale row can outlive its extension (#1662).
+php build/verify-scripture-uninstall.php assert-registry-pruned
 
 echo "-- [13/16] STILL NEEDED: an UNregistered consumer keeps the tables (detection, not registration)"
 "$BIN/cwm-install-zip" --zip "$NEWZIP"

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -58,6 +58,7 @@ $modes = [
     'assert-detected-consumer',
     'seed-detected-consumer',
     'assert-tables-present',
+    'assert-registry-pruned',
     'assert-tables-gone',
     'assert-no-other-consumer',
     'other-consumer-ids',
@@ -492,6 +493,47 @@ foreach ($installs as $install) {
 
             echo '  OK   seeded ' . PROBE_ROWS . ' probe verses and '
                 . PROBE_CACHE_ROWS . " provider cache rows\n";
+
+            break;
+
+        case 'assert-registry-pruned':
+            // After a package removal that KEPT the tables (another consumer
+            // still needs them), the registry must no longer name the two
+            // extensions this package just took away.
+            //
+            // installedExcluding() prunes stale rows, but it runs from the
+            // manifest script — which InstallerAdapter::uninstall() calls
+            // BEFORE removeExtensionFiles(). At that moment the children are
+            // still installed, so it correctly leaves them alone, and nothing
+            // runs afterwards. Hence the explicit unregister this asserts.
+            $consumers = $prefix . 'bsms_scripture_consumers';
+
+            if (!$tableExists($db, $consumers)) {
+                fwrite(STDERR, "  FAIL {$consumers} is missing — this phase expects the tables to have been KEPT.\n");
+                $failures++;
+
+                break;
+            }
+
+            foreach ([['com_proclaim', 'component'], ['scripturelinks', 'plugin']] as [$element, $type]) {
+                $row = mysqli_fetch_row(mysqli_query(
+                    $db,
+                    "SELECT COUNT(*) FROM `{$consumers}` WHERE `element` = '"
+                    . mysqli_real_escape_string($db, $element) . "' AND `type` = '"
+                    . mysqli_real_escape_string($db, $type) . "'"
+                ) ?: null);
+
+                $left = ($row === null || $row === false) ? 0 : (int) $row[0];
+
+                if ($left === 0) {
+                    echo "  OK   registry no longer names {$element} ({$type})\n";
+                } else {
+                    fwrite(STDERR, "  FAIL registry still names {$element} ({$type}) after its removal.\n");
+                    fwrite(STDERR, "       A reinstall would inherit a registry describing the previous install,\n");
+                    fwrite(STDERR, "       and anything reading the table directly sees extensions that do not exist.\n");
+                    $failures++;
+                }
+            }
 
             break;
 


### PR DESCRIPTION
Closes #1662.

After `pkg_proclaim` is removed, `#__bsms_scripture_consumers` still listed `com_proclaim` and `scripturelinks` — extensions that no longer exist anywhere.

## The fix

`dropScriptureTablesIfLastConsumer()` already names both members for its exclusion list, so it now unregisters them explicitly — option 2 from the issue.

**Only in the branch where the tables are kept.** When no other consumer remains, the consumers table is itself among the tables dropped, so there is nothing left to be stale. That narrows the bug: it can only ever bite when a *third party* keeps the tables alive, which is exactly the scenario upgrade phase 12 constructs.

## One correction to the issue

The issue records the effect as low and self-healing — *"`installedExcluding()` prunes them the next time it runs"*. **That is not the case for these two.**

Both are in `ConsumerRegistry::FIRST_PARTY`, and the pruning branch skips first-party rows:

```php
if (!self::isInstalled($db, $consumer)) {
    if (!\in_array($consumer, self::FIRST_PARTY, true)) {
        self::unregister(...);
    }
    continue;
}
```

So nothing was going to collect them later. The rows were permanent, not transient — which raises the value of fixing it, since the consequences the issue lists (a reinstall inheriting a registry describing the previous installation, and direct readers seeing extensions that do not exist) would have persisted indefinitely.

## Guarded

New `assert-registry-pruned` probe in `verify-scripture-uninstall.php`, wired into upgrade **phase 12** — the one phase where the tables survive and a stale row can therefore outlive its extension. It asserts the registry no longer names either member, and explains the consequence when it fails.

## Mutation-tested

Rather than trusting a green run on a fix and its test written together, I removed the fix first and confirmed the assertion fails — reproducing the reported symptom exactly:

```
=== scripture uninstall probe (assert-registry-pruned) on j6-test ===
  FAIL registry still names com_proclaim (component) after its removal.
       A reinstall would inherit a registry describing the previous install,
       and anything reading the table directly sees extensions that do not exist.
  FAIL registry still names scripturelinks (plugin) after its removal.
```

With the fix restored, the full upgrade gate passes:

```
UPGRADE TEST PASSED 10.5.6 -> 10.5.7.
```

(16/16 phases, including the migration re-verification that a 10.5.7 install still carries everything 10.5.6 introduced.)

`php-cs-fixer` clean on both changed PHP files; `bash -n` clean on the shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
