### PR TITLE
chore(deps): intl-tel-input 29.1.2 → 29.2.2 (#1696)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.7",
+  "version": "10.5.8-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.5.7",
+      "version": "10.5.8-dev",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",
@@ -27,7 +27,7 @@
         "csso": "^5.0.5",
         "eslint": "^10.8.0",
         "globals": "^17.8.0",
-        "intl-tel-input": "^29.1.2",
+        "intl-tel-input": "^29.2.2",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "rollup": "^4.62.3",
@@ -5565,9 +5565,9 @@
       "license": "ISC"
     },
     "node_modules/intl-tel-input": {
-      "version": "29.1.2",
-      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-29.1.2.tgz",
-      "integrity": "sha512-xGi4nwQGDRvOcOwW/R2nZ8Fs3FQmbDnaIDNRF+FcM1LeUNDf7e8RBZLuPs9VCR8eMO3rAQiYVdHNds7+F9fn9g==",
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-29.2.2.tgz",
+      "integrity": "sha512-ecrdk3E1TsFPjiDtCKFfLZMu3qwD58lMxj4zIR4n7CCDX/g8WpyUhXOaE5j20OS0nqbZF5zzWhjCQt1ANDJ/Ig==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "csso": "^5.0.5",
     "eslint": "^10.8.0",
     "globals": "^17.8.0",
-    "intl-tel-input": "^29.1.2",
+    "intl-tel-input": "^29.2.2",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "rollup": "^4.62.3",


### PR DESCRIPTION
The one item from this week's vendor check that actually ships.

`intl-tel-input` is a **bundled** library — `build-assets.js` copies it from `node_modules` into `media/vendor` at build time — so the version pinned here is what a church serves to visitors. The rest of the report is dev-only.

## Verified rather than assumed

`media/vendor/` is gitignored, so the copier's "Copied intl-tel-input" line is not evidence the shipped file moved. Checked directly:

```
315903 bytes  media/vendor/intl-tel-input/js/intlTelInputWithUtils.min.js
315903 bytes  node_modules/intl-tel-input/dist/js/intlTelInputWithUtils.min.js
checksums match: YES
```

`lint:js` clean; 232 Jest tests across 17 suites pass.

## Left for a separate decision

**@babel/cli, @babel/core, @babel/preset-env 7 → 8** — a major across three packages, dev-only. It belongs in its own change where a build break is attributable to it, not folded into a shipped-dependency bump.

`eslint` 10.8.0 → 10.8.1 and `terser` 5.49.0 → 5.49.2 are patch-level dev bumps; the next weekly report raises them again if they matter.

Closes #1696 — the check regenerates weekly, so this issue is a snapshot rather than a standing task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)