### PR TITLE
fix: split the compound ALTERs Joomla only half-checks, and reconcile uq_aggregate in PHP (#1664)

### DIFF
--- a/admin/sql/updates/mysql/10.1.0-20260225.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260225.sql
@@ -3,16 +3,30 @@
 -- Enables tracking visits to series pages directly, and attributes all
 -- message-level events (plays, downloads, page views) to their series.
 --
+-- One clause per statement. MysqlChangeItem reads a statement's meaning from its
+-- third and fourth words only, so a compound ALTER is checked and repaired by its
+-- first clause alone; everything after it is invisible to System > Database and
+-- to the schema fix a restore runs. These were one ALTER each (#1664).
+--
 
 ALTER TABLE `#__bsms_analytics_events`
-    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK #__bsms_series' AFTER `study_id`,
+    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK #__bsms_series' AFTER `study_id`;
+
+ALTER TABLE `#__bsms_analytics_events`
     ADD KEY `idx_series_created` (`series_id`, `created`);
 
 ALTER TABLE `#__bsms_analytics_monthly`
-    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL AFTER `study_id`,
-    DROP INDEX `uq_aggregate`,
-    ADD UNIQUE KEY `uq_aggregate` (
-        `series_id`, `study_id`, `media_id`, `location_id`,
-        `event_type`, `referrer_type`, `country_code`, `device_type`,
-        `year`, `month`
-    );
+    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL AFTER `study_id`;
+
+-- The uq_aggregate rework that used to sit here — DROP INDEX followed by a wider
+-- ADD UNIQUE KEY over the same name — is now done by proclaim.script.php's
+-- reconcileAnalyticsAggregateIndex(). It cannot be expressed here safely:
+--
+--   * MySQL has no DROP INDEX IF EXISTS, so a database missing the key stops the
+--     statement with error 1091, and parseSchemaUpdates() aborts the whole update.
+--   * Split into its own statement, the DROP becomes a check item that expects
+--     zero matching indexes forever — and the key is re-added on the next line, so
+--     it would read as unapplied on every check and be re-dropped by every fix.
+--
+-- The PHP reconcile has neither problem, and unlike any SQL formulation it can
+-- also repair a key that exists with the wrong columns.

--- a/admin/sql/updates/mysql/10.1.0-20260304.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260304.sql
@@ -1,6 +1,17 @@
--- Add iTunes configuration columns to podcast table
+-- Add iTunes configuration columns to podcast table.
+--
+-- One ALTER per column. As a single four-clause statement, Joomla's schema check
+-- built its check query from the first clause only, so itunes_category was
+-- verified and the other three were invisible — a database missing them would be
+-- reported as up to date, and the schema fix would never add them (#1664).
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `itunes_category` VARCHAR(100) NOT NULL DEFAULT 'Religion & Spirituality' AFTER `linktype`,
-    ADD COLUMN `itunes_subcategory` VARCHAR(100) NOT NULL DEFAULT 'Christianity' AFTER `itunes_category`,
-    ADD COLUMN `itunes_explicit` VARCHAR(5) NOT NULL DEFAULT 'false' AFTER `itunes_subcategory`,
+    ADD COLUMN `itunes_category` VARCHAR(100) NOT NULL DEFAULT 'Religion & Spirituality' AFTER `linktype`;
+
+ALTER TABLE `#__bsms_podcast`
+    ADD COLUMN `itunes_subcategory` VARCHAR(100) NOT NULL DEFAULT 'Christianity' AFTER `itunes_category`;
+
+ALTER TABLE `#__bsms_podcast`
+    ADD COLUMN `itunes_explicit` VARCHAR(5) NOT NULL DEFAULT 'false' AFTER `itunes_subcategory`;
+
+ALTER TABLE `#__bsms_podcast`
     ADD COLUMN `itunes_type` VARCHAR(10) NOT NULL DEFAULT 'episodic' AFTER `itunes_explicit`;

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -16,15 +16,18 @@
  * add an entry describing the tables/columns/indexes it introduces and the
  * #__schemas version it should advance to.
  *
- * Version resolution — a release that ships no migrations must not fail the gate,
- * but a release that ships migrations nobody described must:
- *   - exact x.y.z entry exists      => verify it
+ * Every entry at or below the version under test is verified, not just the newest.
+ * The release being cut has to carry what all of its predecessors introduced, and
+ * checking only one of them meant an assertion added to an older entry — the usual
+ * way a gap gets recorded once it is found — quietly never ran again.
+ *
+ * A release that ships no migrations must not fail the gate, but one that ships
+ * migrations nobody described must:
+ *   - exact x.y.z entry exists      => verify it, plus every earlier entry
  *   - no entry, but update SQL for  => FAIL; the expectations were forgotten
  *     this version exists
- *   - no entry and no update SQL    => re-verify the newest earlier entry as
- *     regression cover. A fresh install of a no-migration release still has to
- *     carry everything its predecessors introduced, so this is what catches
- *     install.sql drifting behind the update SQL.
+ *   - no entry and no update SQL    => verify every earlier entry as regression
+ *     cover, which is what catches install.sql drifting behind the update SQL.
  *
  * Usage:   php build/verify-migrations.php [version]
  *   version  Optional override; defaults to active_development in versions.json.
@@ -56,6 +59,37 @@ require $root . '/libraries/vendor/autoload.php';
  * Table names use the Joomla `#__` prefix placeholder; it is expanded per install.
  */
 $EXPECTATIONS = [
+    /*
+     * 10.1.0 shipped three ALTER statements that each carried several clauses.
+     * MysqlChangeItem reads only words 3 and 4 of a statement, so all three read
+     * as "ADD COLUMN" and everything after the first clause was neither checked
+     * nor repairable. Splitting them (#1664) made these visible; asserting them
+     * here is what proves the split actually reaches a database.
+     *
+     * itunes_category is deliberately listed alongside the three that were
+     * hidden: it was the one clause the checker could see, so it is the control.
+     */
+    '10.1.0' => [
+        'columns' => [
+            '#__bsms_analytics_events'  => ['series_id'],
+            '#__bsms_analytics_monthly' => ['series_id'],
+            '#__bsms_mediafiles'        => ['content_origin'],
+            '#__bsms_podcast'           => [
+                'itunes_category',
+                'itunes_subcategory',
+                'itunes_explicit',
+                'itunes_type',
+            ],
+        ],
+        'indexes' => [
+            '#__bsms_analytics_events' => ['idx_series_created'],
+            // Reconciled by proclaim.script.php rather than by SQL: the rework
+            // needs a DROP that MySQL cannot make conditional, and a standalone
+            // DROP INDEX item expects zero rows forever after the key is re-added.
+            '#__bsms_analytics_monthly' => ['uq_aggregate'],
+        ],
+        'schemaMin' => '10.1.0',
+    ],
     '10.3.3' => [
         'tables' => [
             '#__bsms_playlists',
@@ -171,14 +205,18 @@ if (preg_match('/^(\d+\.\d+\.\d+)/', $version, $m) !== 1) {
 $base = $m[1];
 
 /*
- * Resolve which expectation set to verify.
+ * Resolve which expectation sets to verify.
  *
- * An exact match is used when present. Otherwise the version either ships
- * migrations nobody described — a real gap, so fail — or ships none at all, in
- * which case the newest earlier set is re-verified rather than skipping the
- * check. That matters: a fresh install of a no-migration release must still
- * carry every table/column/index its predecessors introduced, which is what
- * catches install.sql drifting behind the update SQL.
+ * An exact match names the release under test; when there is none, the version
+ * either ships migrations nobody described — a real gap, so fail — or ships none
+ * at all, which is not a reason to skip the check.
+ *
+ * Either way every entry at or below the version is verified. A fresh install of
+ * any release must carry every table, column and index its predecessors
+ * introduced, and that is what catches install.sql drifting behind the update
+ * SQL. It also keeps an assertion added to an older entry alive: verifying only
+ * the newest set meant such an assertion ran on the release that introduced it
+ * and never again.
  */
 $mode = 'exact';
 
@@ -211,7 +249,13 @@ if ($key === null) {
     exit(0);
 }
 
-$expected = $EXPECTATIONS[$key];
+// Everything the release must carry, oldest first, so failures read in the order
+// the schema was built up.
+$keys = array_filter(
+    array_keys($EXPECTATIONS),
+    static fn (string $k): bool => version_compare($k, $base, '<=')
+);
+usort($keys, 'version_compare');
 
 $reader   = new PropertiesReader($root . '/build.properties');
 $installs = $reader->installsFor('test');
@@ -230,11 +274,11 @@ $reset   = "\033[0m";
 $overall = true;
 
 if ($mode === 'regression') {
-    echo "Version {$base} ships no migrations — re-verifying the {$key} schema as regression cover\n";
-    echo "(a fresh {$base} install must still carry everything {$key} introduced).\n";
+    echo "Version {$base} ships no migrations — verifying earlier schemas as regression cover\n";
+    echo "(a fresh {$base} install must still carry everything they introduced).\n";
 }
 
-echo "Verifying {$key} migrations across " . \count($installs) . " test install(s)\n";
+echo 'Verifying ' . implode(', ', $keys) . ' migrations across ' . \count($installs) . " test install(s)\n";
 
 foreach ($installs as $install) {
     echo "\n=== {$install->id} ({$install->path}) ===\n";
@@ -284,39 +328,45 @@ foreach ($installs as $install) {
 
     $results = [];
 
-    // --- tables -----------------------------------------------------------
-    foreach ($expected['tables'] ?? [] as $table) {
-        $real      = $expand($table);
-        $ok        = tableExists($mysqli, $db['name'], $real);
-        $results[] = [$ok, "table {$table}"];
-    }
+    foreach ($keys as $version) {
+        $expected = $EXPECTATIONS[$version];
 
-    // --- columns ----------------------------------------------------------
-    foreach ($expected['columns'] ?? [] as $table => $cols) {
-        $real = $expand($table);
-
-        foreach ($cols as $col) {
-            $ok        = columnExists($mysqli, $db['name'], $real, $col);
-            $results[] = [$ok, "column {$table}.{$col}"];
+        // --- tables -------------------------------------------------------
+        foreach ($expected['tables'] ?? [] as $table) {
+            $real      = $expand($table);
+            $ok        = tableExists($mysqli, $db['name'], $real);
+            $results[] = [$ok, "[{$version}] table {$table}"];
         }
-    }
 
-    // --- indexes ----------------------------------------------------------
-    foreach ($expected['indexes'] ?? [] as $table => $idxs) {
-        $real = $expand($table);
+        // --- columns ------------------------------------------------------
+        foreach ($expected['columns'] ?? [] as $table => $cols) {
+            $real = $expand($table);
 
-        foreach ($idxs as $idx) {
-            $ok        = indexExists($mysqli, $db['name'], $real, $idx);
-            $results[] = [$ok, "index {$table}.{$idx}"];
+            foreach ($cols as $col) {
+                $ok        = columnExists($mysqli, $db['name'], $real, $col);
+                $results[] = [$ok, "[{$version}] column {$table}.{$col}"];
+            }
+        }
+
+        // --- indexes ------------------------------------------------------
+        foreach ($expected['indexes'] ?? [] as $table => $idxs) {
+            $real = $expand($table);
+
+            foreach ($idxs as $idx) {
+                $ok        = indexExists($mysqli, $db['name'], $real, $idx);
+                $results[] = [$ok, "[{$version}] index {$table}.{$idx}"];
+            }
         }
     }
 
     // --- #__schemas version -----------------------------------------------
-    if (!empty($expected['schemaMin'])) {
+    // Only the newest applicable minimum is asserted; it implies every earlier one.
+    if (!empty($EXPECTATIONS[$key]['schemaMin'])) {
+        $schemaMin     = $EXPECTATIONS[$key]['schemaMin'];
         $schemaVersion = schemaVersion($mysqli, $db['prefix']);
         $ok            = $schemaVersion !== null
-            && version_compare($schemaVersion, $expected['schemaMin'], '>=');
-        $label         = "#__schemas >= {$expected['schemaMin']} (found " . ($schemaVersion ?? 'none') . ')';
+            && version_compare($schemaVersion, $schemaMin, '>=');
+        $label         = "#__schemas >= {$schemaMin} (found " . ($schemaVersion ?? 'none') . ')';
         $results[]     = [$ok, $label];
     }
 
@@ -335,12 +385,12 @@ foreach ($installs as $install) {
 echo "\n";
 
 if ($overall) {
-    echo "{$green}All {$key} migration assertions passed.{$reset}\n";
+    echo "{$green}All migration assertions passed (" . implode(", ", $keys) . ").{$reset}\n";
 
     exit(0);
 }
 
-echo "{$red}One or more {$key} migration assertions FAILED.{$reset}\n";
+echo "{$red}One or more migration assertions FAILED.{$reset}\n";
 
 exit(1);
 

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -326,6 +326,23 @@ foreach ($installs as $install) {
 
     $expand = static fn (string $t): string => str_replace('#__', $db['prefix'], $t);
 
+    /*
+     * Proclaim's tables outlive Proclaim: an uninstall keeps them unless the
+     * administrator opts out. So a site can pass every table, column and index
+     * assertion here while having no com_proclaim row at all, and the only sign
+     * would be the #__schemas check failing for a reason that reads like schema
+     * drift. Say what actually happened instead.
+     */
+    if (!proclaimInstalled($mysqli, $db['prefix'])) {
+        echo "{$red}FAIL{$reset} com_proclaim is not installed on this site — nothing to verify a schema against.\n";
+        echo "       Its bsms_ tables may still be present; an uninstall keeps them by default.\n";
+        echo "       Install Proclaim here (composer test:install) and run this again.\n";
+        $overall = false;
+        $mysqli->close();
+
+        continue;
+    }
+
     $results = [];
 
     foreach ($keys as $version) {
@@ -473,7 +490,32 @@ function indexExists(mysqli $db, string $schema, string $table, string $index): 
 }
 
 /**
- * Latest schema version recorded for com_proclaim in #__schemas, or null.
+ * Whether com_proclaim is registered on this install.
+ *
+ * @param   mysqli  $db      Connection to the install's database.
+ * @param   string  $prefix  That install's table prefix.
+ *
+ * @return  bool
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function proclaimInstalled(mysqli $db, string $prefix): bool
+{
+    $res = $db->query(
+        'SELECT extension_id FROM ' . $prefix . "extensions"
+        . " WHERE element = 'com_proclaim' AND type = 'component' LIMIT 1"
+    );
+
+    return $res !== false && $res->num_rows > 0;
+}
+
+/**
+ * The recorded schema version for com_proclaim, or null when there is none.
+ *
+ * @param   mysqli  $db      Connection to the install's database.
+ * @param   string  $prefix  That install's table prefix.
+ *
+ * @return  string|null
  *
  * @since __DEPLOY_VERSION__
  */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,9 @@
 		<testsuite name="Asset Contract Tests">
 			<directory>tests/unit/Assets</directory>
 		</testsuite>
+		<testsuite name="Migration SQL Contract Tests">
+			<directory>tests/unit/Sql</directory>
+		</testsuite>
 		<testsuite name="Admin Field Tests">
 			<directory>tests/unit/Admin/Field</directory>
 		</testsuite>

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -11,6 +11,7 @@
  * */
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmguidedtourHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
 use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
 use Joomla\CMS\Event\Cache\AfterPurgeEvent;
@@ -757,12 +758,29 @@ class com_proclaimInstallerScript extends InstallerScript
              * and taking down an otherwise good update over an analytics index
              * would be a far worse trade.
              */
-            Log::add(
-                'Proclaim could not reconcile the analytics aggregate index: ' . $e->getMessage()
-                . ' Duplicate monthly rows must be merged before uq_aggregate can be restored.',
-                Log::WARNING,
-                'jerror'
-            );
+            $message = 'Proclaim could not restore the analytics aggregate index (uq_aggregate): '
+                . $e->getMessage()
+                . ' Merge the duplicate #__bsms_analytics_monthly rows, then run a Proclaim update '
+                . 'again to rebuild it.';
+
+            /*
+             * Two channels on purpose, because neither covers both routes.
+             * enqueueMessage is what an administrator updating through the
+             * browser sees; under CLI nothing renders that queue. A file logger
+             * survives CLI — and this method only ever does work on an update, so
+             * CwmlogHelper is already installed and loadable by the time it runs.
+             */
+            try {
+                Factory::getApplication()->enqueueMessage($message, 'warning');
+            } catch (\Throwable) {
+                // No application to talk to; the log below is the record.
+            }
+
+            try {
+                CwmlogHelper::warning($message);
+            } catch (\Throwable) {
+                Log::add($message, Log::WARNING, 'com_proclaim');
+            }
         }
     }
 

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -674,6 +674,99 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
+     * Bring #__bsms_analytics_monthly's uq_aggregate key to the ten dimensions the
+     * rollup groups by, whatever state it is in.
+     *
+     * 10.1.0 widened this key to include series_id, as one ALTER that added the
+     * column, dropped the old key and added the new one. That statement could not
+     * stay in SQL (#1664):
+     *
+     *   - MySQL has no DROP INDEX IF EXISTS, so a database missing the key stops
+     *     it with error 1091 and takes the whole update down with it.
+     *   - Joomla reads a statement's meaning from its third and fourth words, so
+     *     the compound ALTER read as "ADD COLUMN". Once series_id existed the
+     *     statement counted as applied and the index half could never run —
+     *     including on the restore path, where Cwmrestore clears #__schemas
+     *     precisely so migrations replay.
+     *   - Splitting it does not help either: a lone DROP INDEX becomes a check
+     *     that expects the index to be absent, and the next statement puts it
+     *     back, so every check would report it unapplied and every fix re-drop it.
+     *
+     * Here the state can simply be read first. That also covers the one case no
+     * SQL formulation reaches — a key that exists over the wrong columns, which
+     * ChangeSet cannot detect because its index check only looks at the name.
+     *
+     * Column order matters and is compared as a sequence: the same ten columns in
+     * a different order is a different key.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function reconcileAnalyticsAggregateIndex(): void
+    {
+        if (!$this->tableExists('#__bsms_analytics_monthly')) {
+            return;
+        }
+
+        // The dimensions CwmanalyticsHelper's rollup groups by, in order.
+        $wanted = [
+            'series_id', 'study_id', 'media_id', 'location_id', 'event_type',
+            'referrer_type', 'country_code', 'device_type', 'year', 'month',
+        ];
+
+        $table = str_replace('#__', $this->dbo->getPrefix(), '#__bsms_analytics_monthly');
+        $name  = $this->dbo->quoteName('uq_aggregate');
+
+        try {
+            $columns = [];
+
+            foreach (
+                $this->dbo
+                    ->setQuery('SHOW INDEX FROM ' . $this->dbo->quoteName($table) . ' WHERE Key_name = ' . $this->dbo->quote('uq_aggregate'))
+                    ->loadObjectList() as $row
+            ) {
+                $columns[(int) $row->Seq_in_index] = $row->Column_name;
+            }
+
+            ksort($columns);
+
+            if (array_values($columns) === $wanted) {
+                return;
+            }
+
+            if ($columns !== []) {
+                $this->dbo->setQuery(
+                    'ALTER TABLE ' . $this->dbo->quoteName($table) . ' DROP INDEX ' . $name
+                )->execute();
+            }
+
+            $this->dbo->setQuery(
+                'ALTER TABLE ' . $this->dbo->quoteName($table)
+                . ' ADD UNIQUE KEY ' . $name
+                . ' (' . implode(', ', array_map([$this->dbo, 'quoteName'], $wanted)) . ')'
+            )->execute();
+        } catch (Exception $e) {
+            /*
+             * Re-adding the key fails when the table already holds rows that
+             * violate it — a real possibility on a database that has been running
+             * without the correct key, which is exactly the database this method
+             * exists for. Report it and carry on rather than failing the update:
+             * the rollup deletes each matching group before inserting it, so the
+             * counts stay right without the key (CwmanalyticsHelper::rollup()),
+             * and taking down an otherwise good update over an analytics index
+             * would be a far worse trade.
+             */
+            Log::add(
+                'Proclaim could not reconcile the analytics aggregate index: ' . $e->getMessage()
+                . ' Duplicate monthly rows must be merged before uq_aggregate can be restored.',
+                Log::WARNING,
+                'jerror'
+            );
+        }
+    }
+
+    /**
      * Find the installation path for an extension
      *
      * @param   string  $src       The source directory
@@ -1422,6 +1515,10 @@ class com_proclaimInstallerScript extends InstallerScript
         // After the migration SQL has added uq_study_topic, retire the index it
         // replaces. No-op on a fresh install, where install.sql never creates it.
         $this->dropRedundantStudyTopicIndex();
+
+        // The analytics aggregate key cannot be reworked in SQL at all; this is
+        // where it is brought to its intended columns. No-op when already correct.
+        $this->reconcileAnalyticsAggregateIndex();
 
         // Install subExtensions
         $this->installSubExtensions($parent);

--- a/tests/unit/Sql/MigrationStatementContractTest.php
+++ b/tests/unit/Sql/MigrationStatementContractTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Contract tests for the shape of Proclaim's schema migration SQL
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Unit\Sql;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Guards migration SQL against the shapes Joomla's schema checker cannot read.
+ *
+ * Joomla runs update SQL twice over a database's life, by two different
+ * mechanisms. On install and update, Installer::parseSchemaUpdates() executes
+ * each statement raw. On a restore, Cwmrestore clears #__schemas and
+ * DatabaseModel::fix() replays everything through ChangeSet, which does not
+ * execute a statement until MysqlChangeItem has parsed it into a check query and
+ * that check has reported the change missing.
+ *
+ * That parser is far more literal than it looks. MysqlChangeItem::buildCheckQuery()
+ * decides what an ALTER does from words three and four of the statement and
+ * nothing else, so a compound ALTER is represented by its first clause alone.
+ * Every later clause is then invisible: never verified, never repaired, and
+ * silently counted as applied whenever the first clause happens to be in place.
+ *
+ * Nothing reports this. The migration runs correctly on the ordinary upgrade
+ * path, System > Database shows a healthy schema, and the omission only surfaces
+ * as a missing column or index long afterwards. #1664 found three such statements
+ * in 10.1.0 — one hiding three podcast columns behind a fourth — which is why the
+ * rule is asserted here rather than left to review.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[Group('sql')]
+class MigrationStatementContractTest extends ProclaimTestCase
+{
+    /**
+     * Directory holding the MySQL schema updates.
+     */
+    private const UPDATES_DIR = JPATH_ROOT . '/admin/sql/updates/mysql';
+
+    /**
+     * Every ALTER TABLE in the migration set, one case per statement.
+     *
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function alterStatementProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(self::UPDATES_DIR . '/*.sql') ?: [] as $file) {
+            $name  = basename($file);
+            $index = 0;
+
+            foreach (self::statementsIn((string) file_get_contents($file)) as $statement) {
+                if (stripos($statement, 'ALTER TABLE') !== 0) {
+                    continue;
+                }
+
+                $cases[$name . ' #' . ++$index] = [$name, $statement];
+            }
+        }
+
+        // An empty provider would make this suite pass by doing nothing.
+        self::assertNotSame([], $cases, 'No ALTER TABLE statements found — is the updates directory still there?');
+
+        return $cases;
+    }
+
+    /**
+     * An ALTER may carry exactly one clause, because Joomla only ever checks the
+     * first one.
+     *
+     * @param   string  $file       Migration file the statement came from.
+     * @param   string  $statement  The normalised statement.
+     *
+     * @return  void
+     */
+    #[DataProvider('alterStatementProvider')]
+    public function testAlterStatementsCarryOneClause(string $file, string $statement): void
+    {
+        $clauses = self::topLevelClauses($statement);
+
+        $this->assertSame(
+            1,
+            $clauses,
+            "{$file} has an ALTER TABLE with {$clauses} clauses. Joomla builds its check query from "
+            . "words 3-4 of the statement, so only the first is ever verified or repaired — split it "
+            . "into one ALTER per clause.\n\n  " . $statement
+        );
+    }
+
+    /**
+     * MySQL has no DROP INDEX IF EXISTS, and ChangeSet reads a DROP INDEX as
+     * "this index must be absent" — which is false the moment a later statement
+     * re-adds the same name, leaving the check permanently unsatisfied and the
+     * fix re-dropping a key the schema needs. Guarded PHP in proclaim.script.php
+     * is where a conditional drop belongs.
+     *
+     * @param   string  $file       Migration file the statement came from.
+     * @param   string  $statement  The normalised statement.
+     *
+     * @return  void
+     */
+    #[DataProvider('alterStatementProvider')]
+    public function testNoUnguardableIndexDrops(string $file, string $statement): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/\bDROP\s+(INDEX|KEY)\b/i',
+            $statement,
+            "{$file} drops an index in migration SQL. That aborts the update with error 1091 on any "
+            . "database where the index is already absent, and cannot be made conditional in MySQL. "
+            . "Do it in proclaim.script.php behind a SHOW INDEX check instead.\n\n  " . $statement
+        );
+    }
+
+    /**
+     * Split a file into normalised statements.
+     *
+     * Comment lines go first so a semicolon inside one cannot split a statement,
+     * and whitespace is collapsed so word positions match how MysqlChangeItem
+     * tokenises.
+     *
+     * @param   string  $sql  File contents.
+     *
+     * @return  list<string>
+     */
+    private static function statementsIn(string $sql): array
+    {
+        $sql = preg_replace('/^\s*--.*$/m', '', $sql) ?? '';
+
+        $statements = [];
+
+        foreach (explode(';', $sql) as $statement) {
+            $statement = trim(preg_replace('/\s+/', ' ', $statement) ?? '');
+
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+
+    /**
+     * Count an ALTER's top-level clauses.
+     *
+     * Only a comma outside both quotes and parentheses separates clauses. A comma
+     * inside COMMENT 'a, b' or inside an index's column list does not — reading
+     * those as separators is how a first pass at this check reported two
+     * single-clause statements as compound.
+     *
+     * @param   string  $statement  The normalised statement.
+     *
+     * @return  int
+     */
+    private static function topLevelClauses(string $statement): int
+    {
+        $clauses = 1;
+        $depth   = 0;
+        $quote   = null;
+
+        for ($i = 0, $n = \strlen($statement); $i < $n; $i++) {
+            $char = $statement[$i];
+
+            if ($quote !== null) {
+                if ($char === '\\') {
+                    $i++;
+                } elseif ($char === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($char === "'" || $char === '"') {
+                $quote = $char;
+            } elseif ($char === '(') {
+                $depth++;
+            } elseif ($char === ')') {
+                $depth--;
+            } elseif ($char === ',' && $depth === 0) {
+                $clauses++;
+            }
+        }
+
+        return $clauses;
+    }
+}


### PR DESCRIPTION
Closes #1664 — with more in it than the issue describes, and one severity claim corrected.

## The mechanism

`MysqlChangeItem::buildCheckQuery()` decides what an `ALTER` does from **words three and four** of the statement and nothing else. A multi-clause ALTER is represented by its first clause alone: every later clause is never verified, never repaired, and counted as applied whenever the first happens to be in place. On the restore path — `Cwmrestore` clears `#__schemas` so `DatabaseModel::fix()` replays every migration through `ChangeSet` — those clauses simply never run.

## A sweep found three, not one

The issue named the `uq_aggregate` statement. Scanning the whole migration set found **three compound ALTERs, all in 10.1.0**, and the one it didn't mention is the worse find:

```sql
ALTER TABLE `#__bsms_podcast`
    ADD COLUMN `itunes_category` …,      -- the only clause Joomla ever saw
    ADD COLUMN `itunes_subcategory` …,
    ADD COLUMN `itunes_explicit` …,
    ADD COLUMN `itunes_type` …;
```

A database holding `itunes_category` and nothing else reads as up to date, and no schema fix will ever add the other three. **A missing column is a SQL error on the podcast form, not a silent miscount.** The third hid `idx_series_created` behind the events `series_id` column.

Editing released migrations is safe here: a site past 10.1.0 never replays them on the update path, and a site below it runs the same clauses in the same order. Only the *check* path changes.

## Why uq_aggregate left SQL entirely rather than being split

Neither shape works:

- **Compound** — the index half is invisible, which is the bug.
- **Split** — a lone `DROP INDEX` becomes a check item with `checkQueryExpected = 0`, and the very next statement re-adds that name. It would read as unapplied on every check and be **re-dropped by every fix**: a permanently red Database view that actively destroys the key.

So it moves to `reconcileAnalyticsAggregateIndex()` in `proclaim.script.php`, which can read the state first. That also picks up a case **no SQL formulation reaches** — a key over the *wrong columns*. ChangeSet's index check only looks at the name.

Verified against a scratch table in four states — correct key (no-op), the pre-10.1.0 nine-column key (rebuilt), the right ten columns in the wrong order (rebuilt), no key at all (added).

The catch logs rather than aborts, and it is load-bearing: re-adding a unique key over violating rows throws — but **only for rows whose ten dimensions are all non-NULL and equal**, since MySQL treats NULLs as distinct. I confirmed both halves of that empirically.

## Correcting the issue, and correcting #1682

**The issue's severity claim is wrong.** It describes the wrong key as "a silent double-counting shape." It isn't: `CwmanalyticsHelper::rollup()` already deletes each matching group before inserting it, with a comment saying the key only works for entirely-non-NULL rows anyway. The real cases are the **1091 abort** (hard failure) and **unrepairable schema drift** (mechanism, not observed).

**And #1682's body overstated what the release gate does.** `verify-migrations.php` resolved a *single* `$key`, so `idx_playlist_video` in the 10.3.3 block never ran for a 10.5.x release. Fixed here: every entry at or below the version under test is now verified, oldest first, each assertion labelled with the version that introduced it.

## Measured before deciding

The issue asked for this. All five dev sites carry the correct 10-column `uq_aggregate`, `idx_series_created`, and all four podcast columns — so this is **hardening, not repair**. Worth knowing before shipping a migration that claims to fix data.

## The durable part

Fixing three statements doesn't stop a fourth. `MigrationStatementContractTest` asserts every ALTER carries exactly one clause and none drops an index — **157 statements, 314 assertions**. Both rules verified by mutation: restoring the four-clause podcast ALTER and appending a `DROP INDEX` each turn a named assertion red.

The clause counter ignores commas inside quotes and parentheses. My first pass without that reported two single-clause statements as compound, so `10.1.0-20260228.sql` (`COMMENT '0=ministry-created, 1=external/third-party'`) is now the standing control.

Registered in `phpunit.xml` — a new `tests/unit` directory with no suite entry passes by never running.

## Results

- Full suite **2134 tests, 7178 assertions**, green.
- Migration gate against j6-test: **35 schema assertions pass, 9 of them new.** The one failure, `#__schemas >= 10.5.6 (found none)`, is identical before and after this change — j6-test currently has no `com_proclaim` extension row at all, its `bsms_` tables left behind by the uninstall work exactly as designed.

## No changelog entry

Deliberate. Nothing here is observable on a healthy site, and no site was found in the broken state. Adding a line would advertise a data problem nobody has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)