### PR TITLE
fix: ask the studies which books are in use, not the books table (#1687)

### DIFF
--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -507,16 +508,17 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->createQuery();
 
-        $query->select(
-            $db->quoteName('book.booknumber', 'value') . ', ' . $db->quoteName('book.bookname', 'text') . ', ' . $db->quoteName('book.id')
-        );
-        $query->from($db->quoteName('#__bsms_books', 'book'));
-        $query->join(
-            'INNER',
-            $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.booknumber') . ' = ' . $db->quoteName('book.booknumber')
-        );
-        $query->group($db->quoteName('book.id'));
-        $query->order($db->quoteName('value') . ' ASC');
+        // Asks the studies which books are in use, rather than asking
+        // #__bsms_books which of its rows a study points at. Same set, and the
+        // name comes from the scripture library, which holds the language keys
+        // that table stored (#1687).
+        //
+        // booknumber > 0 replaces what the INNER JOIN used to do implicitly: a
+        // study with no book selected matched no row, so it never appeared.
+        $query->select('DISTINCT ' . $db->quoteName('booknumber', 'value'))
+            ->from($db->quoteName('#__bsms_studies'))
+            ->where($db->quoteName('booknumber') . ' > 0')
+            ->order($db->quoteName('value') . ' ASC');
 
         // Get the options.
         $db->setQuery($query);
@@ -528,10 +530,12 @@ class CwmproclaimHelper
         }
 
         foreach ($options as $option) {
-            $option->text = Text::_($option->text);
+            $option->text = ScriptureHelper::getBookName((int) $option->value);
         }
 
-        return $options;
+        // A number the library does not know names nothing, and an option with
+        // no label is worse than an absent one.
+        return array_values(array_filter($options, static fn ($o): bool => $o->text !== ''));
     }
 
     /**


### PR DESCRIPTION
First of the Shape B sites in #1687 — the ones that use `#__bsms_books` as the **driving table** rather than as a name lookup. One site, deliberately, because the other three turned out not to be repeats of it.

## The change

`CwmproclaimHelper::getStudyBooks()` feeds the admin Book filter. It asked the books table which of its rows a study points at:

```sql
SELECT book.booknumber AS value, book.bookname AS text, book.id
  FROM #__bsms_books book
  INNER JOIN #__bsms_studies study ON study.booknumber = book.booknumber
 GROUP BY book.id
```

It now asks the studies directly and takes the name from the scripture library, which holds the same language keys that table stored against the same numbers.

**`booknumber > 0` replaces what the INNER JOIN did implicitly.** A study with no book selected matched no row in `#__bsms_books`, so it never reached the filter. Without the join it would arrive as a zero — this is the part of a driving-table swap that is easy to miss, because nothing fails, an extra option just appears.

Options whose number the library cannot name are dropped rather than rendered blank. The old query could not produce one — a row existed or it did not — so this is the same outcome by a different route, and an unlabelled entry in a filter dropdown is worse than a missing one.

`book.id` was also selected and is read by nothing; the only consumer is `BookListField:61`, which merges the result into `ListField::getOptions()`.

## Why the other three are not in here

They are Shape B by category but not by shape:

- **`BookListField`'s frontend branch** passes `'book'` — the books-table alias — into `CwmfilterHelper::applyCrossFilters()`. The driving table cannot change until I have read what that helper does with the alias, and guessing is how you get a filter that silently stops filtering.
- **`Cwmlanding` has three.** Two are near-identical to each other. The third sits in `buildQueryForType()`, whose result is **UNIONed** with the teachers, years and other branches — every branch has to produce the same column shape (`id`, `text`, `landing_show`, `params`, `type`), so the book name cannot simply move to PHP without restructuring how the union's result is consumed.

That is a different piece of work with a different risk profile, and it deserves its own review rather than riding along here.

## Verification

Full suite green: **2135 tests, 7184 assertions**.

The equivalence this rests on was proved exhaustively before Shape A started — `#__bsms_books` and `ScriptureHelper::BOOK_KEYS` carry the same 73 books over the same 101–173 numbers, with no key differing either way.

Depends on lib_cwmscripture#39 (merged), which made the library able to name a book without `com_proclaim`'s language file already loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
