### PR TITLE
fix: stop Database Maintenance reporting an index we removed on purpose (#1706)

### DIFF
--- a/admin/sql/updates/mysql/10.1.0-20260207.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260207.sql
@@ -66,5 +66,20 @@ ALTER TABLE `#__bsms_topics` ADD KEY `idx_published_access` (`published`, `acces
 -- Locations: Published + access composite
 ALTER TABLE `#__bsms_locations` ADD KEY `idx_published_access` (`published`, `access`);
 
--- Study-Topics junction: Covering composite for dual-direction lookups
-ALTER TABLE `#__bsms_studytopics` ADD KEY `idx_study_topic` (`study_id`, `topic_id`);
+-- Study-Topics junction: covering composite for dual-direction lookups.
+--
+-- The statement that created idx_study_topic is deliberately gone. 10.5.6
+-- replaced it with the UNIQUE uq_study_topic over the same pair and dropped
+-- this one as redundant, so on every site that has taken that update the index
+-- named here no longer exists.
+--
+-- Joomla's schema check reads every historical file in this folder and tests it
+-- against the CURRENT schema — it has no notion of a change being superseded.
+-- Left in place, this line reported a permanent error in System → Maintenance →
+-- Database on every upgraded site, for an index the component removed on
+-- purpose. Removing the statement removes the check with it.
+--
+-- Safe to remove rather than merely comment out: a site replaying history from
+-- an earlier version now skips straight to uq_study_topic, which covers the
+-- same columns, and install.mysql.utf8.sql never created idx_study_topic
+-- either.

--- a/build/test-install.sh
+++ b/build/test-install.sh
@@ -30,10 +30,10 @@ echo "========================================================================"
 echo " CLEAN-INSTALL TEST — pkg_proclaim ${VERSION}"
 echo "========================================================================"
 
-echo "-- [1/9] reset test site(s) to a clean slate"
+echo "-- [1/10] reset test site(s) to a clean slate"
 php build/reset-testsite.php
 
-echo "-- [2/9] build full package ${VERSION}"
+echo "-- [2/10] build full package ${VERSION}"
 bash build/build-package.sh "$VERSION"
 
 if [ ! -f "$ZIP" ]; then
@@ -41,25 +41,28 @@ if [ ! -f "$ZIP" ]; then
     exit 1
 fi
 
-echo "-- [3/9] install ${ZIP} (fresh)"
+echo "-- [3/10] install ${ZIP} (fresh)"
 "$BIN/cwm-install-zip" --zip "$ZIP"
 
-echo "-- [4/9] verify extension registration"
+echo "-- [4/10] verify extension registration"
 "$BIN/cwm-verify" --target test
 
-echo "-- [5/9] verify migrations landed"
+echo "-- [5/10] verify migrations landed"
 php build/verify-migrations.php "$VERSION"
 
-echo "-- [6/9] verify the REST API landed (#1309/#1310/#1331 guards)"
+echo "-- [6/10] verify the REST API landed (#1309/#1310/#1331 guards)"
 php build/verify-api-install.php
 
-echo "-- [7/9] verify the scripture library landed (tables, seed, plugin enabled)"
+echo "-- [7/10] verify the scripture library landed (tables, seed, plugin enabled)"
 php build/verify-scripture-install.php
 
-echo "-- [8/9] seed the site menu items the front end is reached through (#1701)"
+echo "-- [8/10] seed the site menu items the front end is reached through (#1701)"
 php build/seed-testsite-menus.php
 
-echo "-- [9/9] verify the front end renders (#1701 guards)"
+echo "-- [9/10] verify the front end renders (#1701 guards)"
 php build/verify-frontend.php
+
+echo "-- [10/10] verify Joomla's own schema check is clean"
+php build/verify-schema-check.php
 
 echo "CLEAN-INSTALL TEST PASSED for ${VERSION}."

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -80,6 +80,10 @@ echo "-- [6/16] install ${NEWVER} over ${BASEVER} (triggers update() + migration
 echo "-- [7/16] verify registration + migrations"
 "$BIN/cwm-verify" --target test
 php build/verify-migrations.php "$NEWVER"
+# The upgraded state is what a real site is in, and it is the state that
+# reported a Database Maintenance error on a live site after 10.5.6 while
+# every other assertion here passed.
+php build/verify-schema-check.php
 
 echo "-- [8/16] verify the downloaded translation and cached passages survived"
 php build/verify-scripture-upgrade.php verify
@@ -287,5 +291,6 @@ php build/reset-testsite.php
 "$BIN/cwm-install-zip" --zip "$NEWZIP" >/dev/null
 "$BIN/cwm-verify" --target test
 php build/verify-migrations.php "$NEWVER"
+php build/verify-schema-check.php
 
 echo "UPGRADE TEST PASSED ${BASEVER} -> ${NEWVER}."

--- a/build/verify-schema-check.php
+++ b/build/verify-schema-check.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * Run Joomla's own schema check against every `role = test` install and fail on
+ * any error — the same check System → Maintenance → Database performs.
+ *
+ * This is not what build/verify-migrations.php does, and the difference is the
+ * whole point. That script asserts a column or index EXISTS. Joomla's ChangeSet
+ * instead reads every historical file in `sql/updates/mysql`, derives a check
+ * query from each statement, and runs it against the CURRENT schema. The two
+ * disagree in both directions:
+ *
+ *   - A statement Joomla cannot parse is never checked, so a migration can be
+ *     silently unverified while the column it adds is present (#1664).
+ *   - A change that a LATER version deliberately undid still reports an error
+ *     forever, because ChangeSet has no notion of a statement being superseded.
+ *
+ * The second is what shipped. 10.5.6 replaced idx_study_topic with the UNIQUE
+ * uq_study_topic and dropped the old index as redundant, and the ADD KEY in
+ * 10.1.0-20260207.sql went on being checked against a schema that correctly no
+ * longer had it. Every site that took 10.5.6 was left with a red error in
+ * Database Maintenance — reported from a live site — and nothing in the release
+ * gate could see it: the schema was right, the migrations were right, and the
+ * only thing wrong was what Joomla's checker made of them.
+ *
+ * Checks the component and the scripture library, since both ship their own
+ * `<schemapath>` and both appear on that screen.
+ *
+ * Usage:
+ *   php build/verify-schema-check.php              # every role=test install
+ *   php build/verify-schema-check.php <site-path>  # one site (used internally)
+ *
+ * SAFETY: only installs marked `role = test` in build.properties are visited,
+ * and nothing here writes — ChangeSet::check() only reads.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+declare(strict_types=1);
+
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$root = \dirname(__DIR__);
+
+// Child mode: one site, whose CMS this process is about to load.
+if (isset($argv[1]) && $argv[1] !== '') {
+    exit(checkSite((string) $argv[1]));
+}
+
+require $root . '/libraries/vendor/autoload.php';
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+
+    exit(0);
+}
+
+echo "========================================================================\n";
+echo " SCHEMA CHECK — Joomla's own ChangeSet (System → Maintenance → Database)\n";
+echo "========================================================================\n";
+
+$failures = 0;
+
+foreach ($installs as $install) {
+    echo "\n=== {$install->id} ({$install->path}) ===\n";
+
+    if (!is_file($install->path . '/configuration.php')) {
+        fwrite(STDERR, "  configuration.php not found — skipping.\n");
+        $failures++;
+
+        continue;
+    }
+
+    // Each install needs its own JPATH_* constants and its own copy of the CMS,
+    // so the work happens in a subprocess. Defining those once in this process
+    // would pin every later install to the first one's paths.
+    $status = 0;
+    passthru(
+        \sprintf(
+            '%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__FILE__),
+            escapeshellarg($install->path)
+        ),
+        $status
+    );
+
+    if ($status !== 0) {
+        $failures++;
+    }
+}
+
+echo "\n";
+
+if ($failures > 0) {
+    fwrite(STDERR, "Schema check FAILED on {$failures} install(s).\n");
+
+    exit(1);
+}
+
+echo "Schema OK — Joomla reports no database errors.\n";
+
+/**
+ * Load one site's CMS and run ChangeSet over each schema folder it ships.
+ *
+ * @param   string  $site  Absolute path to the Joomla root
+ *
+ * @return  int  0 when Joomla reports no errors, 1 otherwise
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function checkSite(string $site): int
+{
+    \define('_JEXEC', 1);
+    \define('JPATH_BASE', $site);
+    \define('JPATH_ROOT', $site);
+    \define('JPATH_SITE', $site);
+    \define('JPATH_ADMINISTRATOR', $site . '/administrator');
+    \define('JPATH_LIBRARIES', $site . '/libraries');
+    \define('JPATH_PLUGINS', $site . '/plugins');
+    \define('JPATH_CONFIGURATION', $site);
+    \define('JPATH_THEMES', $site . '/templates');
+    \define('JPATH_CACHE', $site . '/cache');
+    \define('JPATH_MANIFESTS', $site . '/administrator/manifests');
+
+    require $site . '/libraries/vendor/autoload.php';
+    require $site . '/libraries/bootstrap.php';
+    require $site . '/configuration.php';
+
+    $cfg  = new \JConfig();
+    $host = $cfg->host;
+
+    $db = (new \Joomla\Database\DatabaseFactory())->getDriver(
+        $cfg->dbtype === 'mysql' ? 'mysqli' : $cfg->dbtype,
+        [
+            'host'     => $host,
+            'user'     => $cfg->user,
+            'password' => $cfg->password,
+            'database' => $cfg->db,
+            'prefix'   => $cfg->dbprefix,
+        ]
+    );
+
+    // ChangeItem resolves the driver through Factory when it builds its checks.
+    \Joomla\CMS\Factory::$database = $db;
+
+    // Paths are given WITHOUT the driver folder: ChangeSet appends the server
+    // type itself, so passing `.../mysql` makes it look for `.../mysql/mysql`,
+    // find nothing, and report a clean bill of health for zero files checked.
+    $folders = [
+        'com_proclaim'     => JPATH_ADMINISTRATOR . '/components/com_proclaim/sql/updates',
+        'lib_cwmscripture' => JPATH_LIBRARIES . '/cwmscripture/sql/updates',
+    ];
+
+    $failed = 0;
+
+    foreach ($folders as $label => $folder) {
+        if (!is_dir($folder . '/mysql')) {
+            echo "  {$label}: no schema folder installed — skipped\n";
+
+            continue;
+        }
+
+        // Constructed directly rather than through getInstance(), which caches a
+        // single instance for the whole process and would hand back the first
+        // folder's ChangeSet for the second.
+        $changeSet = new \Joomla\CMS\Schema\ChangeSet($db, $folder);
+        $changeSet->check();
+        $status = $changeSet->getStatus();
+
+        $errors = $status['error'] ?? [];
+
+        printf(
+            "  %-17s schema=%-18s ok=%-4d error=%-3d skipped=%d\n",
+            $label,
+            $changeSet->getSchema() ?: '(none)',
+            \count($status['ok'] ?? []),
+            \count($errors),
+            \count($status['skipped'] ?? [])
+        );
+
+        foreach ($errors as $item) {
+            $failed++;
+            echo "\n    \033[31mERROR\033[0m in " . basename((string) $item->file) . "\n";
+            echo '      statement: ' . squash((string) $item->updateQuery) . "\n";
+            echo '      check:     ' . squash((string) $item->checkQuery) . "\n";
+        }
+    }
+
+    if ($failed > 0) {
+        // Deliberately STDOUT, not STDERR: the two streams buffer differently,
+        // and a summary on STDERR jumped ahead of the per-folder lines it was
+        // summarising, which reads as if the library folder caused the error.
+        echo "\n  Joomla reports {$failed} database error(s) for this site.\n";
+
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Collapse a SQL statement onto one line for printing.
+ *
+ * @param   string  $sql  Statement to squash
+ *
+ * @return  string
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function squash(string $sql): string
+{
+    return trim((string) preg_replace('/\s+/', ' ', $sql));
+}

--- a/tests/integration/Admin/Helper/CwmstudytopicHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmstudytopicHelperTest.php
@@ -235,7 +235,12 @@ class CwmstudytopicHelperTest extends IntegrationTestCase
         $migrations = glob(JPATH_ROOT . '/admin/sql/updates/mysql/*.sql') ?: [];
         $adds       = array_filter(
             $migrations,
-            static fn (string $f): bool => str_contains((string) file_get_contents($f), 'uq_study_topic')
+            // The statement, not the name. A comment in another migration that
+            // explains why the index exists also contains the word.
+            static fn (string $f): bool => str_contains(
+                (string) file_get_contents($f),
+                'ADD UNIQUE KEY `uq_study_topic`'
+            )
         );
 
         $this->assertNotEmpty($adds, 'Existing installs need a migration, not just a changed install file');
@@ -253,7 +258,10 @@ class CwmstudytopicHelperTest extends IntegrationTestCase
         foreach ($migrations as $file) {
             $sql = (string) file_get_contents($file);
 
-            if (!str_contains($sql, 'uq_study_topic')) {
+            // Selected by the statement rather than the name: glob() returns
+            // these in order, so prose mentioning the index in an earlier file
+            // used to win the scan and be asserted against instead.
+            if (!str_contains($sql, 'ADD UNIQUE KEY `uq_study_topic`')) {
                 continue;
             }
 


### PR DESCRIPTION
Closes #1706. Reported from **nfsda.org** after upgrading to 10.5.6 — and still present on 10.5.7.

## What Joomla reports

```
file:      10.1.0-20260207.sql
statement: ALTER TABLE `#__bsms_studytopics` ADD KEY `idx_study_topic` (`study_id`, `topic_id`);
check:     SHOW INDEXES IN `#__bsms_studytopics` WHERE Key_name = 'idx_study_topic'
```

## The schema is correct; the check is not

`idx_study_topic` is *supposed* to be gone. 10.5.6 replaced it with the UNIQUE `uq_study_topic` over the same pair and dropped the redundant index from `proclaim.script.php` postflight — deliberately, because MySQL has no `DROP INDEX IF EXISTS` and doing it in SQL risked error 1091 aborting the update. The comment in `10.5.6-20260807.sql` says so.

Nobody removed the now-superseded `ADD KEY` from the 10.1.0 file. Joomla's `ChangeSet` reads every historical file and tests it against the **current** schema, with no notion of a statement being superseded — so it errors forever on every site that took 10.5.6.

Nothing is at risk. The index that matters is present. What is wrong is that an administrator sees a red error and cannot clear it.

## Why the gate missed it, and what now catches it

`verify-migrations.php` asserts a column or index **exists**. Joomla's checker asks a different question, and they disagree in both directions:

- a statement Joomla cannot parse is never checked, so a migration can be silently unverified while its column is present — that was #1664
- a change a later version deliberately undid still errors — this

`build/verify-schema-check.php` runs Joomla's own `ChangeSet` and fails on any error, across the component and the library. Wired into `test:install`, and **twice** into `test:upgrade`: once on the upgraded state — which is what a real site is in, and the state that produced this report — and once after the closing clean install.

Two traps documented in the script, because both produce a confident all-clear over zero files:

- `ChangeSet` appends the server type to the folder, so passing `.../sql/updates/mysql` makes it look for `.../mysql/mysql`
- `getInstance()` caches one instance per process, so a second folder silently gets the first folder's result

## Verified

Against j6-test:

```
before:  com_proclaim  ok=163  error=1   skipped=86
after:   com_proclaim  ok=163  error=0   skipped=86
```

Full `composer test:install` green end to end, including the new step 10.

## For existing sites

No repair needed. The error disappears when the corrected file installs, because the statement being checked is no longer there to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)