### PR TITLE
fix: read book names from the scripture library, not #__bsms_books (#1687)

### DIFF
--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -19,6 +19,7 @@ namespace CWM\Plugin\Finder\Proclaim\Extension;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Site\Helper\Cwmhelperroute;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Finder as FinderEvent;
 use Joomla\CMS\Language\Text;
@@ -531,16 +532,13 @@ final class Proclaim extends Adapter implements SubscriberInterface
 
         // Add Scripture/Book
         if (!empty($item->booknumber)) {
-            $query = $db->createQuery()
-                ->select($db->quoteName('bookname'))
-                ->from($db->quoteName('#__bsms_books'))
-                ->where($db->quoteName('booknumber') . ' = ' . (int) $item->booknumber);
-            $db->setQuery($query);
-            $bookname = $db->loadResult();
+            // From the scripture library rather than #__bsms_books, which stores
+            // the same language keys against the same numbers and was costing a
+            // query per indexed item to fetch one (#1687). getBookName()
+            // translates on the way out, so no Text::_() call is needed here.
+            $bookname = ScriptureHelper::getBookName((int) $item->booknumber);
 
             if ($bookname) {
-                // Translate bookname if it's a language key
-                $bookname = Text::_($bookname);
 
                 // Construct reference string
                 $reference = $bookname . ' ' . $item->chapter_begin;

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use CWM\Library\Scripture\Helper\ScriptureReference;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
@@ -2141,7 +2142,18 @@ class Cwmlisting
     }
 
     /**
-     * Get book name from database with caching
+     * Get a translated book name.
+     *
+     * Reads the scripture library's own book map rather than #__bsms_books. The
+     * table stores language keys (JBS_BBK_GENESIS), not names, so this method
+     * queried the database to fetch a key it then handed to Text::_() — and the
+     * library holds the same 73 keys against the same 101-173 numbers, in code.
+     * Verified identical: same count, same numbers, no key differing either way
+     * (#1687).
+     *
+     * The method name and the local cache stay: getBookName() resolves through
+     * array_search over BOOK_KEYS, so caching still earns its place on a listing
+     * that asks for the same handful of books repeatedly.
      *
      * @param   int  $booknumber  The book number to look up
      *
@@ -2155,22 +2167,11 @@ class Cwmlisting
             return '';
         }
 
-        // Preload all book names on first call (66 rows, tiny table)
-        if (empty(self::$bookNameCache)) {
-            $db    = Factory::getContainer()->get(DatabaseInterface::class);
-            $query = $db->createQuery()
-                ->select([$db->quoteName('booknumber'), $db->quoteName('bookname')])
-                ->from($db->quoteName('#__bsms_books'));
-            $db->setQuery($query);
-            $books = $db->loadObjectList();
-
-            foreach ($books as $book) {
-                $name                                         = $book->bookname ? Text::_($book->bookname) : '';
-                self::$bookNameCache[(int) $book->booknumber] = $name;
-            }
+        if (!\array_key_exists($booknumber, self::$bookNameCache)) {
+            self::$bookNameCache[$booknumber] = ScriptureHelper::getBookName($booknumber);
         }
 
-        return self::$bookNameCache[$booknumber] ?? '';
+        return self::$bookNameCache[$booknumber];
     }
 
     /**

--- a/tests/integration/Site/Helper/CwmscriptureRenderingCharacterizationTest.php
+++ b/tests/integration/Site/Helper/CwmscriptureRenderingCharacterizationTest.php
@@ -153,6 +153,38 @@ class CwmscriptureRenderingCharacterizationTest extends IntegrationTestCase
         $this->assertSame('John 3', $out, 'Chapters-only mode renders "Book Chapter"');
     }
 
+    /**
+     * The fallback every caller relies on once the #__bsms_books JOIN is gone.
+     *
+     * A row that arrives without a bookname resolves the name from the book
+     * number instead. Nothing exercised that path before — every fixture here
+     * supplied a bookname, so the branch was invisible — and #1687 makes it the
+     * normal case rather than the exception, since removing the JOIN is exactly
+     * what stops rows carrying a name.
+     *
+     * @return  void
+     */
+    #[TestDox('A row with no bookname resolves the name from its book number')]
+    public function testBookNameIsResolvedWhenTheRowCarriesNone(): void
+    {
+        $withName = $this->legacyRow();
+
+        $withoutName = $this->legacyRow();
+        unset($withoutName->bookname);
+
+        $this->assertSame(
+            $this->listing->getScripture($this->params(), $withName, 0, 1),
+            $this->listing->getScripture($this->params(), $withoutName, 0, 1),
+            'Dropping the JOIN must not change what renders — see #1687'
+        );
+
+        $this->assertSame(
+            'John 3',
+            $this->listing->getScripture($this->params(), $withoutName, 0, 1),
+            'and it must be the right book, not an empty string that happens to match'
+        );
+    }
+
     #[TestDox('Chapters-only and with-verses modes render differently')]
     public function testShowVersesChangesTheOutput(): void
     {


### PR DESCRIPTION
First slice of #1687. Deliberately small — the remaining sites split into two shapes with different risk, and mixing them would produce a diff nobody can check against "the site renders the same".

## The equivalence, proved before anything changed

`#__bsms_books` stores language keys (`JBS_BBK_GENESIS`), not names, so every consumer joined the table and handed the result to `Text::_()`. The library holds the same keys against the same numbers, in code.

```
#__bsms_books:             73 books (101..173)
ScriptureHelper BOOK_KEYS: 73 books (101..173)

only in the table:   none
only in the library: none
differing keys:      none

verdict: IDENTICAL — the JOIN can be replaced with getBookName() for every book
```

That is what makes the rest of this issue mechanical rather than risky.

## What's in this slice

Two sites, chosen because **neither touches a `book2` JOIN**:

- **`plg_finder_proclaim`** ran a single-row `SELECT` per indexed item to fetch one book name — a query per message, every reindex, for a constant.
- **`Cwmlisting::getBookNameFromDb()`** loaded the whole table into a static cache on first use. The method keeps its name and its cache — `getBookName()` resolves by `array_search`, so caching still earns its place — but the database is gone from it.

## The ordering decision worth reviewing

The five files carrying `book`/`book2` JOIN pairs — `Cwmpagebuilder`, `CwmsermonsModel`, `CwmsermonModel`, `CwmseriesdisplayModel`, `CwmseriespodcastdisplayModel` — are **not** in this PR. Their `book2` JOIN exists only to resolve `booknumber2`, which **#1623 deletes outright**. Converting them here would mean editing the same five files twice. They should go with #1623, not before it.

## A gap this found

`Cwmlisting::getBookNameFromDb()` had **no coverage at all**. I mutated it to return an empty string and nothing failed — every fixture in the characterization suite supplies `$row->bookname`, so the fallback branch was invisible.

That matters more than it sounds: the method is the fallback for rows arriving *without* a bookname, and **#1687 makes that the normal case rather than the exception** — removing a JOIN is precisely what stops a row carrying a name. It now has a test, verified to bite (making the lookup return `''` fails it on *"Dropping the JOIN must not change what renders"*).

## Still to come

- **Shape A, the rest** — plain `LEFT JOIN` name lookups in `CwmdescriptionHelper`, `CwmnotificationHelper`, `CwmcommentsModel`, `Cwmpodcast`, `Cwmrelatedstudies`, `Cwmserieslist`. Mechanical, individually verifiable.
- **Shape B** — `CwmproclaimHelper::getStudyBooks()`, `BookListField`, and `Cwmlanding` (×3) use the table as the *driving* table to enumerate books that have studies. That changes query structure, so it deserves its own PR. I checked the one thing that could break silently: `Cwmlanding`'s `SELECT DISTINCT a.*` exposes the surrogate `id`, but its consumers key on `booknumber`, and the `$item->booknumber = $item->id` line sits in an `else` branch operating on a different data shape entirely.
- **Dropping the table**, once nothing reads it — including the dead `published` column, which nothing filters on anywhere.

Full suite green: **2135 tests, 7184 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
