### PR TITLE
docs: note the podcast book-name fix in 10.5.7 (#1687)

### DIFF
--- a/build/proclaim-changelog.xml
+++ b/build/proclaim-changelog.xml
@@ -33,6 +33,7 @@
             <item>Proclaim's own database tables are still kept on uninstall unless you set Drop Tables on Uninstall to Yes, which remains the default. Nothing about that has changed</item>
             <item>Sites that installed Proclaim before 10.4.0 were checking for updates twice, and Extensions - Update listed Proclaim as a component rather than a package. The leftover update site is removed, so the duplicate entry disappears and the row reads Package. Some of those sites carried an update address that only ever served 9.2.x and could never offer them anything</item>
             <item>A playlist sync that overlapped another one - a scheduled sync running while you started one by hand, or an impatient second click - could stop partway through with a database error, or quietly drop the rest of a media file's playlist assignments. Each video is now recorded in a single step, so the two runs agree instead of colliding</item>
+            <item>Podcast episode titles set to the "Book Chapter" format showed an internal code in place of the book name - "JBS_BBK_JOHN 3" rather than "John 3". Only that one title format was affected, and the episodes themselves were fine; the titles correct themselves the next time the feed is built</item>
         </fix>
         <addition>
             <item>The scripture package now installs the Scripture task and system plugins alongside the library. The task plugin downloads Bible translations in the background instead of adding around forty seconds to every install</item>


### PR DESCRIPTION
The one user-visible change to come out of the `#__bsms_books` work.

Episode titles using the **"Book Chapter"** format carried the language key straight into the feed, so subscribers saw `JBS_BBK_JOHN 3` instead of `John 3`. Every other consumer of that column translated it; that one never did.

## Two things the line says on purpose

**Which format was affected.** Every other episode-title format was correct, so a site not using that one has nothing to check. Naming it saves people looking.

**That the episodes were fine and the titles fix themselves.** "My podcast titles were wrong" invites the assumption that something deeper broke — that episodes were mis-tagged, or that directories need resubmitting. Neither is true: the feed regenerates and the titles come back right.

## What stays out

The rest of that work — five join conversions, a driving-table swap, two dead joins removed — is invisible to a site owner.

XML validates; 10.5.7 is still the first block, now **7 fix / 1 addition / 1 change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)