### PR TITLE
fix: finish Shape B, and unbreak the landing page's Books section (#1687)

### DIFF
--- a/admin/src/Field/BookListField.php
+++ b/admin/src/Field/BookListField.php
@@ -18,10 +18,10 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmfilterHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -67,20 +67,20 @@ class BookListField extends ListField
         $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $query  = $db->createQuery();
 
-        $query->select(
-            $db->quoteName('book.booknumber', 'value') . ', '
-            . $db->quoteName('book.bookname', 'text')
-        )
-            ->from($db->quoteName('#__bsms_books', 'book'))
-            ->join(
-                'INNER',
-                $db->quoteName('#__bsms_studies', 's') . ' ON '
-                . $db->quoteName('s.booknumber') . ' = ' . $db->quoteName('book.booknumber')
-            )
+        // Driven by the studies rather than by #__bsms_books, whose bookname
+        // column holds the same language keys the scripture library already has
+        // (#1687). The studies keep the alias `s`: applyCrossFilters() below
+        // writes s.booknumber, s.series_id and s.id, so the alias is part of
+        // that helper's contract even though the table it joined has gone.
+        //
+        // booknumber > 0 is what the INNER JOIN used to do implicitly — a study
+        // with no book matched no row, so it never became an option.
+        $query->select('DISTINCT ' . $db->quoteName('s.booknumber', 'value'))
+            ->from($db->quoteName('#__bsms_studies', 's'))
+            ->where($db->quoteName('s.booknumber') . ' > 0')
             ->whereIn($db->quoteName('s.published'), [1, 2])
             ->whereIn($db->quoteName('s.access'), $groups)
-            ->group($db->quoteName('book.id'))
-            ->order($db->quoteName('book.booknumber') . ' ASC');
+            ->order($db->quoteName('s.booknumber') . ' ASC');
 
         CwmfilterHelper::applyCrossFilters(
             $query,
@@ -93,7 +93,13 @@ class BookListField extends ListField
         $options = [];
 
         foreach ($books as $book) {
-            $options[] = HTMLHelper::_('select.option', $book->value, Text::_($book->text));
+            $name = ScriptureHelper::getBookName((int) $book->value);
+
+            // A number the library cannot name would render as a blank entry,
+            // which the old query could not produce: the row existed or it did not.
+            if ($name !== '') {
+                $options[] = HTMLHelper::_('select.option', $book->value, $name);
+            }
         }
 
         return array_merge(parent::getOptions(), $options);

--- a/build/proclaim-changelog.xml
+++ b/build/proclaim-changelog.xml
@@ -33,6 +33,7 @@
             <item>Proclaim's own database tables are still kept on uninstall unless you set Drop Tables on Uninstall to Yes, which remains the default. Nothing about that has changed</item>
             <item>Sites that installed Proclaim before 10.4.0 were checking for updates twice, and Extensions - Update listed Proclaim as a component rather than a package. The leftover update site is removed, so the duplicate entry disappears and the row reads Package. Some of those sites carried an update address that only ever served 9.2.x and could never offer them anything</item>
             <item>A playlist sync that overlapped another one - a scheduled sync running while you started one by hand, or an impatient second click - could stop partway through with a database error, or quietly drop the rest of a media file's playlist assignments. Each video is now recorded in a single step, so the two runs agree instead of colliding</item>
+            <item>The Books section on a landing page failed with a database error on MySQL, showing nothing where the list of Bible books should be. Sites on MariaDB were unaffected, which is why the same setup could work on one host and not another</item>
             <item>Podcast episode titles set to the "Book Chapter" format showed an internal code in place of the book name - "JBS_BBK_JOHN 3" rather than "John 3". Only that one title format was affected, and the episodes themselves were fine; the titles correct themselves the next time the feed is built</item>
         </fix>
         <addition>

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
+use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
@@ -397,6 +398,19 @@ class Cwmlanding
             $grouped[$row->type][] = $row;
         }
 
+        // The books branch could not name its own rows in SQL; do it here, where
+        // the union's shared column shape no longer constrains anything. Keyed
+        // on `id`, which for that branch is the book number.
+        if (!empty($grouped['books'])) {
+            foreach ($grouped['books'] as $row) {
+                $row->text = ScriptureHelper::getBookName((int) $row->id);
+            }
+
+            $grouped['books'] = array_values(
+                array_filter($grouped['books'], static fn ($row): bool => $row->text !== '')
+            );
+        }
+
         foreach ($grouped as $type => &$items) {
             $orderKey = match ($type) {
                 'teachers'     => 'teachers_order',
@@ -563,18 +577,23 @@ class Cwmlanding
                 break;
 
             case 'books':
+                // `text` is a placeholder here, filled by nameBooks() once the
+                // union has loaded. Every branch of this union has to produce
+                // the same five columns, and a book's name is no longer
+                // available to SQL: #__bsms_books held language keys the
+                // scripture library already carries, so the join it needed
+                // earned nothing (#1687).
+                //
+                // booknumber > 0 is what that INNER JOIN did implicitly.
                 $query->select(
-                    'DISTINCT ' . $this->db->quoteName('a.booknumber', 'id') . ', '
-                    . $this->db->quoteName('a.bookname', 'text') . ', '
+                    'DISTINCT ' . $this->db->quoteName('b.booknumber', 'id') . ', '
+                    . $null . ' AS ' . $this->db->quoteName('text') . ', '
                     . '0 AS ' . $this->db->quoteName('landing_show') . ', '
                     . $null . ' AS ' . $this->db->quoteName('params') . ', '
                     . $this->db->quote('books') . ' AS ' . $this->db->quoteName('type')
                 )
-                    ->from($this->db->quoteName('#__bsms_books', 'a'))
-                    ->innerJoin(
-                        $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
-                        . $this->db->quoteName('a.booknumber') . ' = ' . $this->db->quoteName('b.booknumber')
-                    )
+                    ->from($this->db->quoteName('#__bsms_studies', 'b'))
+                    ->where($this->db->quoteName('b.booknumber') . ' > 0')
                     ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                     ->where($this->db->quoteName('b.published') . ' = 1');
                 $this->addAccessFilter($query);
@@ -1107,17 +1126,21 @@ class Cwmlanding
             $order    = $this->getSortOrder($params, 'books_order');
             $language = $this->getLanguageFilter($params);
 
+            // Asks the studies which books are in use rather than asking
+            // #__bsms_books which of its rows a study points at — same set, and
+            // the name is attached afterwards from the scripture library, which
+            // holds the language keys that table stored (#1687).
+            //
+            // The studies keep the alias `b`, which addAccessFilter() writes as
+            // b.access. booknumber > 0 is what the INNER JOIN did implicitly: a
+            // study with no book matched no row, so it never became an entry.
             $query = $this->db->createQuery();
-            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
-                ->from($this->db->quoteName('#__bsms_books', 'a'))
-                ->innerJoin(
-                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
-                    . $this->db->quoteName('a.booknumber') . ' = ' . $this->db->quoteName('b.booknumber')
-                )
+            $query->select('DISTINCT ' . $this->db->quoteName('b.booknumber'))
+                ->from($this->db->quoteName('#__bsms_studies', 'b'))
+                ->where($this->db->quoteName('b.booknumber') . ' > 0')
                 ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                 ->where($this->db->quoteName('b.published') . ' = 1')
-                ->group($this->db->quoteName('a.bookname'))
-                ->order($this->db->quoteName('a.booknumber') . ' ' . $order);
+                ->order($this->db->quoteName('b.booknumber') . ' ' . $order);
 
             $this->addAccessFilter($query);
 
@@ -1127,7 +1150,7 @@ class Cwmlanding
                 $this->db->setQuery($query);
             }
 
-            $items = $this->db->loadObjectList();
+            $items = self::nameBooks($this->db->loadObjectList() ?: []);
         } else {
             foreach ($items as $item) {
                 $item->booknumber = $item->id;
@@ -1152,6 +1175,33 @@ class Cwmlanding
     // =========================================================================
     // Data-returning methods for layout-based rendering (Phase 1)
     // =========================================================================
+
+    /**
+     * Attach a book name to each row returned by the books queries.
+     *
+     * Those queries used to join #__bsms_books for a `bookname` column holding a
+     * JBS_BBK_* language key, which the callers then passed to Text::_(). The
+     * scripture library holds the same keys against the same numbers, so the
+     * join earned nothing (#1687).
+     *
+     * Rows whose number the library cannot name are dropped. The join could not
+     * produce one — the row existed or it did not — and an entry with no label
+     * links somewhere the reader cannot identify.
+     *
+     * @param   array  $rows  Rows carrying a booknumber.
+     *
+     * @return  array  The same rows, named, minus any that cannot be.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function nameBooks(array $rows): array
+    {
+        foreach ($rows as $row) {
+            $row->bookname = ScriptureHelper::getBookName((int) ($row->booknumber ?? 0));
+        }
+
+        return array_values(array_filter($rows, static fn ($row): bool => $row->bookname !== ''));
+    }
 
     /**
      * Split landing items into visible (above fold) and hidden (below fold) arrays.
@@ -1665,24 +1715,28 @@ class Cwmlanding
             $order    = $this->getSortOrder($params, 'books_order');
             $language = $this->getLanguageFilter($params);
 
+            // Asks the studies which books are in use rather than asking
+            // #__bsms_books which of its rows a study points at — same set, and
+            // the name is attached afterwards from the scripture library, which
+            // holds the language keys that table stored (#1687).
+            //
+            // The studies keep the alias `b`, which addAccessFilter() writes as
+            // b.access. booknumber > 0 is what the INNER JOIN did implicitly: a
+            // study with no book matched no row, so it never became an entry.
             $query = $this->db->createQuery();
-            $query->select('DISTINCT ' . $this->db->quoteName('a') . '.*')
-                ->from($this->db->quoteName('#__bsms_books', 'a'))
-                ->innerJoin(
-                    $this->db->quoteName('#__bsms_studies', 'b') . ' ON '
-                    . $this->db->quoteName('a.booknumber') . ' = ' . $this->db->quoteName('b.booknumber')
-                )
+            $query->select('DISTINCT ' . $this->db->quoteName('b.booknumber'))
+                ->from($this->db->quoteName('#__bsms_studies', 'b'))
+                ->where($this->db->quoteName('b.booknumber') . ' > 0')
                 ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                 ->where($this->db->quoteName('b.published') . ' = 1')
-                ->group($this->db->quoteName('a.bookname'))
-                ->order($this->db->quoteName('a.booknumber') . ' ' . $order);
+                ->order($this->db->quoteName('b.booknumber') . ' ' . $order);
 
             $this->addAccessFilter($query);
 
             // Fetch all items — splitItems() handles visible/hidden split in PHP
             $this->db->setQuery($query);
 
-            $items = $this->db->loadObjectList();
+            $items = self::nameBooks($this->db->loadObjectList() ?: []);
         } else {
             foreach ($items as $item) {
                 $item->booknumber = $item->id;


### PR DESCRIPTION
The last three Shape B sites — and one of them turned out to be a live bug rather than a refactor.

## The part worth reading first

Two of `Cwmlanding`'s three book queries **could not run at all on MySQL**:

```sql
SELECT DISTINCT a.* FROM #__bsms_books a … GROUP BY a.bookname
```

`a.id` is not functionally dependent on `a.bookname`, so under **`ONLY_FULL_GROUP_BY` — MySQL's default since 5.7** — the query is rejected outright. Confirmed against j5-dev: the existing query fails, the replacement returns 41 rows. All six dev databases here run MySQL 8 with that mode on.

`getBooksLandingData()` is live, reached by `getSectionData('books', …)`, so **enabling the Books section on a landing page produced a database error instead of a section.**

Two reasons it has gone unnoticed:

- The section is off on both landing menu items here (`showbooks` unset).
- **MariaDB does not enable that mode by default**, so the same configuration works on one host and fails on another — the kind of thing an administrator blames on their own setup.

**I nearly filed these methods as dead code.** Grepping the method name finds no callers, because `getSectionData()` calls them from a `match` inside the same file my grep excluded. Checking the dispatch is what turned "unused" into "broken", and it is exactly what [[dead-code-reachability]] warns about.

## The conversions

**`BookListField` was easier than I claimed when I set it aside.** I said it passed `'book'` into `applyCrossFilters()` as a table alias. It does not — that argument names the filter to *skip*. What the helper actually needs is the studies table aliased `s`, which it writes as `s.booknumber`, `s.series_id`, `s.id`. The studies keep that alias, so the helper is untouched. Correcting that here since #1692's body states it wrongly.

**The union branch could not name its rows in SQL at all.** Every branch of that union must produce the same five columns, and a book's name now lives in PHP. It selects a placeholder; the caller fills it once the union has loaded, keyed on the `id` column that for that branch is the book number.

`booknumber > 0` appears in every converted query. It is what the INNER JOIN did implicitly — a study with no book matched no row — and it is the half of a driving-table swap that fails silently: nothing errors, an extra entry simply appears.

## Verification

Old and new queries compared against real data on j5-dev, per site. Full suite green: **2135 tests, 7184 assertions**.

## #1687 after this

Every `#__bsms_books` query is gone except the ten `book`/`book2` pairs in five files, which belong to **#1623** — their second join resolves `booknumber2`, which that issue deletes outright.

Second commit adds the 10.5.7 changelog line, since the landing failure is user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)