### PR TITLE
feat: give the test site a front end, and check that it renders (#1701)

### DIFF
--- a/build/seed-testsite-menus.php
+++ b/build/seed-testsite-menus.php
@@ -1,0 +1,380 @@
+<?php
+
+/**
+ * Give every `role = test` install the site menu items post-release
+ * verification needs, and turn on the landing sections it has to render.
+ *
+ * Without this the test site has no `client_id = 0` menu item pointing at
+ * com_proclaim at all, so verification can only ever prove that an update
+ * installs — never that the build it installed renders anything (#1701). The
+ * two most visible fixes in 10.5.7 were both render-path: a landing page whose
+ * Books section died with a database error on MySQL, and podcast titles showing
+ * a raw language key. Neither could be reached on the one site that runs the
+ * real published artifact.
+ *
+ * Four items, chosen to cover four different query paths rather than four
+ * different screens:
+ *
+ *   landing page  the sections aggregate, including the Books query that only
+ *                 failed on MySQL — which is why a real install matters and a
+ *                 unit test did not catch it
+ *   sermons list  the list model, its filters and pagination
+ *   sermon        a single item with its media, teacher and scripture joins
+ *   podcast list  the feed builder, where episode titles are composed
+ *
+ * The landing item is pointless unless the sections are switched on, and
+ * `showbooks` is off in the shipped default template, so this also writes a
+ * `landing_layout` enabling them. It merges into the existing params rather
+ * than replacing them: template params are one payload, and rewriting the whole
+ * thing to set one key produces a template no screen in the admin describes.
+ *
+ * Idempotent. Every row it writes carries a `note` marker and is deleted before
+ * re-seeding, so running it twice leaves the same four items rather than eight.
+ *
+ * SAFETY: only installs marked `role = test` in build.properties are touched,
+ * the same guard reset-testsite.php uses. Never point a dev or production
+ * install at role = test.
+ *
+ * Runs as step 8 of `composer test:install`, after the package is installed and
+ * verified, and is what build/verify-frontend.php then fetches.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+declare(strict_types=1);
+
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$root = \dirname(__DIR__);
+
+require $root . '/libraries/vendor/autoload.php';
+
+/**
+ * Marker written to #__menu.note so a re-seed can find its own rows.
+ *
+ * Deleting by link or title would also delete menu items someone added by hand
+ * while testing; deleting by marker only ever removes what this script wrote.
+ */
+const SEED_NOTE = 'proclaim-testsite-seed';
+
+/**
+ * Landing sections switched on for the seeded landing page.
+ *
+ * books first, deliberately: it is the section that broke, and putting it at
+ * the top means a truncated or half-rendered page still shows whether it ran.
+ */
+const LANDING_SECTIONS = ['books', 'teachers', 'series', 'topics'];
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to seed.\n");
+
+    exit(0);
+}
+
+$failures = 0;
+
+foreach ($installs as $install) {
+    echo "=== seed {$install->id} ({$install->path}) ===\n";
+
+    $configFile = $install->path . '/configuration.php';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "  configuration.php not found — skipping.\n");
+        $failures++;
+
+        continue;
+    }
+
+    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
+        require $file;
+        $c = new \JConfig();
+
+        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
+    })($configFile);
+
+    $port = 3306;
+
+    if (str_contains($host, ':')) {
+        [$host, $portString] = explode(':', $host, 2);
+        $port                = (int) $portString;
+    }
+
+    $db = @mysqli_connect($host, $user, $pass, $name, $port);
+
+    if (!$db) {
+        fwrite(STDERR, '  cannot connect: ' . mysqli_connect_error() . "\n");
+        $failures++;
+
+        continue;
+    }
+
+    try {
+        seedInstall($db, $prefix);
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  ' . $e->getMessage() . "\n");
+        $failures++;
+    } finally {
+        mysqli_close($db);
+    }
+
+    echo "\n";
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "Seeding failed for {$failures} install(s).\n");
+
+    exit(1);
+}
+
+echo "Site menus seeded.\n";
+
+/**
+ * Seed one install: enable the landing sections, then write the menu items.
+ *
+ * @param   \mysqli  $db      Open connection to the install's database
+ * @param   string   $prefix  That install's table prefix
+ *
+ * @return  void
+ *
+ * @throws  \RuntimeException  when the install is missing something to link to
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function seedInstall(\mysqli $db, string $prefix): void
+{
+    $componentId = scalar($db, "SELECT extension_id FROM {$prefix}extensions "
+        . "WHERE element = 'com_proclaim' AND type = 'component'");
+
+    if ($componentId === null) {
+        throw new \RuntimeException('com_proclaim is not installed here — run test:install first.');
+    }
+
+    $templateId = scalar($db, "SELECT id FROM {$prefix}bsms_templates WHERE published = 1 ORDER BY id LIMIT 1");
+    $studyId    = scalar($db, "SELECT id FROM {$prefix}bsms_studies WHERE published = 1 ORDER BY id LIMIT 1");
+
+    if ($templateId === null || $studyId === null) {
+        throw new \RuntimeException('no published template or study to link to — the install seed did not land.');
+    }
+
+    $menutype = scalar($db, "SELECT menutype FROM {$prefix}menu "
+        . "WHERE client_id = 0 AND home = 1 AND published = 1 LIMIT 1")
+        ?? scalar($db, "SELECT menutype FROM {$prefix}menu_types ORDER BY id LIMIT 1");
+
+    if ($menutype === null) {
+        throw new \RuntimeException('this site has no site menu to add items to.');
+    }
+
+    enableLandingSections($db, $prefix, (int) $templateId);
+
+    $items = [
+        [
+            'title' => 'Proclaim Landing (seed)',
+            'alias' => 'proclaim-seed-landing',
+            'link'  => 'index.php?option=com_proclaim&view=cwmlandingpage&t=' . $templateId,
+        ],
+        [
+            'title' => 'Proclaim Sermons (seed)',
+            'alias' => 'proclaim-seed-sermons',
+            'link'  => 'index.php?option=com_proclaim&view=cwmsermons&t=' . $templateId,
+        ],
+        [
+            'title' => 'Proclaim Sermon (seed)',
+            'alias' => 'proclaim-seed-sermon',
+            'link'  => 'index.php?option=com_proclaim&view=cwmsermon&id=' . $studyId . '&t=' . $templateId,
+        ],
+        [
+            'title' => 'Proclaim Podcasts (seed)',
+            'alias' => 'proclaim-seed-podcasts',
+            'link'  => 'index.php?option=com_proclaim&view=cwmseriespodcastlist&t=' . $templateId,
+        ],
+    ];
+
+    run($db, "DELETE FROM {$prefix}menu WHERE client_id = 0 AND note = '" . SEED_NOTE . "'");
+
+    foreach ($items as $item) {
+        $sql = \sprintf(
+            "INSERT INTO {$prefix}menu "
+            . '(menutype, title, alias, note, path, link, type, published, parent_id, level, component_id, '
+            . 'browserNav, access, img, template_style_id, params, lft, rgt, home, language, client_id) '
+            . "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', 'component', 1, 1, 1, %d, 0, 1, '', 0, '{}', 0, 0, 0, '*', 0)",
+            esc($db, $menutype),
+            esc($db, $item['title']),
+            esc($db, $item['alias']),
+            SEED_NOTE,
+            esc($db, $item['alias']),
+            esc($db, $item['link']),
+            (int) $componentId
+        );
+
+        run($db, $sql);
+
+        printf("  + %-24s Itemid=%d\n", $item['alias'], mysqli_insert_id($db));
+    }
+
+    rebuildTree($db, $prefix);
+
+    echo "  menu tree rebuilt (menutype '{$menutype}', template {$templateId}, study {$studyId})\n";
+}
+
+/**
+ * Switch the landing sections on for the seeded template.
+ *
+ * Writes `landing_layout`, the format the Layout Editor produces, rather than
+ * the legacy headingorder_* / show* pairs: a site built today has the former,
+ * and seeding the shape nobody uses any more would exercise a fallback path
+ * instead of the real one.
+ *
+ * @param   \mysqli  $db          Open connection
+ * @param   string   $prefix      Table prefix
+ * @param   int      $templateId  Template whose params to edit
+ *
+ * @return  void
+ *
+ * @throws  \RuntimeException  when the stored params cannot be read as JSON
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function enableLandingSections(\mysqli $db, string $prefix, int $templateId): void
+{
+    $stored = scalar($db, "SELECT params FROM {$prefix}bsms_templates WHERE id = {$templateId}");
+
+    try {
+        $params = json_decode((string) ($stored ?: '{}'), true, 512, JSON_THROW_ON_ERROR) ?: [];
+    } catch (\JsonException $e) {
+        throw new \RuntimeException("template {$templateId} has unreadable params: " . $e->getMessage());
+    }
+
+    $layout = [];
+
+    foreach (LANDING_SECTIONS as $section) {
+        $layout[] = ['id' => $section, 'enabled' => true];
+
+        // The legacy pair as well: a template that predates landing_layout is
+        // still read through getSectionOrderFromLegacy(), and a site upgrading
+        // into this seed should not depend on which branch runs.
+        $params['show' . $section] = 1;
+    }
+
+    $params['landing_layout'] = $layout;
+
+    $encoded = json_encode($params, JSON_THROW_ON_ERROR);
+
+    run($db, "UPDATE {$prefix}bsms_templates SET params = '" . esc($db, $encoded) . "' WHERE id = {$templateId}");
+
+    echo '  landing sections enabled: ' . implode(', ', LANDING_SECTIONS) . "\n";
+}
+
+/**
+ * Renumber lft/rgt across the whole menu tree from parent_id.
+ *
+ * Inserting with lft = rgt = 0 leaves the nested set wrong, and Joomla reads
+ * lft to order and to resolve a menu item's ancestors. Rebuilding by depth-first
+ * walk is used in preference to shifting neighbours: it costs one pass, it is
+ * the same operation Joomla's own "Rebuild" button performs, and it repairs any
+ * drift already present instead of preserving it.
+ *
+ * The walk starts at the root (id 1) and covers every row, admin items
+ * included — they share this table and this tree.
+ *
+ * @param   \mysqli  $db      Open connection
+ * @param   string   $prefix  Table prefix
+ *
+ * @return  void
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function rebuildTree(\mysqli $db, string $prefix): void
+{
+    $children = [];
+    $result   = mysqli_query($db, "SELECT id, parent_id FROM {$prefix}menu ORDER BY parent_id, lft, id");
+
+    while ($row = mysqli_fetch_assoc($result)) {
+        $children[(int) $row['parent_id']][] = (int) $row['id'];
+    }
+
+    $updates = [];
+
+    $walk = static function (int $id, int $left, int $level) use (&$walk, $children, &$updates): int {
+        $right = $left + 1;
+
+        foreach ($children[$id] ?? [] as $childId) {
+            $right = $walk($childId, $right, $level + 1);
+        }
+
+        $updates[] = [$id, $left, $right, $level];
+
+        return $right + 1;
+    };
+
+    $walk(1, 0, 0);
+
+    foreach ($updates as [$id, $left, $right, $level]) {
+        run($db, "UPDATE {$prefix}menu SET lft = {$left}, rgt = {$right}, level = {$level} WHERE id = {$id}");
+    }
+}
+
+/**
+ * Run a statement, turning a failure into an exception.
+ *
+ * @param   \mysqli  $db   Open connection
+ * @param   string   $sql  Statement to run
+ *
+ * @return  void
+ *
+ * @throws  \RuntimeException  when the statement fails
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function run(\mysqli $db, string $sql): void
+{
+    if (mysqli_query($db, $sql) === false) {
+        throw new \RuntimeException('query failed: ' . mysqli_error($db));
+    }
+}
+
+/**
+ * Fetch the first column of the first row, or null when there is no row.
+ *
+ * @param   \mysqli  $db   Open connection
+ * @param   string   $sql  Statement to run
+ *
+ * @return  string|null
+ *
+ * @throws  \RuntimeException  when the statement fails
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function scalar(\mysqli $db, string $sql): ?string
+{
+    $result = mysqli_query($db, $sql);
+
+    if ($result === false) {
+        throw new \RuntimeException('query failed: ' . mysqli_error($db));
+    }
+
+    $row = mysqli_fetch_row($result);
+
+    return $row === null ? null : (string) $row[0];
+}
+
+/**
+ * Escape a value for interpolation.
+ *
+ * @param   \mysqli  $db     Open connection
+ * @param   string   $value  Value to escape
+ *
+ * @return  string
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function esc(\mysqli $db, string $value): string
+{
+    return mysqli_real_escape_string($db, $value);
+}

--- a/build/seed-testsite-menus.php
+++ b/build/seed-testsite-menus.php
@@ -172,6 +172,7 @@ function seedInstall(\mysqli $db, string $prefix): void
     }
 
     enableLandingSections($db, $prefix, (int) $templateId);
+    ensureCitedBook($db, $prefix, (int) $studyId);
 
     $items = [
         [
@@ -221,6 +222,50 @@ function seedInstall(\mysqli $db, string $prefix): void
     rebuildTree($db, $prefix);
 
     echo "  menu tree rebuilt (menutype '{$menutype}', template {$templateId}, study {$studyId})\n";
+}
+
+/**
+ * Make sure some published study cites a book, so the Books section has a row.
+ *
+ * The Books section lists the books the studies are actually in (#1687), so with
+ * no scripture reference anywhere it renders nothing and the strongest assertion
+ * in verify-frontend.php quietly skips itself. That is what happens on the CI
+ * disposable install, whose seed study carries no reference — the check reported
+ * "no cited book" and passed, covering none of the path it exists for.
+ *
+ * Colossians (booknumber 151) for no reason beyond it being what the shipped
+ * sample data uses, so a site that already has data and one that does not end up
+ * looking the same.
+ *
+ * Only ever adds. A study that already cites something is left exactly as it is,
+ * because the point is to guarantee a floor, not to impose a fixture.
+ *
+ * @param   \mysqli  $db       Open connection
+ * @param   string   $prefix   Table prefix
+ * @param   int      $studyId  Study to attach the reference to
+ *
+ * @return  void
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function ensureCitedBook(\mysqli $db, string $prefix, int $studyId): void
+{
+    $existing = scalar($db, "SELECT COUNT(*) FROM {$prefix}bsms_study_scriptures AS s "
+        . "INNER JOIN {$prefix}bsms_studies AS st ON st.id = s.study_id "
+        . "WHERE st.published = 1 AND s.reference_text <> ''");
+
+    if ((int) $existing > 0) {
+        echo "  cited book already present ({$existing} reference(s))\n";
+
+        return;
+    }
+
+    run($db, "INSERT INTO {$prefix}bsms_study_scriptures "
+        . '(study_id, ordering, booknumber, chapter_begin, verse_begin, chapter_end, verse_end, '
+        . 'bible_version, reference_text) '
+        . "VALUES ({$studyId}, 0, 151, 3, 5, 3, 11, '', 'Colossians 3:5-11')");
+
+    echo "  cited book added to study {$studyId}: Colossians 3:5-11\n";
 }
 
 /**

--- a/build/test-install.sh
+++ b/build/test-install.sh
@@ -30,10 +30,10 @@ echo "========================================================================"
 echo " CLEAN-INSTALL TEST — pkg_proclaim ${VERSION}"
 echo "========================================================================"
 
-echo "-- [1/7] reset test site(s) to a clean slate"
+echo "-- [1/9] reset test site(s) to a clean slate"
 php build/reset-testsite.php
 
-echo "-- [2/7] build full package ${VERSION}"
+echo "-- [2/9] build full package ${VERSION}"
 bash build/build-package.sh "$VERSION"
 
 if [ ! -f "$ZIP" ]; then
@@ -41,19 +41,25 @@ if [ ! -f "$ZIP" ]; then
     exit 1
 fi
 
-echo "-- [3/7] install ${ZIP} (fresh)"
+echo "-- [3/9] install ${ZIP} (fresh)"
 "$BIN/cwm-install-zip" --zip "$ZIP"
 
-echo "-- [4/7] verify extension registration"
+echo "-- [4/9] verify extension registration"
 "$BIN/cwm-verify" --target test
 
-echo "-- [5/7] verify migrations landed"
+echo "-- [5/9] verify migrations landed"
 php build/verify-migrations.php "$VERSION"
 
-echo "-- [6/7] verify the REST API landed (#1309/#1310/#1331 guards)"
+echo "-- [6/9] verify the REST API landed (#1309/#1310/#1331 guards)"
 php build/verify-api-install.php
 
-echo "-- [7/7] verify the scripture library landed (tables, seed, plugin enabled)"
+echo "-- [7/9] verify the scripture library landed (tables, seed, plugin enabled)"
 php build/verify-scripture-install.php
+
+echo "-- [8/9] seed the site menu items the front end is reached through (#1701)"
+php build/seed-testsite-menus.php
+
+echo "-- [9/9] verify the front end renders (#1701 guards)"
+php build/verify-frontend.php
 
 echo "CLEAN-INSTALL TEST PASSED for ${VERSION}."

--- a/build/verify-frontend.php
+++ b/build/verify-frontend.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Fetch the seeded site menu items and assert the front end actually rendered.
+ *
+ * Everything else in the release gate stops at the install boundary: the
+ * package registers, the migrations land, the API answers. None of it loads a
+ * page, so a build can pass the whole gate and still show a site owner an empty
+ * box (#1701).
+ *
+ * The assertions are chosen against what 10.5.7 shipped, because those two bugs
+ * are the shape this check exists to catch:
+ *
+ *   - The landing page's Books section died with a database error on MySQL and
+ *     rendered nothing. So a 200 is not enough — the section has to be present
+ *     and it has to contain the book the seeded study actually cites.
+ *   - Book names resolved to raw language keys ("JBS_BBK_JOHN 3") wherever
+ *     com_proclaim's language file had not been loaded. So any JBS_BBK_ in the
+ *     body is a failure, not cosmetic.
+ *
+ * Both failures rendered a valid page with a 200 status. Checking only the
+ * status code would have caught neither.
+ *
+ * Depends on build/seed-testsite-menus.php having run: it reads the menu items
+ * back by their seed marker rather than guessing URLs, so the two scripts
+ * cannot drift apart.
+ *
+ * SAFETY: only installs marked `role = test` in build.properties are touched.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+declare(strict_types=1);
+
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$root = \dirname(__DIR__);
+
+require $root . '/libraries/vendor/autoload.php';
+
+/**
+ * Must match build/seed-testsite-menus.php.
+ */
+const SEED_NOTE = 'proclaim-testsite-seed';
+
+/**
+ * Markers that mean the page failed while still returning 200.
+ *
+ * `SQL=` is Joomla's own database-error format, and is what the Books failure
+ * would have printed had display_errors been on; the PHP-level markers catch a
+ * fatal rendered inside the component's output buffer.
+ */
+const ERROR_MARKERS = [
+    'Fatal error',
+    'Uncaught',
+    'Parse error',
+    'Warning:',
+    'Deprecated:',
+    'SQL=',
+    'JDatabaseExceptionExecuting',
+    'Error displaying the error page',
+];
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+
+    exit(0);
+}
+
+$failures = 0;
+
+echo "========================================================================\n";
+echo " FRONT-END CHECK — seeded site menu items\n";
+echo "========================================================================\n";
+
+foreach ($installs as $install) {
+    echo "\n=== {$install->id} ({$install->url}) ===\n";
+
+    if ($install->url === null || $install->url === '') {
+        fwrite(STDERR, "  no url in build.properties — skipping.\n");
+        $failures++;
+
+        continue;
+    }
+
+    $configFile = $install->path . '/configuration.php';
+
+    if (!is_file($configFile)) {
+        fwrite(STDERR, "  configuration.php not found — skipping.\n");
+        $failures++;
+
+        continue;
+    }
+
+    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
+        require $file;
+        $c = new \JConfig();
+
+        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
+    })($configFile);
+
+    $port = 3306;
+
+    if (str_contains($host, ':')) {
+        [$host, $portString] = explode(':', $host, 2);
+        $port                = (int) $portString;
+    }
+
+    $db = @mysqli_connect($host, $user, $pass, $name, $port);
+
+    if (!$db) {
+        fwrite(STDERR, '  cannot connect: ' . mysqli_connect_error() . "\n");
+        $failures++;
+
+        continue;
+    }
+
+    $items  = [];
+    $result = mysqli_query(
+        $db,
+        "SELECT id, alias, link FROM {$prefix}menu WHERE client_id = 0 AND note = '" . SEED_NOTE . "' ORDER BY id"
+    );
+
+    while ($result && $row = mysqli_fetch_assoc($result)) {
+        $items[] = $row;
+    }
+
+    // The book the seeded study cites, read from the stored reference rather
+    // than resolved through the library: this script asserts what the page
+    // says, so it must not get its expectation from the same code that
+    // produces the page.
+    $expectedBook = null;
+    $reference    = mysqli_fetch_row(mysqli_query(
+        $db,
+        "SELECT s.reference_text FROM {$prefix}bsms_study_scriptures AS s "
+        . "INNER JOIN {$prefix}bsms_studies AS st ON st.id = s.study_id "
+        . 'WHERE st.published = 1 AND s.reference_text <> \'\' ORDER BY s.id LIMIT 1'
+    ) ?: null);
+
+    if ($reference !== null) {
+        $expectedBook = trim(preg_replace('/\s+\d.*$/', '', (string) $reference[0]));
+    }
+
+    mysqli_close($db);
+
+    if ($items === []) {
+        fwrite(STDERR, "  no seeded menu items — run build/seed-testsite-menus.php first.\n");
+        $failures++;
+
+        continue;
+    }
+
+    foreach ($items as $item) {
+        $url  = rtrim($install->url, '/') . '/index.php?Itemid=' . $item['id'];
+        $body = fetch($url, $status);
+
+        if ($body === null) {
+            report(false, $item['alias'], 'no response from ' . $url);
+            $failures++;
+
+            continue;
+        }
+
+        if ($status !== 200) {
+            report(false, $item['alias'], "HTTP {$status}");
+            $failures++;
+
+            continue;
+        }
+
+        $found = [];
+
+        foreach (ERROR_MARKERS as $marker) {
+            if (str_contains($body, $marker)) {
+                $found[] = $marker;
+            }
+        }
+
+        if ($found !== []) {
+            report(false, $item['alias'], 'error marker in body: ' . implode(', ', $found));
+            $failures++;
+
+            continue;
+        }
+
+        if (str_contains($body, 'JBS_BBK_')) {
+            report(false, $item['alias'], 'raw JBS_BBK_ language key in body — book names are not resolving');
+            $failures++;
+
+            continue;
+        }
+
+        // The landing page carries the assertion the others cannot: that the
+        // Books section both ran and produced a row.
+        //
+        // Asserted on rendered text, not on markup. The three landing styles
+        // emit different containers for the same section — hero prints a band
+        // with no section identifier at all, while cards prints
+        // data-section="books" — so any class or attribute check passes on one
+        // style and fails on the other two for no reason a reader could guess.
+        // The heading text and the book name are the only things all three
+        // agree on, and they are also the two things the 10.5.7 bugs removed.
+        //
+        // This does assume the site renders en-GB. A localised test site would
+        // need the expected heading read from the language file instead.
+        //
+        // Both assertions are gated on the database actually holding a cited
+        // book. A section with nothing to list does not render, so on a site
+        // whose install seed carried no scripture reference this would fail for
+        // having no data rather than for being broken — and a check that fails
+        // when nothing is wrong gets muted, which costs more than it caught.
+        if (str_contains((string) $item['link'], 'cwmlandingpage')) {
+            if ($expectedBook === null || $expectedBook === '') {
+                report(true, $item['alias'], \strlen($body) . ' bytes (no cited book — Books section not asserted)');
+
+                continue;
+            }
+
+            if (!str_contains($body, '>Books')) {
+                report(false, $item['alias'], 'no Books heading in the landing page');
+                $failures++;
+
+                continue;
+            }
+
+            if (!str_contains($body, $expectedBook)) {
+                report(false, $item['alias'], "Books section rendered without '{$expectedBook}'");
+                $failures++;
+
+                continue;
+            }
+        }
+
+        report(true, $item['alias'], \strlen($body) . ' bytes');
+    }
+}
+
+echo "\n";
+
+if ($failures > 0) {
+    fwrite(STDERR, "Front-end check FAILED ({$failures} problem(s)).\n");
+
+    exit(1);
+}
+
+echo "Front-end OK.\n";
+
+/**
+ * Fetch a URL, returning the body and setting the status code.
+ *
+ * TLS verification is off: these are local .local hosts with self-signed
+ * certificates, and the thing under test is the page, not the certificate.
+ *
+ * @param   string    $url     Absolute URL to fetch
+ * @param   int|null  $status  Set to the HTTP status, or 0 when there was none
+ *
+ * @return  string|null  Body, or null when the request produced nothing
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function fetch(string $url, ?int &$status): ?string
+{
+    $status  = 0;
+    $context = stream_context_create([
+        'http' => [
+            'timeout'       => 30,
+            'ignore_errors' => true,
+            'user_agent'    => 'proclaim-release-gate',
+        ],
+        'ssl' => [
+            'verify_peer'      => false,
+            'verify_peer_name' => false,
+        ],
+    ]);
+
+    $body = @file_get_contents($url, false, $context);
+
+    foreach ($http_response_header ?? [] as $header) {
+        if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $m) === 1) {
+            $status = (int) $m[1];
+        }
+    }
+
+    return $body === false ? null : $body;
+}
+
+/**
+ * Print one PASS/FAIL line.
+ *
+ * @param   bool    $ok      Whether the check passed
+ * @param   string  $label   What was checked
+ * @param   string  $detail  Supporting detail
+ *
+ * @return  void
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function report(bool $ok, string $label, string $detail): void
+{
+    printf(
+        "%s %-24s %s\n",
+        $ok ? "\033[32mPASS\033[0m" : "\033[31mFAIL\033[0m",
+        $label,
+        $detail
+    );
+}


### PR DESCRIPTION
Closes #1701.

## The gap

The release gate stopped at the install boundary — package registers, migrations land, API answers — and never loaded a page, because the role=test site had no `client_id = 0` menu item pointing at com_proclaim:

```sql
SELECT id FROM #__menu WHERE link LIKE '%com_proclaim%' AND client_id = 0;
-- 0 rows
```

Both of 10.5.7's most visible fixes were render-path — the landing page's Books section dying with a database error on MySQL, and podcast titles printing `JBS_BBK_JOHN 3` — and **both returned HTTP 200**. The gate passed either way.

## What this adds

Two scripts, wired as steps 8 and 9 of `composer test:install`.

**`build/seed-testsite-menus.php`** writes four menu items — landing, sermons list, one sermon, podcast list — chosen to cover four query paths rather than four screens, and switches the landing sections on (`showbooks` is off in the shipped default template, so a seeded landing page would otherwise prove nothing).

- Merges into the template params rather than replacing them
- Writes both `landing_layout` and the legacy `show*` pair, so neither branch of `getSectionOrder()` is assumed
- Marks every row with a `note` so a re-seed removes its own rows and nobody else's — idempotent
- Renumbers `lft`/`rgt` afterwards, repairing the gaps the reset leaves behind
- Same `role = test` guard as `reset-testsite.php`

**`build/verify-frontend.php`** fetches those items back *by their marker* (so the two scripts cannot drift apart) and asserts what a 200 cannot: no error markers in the body, no raw `JBS_BBK_` anywhere, and on the landing page the Books heading plus the book the seeded study actually cites.

The expected book is read from `#__bsms_study_scriptures`, not resolved through `ScriptureHelper` — the assertion must not come from the code under test.

## Two judgement calls worth flagging

**Assertions on rendered text, not markup.** The three landing styles emit different containers for the same section — `cards` prints `data-section="books"`, `hero` prints a band with no section identifier at all. My first version keyed on the CSS marker and failed against `hero` while the page was rendering perfectly. Text is the only thing all three agree on.

**The landing assertions are skipped when no published study cites a book.** A section with nothing to list does not render, so on a site whose install seed carried no scripture reference this would fail for having no data rather than for being broken. That matters for the CI disposable install in `e2e.yml`, which runs this same harness.

## Verified

Against j6-test running the published 10.5.7 artifact:

```
PASS proclaim-seed-landing    12761 bytes
PASS proclaim-seed-sermons    15491 bytes
PASS proclaim-seed-sermon     22459 bytes
PASS proclaim-seed-podcasts   11364 bytes
```

The landing page renders the Books band with `Colossians` in it — which is 10.5.7's Books fix *and* its book-naming fix, positively confirmed on the shipped build for the first time.

And mutation-tested, because a green check proves nothing until you have seen it go red. Disabling the Books section:

```
FAIL proclaim-seed-landing    no Books heading in the landing page
```

The page still returns 200 with the section gone — exactly the failure mode this exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)