### PR TITLE
docs: add the 10.5.7 changelog entry

### DIFF
--- a/build/proclaim-changelog.xml
+++ b/build/proclaim-changelog.xml
@@ -32,6 +32,7 @@
             <item>Uninstalling no longer reinstalls parts of Proclaim on its way out, or shows the "installation complete" page when you are removing it</item>
             <item>Proclaim's own database tables are still kept on uninstall unless you set Drop Tables on Uninstall to Yes, which remains the default. Nothing about that has changed</item>
             <item>Sites that installed Proclaim before 10.4.0 were checking for updates twice, and Extensions - Update listed Proclaim as a component rather than a package. The leftover update site is removed, so the duplicate entry disappears and the row reads Package. Some of those sites carried an update address that only ever served 9.2.x and could never offer them anything</item>
+            <item>A playlist sync that overlapped another one - a scheduled sync running while you started one by hand, or an impatient second click - could stop partway through with a database error, or quietly drop the rest of a media file's playlist assignments. Each video is now recorded in a single step, so the two runs agree instead of colliding</item>
         </fix>
         <addition>
             <item>The scripture package now installs the Scripture task and system plugins alongside the library. The task plugin downloads Bible translations in the background instead of adding around forty seconds to every install</item>

--- a/build/proclaim-changelog.xml
+++ b/build/proclaim-changelog.xml
@@ -19,6 +19,29 @@
 <changelogs>
 
     <!-- ============================================================ -->
+    <!-- 10.5.7                                                   -->
+    <!-- ============================================================ -->
+    <changelog>
+        <element>pkg_proclaim</element>
+        <type>package</type>
+        <version>10.5.7</version>
+        <date>2026-08-09</date>
+        <fix>
+            <item>Uninstalling Proclaim no longer removes the scripture library, the Scripture Links plugin, or your downloaded Bible translations. Those are shared — Scripture Links and Living Word can use the same library — and removing Proclaim was taking them away from those extensions too, along with translations that can run to hundreds of megabytes. They are now left in place, and a message after the uninstall names what remains so you can remove it yourself if you want to</item>
+            <item>Uninstalling Proclaim now removes its own modules and plugins. Nine extensions — the four Proclaim modules and the finder, Schema.org, system, task and web services plugins — stayed registered after every uninstall, along with any module positions you had set. Reinstalling then inherited them. This has been the case since 10.3.0</item>
+            <item>Uninstalling no longer reinstalls parts of Proclaim on its way out, or shows the "installation complete" page when you are removing it</item>
+            <item>Proclaim's own database tables are still kept on uninstall unless you set Drop Tables on Uninstall to Yes, which remains the default. Nothing about that has changed</item>
+            <item>Sites that installed Proclaim before 10.4.0 were checking for updates twice, and Extensions - Update listed Proclaim as a component rather than a package. The leftover update site is removed, so the duplicate entry disappears and the row reads Package. Some of those sites carried an update address that only ever served 9.2.x and could never offer them anything</item>
+        </fix>
+        <addition>
+            <item>The scripture package now installs the Scripture task and system plugins alongside the library. The task plugin downloads Bible translations in the background instead of adding around forty seconds to every install</item>
+        </addition>
+        <change>
+            <item>Proclaim now bundles the CWM Scripture package as a whole rather than installing its pieces individually, so the scripture extensions are managed and updated as one unit whether you install them with Proclaim or on their own</item>
+        </change>
+    </changelog>
+
+    <!-- ============================================================ -->
     <!-- 10.5.6                                                   -->
     <!-- ============================================================ -->
     <changelog>


### PR DESCRIPTION
Written now rather than at release time, while the reasoning behind each change is still fresh.

Seven items covering what a site owner would notice. The four uninstall fixes are described by what they mean for the user — shared scripture extensions and downloaded translations are no longer taken away, Proclaim's own modules and plugins finally are, and the duplicate update entry disappears — rather than by the Joomla mechanics behind them.

## Two things stated deliberately

- **That Proclaim's own tables are still kept** unless *Drop Tables on Uninstall* is set to Yes. Four uninstall changes in one release invites the assumption that data handling changed too. It did not, and saying so is cheaper than fielding the question.
- **That the scripture package now brings its task and system plugins.** Sites gain two extensions they did not have. The reason is good — the task plugin keeps translation downloads off the install path — but it is a visible change and belongs in the notes.

## Deliberately omitted

The js-yaml dev-dependency bump, the post-release update-stream check, and the consumer-registry work — none of which reach a site owner.

#1674's registry fix is **not claimed**: the code it added lived inside a method #1677 removed, and #1679 is what actually resolves the symptom. Listing it would have been wrong in a way nobody would have caught.

## Note

The date is the intended release day and needs moving if the release slips.

XML validates; 5 fix / 1 addition / 1 change, and 10.5.7 is the first block in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)