### PR TITLE
feat: make the admin toolbars ask the section, not the component (#1653 phase 1.5b)

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -16,8 +16,11 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\MVC\View\CanDo;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
 
@@ -79,6 +82,116 @@ class Cwmassets
     }
 
     /**
+     * Absolute path to admin/access.xml, or an empty string when it is missing.
+     *
+     * Resolved relative to this class rather than through JPATH_ADMINISTRATOR.
+     * Both layouts put access.xml two levels above src/Lib —
+     * administrator/components/com_proclaim/ when installed, admin/ in the
+     * repository — so the same expression works under test, where
+     * JPATH_ADMINISTRATOR points at the Joomla install rather than at us.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function accessFile(): string
+    {
+        $file = \dirname(__DIR__, 2) . '/access.xml';
+
+        if (is_file($file)) {
+            return $file;
+        }
+
+        $file = JPATH_ADMINISTRATOR . '/components/com_proclaim/access.xml';
+
+        return is_file($file) ? $file : '';
+    }
+
+    /**
+     * The permissions a user holds on `com_proclaim.<section>`.
+     *
+     * ⚠️ Use this, not `ContentHelper::getActions()`, for a section question:
+     * core discards its `$section` argument unless an item id comes with it and
+     * always reads the component's action list, so the two-argument form
+     * returns exactly what the bare one returns.
+     *
+     * Falls back to the component for an undeclared section. A section asset
+     * carrying empty rules inherits, so this is inert until a rule is set.
+     *
+     * @param   string  $section  Section name as declared in access.xml
+     *
+     * @return  CanDo
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function sectionActions(string $section): CanDo
+    {
+        if (!\in_array($section, self::declaredSections(), true)) {
+            Log::add(
+                "No '{$section}' section in access.xml; falling back to component permissions",
+                Log::WARNING,
+                'com_proclaim'
+            );
+
+            return self::componentActions();
+        }
+
+        return self::actionsFor($section, 'com_proclaim.' . $section) ?? self::componentActions();
+    }
+
+    /**
+     * The permissions a user holds on `com_proclaim` itself.
+     *
+     * Equivalent to `ContentHelper::getActions('com_proclaim')`, but resolves
+     * access.xml through `accessFile()`. ⚠️ Core reads only from
+     * `JPATH_ADMINISTRATOR`, so under test it returns an all-null CanDo and any
+     * comparison against it passes vacuously.
+     *
+     * @return  CanDo
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function componentActions(): CanDo
+    {
+        return self::actionsFor('component', 'com_proclaim')
+            ?? ContentHelper::getActions('com_proclaim');
+    }
+
+    /**
+     * Build a CanDo from one access.xml section, answered against one asset.
+     *
+     * @param   string  $section    Section name to read the action list from
+     * @param   string  $assetName  Asset the actions are authorised against
+     *
+     * @return  CanDo|null  Null when access.xml cannot be read
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function actionsFor(string $section, string $assetName): ?CanDo
+    {
+        $file = self::accessFile();
+
+        if ($file === '') {
+            return null;
+        }
+
+        $actions = Access::getActionsFromFile($file, '/access/section[@name="' . $section . '"]/');
+
+        if ($actions === false) {
+            return null;
+        }
+
+        $result = new CanDo();
+        $user   = Factory::getApplication()->getIdentity();
+
+        foreach ($actions as $action) {
+            $result->set($action->name, $user->authorise($action->name, $assetName));
+        }
+
+        return $result;
+    }
+
+    /**
      * Section names admin/access.xml declares, excluding `component`.
      *
      * Read from the manifest rather than hardcoded so the list cannot drift
@@ -96,18 +209,9 @@ class Cwmassets
 
         self::$declaredSections = [];
 
-        // Resolved relative to this class rather than through JPATH_ADMINISTRATOR.
-        // Both layouts put access.xml two levels above src/Lib —
-        // administrator/components/com_proclaim/ when installed, admin/ in the
-        // repository — so the same expression works under test, where
-        // JPATH_ADMINISTRATOR points at the Joomla install rather than at us.
-        $file = \dirname(__DIR__, 2) . '/access.xml';
+        $file = self::accessFile();
 
-        if (!is_file($file)) {
-            $file = JPATH_ADMINISTRATOR . '/components/com_proclaim/access.xml';
-        }
-
-        if (!is_file($file)) {
+        if ($file === '') {
             Log::add('access.xml not found; no section assets can be resolved', Log::ERROR, 'com_proclaim');
 
             return self::$declaredSections;

--- a/admin/src/View/Cwmcomments/HtmlView.php
+++ b/admin/src/View/Cwmcomments/HtmlView.php
@@ -16,9 +16,9 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmcomments;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmcommentsModel;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -117,7 +117,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('comment');
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance

--- a/admin/src/View/Cwmlocations/HtmlView.php
+++ b/admin/src/View/Cwmlocations/HtmlView.php
@@ -16,9 +16,9 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmlocations;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmlocationsModel;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -114,7 +114,7 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
-        $this->canDo         = ContentHelper::getActions('com_proclaim');
+        $this->canDo         = Cwmassets::sectionActions('location');
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {

--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmmediafiles;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmmediafilesModel;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -25,7 +26,6 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -140,7 +140,7 @@ class HtmlView extends BaseHtmlView
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
         $this->state         = $model->getState();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'message');
+        $this->canDo         = Cwmassets::sectionActions('mediafile');
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
@@ -189,7 +189,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo   = ContentHelper::getActions('com_proclaim');
+        $canDo   = Cwmassets::sectionActions('mediafile');
         $user    = Factory::getApplication()->getIdentity();
         /** @var Toolbar $toolbar **/
         $toolbar = $this->getDocument()->getToolbar();

--- a/admin/src/View/Cwmmessages/HtmlView.php
+++ b/admin/src/View/Cwmmessages/HtmlView.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmmessages;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmmessagesModel;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -31,7 +32,6 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 /**
  * View class for a list of Messages.
@@ -121,7 +121,7 @@ class HtmlView extends BaseHtmlView
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
         $this->state         = $model->getState();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'message');
+        $this->canDo         = Cwmassets::sectionActions('message');
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
@@ -170,7 +170,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo   = ContentHelper::getActions('com_proclaim');
+        $canDo   = Cwmassets::sectionActions('message');
         $user    = $this->getCurrentUser();
         $toolbar = $this->getDocument()->getToolbar();
 

--- a/admin/src/View/Cwmmessagetypes/HtmlView.php
+++ b/admin/src/View/Cwmmessagetypes/HtmlView.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmmessagetypes;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmmessagetypesModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -23,7 +24,6 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 /**
  * View class for Messagetype
@@ -137,7 +137,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('messagetype');
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance

--- a/admin/src/View/Cwmplaylists/HtmlView.php
+++ b/admin/src/View/Cwmplaylists/HtmlView.php
@@ -16,8 +16,8 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmplaylists;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmplaylistsModel;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
-        $this->canDo         = ContentHelper::getActions('com_proclaim');
+        $this->canDo         = Cwmassets::sectionActions('playlist');
 
         if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);

--- a/admin/src/View/Cwmpodcasts/HtmlView.php
+++ b/admin/src/View/Cwmpodcasts/HtmlView.php
@@ -12,9 +12,9 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmpodcasts;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmpodcastsModel;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
         $this->state         = $model->getState();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'podcast');
+        $this->canDo         = Cwmassets::sectionActions('podcast');
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 

--- a/admin/src/View/Cwmseries/HtmlView.php
+++ b/admin/src/View/Cwmseries/HtmlView.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmseries;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmseriesModel;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Multilanguage;
@@ -22,7 +23,6 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -124,7 +124,7 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'serie');
+        $this->canDo         = Cwmassets::sectionActions('serie');
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {
@@ -161,7 +161,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('serie');
         $user  = $this->getCurrentUser();
 
         // Get the toolbar object instance

--- a/admin/src/View/Cwmserver/HtmlView.php
+++ b/admin/src/View/Cwmserver/HtmlView.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmserver;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmserverModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
@@ -148,7 +149,7 @@ class HtmlView extends BaseHtmlView
     {
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
         $isNew = ($this->item->id < 1);
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('server');
         $title = $isNew ? Text::_('JBS_CMN_NEW') : Text::_('JBS_CMN_EDIT');
         ToolbarHelper::title(
             Text::_('JBS_CMN_SERVERS') . ': <small><small>[' . $title . ']</small></small>',

--- a/admin/src/View/Cwmservers/HtmlView.php
+++ b/admin/src/View/Cwmservers/HtmlView.php
@@ -16,9 +16,9 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmservers;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmserversModel;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
         $this->state         = $model->getState();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'server');
+        $this->canDo         = Cwmassets::sectionActions('server');
         $this->types         = $model->getServerOptions();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();

--- a/admin/src/View/Cwmteachers/HtmlView.php
+++ b/admin/src/View/Cwmteachers/HtmlView.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmteachers;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmteachersModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -24,7 +25,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 /**
  * View class for Teachers
@@ -115,7 +115,7 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
-        $this->canDo         = ContentHelper::getActions('com_proclaim', 'teacher');
+        $this->canDo         = Cwmassets::sectionActions('teacher');
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {
@@ -147,7 +147,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('teacher');
         $user  = Factory::getApplication()->getIdentity();
 
         // Get the toolbar object instance

--- a/admin/src/View/Cwmtemplatecodes/HtmlView.php
+++ b/admin/src/View/Cwmtemplatecodes/HtmlView.php
@@ -14,13 +14,13 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmtemplatecodes;
 
 // No Direct Access
 use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmtemplatecodesModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -155,7 +155,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_proclaim');
+        $canDo = Cwmassets::sectionActions('templatecode');
         $user  = $this->getCurrentUser();
 
         // Get the toolbar object instance

--- a/admin/src/View/Cwmtemplates/HtmlView.php
+++ b/admin/src/View/Cwmtemplates/HtmlView.php
@@ -12,9 +12,9 @@
 namespace CWM\Component\Proclaim\Administrator\View\Cwmtemplates;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmtemplatesModel;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -119,7 +119,7 @@ class HtmlView extends BaseHtmlView
         $this->pagination = $model->getPagination();
         $this->state      = $model->getState();
         $this->filterForm = $model->getFilterForm();
-        $this->canDo      = ContentHelper::getActions('com_proclaim', 'template');
+        $this->canDo      = Cwmassets::sectionActions('template');
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {

--- a/admin/src/View/Cwmtopics/HtmlView.php
+++ b/admin/src/View/Cwmtopics/HtmlView.php
@@ -16,13 +16,13 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmtopics;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmtopicsModel;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
-use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 
 /**
  * View class for Topics
@@ -119,7 +119,7 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
-        $this->canDo         = ContentHelper::getActions('com_proclaim');
+        $this->canDo         = Cwmassets::sectionActions('topic');
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {

--- a/admin/tmpl/cwmcomments/default.php
+++ b/admin/tmpl/cwmcomments/default.php
@@ -187,7 +187,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                             $link       = Route::_('index.php?option=com_proclaim&task=cwmcomment.edit&id=' . (int)$item->id);
                             $canCheckin  = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate  = $user->authorise('core.create');
+                            $canCreate  = $user->authorise('core.create', 'com_proclaim.comment');
                             $canEdit    = $user->authorise('core.edit', 'com_proclaim.comment.' . $item->id);
                             $canEditOwn = $user->authorise('core.edit.own', 'com_proclaim.comment.' . $item->id);
                             $canChange  = $user->authorise('core.edit.state', 'com_proclaim.comment.' . $item->id);

--- a/admin/tmpl/cwmlocations/default.php
+++ b/admin/tmpl/cwmlocations/default.php
@@ -132,7 +132,7 @@ if (empty($this->items)) : ?>
                         $ordering           = ($listOrder === 'location.ordering');
                         $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                             || $item->checked_out == $userId || \is_null($item->checked_out);
-                        $canCreate          = $user->authorise('core.create');
+                        $canCreate          = $user->authorise('core.create', 'com_proclaim.location');
                         $canEdit            = $user->authorise('core.edit', 'com_proclaim.location.' . $item->id);
                         $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.location.' . $item->id);
                         $canChange          = $user->authorise('core.edit.state', 'com_proclaim.location.' . $item->id);

--- a/admin/tmpl/cwmmessage/edit.php
+++ b/admin/tmpl/cwmmessage/edit.php
@@ -17,7 +17,6 @@
 use CWM\Component\Proclaim\Administrator\Helper\CwmaiHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlangHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -32,7 +31,6 @@ CwmlangHelper::registerAllForJs();
 $this->configFieldsets  = ['editorConfig'];
 $this->hiddenFieldsets  = ['basic-limited'];
 $this->ignore_fieldsets = ['jmetadata', 'item_associations'];
-$this->canDo            = ContentHelper::getActions('com_proclaim', 'message');
 
 // Create shortcut to parameters.
 $params = $this->form->getFieldsets('params');

--- a/admin/tmpl/cwmmessages/default.php
+++ b/admin/tmpl/cwmmessages/default.php
@@ -242,7 +242,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessages'); ?>" method="pos
                                 'core.manage',
                                 'com_checkin'
                             ) || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate  = $user->authorise('core.create');
+                            $canCreate  = $user->authorise('core.create', 'com_proclaim.message');
                             $canEdit    = $user->authorise('core.edit', 'com_proclaim.message.' . $item->id);
                             $canEditOwn = $user->authorise('core.edit.own', 'com_proclaim.message.' . $item->id);
                             $canChange  = $user->authorise('core.edit.state', 'com_proclaim.message.' . $item->id);

--- a/admin/tmpl/cwmmessagetypes/default.php
+++ b/admin/tmpl/cwmmessagetypes/default.php
@@ -101,7 +101,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessagetypes'); ?>" method=
                             $item->max_ordering = 0;
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.messagetype');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.messagetype.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.messagetype.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.messagetype.' . $item->id);

--- a/admin/tmpl/cwmpodcasts/default.php
+++ b/admin/tmpl/cwmpodcasts/default.php
@@ -124,7 +124,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmpodcasts'); ?>" method="pos
                             $item->max_ordering = 0; //??
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.podcast');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.podcast.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.podcast.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.podcast.' . $item->id);

--- a/admin/tmpl/cwmseries/default.php
+++ b/admin/tmpl/cwmseries/default.php
@@ -135,7 +135,7 @@ if (str_contains($listOrder, 'publish_up')) {
                             $item->max_ordering  = 0;
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.serie');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.serie.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.serie.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.serie.' . $item->id);

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -152,7 +152,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                             $item->max_ordering = 0;
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.server');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.server.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.server.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.server.' . $item->id);

--- a/admin/tmpl/cwmteachers/default.php
+++ b/admin/tmpl/cwmteachers/default.php
@@ -158,7 +158,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmteachers'); ?>" method="pos
                             $item->max_ordering = 0;
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.teacher');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.teacher.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.teacher.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.teacher.' . $item->id);

--- a/admin/tmpl/cwmtemplatecodes/default.php
+++ b/admin/tmpl/cwmtemplatecodes/default.php
@@ -98,7 +98,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplatecodes'); ?>" method
                             $item->max_ordering = 0; //??
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.templatecode');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.templatecode.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.templatecode.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.templatecode.' . $item->id);

--- a/admin/tmpl/cwmtemplates/default.php
+++ b/admin/tmpl/cwmtemplates/default.php
@@ -104,7 +104,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtemplates'); ?>" method="po
                             $item->max_ordering = 0;
                             $canCheckin          = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate          = $user->authorise('core.create');
+                            $canCreate          = $user->authorise('core.create', 'com_proclaim.template');
                             $canEdit            = $user->authorise('core.edit', 'com_proclaim.template.' . $item->id);
                             $canEditOwn         = $user->authorise('core.edit.own', 'com_proclaim.template.' . $item->id);
                             $canChange          = $user->authorise('core.edit.state', 'com_proclaim.template.' . $item->id);

--- a/admin/tmpl/cwmtopics/default.php
+++ b/admin/tmpl/cwmtopics/default.php
@@ -101,7 +101,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmtopics'); ?>" method="post"
                             $link       = Route::_('index.php?option=com_proclaim&task=topic.edit&id=' . (int)$item->id);
                             $canCheckin  = $user->authorise('core.manage', 'com_checkin')
                                 || $item->checked_out == $userId || \is_null($item->checked_out);
-                            $canCreate  = $user->authorise('core.create');
+                            $canCreate  = $user->authorise('core.create', 'com_proclaim.topic');
                             $canEdit    = $user->authorise('core.edit', 'com_proclaim.topic.' . $item->id);
                             $canEditOwn = $user->authorise('core.edit.own', 'com_proclaim.topic.' . $item->id);
                             $canChange  = $user->authorise('core.edit.state', 'com_proclaim.topic.' . $item->id);

--- a/tests/integration/Admin/Lib/CwmassetsSectionActionsTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsSectionActionsTest.php
@@ -1,0 +1,419 @@
+<?php
+
+/**
+ * Section permissions have to actually govern something (#1653).
+ *
+ * Phase 1 created the `com_proclaim.<section>` assets and phase 1.5 converted
+ * the batch-button guards. The toolbars kept asking `com_proclaim`, because
+ * they go through `ContentHelper::getActions()` — which cannot ask a section
+ * question at all:
+ *
+ *     if ($section && $id) { $assetName .= '.' . $section . '.' . (int) $id; }
+ *
+ * discards the section unless an item id comes with it, and the action list is
+ * read from a hardcoded `/access/section[@name="component"]/` xpath either way.
+ * So `getActions('com_proclaim', 'teacher')` returns exactly what
+ * `getActions('com_proclaim')` returns, and a Permissions panel built on top of
+ * it would have set values that governed nothing.
+ *
+ * `Cwmassets::sectionActions()` is the call that does ask. This measures both
+ * halves: core's is inert, ours is not.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Access\Access;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ContentHelper;
+use Joomla\CMS\Table\Asset;
+use Joomla\CMS\User\User;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsSectionActionsTest extends IntegrationTestCase
+{
+    /**
+     * The section used for every assertion here.
+     *
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    private const SECTION = 'teacher';
+
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $savedIdentity = null;
+
+    /**
+     * Section asset id under test, and its rules on the way in.
+     *
+     * @var int
+     * @since __DEPLOY_VERSION__
+     */
+    private int $assetId = 0;
+
+    /**
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    private string $savedRules = '{}';
+
+    /**
+     * Whether this test created the section asset, and must remove it again.
+     *
+     * @var bool
+     * @since __DEPLOY_VERSION__
+     */
+    private bool $created = false;
+
+    /**
+     * Groups the acting identity belongs to.
+     *
+     * @var list<int>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $groups = [];
+
+    /**
+     * `com_proclaim` asset id and its rules, when a test stages a grant on it.
+     *
+     * @var int
+     * @since __DEPLOY_VERSION__
+     */
+    private int $componentAssetId = 0;
+
+    /**
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    private string $savedComponentRules = '';
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if (!\in_array(self::SECTION, Cwmassets::declaredSections(), true)) {
+            $this->markTestSkipped('access.xml is not readable from this install path.');
+        }
+
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+
+        // sectionActions() resolves the caller's groups, so it needs a real
+        // user — and one that is not a Super User, whose core.admin at root
+        // short-circuits authorise() before any asset is consulted.
+        $uid = $this->nonRootUserId();
+
+        if ($uid === 0) {
+            $this->markTestSkipped('No non-Super-User with a group is available');
+        }
+
+        $app->loadIdentity(User::getInstance($uid));
+        $this->groups = array_map('intval', Access::getGroupsByUser($uid));
+
+        $existing      = $this->sectionAssetExists();
+        $this->assetId = Cwmassets::sectionId(self::SECTION);
+        $this->created = !$existing && $this->assetId > 0;
+
+        if ($this->assetId < 1) {
+            $this->markTestSkipped('Section asset could not be resolved');
+        }
+
+        $asset = new Asset($this->db);
+        $asset->load($this->assetId);
+        $this->savedRules = (string) $asset->rules;
+    }
+
+    /**
+     * Restore the asset exactly as found, and the identity with it.
+     *
+     * Not a transaction: `Table\Asset::store()` takes a table lock, which is an
+     * implicit COMMIT in MySQL, so a rollback would leave the write behind.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->assetId > 0) {
+            if ($this->created) {
+                $asset = new Asset($this->db);
+
+                if ($asset->load($this->assetId)) {
+                    $asset->delete($this->assetId);
+                }
+
+                Cwmassets::clearSectionCache();
+            } else {
+                $this->writeRules($this->savedRules);
+            }
+        }
+
+        if ($this->componentAssetId > 0) {
+            $restore = $this->db->createQuery()
+                ->update($this->db->quoteName('#__assets'))
+                ->set($this->db->quoteName('rules') . ' = :rules')
+                ->where($this->db->quoteName('id') . ' = :id')
+                ->bind(':rules', $this->savedComponentRules)
+                ->bind(':id', $this->componentAssetId, \Joomla\Database\ParameterType::INTEGER);
+
+            $this->db->setQuery($restore)->execute();
+        }
+
+        Access::clearStatics();
+
+        if ($this->savedIdentity !== null) {
+            Factory::getApplication()->loadIdentity($this->savedIdentity);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Id of a user who holds a group but is not a Super User.
+     *
+     * @return  int
+     * @since __DEPLOY_VERSION__
+     */
+    private function nonRootUserId(): int
+    {
+        $query = $this->db->createQuery()
+            ->select('DISTINCT ' . $this->db->quoteName('user_id'))
+            ->from($this->db->quoteName('#__user_usergroup_map'));
+
+        foreach ((array) $this->db->setQuery($query)->loadColumn() as $candidate) {
+            if (!Access::check((int) $candidate, 'core.admin')) {
+                return (int) $candidate;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Whether the section asset was already present before this test ran.
+     *
+     * @return  bool
+     * @since __DEPLOY_VERSION__
+     */
+    private function sectionAssetExists(): bool
+    {
+        $query = $this->db->createQuery()
+            ->select('id')
+            ->from($this->db->quoteName('#__assets'))
+            ->where($this->db->quoteName('name') . ' = :name')
+            ->bind(':name', $name);
+
+        $name = 'com_proclaim.' . self::SECTION;
+
+        return (int) $this->db->setQuery($query)->loadResult() > 0;
+    }
+
+    /**
+     * Grant core.edit on `com_proclaim` to every group the acting user holds.
+     *
+     * Staged, not assumed: the assertion needs a component-level allow so that
+     * a section-level deny has something to overturn. Restored in tearDown.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    private function grantComponentEdit(): void
+    {
+        $query = $this->db->createQuery()
+            ->select('id, rules')
+            ->from($this->db->quoteName('#__assets'))
+            ->where($this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim'));
+
+        $row = $this->db->setQuery($query)->loadObject();
+
+        if ($row === null) {
+            $this->fail('com_proclaim has no #__assets row; the component is not installed here.');
+        }
+
+        $this->componentAssetId    = (int) $row->id;
+        $this->savedComponentRules = (string) $row->rules;
+
+        $rules = json_decode($this->savedComponentRules, true, 512, \JSON_THROW_ON_ERROR) ?: [];
+
+        foreach ($this->groups as $groupId) {
+            $rules['core.edit'][(string) $groupId] = 1;
+        }
+
+        $encoded = json_encode($rules, \JSON_THROW_ON_ERROR);
+        $id      = $this->componentAssetId;
+
+        $update = $this->db->createQuery()
+            ->update($this->db->quoteName('#__assets'))
+            ->set($this->db->quoteName('rules') . ' = :rules')
+            ->where($this->db->quoteName('id') . ' = :id')
+            ->bind(':rules', $encoded)
+            ->bind(':id', $id, \Joomla\Database\ParameterType::INTEGER);
+
+        $this->db->setQuery($update)->execute();
+
+        Access::clearStatics();
+    }
+
+    /**
+     * Write rules straight onto the section asset and drop every ACL cache.
+     *
+     * @param   string  $rules  A JSON rule set
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    private function writeRules(string $rules): void
+    {
+        $query = $this->db->createQuery()
+            ->update($this->db->quoteName('#__assets'))
+            ->set($this->db->quoteName('rules') . ' = :rules')
+            ->where($this->db->quoteName('id') . ' = :id')
+            ->bind(':rules', $rules)
+            ->bind(':id', $this->assetId, \Joomla\Database\ParameterType::INTEGER);
+
+        $this->db->setQuery($query)->execute();
+
+        Access::clearStatics();
+    }
+
+    #[TestDox('sectionActions() asks the section asset, not the component')]
+    public function testSectionActionsAsksTheSectionAsset(): void
+    {
+        $user  = Factory::getApplication()->getIdentity();
+        $canDo = Cwmassets::sectionActions(self::SECTION);
+
+        foreach (['core.create', 'core.delete', 'core.edit', 'core.edit.state', 'core.edit.own'] as $action) {
+            $this->assertSame(
+                $user->authorise($action, 'com_proclaim.' . self::SECTION),
+                $canDo->get($action),
+                "sectionActions() disagreed with authorise() on {$action}; it is not asking the section asset."
+            );
+        }
+    }
+
+    #[TestDox('a deny on the section changes sectionActions() but not the component answer')]
+    public function testSectionDenyBitesOnlyTheSection(): void
+    {
+        // Grant on the component first rather than skipping when the site's
+        // own rules happen not to allow it. A skip here would read as a pass
+        // while proving nothing, and this is the one assertion that shows
+        // section permissions govern anything at all.
+        $this->grantComponentEdit();
+
+        if (!Factory::getApplication()->getIdentity()->authorise('core.edit', 'com_proclaim')) {
+            $this->fail(
+                'core.edit could not be granted on com_proclaim for the acting user. '
+                . 'An explicit deny above the component (root, or a parent group) is overriding it, '
+                . 'so this environment cannot express the baseline the assertion needs.'
+            );
+        }
+
+        $this->assertTrue(
+            Cwmassets::sectionActions(self::SECTION)->get('core.edit'),
+            'Baseline: the section must inherit core.edit before the deny is written.'
+        );
+
+        $deny = json_encode(['core.edit' => array_fill_keys(array_map('strval', $this->groups), 0)]);
+        $this->writeRules((string) $deny);
+
+        $this->assertFalse(
+            Cwmassets::sectionActions(self::SECTION)->get('core.edit'),
+            'A deny written to the section asset did not reach sectionActions(). '
+            . 'Section permissions govern nothing.'
+        );
+
+        // Asserted through authorise() rather than ContentHelper::getActions(),
+        // which reads access.xml only from JPATH_ADMINISTRATOR and so returns
+        // an all-null CanDo under test. Comparing against null passes without
+        // measuring anything.
+        $this->assertTrue(
+            Factory::getApplication()->getIdentity()->authorise('core.edit', 'com_proclaim'),
+            'A section deny leaked into the component answer. Sections must not re-permission '
+            . 'the component itself.'
+        );
+    }
+
+    #[TestDox("core's getActions() cannot ask a section question, which is why this helper exists")]
+    public function testCoreGetActionsIgnoresASectionWithoutAnId(): void
+    {
+        $this->grantComponentEdit();
+
+        $deny = json_encode(['core.edit' => array_fill_keys(array_map('strval', $this->groups), 0)]);
+        $this->writeRules((string) $deny);
+
+        $user = Factory::getApplication()->getIdentity();
+
+        // Characterises core, not Proclaim: the two-argument form resolves the
+        // same asset as the bare one. Asserted on the asset answers core would
+        // authorise against, because getActions() itself cannot find
+        // access.xml here. If a future Joomla makes the two-argument form
+        // section-aware, the section answer stops matching the component one
+        // and this fails — at which point the helper, and the contract test
+        // forbidding the form, can be revisited.
+        $this->assertTrue(
+            $user->authorise('core.edit', 'com_proclaim'),
+            'Baseline: the component must still allow core.edit after the section deny.'
+        );
+        $this->assertFalse(
+            $user->authorise('core.edit', 'com_proclaim.' . self::SECTION),
+            'Baseline: the section must deny core.edit.'
+        );
+        $this->assertSame(
+            ContentHelper::getActions('com_proclaim')->get('core.edit'),
+            ContentHelper::getActions('com_proclaim', self::SECTION)->get('core.edit'),
+            'ContentHelper::getActions() answered differently for a section with no item id. '
+            . 'Core changed; revisit Cwmassets::sectionActions() and the contract test guarding '
+            . 'the two-argument form.'
+        );
+    }
+
+    #[TestDox('an undeclared section falls back to the component rather than answering nothing')]
+    public function testUndeclaredSectionFallsBackToTheComponent(): void
+    {
+        $this->grantComponentEdit();
+
+        $canDo = Cwmassets::sectionActions('no_such_section');
+
+        $this->assertTrue(
+            $canDo->get('core.edit'),
+            'An undeclared section must answer exactly what the component answers, which is what '
+            . 'every call site produced before section assets existed — not null, which is what a '
+            . 'CanDo built from an unreadable access.xml returns.'
+        );
+        $this->assertSame(
+            Factory::getApplication()->getIdentity()->authorise('core.edit', 'com_proclaim'),
+            $canDo->get('core.edit'),
+            'The fallback must equal the component answer.'
+        );
+    }
+}

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -115,6 +115,41 @@ class AssetNameContractTest extends TestCase
         return $files;
     }
 
+    /**
+     * A file's PHP source with comments removed.
+     *
+     * These tests match call shapes with regular expressions, and the docblocks
+     * on this feature quote the very calls being guarded against -- explaining
+     * why `getActions('com_proclaim', 'teacher')` is inert is the whole point of
+     * the comment on `Cwmassets::sectionActions()`. Scanning raw text flags the
+     * explanation as the offence.
+     *
+     * @param   string  $file  Absolute path to a PHP file
+     *
+     * @return  string
+     * @since __DEPLOY_VERSION__
+     */
+    private static function codeWithoutComments(string $file): string
+    {
+        $code = '';
+
+        foreach (token_get_all((string) file_get_contents($file)) as $token) {
+            if (\is_array($token)) {
+                if ($token[0] === \T_COMMENT || $token[0] === \T_DOC_COMMENT) {
+                    continue;
+                }
+
+                $code .= $token[1];
+
+                continue;
+            }
+
+            $code .= $token;
+        }
+
+        return $code;
+    }
+
     #[TestDox('every section passed to authorise() is declared in access.xml')]
     public function testAuthoriseTargetsAreDeclaredSections(): void
     {
@@ -122,7 +157,7 @@ class AssetNameContractTest extends TestCase
         $offences = [];
 
         foreach (self::sourceFiles() as $file) {
-            $code = (string) file_get_contents($file);
+            $code = self::codeWithoutComments($file);
 
             // Only authorise() calls. loadForm('com_proclaim.server.<type>'),
             // setUserState() and $typeAlias share the prefix but are unrelated
@@ -150,6 +185,69 @@ class AssetNameContractTest extends TestCase
         );
     }
 
+    #[TestDox('every section passed to Cwmassets::sectionActions() is declared in access.xml')]
+    public function testSectionActionsTargetsAreDeclaredSections(): void
+    {
+        $declared = self::declaredSections();
+        $offences = [];
+
+        foreach (self::sourceFiles() as $file) {
+            $code = self::codeWithoutComments($file);
+
+            preg_match_all('/sectionActions\(\s*[\'"]([a-z_]+)[\'"]/i', $code, $matches, PREG_SET_ORDER);
+
+            foreach ($matches as $match) {
+                if (!\in_array($match[1], $declared, true)) {
+                    $offences[] = str_replace(self::root() . '/', '', $file) . ' -> ' . $match[1];
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            array_values(array_unique($offences)),
+            "Cwmassets::sectionActions() named a section admin/access.xml does not declare.\n"
+            . "It falls back to the component's own permissions, so the toolbar looks correct\n"
+            . 'while the section rules govern nothing. Declare the section, or correct the name.'
+        );
+    }
+
+    #[TestDox('nothing passes a section to ContentHelper::getActions() without an item id')]
+    public function testGetActionsIsNeverGivenASectionWithoutAnId(): void
+    {
+        // Core drops the section unless an id comes with it, so the two-argument
+        // form reads as section-scoped and is not. Use sectionActions() instead.
+        $offences = [];
+
+        foreach (self::sourceFiles() as $file) {
+            $code = self::codeWithoutComments($file);
+
+            preg_match_all(
+                '/getActions\(\s*[\'"]com_proclaim[\'"]\s*,\s*[\'"]([a-z_]+)[\'"]\s*([,)])/i',
+                $code,
+                $matches,
+                PREG_SET_ORDER
+            );
+
+            foreach ($matches as $match) {
+                // A third argument follows, so the section genuinely reaches the asset name.
+                if ($match[2] === ',') {
+                    continue;
+                }
+
+                $offences[] = str_replace(self::root() . '/', '', $file) . " -> getActions('com_proclaim', '{$match[1]}')";
+            }
+        }
+
+        $this->assertSame(
+            [],
+            array_values(array_unique($offences)),
+            "ContentHelper::getActions() was given a section but no item id, so core drops the\n"
+            . "section and answers for com_proclaim. Use Cwmassets::sectionActions('<section>')\n"
+            . 'for a section question, or pass the item id for an item question.'
+        );
+    }
+
     #[TestDox('every asset name written by a Table is declared in access.xml')]
     public function testTableAssetNamesAreDeclaredSections(): void
     {
@@ -157,7 +255,7 @@ class AssetNameContractTest extends TestCase
         $offences = [];
 
         foreach (glob(self::root() . '/admin/src/Table/*.php') as $file) {
-            $code = (string) file_get_contents($file);
+            $code = self::codeWithoutComments($file);
 
             if (!preg_match('/function\s+_getAssetName\b(.+?)\n    }/s', $code, $body)) {
                 continue;


### PR DESCRIPTION
> **Stacked on #1671.** Targets the phase 1.5 branch so the diff shows only this change.

Phase 1.5 converted 60 `authorise()` call sites, and every one of them guards a **Batch** button. The toolbars themselves — New, publish, unpublish, archive, trash, empty-trash — read `ContentHelper::getActions('com_proclaim')` in all 12 list views and were never touched. So *Teachers → Edit → Denied* would have removed the Batch button and nothing else.

## Core cannot answer a section question

```php
$assetName = $component;
if ($section && $id) { $assetName .= '.' . $section . '.' . (int) $id; }
...
$actions = Access::getActionsFromFile($file, '/access/section[@name="component"]/');
```

The section is discarded unless an item id comes with it, and the action list is read from a hardcoded `component` xpath either way. `getActions('com_proclaim', 'podcast')` returns exactly what `getActions('com_proclaim')` returns.

`Cwmpodcasts`, `Cwmservers` and `Cwmtemplates` all used that two-argument form and read as though they had been converted. `Cwmplaylists` and `Cwmtopics` had no section-scoped call at all.

## What this adds

`Cwmassets::sectionActions()` reads the action list from the section's own block in access.xml and authorises against `com_proclaim.<section>`. An undeclared section falls back to the component, so this stays inert until an administrator writes a section rule.

18 call sites converted across 14 views. Same defect family, also fixed:

- `admin/tmpl/cwmmessage/edit.php` overwrote the item-scoped `$this->canDo` the view had already set correctly, with the inert two-argument form
- `Cwmmediafiles` asked for the **`message`** section on the media files screen
- 11 list templates computed `$canCreate` from `authorise('core.create')` with **no asset at all** — a site-wide question against the root asset

## Verified in the browser

As a real Manager-tier user (`bccadmin`, groups 1/6/10) with `core.create` and `core.edit` denied on `com_proclaim.teacher`:

| | Teachers (denied) | Series (control) |
|---|---|---|
| New | **absent** | present |
| Batch | **absent** | present |
| Publish / Unpublish / Archive / Trash | present | present |

`core.edit.state` was left allowed and the status buttons correctly stayed. That is the acceptance test from #1653.

## Guarded, and mutation-validated

| mutation | result |
|---|---|
| `sectionActions('teacher')` → `'teachers'` | contract test **fails**, naming the file |
| inert `getActions('com_proclaim', 'podcast')` reintroduced | contract test **fails** |
| `sectionActions()` authorises against the component | integration test **fails** |
| unchanged | green |

The contract scans strip comments before matching, since the docblocks here quote the very call shapes being forbidden.

## ⚠️ Known gap, not closed by this PR

Item-level checks ask `com_proclaim.<section>.<id>`, which falls back to `com_proclaim` for any record without an `#__assets` row, and `FormController::allowEdit()` still authorises against the component. Confirmed on j6-dev: with the deny in place, `bccadmin` opened `view=cwmteacher&layout=edit&id=123` (a teacher with `asset_id=0`) and got the full edit form with Save. **Phase 3's reparenting does not close this** — it only affects records that already have a row.

## Verification

```
composer test:unit          1401 tests, 2997 assertions — OK
composer test:integration    428 tests, 3908 assertions — OK
php-cs-fixer                 0 of 617 files
```

Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
