### PR TITLE
fix: stop postflight running install work during an uninstall (#1679)

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -173,23 +173,14 @@ fi
 
 php build/verify-scripture-uninstall.php assert-library-present
 php build/verify-scripture-uninstall.php assert-tables-present
-# NOT asserted yet — and not for the reason first assumed.
+# com_proclaim's own uninstall unregisters it, and that now sticks: postflight
+# was re-registering it immediately afterwards, because Joomla calls postflight
+# on uninstall too and every install-time step in it ran unguarded (#1679).
 #
-# #1676 fixed the guard that was refusing sub-extension removal, so
-# com_proclaim's uninstall now reaches scriptureConsumer('unregister'), and
-# probing a real removal shows it SUCCEEDS:
-#
-#   SC: called action=unregister ... unregister returned true
-#   SC: called action=register            <- immediately afterwards
-#
-# Something calls scriptureConsumer('register') after the unregister, putting
-# the row straight back. The only caller is com_proclaim's postflight
-# (proclaim.script.php:1419), which should not run during an uninstall at all.
-# Adding a $type !== 'uninstall' guard to THIS package's preflight did not stop
-# it, so the re-registration comes from the component side.
-#
-# Tracked separately rather than worked around here. Re-enable once fixed.
-# php build/verify-scripture-uninstall.php assert-registry-pruned
+# The registry outlives every Proclaim uninstall now that the scripture stack is
+# not removed with it, so a stale row would persist rather than vanish with the
+# dropped table (#1662).
+php build/verify-scripture-uninstall.php assert-registry-pruned
 
 echo "-- [12/16] STILL NEEDED: a registered consumer blocks a STANDALONE library uninstall"
 # Repointed at the standalone path (#1675). The consumer guard used to be

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1391,6 +1391,29 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     public function postflight(string $type, ComponentAdapter $parent): void
     {
+        // Joomla calls postflight on UNINSTALL too — InstallerAdapter::uninstall()
+        // runs triggerManifestScript('postflight') after removing the extension
+        // (InstallerAdapter.php:1249). Everything below this guard is install-time
+        // work, and it was all running on the way out:
+        //
+        //   - installSubExtensions() reinstalling the modules and plugins that
+        //     uninstallSubExtensions() had just removed
+        //   - renderPostInstallation() showing the "installation complete" page
+        //   - scriptureConsumer('register') putting the consumer row straight
+        //     back after uninstall() had removed it (#1679)
+        //
+        // Most of it failed quietly because removeExtensionFiles() has already
+        // taken the source away by then, which is why only the row — a plain DB
+        // write needing no files — survived visibly. lib_cwmscripture's own
+        // script has carried this guard from the start; the component never did.
+        //
+        // Caches are still cleared below: that is worth doing on the way out.
+        if ($type === 'uninstall') {
+            $this->clearCaches();
+
+            return;
+        }
+
         // Rename old folders before deletion (must happen before removeFiles is called)
         if ($type === 'update') {
             $this->renameLegacyFolders();
@@ -1398,9 +1421,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
         // After the migration SQL has added uq_study_topic, retire the index it
         // replaces. No-op on a fresh install, where install.sql never creates it.
-        if ($type !== 'uninstall') {
-            $this->dropRedundantStudyTopicIndex();
-        }
+        $this->dropRedundantStudyTopicIndex();
 
         // Install subExtensions
         $this->installSubExtensions($parent);


### PR DESCRIPTION
Closes #1679 — and the root cause turned out to be considerably larger than the symptom.

## The symptom

`com_proclaim`'s row in `#__bsms_scripture_consumers` survived every uninstall. Its own `uninstall()` unregisters it, and probing showed that call **succeeding** — then something put the row straight back in the same request.

## The cause

A backtrace named it. **Joomla calls postflight on uninstall too:**

```
InstallerAdapter->uninstall              Installer.php:920
InstallerAdapter->triggerManifestScript  InstallerAdapter.php:1249
LegacyInstallerScript->postflight        InstallerAdapter.php:1073
```

`com_proclaim`'s postflight had no `$type` guard, so **every install-time step ran on the way out**:

| | |
|---|---|
| `installSubExtensions()` | reinstalling the modules and plugins `uninstallSubExtensions()` had just removed |
| `copyLanguageFiles()` | |
| `renderPostInstallation()` | the "installation complete" page — on an uninstall |
| `removeBibleStudyVersion()` | |
| `scriptureConsumer('register')` | putting the registry row back |

Most failed quietly because `removeExtensionFiles()` has already taken the component's source away by that point. That is why only the registry row surfaced — a plain DB write needing no files. **The steps that were failing silently are the more alarming half:** had the source still been present, an uninstall would have reinstalled the extensions it was removing.

`lib_cwmscripture`'s own script has carried this guard from the start (`if ($type === 'uninstall') { return true; }`). The component never did.

## The fix

postflight clears caches and returns on uninstall. Cache clearing is kept deliberately — worth doing on the way out.

The separate `if ($type !== 'uninstall')` around `dropRedundantStudyTopicIndex()` is folded into the new guard rather than left as a second check for the same condition.

## Verified

`assert-registry-pruned` is **re-enabled** at upgrade-gate step 11 and passes:

```
=== scripture uninstall probe (assert-registry-pruned) on j6-test ===
  OK   registry no longer names com_proclaim (component)
```

After a real package removal:

```
proclaim ext rows      : 0
module instances       : 0
action_log_config      : 0
consumer registry rows : cwmscripture, scripturelinks   <- both still installed, both correct
scripture kept         : library present, bible tables present
```

```
UPGRADE TEST PASSED 10.5.6 -> 10.5.7.
CLEAN-INSTALL TEST PASSED for 10.5.7.
composer test:unit — 1396 tests, 2990 assertions, OK
```

## Note

This retires the last commented-out assertion left by #1677. It also completes the uninstall work started in #1662 and #1676: a Proclaim removal now leaves behind nothing of its own, and everything of the scripture stack's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
