### PR TITLE
fix: Shape A — stop joining #__bsms_books for a name the library already has (#1687)

### DIFF
--- a/admin/src/Helper/CwmdescriptionHelper.php
+++ b/admin/src/Helper/CwmdescriptionHelper.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
@@ -403,17 +404,13 @@ class CwmdescriptionHelper
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery()
             ->select([
-                $db->quoteName('b.bookname'),
+                $db->quoteName('ss.booknumber'),
                 $db->quoteName('ss.chapter_begin'),
                 $db->quoteName('ss.verse_begin'),
                 $db->quoteName('ss.chapter_end'),
                 $db->quoteName('ss.verse_end'),
             ])
             ->from($db->quoteName('#__bsms_study_scriptures', 'ss'))
-            ->leftJoin(
-                $db->quoteName('#__bsms_books', 'b') .
-                ' ON ' . $db->quoteName('b.booknumber') . ' = ' . $db->quoteName('ss.booknumber')
-            )
             ->where($db->quoteName('ss.study_id') . ' = ' . (int) $studyId)
             ->order($db->quoteName('ss.ordering') . ' ASC');
         $db->setQuery($query);
@@ -422,8 +419,12 @@ class CwmdescriptionHelper
         $refs = [];
 
         foreach ($rows as $row) {
-            $bookname = $row->bookname ?? '';
-            $ref      = Text::_($bookname) . ' ' . ($row->chapter_begin ?? '');
+            // The book name comes from the scripture library rather than a
+            // #__bsms_books JOIN: the table stored the same language keys this
+            // resolves, against the same numbers (#1687). getBookName()
+            // translates, so no Text::_() call is needed here.
+            $ref = ScriptureHelper::getBookName((int) ($row->booknumber ?? 0))
+                . ' ' . ($row->chapter_begin ?? '');
 
             if (!empty($row->verse_begin)) {
                 $ref .= ':' . $row->verse_begin;

--- a/admin/src/Helper/CwmnotificationHelper.php
+++ b/admin/src/Helper/CwmnotificationHelper.php
@@ -120,13 +120,8 @@ class CwmnotificationHelper
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery()
-            ->select($db->quoteName(['s.studytitle', 's.studydate', 'b.bookname']))
+            ->select($db->quoteName(['s.studytitle', 's.studydate']))
             ->from($db->quoteName('#__bsms_studies', 's'))
-            ->join(
-                'LEFT',
-                $db->quoteName('#__bsms_books', 'b') . ' ON '
-                . $db->quoteName('b.booknumber') . ' = ' . $db->quoteName('s.booknumber')
-            )
             ->where($db->quoteName('s.id') . ' = ' . (int) $studyId);
         $db->setQuery($query);
 

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\DatabaseInterface;
@@ -222,13 +223,6 @@ class CwmcommentsModel extends ListModel
             $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.id') . ' = ' . $db->quoteName('comment.study_id')
         );
 
-        // Join over books
-        $query->select($db->quoteName('book.bookname', 'bookname'));
-        $query->join(
-            'LEFT',
-            $db->quoteName('#__bsms_books', 'book') . ' ON ' . $db->quoteName('book.booknumber') . ' = ' . $db->quoteName('study.booknumber')
-        );
-
         // Join over the asset groups.
         $query->select($db->quoteName('ag.title', 'access_level'));
         $query->join(
@@ -284,5 +278,34 @@ class CwmcommentsModel extends ListModel
         $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
         return $query;
+    }
+
+    /**
+     * Attach each comment's book name.
+     *
+     * Was a #__bsms_books JOIN in the list query. That table stores language
+     * keys, not names, so the join fetched a key the scripture library already
+     * holds against the same number (#1687).
+     *
+     * Set on the item rather than resolved in the layout because this list has
+     * a template a site can override, and an override may read $item->bookname.
+     *
+     * @return  mixed  An array of data items on success, false on failure.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getItems(): mixed
+    {
+        $items = parent::getItems();
+
+        if (!\is_array($items)) {
+            return $items;
+        }
+
+        foreach ($items as $item) {
+            $item->bookname = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
+        }
+
+        return $items;
     }
 }

--- a/admin/tmpl/cwmcomments/default.php
+++ b/admin/tmpl/cwmcomments/default.php
@@ -243,12 +243,11 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                                             <a href="<?php
                                             echo $link; ?>"><?php
                                                 echo $this->escape($item->studytitle) . ' - '
-                                                    . Text::_($item->bookname) . ' ' . $item->chapter_begin; ?></a>
+                                                    . $this->escape($item->bookname) . ' ' . $item->chapter_begin; ?></a>
                                             <?php else : ?>
                                             <?php
-                                            echo $this->escape($item->studytitle) . ' - ' . Text::_(
-                                                $item->bookname
-                                            ) . ' ' . $item->chapter_begin; ?>
+                                            echo $this->escape($item->studytitle) . ' - '
+                                                . $this->escape($item->bookname) . ' ' . $item->chapter_begin; ?>
                                             <?php
                                             endif; ?>
                                     </div>

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -23,6 +23,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmpodcastTrackHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Factory;
@@ -1094,7 +1095,6 @@ class Cwmpodcast
                 'se.series_text', 'se.published',
                 'sr.id AS srid', 'sr.params as srparams',
                 't.id AS tid', 't.teachername',
-                'b.id AS bid', 'b.booknumber AS bnumber', 'b.bookname',
                 'loc.location_text',
             ]
         )
@@ -1102,7 +1102,6 @@ class Cwmpodcast
             ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('mf.study_id'))
             ->leftJoin($db->quoteName('#__bsms_series', 'se') . ' ON ' . $db->quoteName('se.id') . ' = ' . $db->quoteName('s.series_id'))
             ->leftJoin($db->quoteName('#__bsms_servers', 'sr') . ' ON ' . $db->quoteName('sr.id') . ' = ' . $db->quoteName('mf.server_id'))
-            ->leftJoin($db->quoteName('#__bsms_books', 'b') . ' ON ' . $db->quoteName('b.booknumber') . ' = ' . $db->quoteName('s.booknumber'))
             ->leftJoin($db->quoteName('#__bsms_study_teachers', 'stj') . ' ON '
                 . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                 . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
@@ -1125,6 +1124,13 @@ class Cwmpodcast
         foreach ($episodes as $e) {
             $e->params   = new Registry($e->params);
             $e->srparams = new Registry($e->srparams);
+
+            // Was a #__bsms_books JOIN, which fetched the same language keys the
+            // scripture library already holds against the same numbers (#1687).
+            // Still set on the row rather than resolved at the point of use: an
+            // episode reaches template overrides outside this repository, and
+            // one of those may read $episode->bookname.
+            $e->bookname = ScriptureHelper::getBookName((int) ($e->booknumber ?? 0));
         }
 
         return $episodes;

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -395,7 +395,6 @@ class Cwmrelatedstudies
                 's.booknumber', 's.chapter_begin', 's.thumbnailm', 's.image',
             ]))
             ->select($db->quoteName('t.teachername'))
-            ->select($db->quoteName('b.bookname'))
             ->from($db->quoteName('#__bsms_studies', 's'))
             ->leftJoin(
                 $db->quoteName('#__bsms_study_teachers', 'stj2') . ' ON '
@@ -405,10 +404,6 @@ class Cwmrelatedstudies
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't')
                 . ' ON ' . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj2.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')'
-            )
-            ->leftJoin(
-                $db->quoteName('#__bsms_books', 'b')
-                . ' ON ' . $db->quoteName('b.booknumber') . ' = ' . $db->quoteName('s.booknumber')
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_series', 'ser')

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
@@ -199,9 +200,9 @@ class Cwmserieslist extends Cwmlisting
             . $db->quoteName('t.teacher_thumbnail') . ', ' . $db->quoteName('se.series_text') . ', '
             . $db->quoteName('se.description', 'sdescription') . ', '
             . $db->quoteName('se.series_thumbnail') . ', '
+            . $db->quoteName('s.booknumber') . ', '
             . $db->quoteName('#__bsms_message_type.id', 'mid') . ', '
             . $db->quoteName('#__bsms_message_type.message_type', 'message_type') . ', '
-            . $db->quoteName('#__bsms_books.bookname') . ', '
             . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.id') . ' SEPARATOR ", ") AS ' . $db->quoteName('tp_id') . ', '
             . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.topic_text') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_text') . ', '
             . 'GROUP_CONCAT(' . $db->quoteName('#__bsms_topics.params') . ' SEPARATOR ", ") AS ' . $db->quoteName('topic_params') . ', '
@@ -221,10 +222,6 @@ class Cwmserieslist extends Cwmlisting
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't') . ' ON ('
                 . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('st.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
-            )
-            ->leftJoin(
-                $db->quoteName('#__bsms_books') . ' ON ('
-                . $db->quoteName('s.booknumber') . ' = ' . $db->quoteName('#__bsms_books.booknumber') . ')'
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_message_type') . ' ON ('
@@ -266,6 +263,11 @@ class Cwmserieslist extends Cwmlisting
         foreach ($items as $item) {
             // Concat topic_text and concat topic_params do not fit, so translate individually
             $item->topics_text = Cwmtranslated::getConcatTopicItemTranslated($item);
+
+            // Was a #__bsms_books JOIN for a language key the scripture library
+            // already holds (#1687). Still set on the row: these items reach
+            // templates a site can override, and one may read $item->bookname.
+            $item->bookname = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
         }
 
         return $items;


### PR DESCRIPTION
Shape A of #1687 — the plain name lookups. Builds on lib_cwmscripture#39, which had to land first: the library could not name a book without `com_proclaim`'s language file already loaded, and every conversion here adds a caller that depends on it.

## Tracing the consumers turned one job into three

I expected five near-identical edits. They weren't.

**Two joins fetched a column nobody reads.**

- `CwmnotificationHelper::getStudyDetails()` selected `b.bookname`; its only caller uses `studytitle`.
- `Cwmrelatedstudies` selected `b.bookname` and builds its HTML in PHP without ever touching it.

Both are simply gone — no replacement, because there was nothing to replace.

**One is private and converts outright.** `CwmdescriptionHelper::getScriptureReferences()` is consumed three lines later: select `ss.booknumber`, resolve with `getBookName()`, drop the now-redundant `Text::_()`.

**Two hand rows to overridable templates.** `Cwmserieslist` and `CwmcommentsModel` keep the `bookname` property and fill it in PHP. Nothing *in this repository* reads it from either, but a site's template override might, and that is exactly the third-party caveat #1623 and #1687 both carry. Same row shape, no table.

`Cwmserieslist` had to start selecting `s.booknumber` — the join had been its only source. It is functionally dependent on the `s.id` it groups by, so `ONLY_FULL_GROUP_BY` is satisfied.

The comments layout stops calling `Text::_()` on a value that now arrives translated, and escapes it instead — which it should have been doing anyway.

## A bug that fell out — second commit, on purpose

Podcast episode-title format 6:

```php
return $episode->bookname . ' ' . $episode->chapter_begin;
```

No `Text::_()`. `bookname` came straight from the join, and that column holds **language keys** — so the feed carried `JBS_BBK_JOHN 3` where it meant `John 3`. Every other consumer of that column translates it; this one never did.

Replacing the join with `getBookName()` fixes it by construction, since that translates on the way out. **Kept as its own commit** because it is a visible change to published podcast feeds and belongs in the release notes as a fix, not buried in a refactor.

Also drops `b.id AS bid` and `b.booknumber AS bnumber` from the same select — neither is referenced anywhere.

## Deliberately not in this PR

- **The five files with `book`/`book2` pairs.** Their second join exists only to resolve `booknumber2`, which **#1623 deletes outright**. Doing them here means editing the same five files twice.
- **The four Shape B sites** (`CwmproclaimHelper::getStudyBooks()`, `BookListField`, `Cwmlanding` ×3), which use the table as the *driving* table to enumerate books that have studies. That changes query structure and wants its own review.

15 references remain, and they are exactly those two groups.

## Verification

Full suite green: **2135 tests, 7184 assertions**.

Coverage is honest rather than complete: the characterization tests cover `Cwmlisting`'s path (converted in #1689), and the equivalence of table-to-library was proved exhaustively before any of this started — 73 books each, no key differing either way. The five sites here have no direct test; what they have is that the value they now produce comes from the same map, through the same `Text::_()`, as the value the join produced.

## Note

I owe #1687 one correction, now posted there: I claimed nothing filters on the `published` column. `site/tmpl/cwmsermons/default.xml:90` runs `SELECT … WHERE published = 1` in a `type="sql"` field, so dropping the table needs that replaced too.

The submodule pin is **not** bumped here — that is a release action needing a tag on lib_cwmscripture, in the order lib → scripturelinks → Proclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
