### PR TITLE
chore: make the component-entry review date announce itself (#1666)

### DIFF
--- a/build/verify-update-stream.php
+++ b/build/verify-update-stream.php
@@ -66,6 +66,20 @@ declare(strict_types=1);
  */
 const COMPONENT_ENTRY_SUNSET = '2027-08-09';
 
+/**
+ * When to reconsider the sunset rather than wait for it.
+ *
+ * Half the window. The date above was chosen without evidence and cannot be
+ * checked against any: both entries point at the same download URL, so no count
+ * distinguishes a straggler taking the update from anyone else. Splitting the
+ * two entries across separate update sites would make that number observable and
+ * let the entry retire on evidence instead of a guess (#1666).
+ *
+ * A notice, never a failure. The point is that the release that crosses this date
+ * says so out loud, which prose in a docblock cannot do.
+ */
+const COMPONENT_ENTRY_REVIEW = '2027-02-09';
+
 $root   = \dirname(__DIR__);
 $red    = "\033[31m";
 $green  = "\033[32m";
@@ -229,6 +243,13 @@ if ($sunset) {
     $failures++;
 } else {
     echo "{$green}PASS{$reset} com_proclaim entry present at {$version} (not stale)\n";
+
+    if (strtotime(COMPONENT_ENTRY_REVIEW) < time()) {
+        echo "{$yellow}NOTE{$reset} the " . COMPONENT_ENTRY_REVIEW . " review of this entry is due (#1666).\n";
+        echo "       It carries sites that predate pkg_proclaim (10.3.0, 2026-05-01); each converts\n";
+        echo "       itself on one update check. Retire it early if that population is done, or let\n";
+        echo "       it run to " . COMPONENT_ENTRY_SUNSET . " — but decide, rather than defaulting.\n";
+    }
 
     // --- the tie-break ------------------------------------------------------
     if ($package !== null && $component['position'] > $package['position']) {


### PR DESCRIPTION
Small, and deliberately the only code in this turn — see the analysis I posted on #1666 for why the rest of it should not be built yet.

The 12-month sunset is enforced by `verify-update-stream.php`. The 6-month review existed only as prose in a docblock, which is the same as not existing. The release that crosses **2027-02-09** now says so out loud.

A **notice, never a failure**. Nothing is wrong at that point; there is only a decision worth making on purpose rather than by default. The wording states what the entry is for and that both outcomes are legitimate, because whoever reads it in February 2027 will not be carrying this context.

Verified by moving the date into the past — the notice prints between the staleness and tie-break assertions, and the script still exits 0. Today's run is unchanged and green against the live stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)