### PR TITLE
fix: close the playlist junction upsert race (#1658)

### DIFF
--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -1207,6 +1207,16 @@ final class CwmplaylistSyncHelper
      * the platform — it is left in place with its source preserved and only its
      * mediafile_id ensured; otherwise a new source='manual' row is inserted.
      *
+     * One statement, on the same unique key upsertItem() relies on, so a media save
+     * racing a playlist sync updates the row the sync just created rather than
+     * failing on it. Failing here is silent — the caller swallows exceptions so
+     * bookkeeping can never break a media save — which would have dropped the
+     * remaining assignments in the same run without a trace.
+     *
+     * Only mediafile_id and source are updated: title and position belong to the
+     * platform's own ordering, and blanking a title a later sync backfilled is
+     * exactly what an existing row must be protected from.
+     *
      * @param   DatabaseInterface  $db           Database driver.
      * @param   int            $playlistId   Playlist row ID.
      * @param   string             $videoId      Remote video ID (junction key).
@@ -1219,46 +1229,35 @@ final class CwmplaylistSyncHelper
      */
     private static function upsertManualItem(DatabaseInterface $db, int $playlistId, string $videoId, int $mediafileId, string $now): void
     {
-        $existingId = (int) ($db->setQuery(
-            $db->createQuery()
-                ->select($db->quoteName('id'))
-                ->from($db->quoteName('#__bsms_playlist_items'))
-                ->where($db->quoteName('playlist_id') . ' = :pid')
-                ->where($db->quoteName('remote_video_id') . ' = :vid')
-                ->bind(':pid', $playlistId, \Joomla\Database\ParameterType::INTEGER)
-                ->bind(':vid', $videoId, \Joomla\Database\ParameterType::STRING)
-        )->loadResult() ?? 0);
-
-        if ($existingId > 0) {
-            // Already a member (imported or manual): ensure it links here. If it was
-            // queued for removal, re-selecting it cancels that — it is confirmed on
-            // the platform, so restore it to 'remote'.
-            $query = $db->createQuery()
-                ->update($db->quoteName('#__bsms_playlist_items'))
-                ->set($db->quoteName('mediafile_id') . ' = :mid')
-                ->set(
-                    $db->quoteName('source') . ' = CASE WHEN ' . $db->quoteName('source')
-                    . ' = ' . $db->quote('remove_pending') . ' THEN ' . $db->quote('remote')
-                    . ' ELSE ' . $db->quoteName('source') . ' END'
-                )
-                ->where($db->quoteName('id') . ' = :rid')
-                ->bind(':mid', $mediafileId, \Joomla\Database\ParameterType::INTEGER)
-                ->bind(':rid', $existingId, \Joomla\Database\ParameterType::INTEGER);
-
-            $db->setQuery($query)->execute();
-
+        // See upsertItem(): an empty ID is a shared key, not an absent one.
+        if ($videoId === '') {
             return;
         }
 
-        $db->insertObject('#__bsms_playlist_items', (object) [
-            'playlist_id'     => $playlistId,
-            'mediafile_id'    => $mediafileId,
-            'remote_video_id' => $videoId,
-            'title'           => '',
-            'position'        => 0,
-            'source'          => 'manual',
-            'created'         => $now,
-        ]);
+        // In ON DUPLICATE KEY UPDATE an unqualified column reads the stored row, so
+        // the CASE still sees the source the row arrived with: re-selecting a video
+        // queued for removal cancels that — it is confirmed on the platform, so it
+        // goes back to 'remote' — and any other source is preserved.
+        $query = $db->createQuery()
+            ->setQuery(
+                'INSERT INTO ' . $db->quoteName('#__bsms_playlist_items')
+                . ' (' . implode(', ', $db->quoteName(
+                    ['playlist_id', 'mediafile_id', 'remote_video_id', 'title', 'position', 'source', 'created']
+                )) . ')'
+                . ' VALUES (:pid, :mid, :vid, ' . $db->quote('') . ', 0, ' . $db->quote('manual') . ', :created)'
+                . ' ON DUPLICATE KEY UPDATE '
+                . $db->quoteName('mediafile_id') . ' = :midNew, '
+                . $db->quoteName('source') . ' = CASE WHEN ' . $db->quoteName('source')
+                . ' = ' . $db->quote('remove_pending') . ' THEN ' . $db->quote('remote')
+                . ' ELSE ' . $db->quoteName('source') . ' END'
+            )
+            ->bind(':pid', $playlistId, ParameterType::INTEGER)
+            ->bind(':mid', $mediafileId, ParameterType::INTEGER)
+            ->bind(':vid', $videoId)
+            ->bind(':created', $now)
+            ->bind(':midNew', $mediafileId, ParameterType::INTEGER);
+
+        $db->setQuery($query)->execute();
     }
 
     /**
@@ -1463,6 +1462,22 @@ final class CwmplaylistSyncHelper
     /**
      * Insert or update a junction row for a playlist/video pair.
      *
+     * A single statement, so there is no window between deciding the row is absent
+     * and inserting it: two concurrent syncs of the same playlist — a scheduled run
+     * overlapping a manual one — both land on the update branch instead of the
+     * second raising a duplicate-key error that aborts the whole run.
+     *
+     * Correctness rests on `idx_playlist_video`, the unique key over
+     * (playlist_id, remote_video_id). That index is declared inside a CREATE TABLE,
+     * and Joomla's schema checker reduces CREATE TABLE to `SHOW TABLES LIKE`, so
+     * System → Database can neither report nor restore it if a site loses it —
+     * `build/verify-migrations.php` asserts it at release time instead.
+     *
+     * The update list is deliberately narrower than the insert list: `created` keeps
+     * the original timestamp, and `source` is left to upsertManualItem(). Passing a
+     * null $mediafileId leaves an existing link in place rather than clearing it,
+     * matching updateObject()'s null-skipping default that this replaces.
+     *
      * @param   DatabaseInterface  $db           Database driver.
      * @param   int            $playlistId   Playlist row ID.
      * @param   string             $videoId      YouTube video ID.
@@ -1477,33 +1492,39 @@ final class CwmplaylistSyncHelper
      */
     private static function upsertItem(DatabaseInterface $db, int $playlistId, string $videoId, string $title, ?int $mediafileId, int $position, string $now): void
     {
-        $existingId = (int) ($db->setQuery(
-            $db->createQuery()
-                ->select($db->quoteName('id'))
-                ->from($db->quoteName('#__bsms_playlist_items'))
-                ->where($db->quoteName('playlist_id') . ' = :pid')
-                ->where($db->quoteName('remote_video_id') . ' = :vid')
-                ->bind(':pid', $playlistId, \Joomla\Database\ParameterType::INTEGER)
-                ->bind(':vid', $videoId, \Joomla\Database\ParameterType::STRING)
-        )->loadResult() ?? 0);
-
-        $item = (object) [
-            'playlist_id'     => $playlistId,
-            'mediafile_id'    => $mediafileId,
-            'remote_video_id' => $videoId,
-            'title'           => $title,
-            'position'        => $position,
-        ];
-
-        if ($existingId > 0) {
-            $item->id = $existingId;
-            $db->updateObject('#__bsms_playlist_items', $item, 'id');
-
+        // Only one row per playlist may carry an empty remote_video_id, so an empty
+        // ID would merge unrelated videos into a single row rather than error.
+        if ($videoId === '') {
             return;
         }
 
-        $item->created = $now;
-        $db->insertObject('#__bsms_playlist_items', $item);
+        $mediafileType = $mediafileId === null ? ParameterType::NULL : ParameterType::INTEGER;
+
+        // Each reused value needs its own placeholder: a named parameter may not
+        // appear twice in one prepared statement.
+        $query = $db->createQuery()
+            ->setQuery(
+                'INSERT INTO ' . $db->quoteName('#__bsms_playlist_items')
+                . ' (' . implode(', ', $db->quoteName(
+                    ['playlist_id', 'mediafile_id', 'remote_video_id', 'title', 'position', 'created']
+                )) . ')'
+                . ' VALUES (:pid, :mid, :vid, :title, :pos, :created)'
+                . ' ON DUPLICATE KEY UPDATE '
+                . $db->quoteName('mediafile_id') . ' = COALESCE(:midKeep, ' . $db->quoteName('mediafile_id') . '), '
+                . $db->quoteName('title') . ' = :titleNew, '
+                . $db->quoteName('position') . ' = :posNew'
+            )
+            ->bind(':pid', $playlistId, ParameterType::INTEGER)
+            ->bind(':mid', $mediafileId, $mediafileType)
+            ->bind(':vid', $videoId)
+            ->bind(':title', $title)
+            ->bind(':pos', $position, ParameterType::INTEGER)
+            ->bind(':created', $now)
+            ->bind(':midKeep', $mediafileId, $mediafileType)
+            ->bind(':titleNew', $title)
+            ->bind(':posNew', $position, ParameterType::INTEGER);
+
+        $db->setQuery($query)->execute();
     }
 
     /**

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -71,6 +71,12 @@ $EXPECTATIONS = [
         ],
         'indexes' => [
             '#__bsms_studies' => ['idx_transcript'],
+            // Declared inside the CREATE TABLE, which MysqlChangeItem reduces to
+            // SHOW TABLES LIKE — so System → Database cannot see this index, let
+            // alone restore it. CwmplaylistSyncHelper's upserts depend on it
+            // firing (#1658); without it they silently duplicate rows instead of
+            // updating them. This gate is the only thing that checks.
+            '#__bsms_playlist_items' => ['idx_playlist_video'],
         ],
         'schemaMin' => '10.3.3',
     ],

--- a/tests/integration/Admin/Helper/CwmplaylistUpsertTest.php
+++ b/tests/integration/Admin/Helper/CwmplaylistUpsertTest.php
@@ -1,0 +1,476 @@
+<?php
+
+/**
+ * Integration tests for CwmplaylistSyncHelper's junction-row upserts
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
+use CWM\Component\Proclaim\Administrator\Helper\CwmplaylistSyncHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Input\Input;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Pins what an upsert onto an existing #__bsms_playlist_items row must and must
+ * not overwrite (#1658).
+ *
+ * Both writers became single INSERT … ON DUPLICATE KEY UPDATE statements, which
+ * makes the update list explicit where it used to be implied — updateObject()
+ * skipped null properties by default, and only the columns each helper named were
+ * ever touched. A statement that simply assigns every inserted value would still
+ * pass a row-count assertion while clearing a media link, resetting a created
+ * date, or blanking a title the platform supplied. These tests assert the columns
+ * that must survive, not just that one row exists.
+ *
+ * Each test runs inside a transaction that is rolled back, so nothing persists.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmplaylistSyncHelper::class)]
+class CwmplaylistUpsertTest extends IntegrationTestCase
+{
+    /**
+     * A stable remote video ID used as the junction key throughout.
+     */
+    private const VIDEO_ID = 'dQw4w9WgXcQ';
+
+    /**
+     * A created timestamp old enough that an accidental overwrite is unmistakable.
+     */
+    private const SEEDED_CREATED = '2020-01-01 00:00:00';
+
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * Factory::$language as it was before silenceDateLanguageWarnings()
+     * replaced it, so tearDown() can restore process-wide state.
+     *
+     * @var mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @var  int
+     */
+    private int $serverId = 0;
+
+    /**
+     * @var  int
+     */
+    private int $seriesId = 0;
+
+    /**
+     * Begin a transaction and seed a YouTube server + a series.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart();
+
+        $this->serverId = $this->insertServer();
+        $this->seriesId = $this->insertSeries();
+    }
+
+    /**
+     * Roll back everything this test inserted.
+     *
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback();
+            } catch (\Throwable) {
+                // Connection may have been lost — nothing to roll back.
+            }
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    /**
+     * The load-bearing case. A sync run that cannot match a video to local media
+     * passes a null media file ID; the row it lands on may already be linked, and
+     * that link must survive. updateObject() skipped nulls, so this was previously
+     * true by accident — expressing it as COALESCE is what keeps it true.
+     *
+     * @return  void
+     */
+    public function testReconcileKeepsMediafileLinkWhenRemoteHasNoLocalMatch(): void
+    {
+        $mediafileId = $this->insertSeriesMedia('https://youtu.be/' . self::VIDEO_ID, 'Sermon A');
+        $playlistId  = $this->insertPlaylist();
+
+        $this->insertJunction($playlistId, self::VIDEO_ID, $mediafileId, 7, 'Stale title');
+
+        // An empty video map is the unmatched case: reconcile passes null through.
+        $result = CwmplaylistSyncHelper::reconcilePlaylist(
+            $this->db,
+            $this->fakeAddon([['videoId' => self::VIDEO_ID, 'title' => 'Fresh title']]),
+            $playlistId,
+            []
+        );
+
+        $this->assertNull($result['error']);
+        $this->assertSame(1, $result['unmatched']);
+
+        $rows = $this->junctionRows($playlistId);
+        $this->assertCount(1, $rows, 'The unique key must have made this an update, not a second row.');
+
+        $row = $rows[0];
+        $this->assertSame($mediafileId, (int) $row->mediafile_id, 'An unmatched sync must not clear an existing media link.');
+        $this->assertSame('Fresh title', $row->title, 'The platform title is authoritative and must be applied.');
+        $this->assertSame(0, (int) $row->position, 'Position follows the platform ordering.');
+        $this->assertSame(self::SEEDED_CREATED, $row->created, 'created records when the row first appeared and must not be reset.');
+    }
+
+    /**
+     * A matched video links the row it lands on, and repeating the whole run
+     * changes nothing — which is what the duplicate-key path is for.
+     *
+     * @return  void
+     */
+    public function testReconcileLinksMatchedVideoAndIsRepeatable(): void
+    {
+        $mediafileId = $this->insertSeriesMedia('https://youtu.be/' . self::VIDEO_ID, 'Sermon A');
+        $playlistId  = $this->insertPlaylist();
+
+        $this->insertJunction($playlistId, self::VIDEO_ID, null, 0, '');
+
+        $videoMap = ['youtube' => [self::VIDEO_ID => $mediafileId]];
+        $addon    = $this->fakeAddon([['videoId' => self::VIDEO_ID, 'title' => 'Sermon A']]);
+
+        $first = CwmplaylistSyncHelper::reconcilePlaylist($this->db, $addon, $playlistId, $videoMap);
+        $this->assertSame(1, $first['matched']);
+
+        $second = CwmplaylistSyncHelper::reconcilePlaylist($this->db, $addon, $playlistId, $videoMap);
+        $this->assertNull($second['error']);
+
+        $rows = $this->junctionRows($playlistId);
+        $this->assertCount(1, $rows);
+        $this->assertSame($mediafileId, (int) $rows[0]->mediafile_id);
+    }
+
+    /**
+     * Selecting a playlist the video is already in — imported from the platform,
+     * not yet linked to any media — links it without disturbing what the platform
+     * put there. A row that says 'remote' is on the platform; calling it 'manual'
+     * would make the write-back push try to add it again.
+     *
+     * @return  void
+     */
+    public function testManualAssignmentPreservesImportedSourceAndTitle(): void
+    {
+        $mediafileId = $this->insertSeriesMedia('https://youtu.be/' . self::VIDEO_ID, 'Sermon A');
+        $playlistId  = $this->insertPlaylist();
+
+        $this->insertJunction($playlistId, self::VIDEO_ID, null, 4, 'From platform', 'remote');
+
+        CwmplaylistSyncHelper::setManualPlaylistAssignments(
+            $mediafileId,
+            [$playlistId],
+            json_encode(['filename' => 'https://youtu.be/' . self::VIDEO_ID])
+        );
+
+        $rows = $this->junctionRows($playlistId);
+        $this->assertCount(1, $rows);
+
+        $row = $rows[0];
+        $this->assertSame($mediafileId, (int) $row->mediafile_id, 'The assignment must link the media file.');
+        $this->assertSame('remote', $row->source, 'A row confirmed on the platform must not be downgraded to manual.');
+        $this->assertSame('From platform', $row->title, 'A title the platform supplied must not be blanked.');
+        $this->assertSame(4, (int) $row->position, 'Position belongs to the platform ordering.');
+        $this->assertSame(self::SEEDED_CREATED, $row->created);
+    }
+
+    /**
+     * Re-selecting a playlist that was queued for removal cancels the removal: the
+     * video is still on the platform, so the row goes back to 'remote'.
+     *
+     * @return  void
+     */
+    public function testManualAssignmentCancelsAQueuedRemoval(): void
+    {
+        $mediafileId = $this->insertSeriesMedia('https://youtu.be/' . self::VIDEO_ID, 'Sermon A');
+        $playlistId  = $this->insertPlaylist();
+
+        $this->insertJunction($playlistId, self::VIDEO_ID, $mediafileId, 0, 'Queued', 'remove_pending');
+
+        CwmplaylistSyncHelper::setManualPlaylistAssignments(
+            $mediafileId,
+            [$playlistId],
+            json_encode(['filename' => 'https://youtu.be/' . self::VIDEO_ID])
+        );
+
+        $rows = $this->junctionRows($playlistId);
+        $this->assertCount(1, $rows);
+        $this->assertSame('remote', $rows[0]->source, 'Re-selecting a queued removal restores it to remote.');
+    }
+
+    /**
+     * With no row to collide with, the insert branch runs and the row is marked as
+     * the user's own assignment, awaiting a push.
+     *
+     * @return  void
+     */
+    public function testManualAssignmentInsertsANewRowAsManual(): void
+    {
+        $mediafileId = $this->insertSeriesMedia('https://youtu.be/' . self::VIDEO_ID, 'Sermon A');
+        $playlistId  = $this->insertPlaylist();
+
+        CwmplaylistSyncHelper::setManualPlaylistAssignments(
+            $mediafileId,
+            [$playlistId],
+            json_encode(['filename' => 'https://youtu.be/' . self::VIDEO_ID])
+        );
+
+        $rows = $this->junctionRows($playlistId);
+        $this->assertCount(1, $rows);
+
+        $row = $rows[0];
+        $this->assertSame('manual', $row->source);
+        $this->assertSame($mediafileId, (int) $row->mediafile_id);
+        $this->assertSame(self::VIDEO_ID, $row->remote_video_id);
+        $this->assertSame('', $row->title);
+    }
+
+    /**
+     * Build a fake playlist-capable addon that serves a fixed page of videos.
+     *
+     * The CWMAddon constructor (which loads an addon XML file) is deliberately
+     * overridden to a no-op so the double needs no config on disk, and ID
+     * extraction delegates to the real YouTube extractor.
+     *
+     * @param   array<int,array{videoId:string,title:string}>  $videos  Page to serve.
+     *
+     * @return  CWMAddon
+     */
+    private function fakeAddon(array $videos): CWMAddon
+    {
+        return new class ($videos) extends CWMAddon {
+            /** @var array<int,array{videoId:string,title:string}> */
+            private array $videos;
+
+            public function __construct(array $videos)
+            {
+                $this->videos = $videos;
+            }
+
+            public function supportsPlaylists(): bool
+            {
+                return true;
+            }
+
+            public function extractRemoteMediaId(string $text): ?string
+            {
+                return CWMAddonYoutube::extractMediaId($text);
+            }
+
+            public function fetchRemotePlaylistItems(Input $input): array
+            {
+                return ['success' => true, 'videos' => $this->videos, 'nextPageToken' => ''];
+            }
+
+            public function renderGeneral(object $media_form, bool $new): string
+            {
+                return '';
+            }
+
+            public function render(object $media_form, bool $new): string
+            {
+                return '';
+            }
+
+            protected function upload(Input $data): mixed
+            {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Insert a published YouTube server.
+     *
+     * @return  int  Server ID.
+     */
+    private function insertServer(): int
+    {
+        $row = (object) [
+            'server_name' => 'Test YouTube',
+            'published'   => 1,
+            'access'      => 1,
+            'type'        => 'youtube',
+            'params'      => '{}',
+            'media'       => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_servers', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Insert a published series.
+     *
+     * @return  int  Series ID.
+     */
+    private function insertSeries(): int
+    {
+        $row = (object) [
+            'series_text' => 'Test Series',
+            'alias'       => 'test-series',
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+        ];
+
+        $this->db->insertObject('#__bsms_series', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Insert a study in the seeded series plus a media file pointing at a URL.
+     *
+     * @param   string  $url    Media URL stored in params.filename.
+     * @param   string  $title  Study title.
+     *
+     * @return  int  The media file ID.
+     */
+    private function insertSeriesMedia(string $url, string $title): int
+    {
+        $study = (object) [
+            'studytitle'  => $title,
+            'alias'       => strtolower(str_replace(' ', '-', $title)),
+            'studydate'   => '2026-01-15 10:00:00',
+            'series_id'   => $this->seriesId,
+            'messagetype' => 1,
+            'booknumber'  => 101,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $study);
+        $studyId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $studyId,
+            'server_id' => $this->serverId,
+            'metadata'  => '',
+            'params'    => json_encode(['filename' => $url]),
+            'published' => 1,
+            'access'    => 1,
+            'language'  => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_mediafiles', $media);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Insert a playlist on the seeded server.
+     *
+     * @return  int  Playlist ID.
+     */
+    private function insertPlaylist(): int
+    {
+        $row = (object) [
+            'title'              => 'Test Playlist',
+            'alias'              => 'test-playlist',
+            'remote_playlist_id' => 'PL_TEST_123',
+            'server_id'          => $this->serverId,
+            'series_id'          => $this->seriesId,
+            'sync_enabled'       => 1,
+            'writeback_enabled'  => 0,
+            'params'             => '{}',
+            'language'           => '*',
+            'published'          => 1,
+            'access'             => 1,
+        ];
+
+        $this->db->insertObject('#__bsms_playlists', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * Seed a junction row. Written with a raw statement rather than insertObject()
+     * because a null mediafile_id — the unmatched-import case these tests turn on —
+     * is exactly what insertObject() drops.
+     *
+     * @param   int       $playlistId   Playlist ID.
+     * @param   string    $videoId      Remote video ID.
+     * @param   int|null  $mediafileId  Linked media file ID, or null when unmatched.
+     * @param   int       $position     Position in the playlist.
+     * @param   string    $title        Stored title.
+     * @param   string    $source       Row provenance.
+     *
+     * @return  void
+     */
+    private function insertJunction(
+        int $playlistId,
+        string $videoId,
+        ?int $mediafileId,
+        int $position,
+        string $title,
+        string $source = 'remote'
+    ): void {
+        $this->db->setQuery(
+            'INSERT INTO ' . $this->db->quoteName('#__bsms_playlist_items')
+            . ' (' . implode(', ', $this->db->quoteName(
+                ['playlist_id', 'mediafile_id', 'remote_video_id', 'title', 'position', 'source', 'created']
+            )) . ')'
+            . ' VALUES (' . (int) $playlistId . ', ' . ($mediafileId === null ? 'NULL' : (int) $mediafileId) . ', '
+            . $this->db->quote($videoId) . ', ' . $this->db->quote($title) . ', ' . (int) $position . ', '
+            . $this->db->quote($source) . ', ' . $this->db->quote(self::SEEDED_CREATED) . ')'
+        )->execute();
+    }
+
+    /**
+     * Fetch the junction rows for a playlist, ordered by position.
+     *
+     * @param   int  $playlistId  Playlist ID.
+     *
+     * @return  object[]
+     */
+    private function junctionRows(int $playlistId): array
+    {
+        return $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('*')
+                ->from($this->db->quoteName('#__bsms_playlist_items'))
+                ->where($this->db->quoteName('playlist_id') . ' = ' . (int) $playlistId)
+                ->order($this->db->quoteName('position') . ' ASC')
+        )->loadObjectList() ?: [];
+    }
+}


### PR DESCRIPTION
Closes #1658. Changelog line is in **#1681**, not here — see the note at the bottom.

## The two failures looked nothing alike

Both upsert helpers decided a row was absent with a `SELECT` and then inserted it, against a table whose unique key covers exactly the pair they checked. The constraint was never the problem — it did its job. Nothing handled it *firing*.

| | what the user saw |
|---|---|
| `upsertItem()` | Exception escapes `reconcilePlaylist()` to `CwmplaylistsController.php:91` and the task plugin: **"Playlist import failed"** with a raw SQL string, run stopped partway through |
| `upsertManualItem()` | Caught by the `catch` that exists so bookkeeping can never fail a media save — **silent**, and since that `catch` wraps the whole `foreach ($plan['add'])`, it took the remaining playlists with it |

Nothing was shown for the second case. Not a warning, not a log line.

## The change

Each is now one `INSERT … ON DUPLICATE KEY UPDATE`, so there is no window to lose. Joomla's query builder has no vocabulary for the clause (zero hits for `DUPLICATE` in `joomla/database`), so the SQL is written out and handed to `createQuery()->setQuery()` — which core's own comment documents as the way to *"take advantage of bound variables in a direct query."* Reused values get their own placeholders; a named parameter may not appear twice in one prepared statement.

**The update list had to be reconstructed, not mirrored from the insert.** `updateObject()`'s `$nulls` argument defaults to `false`, so an unmatched sync passing a null `mediafile_id` silently left an existing link alone. Nobody wrote that down, and a plain assignment would have destroyed it — `COALESCE` keeps it. `created` keeps its original timestamp; `source` stays untouched in `upsertItem()`; `title` and `position` stay untouched in `upsertManualItem()`, where the `CASE` still reads the stored row and so goes on reviving a queued removal.

Both now return early on an empty video ID. Nothing passes one today, but the key spans `(playlist_id, remote_video_id)` and MySQL treats `''` as a value — an empty ID is a *shared* key, not an absent one, and the upsert would have merged unrelated videos rather than erroring the way the old insert did.

The unchecked `insertObject()` return values the issue also raised are resolved by construction: `execute()` throws.

## Compatibility with System → Database — the answer is a limitation, not a fix

`MysqlChangeItem` maps `CREATE TABLE` to `SHOW TABLES LIKE` and nothing else, so **every index declared inside one is invisible to `ChangeSet`**. Joomla's Database view can neither report `idx_playlist_video` missing nor restore it. ODKU itself is runtime DML and never touches the checker, so nothing *breaks* — but where the old select-then-insert was merely racy, it was at least correct on a table with no constraint. The new code silently duplicates rows without one.

Making it checker-visible would mean stripping the inline key from the released `10.3.3-20260513.sql` and re-adding it by `ALTER`. That buys a check item which **fails on any site already holding duplicates, with no repair path** — a permanently red Database view traded for a silent gap. Not worth it for an index that has been inline since the table was created and that no supported schema state lacks.

So the release gate asserts it instead: `idx_playlist_video` added to `verify-migrations.php`'s 10.3.3 block, checked on both the fresh-install and upgrade paths of every role=test install. The reasoning is recorded at both ODKU sites and in the expectations file so the next reader isn't left to rediscover it.

## Tests

Five integration tests assert **the columns that must survive**, not just that one row exists — a statement that assigns every inserted value would pass a row count while clearing a media link or blanking a platform title.

Each verified by mutation; all four killed a **named** assertion:

| mutation | assertion that went red |
|---|---|
| drop `COALESCE` | *An unmatched sync must not clear an existing media link* |
| add `created` to the update list | *created records when the row first appeared and must not be reset* |
| overwrite `source` with `'manual'` | *A row confirmed on the platform must not be downgraded* + *Re-selecting a queued removal restores it to remote* |
| add `title` to the manual update list | *A title the platform supplied must not be blanked* |

Full suite green: **1820 tests, 6864 assertions**.

Three of the five tests call `setManualPlaylistAssignments()`, which resolves its own driver from the container rather than taking the test's. Given [[transactionstart-implicit-commit]], I checked rather than assumed: `DatabaseDriver::class` and `DatabaseInterface::class` return the same instance, and three consecutive suite runs left every row count in `j5_dev` unchanged.

## Note on the split

The changelog line lives in **#1681** so the 10.5.7 block stays in one place and two branches don't both edit the top of the file. That means this can merge with no changelog entry, or #1681 can merge describing a fix not yet in `development`. Neither matters for an unreleased version — flagging it so a reviewer doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)