### PR TITLE
chore(deps): eslint 10.8.1, terser 5.49.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@types/jest": "^30.0.0",
         "csso": "^5.0.5",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "globals": "^17.8.0",
         "intl-tel-input": "^29.2.2",
         "jest": "^30.4.2",
@@ -33,7 +33,7 @@
         "rollup": "^4.62.3",
         "rollup-plugin-gzip": "^4.1.1",
         "sortablejs": "^1.15.7",
-        "terser": "^5.49.0"
+        "terser": "^5.49.2"
       },
       "engines": {
         "node": ">=24.0.0",
@@ -4908,9 +4908,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -7865,9 +7865,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
+      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@types/jest": "^30.0.0",
     "csso": "^5.0.5",
-    "eslint": "^10.8.0",
+    "eslint": "^10.8.1",
     "globals": "^17.8.0",
     "intl-tel-input": "^29.2.2",
     "jest": "^30.4.2",
@@ -31,7 +31,7 @@
     "rollup": "^4.62.3",
     "rollup-plugin-gzip": "^4.1.1",
     "sortablejs": "^1.15.7",
-    "terser": "^5.49.0"
+    "terser": "^5.49.2"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
The two patch-level dev bumps from this week's vendor check. Neither reaches a site — eslint runs in CI, terser is the minifier rollup calls — so the failure mode is a build that stops working, not something a visitor sees.

Verified as such rather than assumed:

- `lint:js` clean
- 232 Jest tests across 17 suites
- `npm run build:js` still produces minified output, which is the only part terser actually touches

## Not taken here

**`@babel/*` 7 → 8** — a major across three packages. It belongs in its own change where a build break is attributable to it.

**PHPUnit majors in the submodules** — lib_cwmscripture 11.5 → 12.5, scripturelinks 12.5 → 13.3. Worth deciding together rather than piecemeal: those two plus Proclaim currently sit on three different majors, which makes "the suite passes" mean something slightly different in each repo.

## Companion commits

Pushed straight to the submodules' `main`, since they are dev-only lock changes:

- `Joomla-Bible-Study/CWMScriptureLinks@6cfdeba` — php-cs-fixer v3.95.18, the third patch
- `Joomla-Bible-Study/CWMScriptureLinks@e08f642` — drops `ReflectionMethod::setAccessible()`, deprecated in PHP 8.5

Proclaim's submodule pins are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)