### PR TITLE
test: give #1623's safety net back the two tests it was missing

### DIFF
--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -199,6 +199,34 @@ if ($joomlaCmsPath !== '' && is_dir($joomlaCmsPath)) {
             \define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . '/manifests');
         }
 
+        /*
+         * Make the site component resolvable from JPATH_SITE.
+         *
+         * Joomla's LayoutHelper looks for a component layout under
+         * JPATH_SITE/components/<component>/layouts. The CMS clone is a bare
+         * Joomla with nothing installed into it, so anything rendered through a
+         * layout returned an empty string — and a test comparing two empty
+         * strings passes while verifying nothing. Two characterization tests for
+         * multi-reference scripture rendering skipped for exactly this reason,
+         * which left the seam #1623 has to move through uncovered.
+         *
+         * A symlink is what a linked dev install already does (composer symlink),
+         * so this only reproduces the layout a real site has. Created once and
+         * left in place; never replaced, so a clone that has Proclaim genuinely
+         * installed is not disturbed.
+         */
+        $siteComponentLink = $rootDir . '/components/com_proclaim';
+
+        if (!file_exists($siteComponentLink) && is_dir($componentRoot . '/site')) {
+            if (!is_dir(\dirname($siteComponentLink))) {
+                @mkdir(\dirname($siteComponentLink), 0755, true);
+            }
+
+            // Failure is not fatal: the tests that need it skip with a message
+            // saying so, which is how this was found in the first place.
+            @symlink($componentRoot . '/site', $siteComponentLink);
+        }
+
         if (!\defined('JDEBUG')) {
             \define('JDEBUG', false);
         }


### PR DESCRIPTION
Groundwork for #1623, and a gap worth closing before any file gets converted.

The characterization tests from #1649 are what make step 1 reviewable — they pin that the junction branch and the flat-column branch render the same thing. **Two of them skipped, and they were the two that mattered:** the multi-reference cases, which are the entire reason the junction exists.

```
1) …CwmscriptureRenderingCharacterizationTest::testJunctionJoinsMultipleReferences
2) …CwmscriptureRenderingCharacterizationTest::testJunctionCarriesMoreThanTwoReferences
   The scripture.list layout is not resolvable from JPATH_SITE in this harness…
```

Joomla's `LayoutHelper` resolves a component layout under `JPATH_SITE/components/com_proclaim/layouts`, and `JPATH_SITE` is a bare CMS clone with nothing installed into it. Anything rendered through a layout came back empty, so the tests skipped rather than compare two empty strings — honest, but it left the seam the refactor moves through uncovered **in CI as well as locally**. CI clones Joomla to a sibling directory and never installs Proclaim into it, so these have never run there.

## The fix

The bootstrap symlinks the repository's `site/` into the clone as `components/com_proclaim` — the same layout `composer symlink` gives a linked dev install, so it only reproduces what a real site has. Created once and never replaced, so a clone that *does* have Proclaim installed is untouched. Failure to create it is not fatal: the tests go back to skipping with the message that found this in the first place.

## Verified non-vacuous

14 assertions → **18**, nothing skipped. And they bite: making the junction branch render only its first reference —

```php
foreach (array_slice($row->scriptures, 0, 1) as $ref) {
```

— turns **both** of them red on the assertion that names the issue: *"Two references must render identically whichever store they came from — see #1623"*.

Full suite green at **2134 tests / 7182 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)