### PR TITLE
fix: stop the E2E API job timing out, and make a failing nightly reach a human

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -138,6 +138,19 @@ jobs:
           # showed the tour modal. No tours for a disposable site.
           mysql -h 127.0.0.1 -u root -pjoomla_ci joomla_ci \
             -e "UPDATE jos_extensions SET enabled = 0 WHERE folder = 'system' AND element = 'guidedtours';"
+          # The admin dashboard's update quickicons call out to update.joomla.org
+          # and to every registered update site — which, once test:install has
+          # run, includes Proclaim's own on christianwebministries.org. Each of
+          # those AJAX calls holds a dev-server worker for the length of an
+          # internet round trip, so CI runs took a dependency on servers it does
+          # not control and gets nothing in return: no test asserts on an update
+          # count. Statistics reporting goes the same way — a disposable site
+          # should not phone home either.
+          mysql -h 127.0.0.1 -u root -pjoomla_ci joomla_ci -e "
+            UPDATE jos_extensions SET enabled = 0
+             WHERE (folder = 'quickicon'
+                    AND element IN ('joomlaupdate','extensionupdate','autoupdate','downloadkey','eos'))
+                OR (folder = 'system' AND element = 'stats');"
 
       - name: Write build.properties for the disposable site
         # The harness discovers the test site by role, not by name (#1353),
@@ -159,8 +172,15 @@ jobs:
           EOF
 
       - name: Serve the site
+        # Workers must exceed Chromium's 6-connections-per-host limit. At 4, a
+        # page opening six parallel requests left two queued behind whichever
+        # worker was slowest, and Playwright's `networkidle` — 500ms with no
+        # in-flight request — could not reach its window inside the 30s
+        # navigation timeout. That is the whole flake: an intermittent
+        # "page.goto: Timeout 30000ms exceeded" on /administrator/index.php,
+        # which retried green and so read as noise for weeks.
         run: |
-          PHP_CLI_SERVER_WORKERS=4 php -S 127.0.0.1:8890 -t "$SITE_DIR" &> /tmp/php-server.log &
+          PHP_CLI_SERVER_WORKERS=10 php -S 127.0.0.1:8890 -t "$SITE_DIR" &> /tmp/php-server.log &
           sleep 2
           curl -sSf -o /dev/null "$SITE_URL/index.php"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# issues: write is for the nightly failure issue at the end of the job. Declared
+# explicitly rather than relying on the repository default, so tightening that
+# default later cannot silently take the monitoring away again.
+permissions:
+  contents: read
+  issues: write
+
 env:
   JOOMLA_VERSION: '5.4.3'
   SITE_DIR: /home/runner/joomla-site
@@ -216,3 +223,67 @@ jobs:
           name: php-server-log
           path: /tmp/php-server.log
           retention-days: 7
+
+      # A nightly nobody hears about is not a monitor. Until now the only thing
+      # a scheduled failure produced was two artifacts on a page no one opens,
+      # so this job failed on 2026-08-07 and again on 2026-08-08 without ever
+      # reaching a human. A failure on a pull request is already visible on that
+      # pull request; the scheduled run is the one with no audience, so only it
+      # opens an issue.
+      #
+      # One issue, reopened and updated rather than one per night, and closed
+      # automatically when the job comes back green — the same shape
+      # vendor-check.yml uses, so there is one pattern here rather than two.
+      - name: Open or update the nightly failure issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LABEL: 'ci: nightly'
+        run: |
+          TITLE="Nightly E2E is failing"
+          BODY="The scheduled E2E run failed on $(date -u +%Y-%m-%d).
+
+          **Run:** $RUN_URL
+
+          The Playwright report and the PHP server log are attached to that run as
+          artifacts, kept for 7 days. This issue is updated on each further failure
+          and closed automatically once the nightly is green again.
+
+          A red nightly does not block merges: E2E is deliberately not a required
+          check, because its path filter means it does not report at all on most
+          pull requests and a required check that never reports blocks them forever."
+
+          # Found by label, not by title search. `--search "in:title …"` is fuzzy
+          # — it matches a renamed or similarly-titled issue — and it reads
+          # GitHub's search index, which lags creation by seconds to minutes. A
+          # re-run or a manual dispatch landing inside that window would each
+          # find nothing and open its own duplicate. --label queries the API
+          # directly and is exact.
+          NUM=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --json number --jq '.[0].number // ""')
+
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --repo "$REPO" --body "Still failing on $(date -u +%Y-%m-%d): $RUN_URL"
+          else
+            gh issue create --repo "$REPO" \
+              --title "$TITLE" \
+              --label "$LABEL" \
+              --label "bug" \
+              --body "$BODY"
+          fi
+
+      - name: Close the nightly failure issue when green
+        if: success() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LABEL: 'ci: nightly'
+        run: |
+          NUM=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --json number --jq '.[0].number // ""')
+
+          if [ -n "$NUM" ]; then
+            gh issue close "$NUM" --repo "$REPO" \
+              --comment "Nightly E2E passed on $(date -u +%Y-%m-%d): $RUN_URL. Closing automatically."
+          fi

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -88,11 +88,16 @@ test.describe.serial('REST API acceptance (package install) @api', () => {
         // user is saved with the plugin active, so a fresh install's
         // installer-created admin has no field at all until saved once.
         // That is the state every CI run starts from.
-        await page.goto('/administrator/index.php', { waitUntil: 'networkidle' });
+        // domcontentloaded, not networkidle: the assertion below already waits
+        // for the thing this navigation exists to reach, and it waits for that
+        // specific element rather than for the whole page to stop talking.
+        // Under the dev server, networkidle here was the flake — see the Serve
+        // step in e2e.yml.
+        await page.goto('/administrator/index.php', { waitUntil: 'domcontentloaded' });
 
         const editAccount = page.locator('a[href*="task=user.edit"]', { hasText: 'Edit Account' }).first();
         await expect(editAccount, 'No "Edit Account" link in the admin header').toBeAttached();
-        await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'networkidle' });
+        await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'domcontentloaded' });
 
         if (!(await page.locator('#jform_joomlatoken_token').count())) {
             // Pristine account: save once to generate the seed, which lands

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -95,15 +95,30 @@ async function loginAdmin(browser, baseUrl, username, password, storageStatePath
     try {
         const page = await ctx.newPage();
 
-        // Load the login page
-        await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'networkidle' });
+        // Load the login page. domcontentloaded because every check below waits
+        // for its own element anyway; networkidle here spent the whole retry
+        // budget waiting for a dev server that had run out of workers.
+        await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'domcontentloaded' });
+
+        const loginForm = page.locator('#form-login');
+        const adminUi   = page.locator('#menu-collapse');
+
+        // Settle on whichever arrives first. isVisible() answers for the
+        // instant it is called, which networkidle used to make safe by having
+        // already waited for everything; under domcontentloaded it would be
+        // asking an empty document and getting "no login form" from a page
+        // that simply had not rendered yet.
+        await Promise.race([
+            loginForm.waitFor({ state: 'visible', timeout: 20000 }).catch(() => {}),
+            adminUi.waitFor({ state: 'visible', timeout: 20000 }).catch(() => {}),
+        ]);
 
         // Confirm the login form is present. Already-authenticated is only
         // claimed on the positive signal (the admin sidebar), never on the
         // form's mere absence.
-        const loginVisible = await page.locator('#form-login').isVisible().catch(() => false);
+        const loginVisible = await loginForm.isVisible().catch(() => false);
         if (!loginVisible) {
-            const authed = await page.locator('#menu-collapse')
+            const authed = await adminUi
                 .waitFor({ state: 'visible', timeout: 5000 })
                 .then(() => true, () => false);
             if (authed) {


### PR DESCRIPTION
You're right that it's happening a lot: **three failures in the last fifteen E2E runs** — 2026-08-07, 2026-08-08, and the first push of #1664 — all the same shape.

```
page.goto: Timeout 30000ms exceeded
navigating to "http://127.0.0.1:8890/administrator/index.php", waiting until "networkidle"
```

Always a retry away from green, which is why it read as noise. It isn't. Two things in the setup guaranteed this would happen eventually.

## 1. The worker pool was smaller than one page's connections

`networkidle` resolves after **500ms with no request in flight**. Chromium opens up to **six connections per host**. The dev server was started with **four workers**:

```
PHP_CLI_SERVER_WORKERS=4 php -S 127.0.0.1:8890 …
```

So two requests out of any six sat queued behind whichever worker was slowest, and the idle window couldn't open until they drained. Now 10 — above what a single page can ask for.

## 2. What kept the workers busy was an internet round trip

The dashboard's update quickicons fire an AJAX that **core itself introduces with this comment**:

```php
// Close the session before we make a long running request
$app->getSession()->abort();
```

`com_installer`'s `update.ajax` polls **every enabled update site** — and after `test:install` runs, that includes Proclaim's own on christianwebministries.org. Every CI run was taking a dependency on an external server, for a number **no test asserts on**.

Those plugins and Joomla's statistics reporting are now disabled for the disposable site, alongside `guidedtours`, which was switched off for exactly this class of reason.

## The wait strategy

The two navigations that actually timed out drop `networkidle` for `domcontentloaded`. Both are immediately followed by a wait for the specific element the navigation exists to reach — stricter than "the page stopped talking", and what Playwright recommends instead of `networkidle`.

**That change is not free in `global-setup`,** and this is the part worth reviewing. `isVisible()` answers for the instant it is called; `networkidle` was what made that safe by having already waited for everything. Under `domcontentloaded` it would be asking an empty document and getting *"no login form"* from a page that simply hadn't rendered — the same false negative the file's own comment records as having once **saved a guest session as valid auth state**. It now races the login form against the admin sidebar before deciding, so a slow render reads as "not yet".

## Scope

The other 24 `networkidle` uses are in the a11y, navigation and dragging specs — which **this job does not run** (`--project=api-test` only), and where waiting for a settled page is closer to the point. Left alone deliberately rather than swept up.

I also didn't reach for `retries: 1`. It would have hidden this rather than fixed it, and the suite has been telling us something true for a month.

## Verification

The mechanism is proven from core's source rather than by reproduction — I can't reproduce a timing-dependent external-network flake locally on demand. What the next few runs of this job show is the real test, and the scheduled nightly gives us one a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)