### PR TITLE
fix: let com_proclaim actually remove its own modules and plugins (#1676)

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -762,6 +762,9 @@ class com_proclaimInstallerScript extends InstallerScript
         // Clean up post-install messages
         $this->cleanupPostInstallMessages();
 
+        // Clean up the action log registration
+        $this->cleanupActionLogConfig();
+
         // We no longer depend on lib_cwmscripture — stop blocking its removal
         $this->scriptureConsumer('unregister');
 
@@ -769,6 +772,43 @@ class com_proclaimInstallerScript extends InstallerScript
         $this->renderPostUninstallation($this->status, $parent);
 
         return true;
+    }
+
+    /**
+     * Remove Proclaim's rows from Joomla's action-log tables.
+     *
+     * `install.mysql.utf8.sql` seeds `#__action_log_config` with one row per
+     * loggable entity, and `10.1.0-20260207.sql` adds to it, but nothing has
+     * ever taken them out again — five rows survived every uninstall (#1676).
+     *
+     * Deliberately not part of `dropTablesIfRequested()`. That is gated on the
+     * administrator's `drop_tables` setting because it destroys sermons; these
+     * rows are Joomla's own configuration describing an extension that no longer
+     * exists, so they should always go. Leaving them makes com_actionlogs offer
+     * filters for a component that is not installed.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function cleanupActionLogConfig(): void
+    {
+        foreach (['#__action_log_config' => 'type_alias', '#__action_logs_extensions' => 'extension'] as $table => $column) {
+            try {
+                $query = $this->dbo->getQuery(true)
+                    ->delete($this->dbo->quoteName($table))
+                    ->where($this->dbo->quoteName($column) . ' LIKE ' . $this->dbo->quote('com_proclaim%'));
+
+                $this->dbo->setQuery($query)->execute();
+            } catch (\Throwable $e) {
+                // Housekeeping only — never fail an uninstall over it.
+                Log::add(
+                    'com_proclaim: could not clean ' . $table . ': ' . $e->getMessage(),
+                    Log::WARNING,
+                    'com_proclaim'
+                );
+            }
+        }
     }
 
     /**
@@ -1152,7 +1192,21 @@ class com_proclaimInstallerScript extends InstallerScript
             if ($id) {
                 $installer = new Installer();
                 $installer->setDatabase($this->dbo);
-                $result = $installer->uninstall('module', $id, 1);
+
+                // pkg_proclaim declares <blockChildUninstall>, which makes
+                // Access's guard refuse any removal of a package child that is
+                // not itself part of a package teardown:
+                //
+                //   package_id && !isPackageUninstall() && !canUninstallPackageChild()
+                //
+                // That protection is for administrators picking off a single
+                // module; this IS the teardown, so say so. Without it every call
+                // here returned false with
+                // JLIB_INSTALLER_ERROR_CANNOT_UNINSTALL_CHILD_OF_PACKAGE and the
+                // rows leaked (#1676).
+                $installer->setPackageUninstall(true);
+
+                $result = $installer->uninstall('module', $id);
 
                 $this->status->modules[] = [
                     'name'   => $element,
@@ -1180,7 +1234,11 @@ class com_proclaimInstallerScript extends InstallerScript
             if ($id) {
                 $installer = new Installer();
                 $installer->setDatabase($this->dbo);
-                $result = $installer->uninstall('plugin', $id, 1);
+
+                // See uninstallModules() — same guard, same reason (#1676).
+                $installer->setPackageUninstall(true);
+
+                $result = $installer->uninstall('plugin', $id);
 
                 $this->status->plugins[] = [
                     'name'   => 'plg_' . $plugin,


### PR DESCRIPTION
Closes #1676. Uninstalling Proclaim left **nine** extension rows behind — four modules and five plugins — plus four positioned module instances, their menu assignments, five action-log config rows, and most of the files on disk.

## The cause

The code was running correctly the whole time. Instrumenting a real uninstall showed `uninstallSubExtensions()` reached, the queue fully populated, `$this->dbo` set, every id found — and `Installer::uninstall()` returning `false` for all nine.

Attaching a callback logger to the `jerror` category named it:

```
JLIB_INSTALLER_ERROR_CANNOT_UNINSTALL_CHILD_OF_PACKAGE
```

`pkg_proclaim.xml` has declared `<blockChildUninstall>true</blockChildUninstall>` since 10.3.0, so `canUninstallPackageChild()` returns `false` and this guard fires:

```php
if ($this->extension->package_id && !$this->parent->isPackageUninstall() && !$this->canUninstallPackageChild(...)) {
```

The component removes its sub-extensions through its own `new Installer()`, which never sets the package-uninstall flag. So Joomla saw a third party trying to pick off a package child and refused — every time, **silently**, because `jerror` has no logger under CLI.

That last detail is why this survived: the failure produced no output anywhere.

## The fix

`setPackageUninstall(true)` on both call sites. That is exactly what `PackageAdapter::removeExtensionFiles()` does before removing its own children, and it is true here — this *is* the teardown.

The protection `<blockChildUninstall>` exists for stays intact: an administrator still cannot remove `mod_proclaim` on its own.

Two things came out of the same investigation:

- **The hardcoded third argument was dead.** `Installer::uninstall($type, $identifier)` takes two parameters in Joomla 5, so the client id of `1` had been silently discarded — which is why admin and site modules failed identically despite it.
- **`#__action_log_config` was never cleaned.** `install.mysql.utf8.sql` seeds it and nothing removed the rows. `cleanupActionLogConfig()` now does, unconditionally — that is Joomla's own configuration describing an extension that no longer exists, not user data, so it does not belong behind the `drop_tables` opt-in. Leaving it made com_actionlogs offer filters for a component that is not installed.

## Measured on j6-test

Install, then uninstall:

| | before | after |
|---|---|---|
| extension rows | 9 | **0** |
| module instances | 4 | **0** |
| menu assignments | 4 | **0** |
| `action_log_config` | 5 | **0** |
| `action_logs_extensions` | — | **0** |
| files on disk | 6 of 9 dirs left | **all removed** |
| **`bsms_` data tables** | 28 | **retained** |

That last row is the one that must not change. Proclaim's own tables stay unless the administrator has set `drop_tables` — a cleanup that took someone's sermons with it would be worse than the leak.

## Not CLI-specific

Worth recording, because it was the obvious hypothesis: com_installer's `ManageModel::remove()` and the console command both call `$installer->uninstall($row->type, $id)`. Same method, same arguments — the admin UI leaked identically. This affected real users, not just the test harness.

## Verification

```
UPGRADE TEST PASSED 10.5.6 -> 10.5.7.
composer test:unit — 1396 tests, 2990 assertions, OK
php-cs-fixer — clean
```

## Follow-up

This unblocks re-enabling `assert-registry-pruned` at gate step 11 in #1677: `com_proclaim`'s own `scriptureConsumer('unregister')` sits behind the same call and now runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
