### PR TITLE
feat: gate create and edit on the section, not the component (#1653 phase 3)

### DIFF
--- a/admin/src/Controller/CwmcommentController.php
+++ b/admin/src/Controller/CwmcommentController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -31,6 +32,7 @@ use Joomla\CMS\Router\Route;
 class CwmcommentController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * Prevents Joomla's pluralization mechanism from altering the view name.
@@ -47,6 +49,14 @@ class CwmcommentController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_comments';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'comment';
 
     /**
      * Method to run batch operations.
@@ -109,6 +119,6 @@ class CwmcommentController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 }

--- a/admin/src/Controller/CwmlocationController.php
+++ b/admin/src/Controller/CwmlocationController.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\ModalFormTrait;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Model\CwmlocationModel;
 use Joomla\CMS\MVC\Controller\FormController;
@@ -33,6 +34,7 @@ use Joomla\CMS\Router\Route;
 class CwmlocationController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
     use ModalFormTrait;
 
     /**
@@ -50,6 +52,14 @@ class CwmlocationController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_locations';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'location';
 
     /**
      * Method to cancel an edit — redirects to modalreturn when in modal layout.
@@ -87,7 +97,7 @@ class CwmlocationController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmcaptionValidator;
 use CWM\Component\Proclaim\Administrator\Table\CwmmediafileTable;
@@ -39,6 +40,7 @@ use Joomla\Database\DatabaseInterface;
 class CwmmediafileController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * Prevents Joomla's pluralization mechanism from altering the view name.
@@ -63,6 +65,14 @@ class CwmmediafileController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_mediafiles';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'mediafile';
 
     /**
      * Method to add a new record.
@@ -130,7 +140,7 @@ class CwmmediafileController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmmessageController.php
+++ b/admin/src/Controller/CwmmessageController.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\ModalFormTrait;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmaiHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmtopicSuggestionHelper;
@@ -38,6 +39,7 @@ use Joomla\Database\DatabaseInterface;
 class CwmmessageController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
     use ModalFormTrait;
 
     /**
@@ -55,6 +57,14 @@ class CwmmessageController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_studies';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'message';
 
     /**
      * Reset Hits
@@ -382,6 +392,6 @@ class CwmmessageController extends FormController
         }
 
         // Since there is no asset tracking, revert to the component permissions.
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 }

--- a/admin/src/Controller/CwmmessagetypeController.php
+++ b/admin/src/Controller/CwmmessagetypeController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -31,6 +32,7 @@ use Joomla\CMS\Router\Route;
 class CwmmessagetypeController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The database table for access level checks.
@@ -39,6 +41,14 @@ class CwmmessagetypeController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_message_type';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'messagetype';
 
     /**
      * Method to run after a successful save — records the action in Joomla's logs.
@@ -77,7 +87,7 @@ class CwmmessagetypeController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmplaylistController.php
+++ b/admin/src/Controller/CwmplaylistController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -30,6 +31,7 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 class CwmplaylistController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The URL view list variable.
@@ -46,6 +48,14 @@ class CwmplaylistController extends FormController
      * @since  10.5.6
      */
     protected string $accessTable = '#__bsms_playlists';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'playlist';
 
     /**
      * Method override to check if you can edit an existing record.
@@ -70,7 +80,7 @@ class CwmplaylistController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmpodcastController.php
+++ b/admin/src/Controller/CwmpodcastController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmpodcastIndexHelper;
 use CWM\Component\Proclaim\Administrator\Model\CwmpodcastModel;
@@ -39,6 +40,7 @@ use Joomla\Database\ParameterType;
 class CwmpodcastController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The database table for access level checks.
@@ -47,6 +49,14 @@ class CwmpodcastController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_podcast';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'podcast';
 
     /**
      * Method override to check if you can edit an existing record.
@@ -66,7 +76,7 @@ class CwmpodcastController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmserieController.php
+++ b/admin/src/Controller/CwmserieController.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\ModalFormTrait;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -32,6 +33,7 @@ use Joomla\CMS\Router\Route;
 class CwmserieController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
     use ModalFormTrait;
 
     /**
@@ -49,6 +51,14 @@ class CwmserieController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_series';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'serie';
 
     /**
      * Method to cancel an edit — redirects to modalreturn when in modal layout.
@@ -129,6 +139,6 @@ class CwmserieController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 }

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -15,6 +15,7 @@ use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
 use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\ModalFormTrait;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Model\CwmserverModel;
 use Joomla\CMS\Factory;
@@ -38,6 +39,7 @@ use Joomla\CMS\Uri\Uri;
 class CwmserverController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
     use ModalFormTrait;
 
     /**
@@ -47,6 +49,14 @@ class CwmserverController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_servers';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'server';
 
     /**
      * Method to add a new record.
@@ -113,7 +123,7 @@ class CwmserverController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmteacherController.php
+++ b/admin/src/Controller/CwmteacherController.php
@@ -13,6 +13,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\ModalFormTrait;
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -35,6 +36,7 @@ use Joomla\CMS\Session\Session;
 class CwmteacherController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
     use ModalFormTrait;
 
     /**
@@ -60,6 +62,14 @@ class CwmteacherController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_teachers';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'teacher';
 
     /**
      * Method to cancel an edit — redirects to modalreturn when in modal layout.
@@ -116,7 +126,7 @@ class CwmteacherController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmtemplateController.php
+++ b/admin/src/Controller/CwmtemplateController.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use CWM\Component\Proclaim\Administrator\Model\CwmtemplateModel;
@@ -39,6 +40,7 @@ use Joomla\Utilities\ArrayHelper;
 class CwmtemplateController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The database table for access level checks.
@@ -47,6 +49,14 @@ class CwmtemplateController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_templates';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'template';
 
     /**
      * Method override to check if you can edit an existing record.
@@ -95,7 +105,7 @@ class CwmtemplateController extends FormController
             }
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 
     /**

--- a/admin/src/Controller/CwmtemplatecodeController.php
+++ b/admin/src/Controller/CwmtemplatecodeController.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
@@ -33,6 +34,7 @@ use Joomla\Database\ParameterType;
 class CwmtemplatecodeController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The database table for access level checks.
@@ -41,6 +43,14 @@ class CwmtemplatecodeController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_templatecode';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'templatecode';
 
     /**
      * Protect the view
@@ -124,6 +134,6 @@ class CwmtemplatecodeController extends FormController
             }
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 }

--- a/admin/src/Controller/CwmtopicController.php
+++ b/admin/src/Controller/CwmtopicController.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Administrator\Controller;
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\MultiCampusAccessTrait;
+use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -29,6 +30,7 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 class CwmtopicController extends FormController
 {
     use MultiCampusAccessTrait;
+    use SectionAccessTrait;
 
     /**
      * The database table for access level checks.
@@ -37,6 +39,14 @@ class CwmtopicController extends FormController
      * @since  10.3.0
      */
     protected string $accessTable = '#__bsms_topics';
+
+    /**
+     * The access.xml section these records belong to.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected string $aclSection = 'topic';
 
     /**
      * Method to run after a successful save — records the action in Joomla's logs.
@@ -75,6 +85,6 @@ class CwmtopicController extends FormController
             return false;
         }
 
-        return parent::allowEdit($data, $key);
+        return $this->allowSectionEdit();
     }
 }

--- a/admin/src/Controller/DisplayController.php
+++ b/admin/src/Controller/DisplayController.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
@@ -68,6 +69,31 @@ class DisplayController extends BaseController
     }
 
     /**
+     * Where a refused edit request goes back to, keyed by edit view.
+     *
+     * Routing only; which section governs an entity is
+     * `Cwmassets::sectionForView()`.
+     *
+     * @var    array<string, string>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const EDIT_VIEW_LISTS = [
+        'cwmcomment'      => 'cwmcomments',
+        'cwmlocation'     => 'cwmlocations',
+        'cwmmediafile'    => 'cwmmediafiles',
+        'cwmmessage'      => 'cwmmessages',
+        'cwmmessagetype'  => 'cwmmessagetypes',
+        'cwmplaylist'     => 'cwmplaylists',
+        'cwmpodcast'      => 'cwmpodcasts',
+        'cwmserie'        => 'cwmseries',
+        'cwmserver'       => 'cwmservers',
+        'cwmteacher'      => 'cwmteachers',
+        'cwmtemplate'     => 'cwmtemplates',
+        'cwmtemplatecode' => 'cwmtemplatecodes',
+        'cwmtopic'        => 'cwmtopics',
+    ];
+
+    /**
      * Method to display a view.
      *
      * @param   bool   $cachable   If true, the view output will be cached
@@ -86,15 +112,30 @@ class DisplayController extends BaseController
         $id      = $this->input->getInt('id');
 
         // Check for an edit form.
-        if ($vName === 'cwmmessage' && $lName === 'edit' && !$this->checkEditId('com_proclaim.edit.cwmmessage', $id)) {
-            // Somehow the person just went to the form - we don't allow that.
-            if (!\count($this->app->getMessageQueue())) {
-                $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
+        if ($lName === 'edit' && isset(self::EDIT_VIEW_LISTS[$vName])) {
+            $redirect = Route::_('index.php?option=com_proclaim&view=' . self::EDIT_VIEW_LISTS[$vName], false);
+            $section  = Cwmassets::sectionForView($vName);
+
+            // A task-less GET never reaches the entity controller, so
+            // allowAdd()/allowEdit() do not run. Without this the form renders
+            // for a section the user is denied, and only refuses on save.
+            if ($section !== '' && !$this->app->getIdentity()->authorise($id ? 'core.edit' : 'core.create', 'com_proclaim.' . $section)) {
+                $this->setMessage(Text::_('JERROR_ALERTNOAUTHOR'), 'error');
+                $this->setRedirect($redirect);
+
+                return $this;
             }
 
-            $this->setRedirect(Route::_('index.php?option=com_proclaim&view=cwmmessages', false));
+            if (!$this->checkEditId('com_proclaim.edit.' . $vName, $id)) {
+                // Somehow the person just went to the form - we don't allow that.
+                if (!\count($this->app->getMessageQueue())) {
+                    $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
+                }
 
-            return $this;
+                $this->setRedirect($redirect);
+
+                return $this;
+            }
         }
 
         $safeurlparams = [

--- a/admin/src/Controller/Trait/SectionAccessTrait.php
+++ b/admin/src/Controller/Trait/SectionAccessTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Administrator\Controller\Trait;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+
+/**
+ * Answers create and edit against `com_proclaim.<section>` rather than the component.
+ *
+ * `FormController::allowAdd()` and `allowEdit()` ask `com_proclaim`, so a section
+ * rule hid a list's buttons while the record stayed reachable and saveable by URL.
+ *
+ * Usage: `use SectionAccessTrait;` in a FormController subclass and set
+ * `protected string $aclSection = 'teacher';`
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait SectionAccessTrait
+{
+    /**
+     * The access.xml section this controller's records belong to.
+     * Must be set by the using class.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    // protected string $aclSection = 'teacher';
+
+    /**
+     * The asset create and edit are authorised against.
+     *
+     * Always the section, never `com_proclaim.<section>.<id>`. Item assets are
+     * parented to the component, so asking one lets any record that happens to
+     * carry an `#__assets` row escape the section rule entirely. Records with an
+     * explicit item grant are therefore governed by the section too.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function sectionAsset(): string
+    {
+        return isset($this->aclSection) ? 'com_proclaim.' . $this->aclSection : 'com_proclaim';
+    }
+
+    /**
+     * Whether the user may create a record in this section.
+     *
+     * @param   array  $data  An array of input data.
+     *
+     * @return  bool
+     *
+     * @throws  \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowAdd($data = []): bool
+    {
+        return Factory::getApplication()->getIdentity()->authorise('core.create', $this->sectionAsset());
+    }
+
+    /**
+     * Whether the user may edit records in this section.
+     *
+     * Does not consider `core.edit.own`, matching what `FormController` did
+     * before: only the asset changes here, not the question.
+     *
+     * @return  bool
+     *
+     * @throws  \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowSectionEdit(): bool
+    {
+        return Factory::getApplication()->getIdentity()->authorise('core.edit', $this->sectionAsset());
+    }
+}

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -108,6 +108,45 @@ class Cwmassets
     }
 
     /**
+     * The access.xml section each entity belongs to, keyed by view name.
+     *
+     * The single place that knows which section governs which entity;
+     * controllers ask rather than carry their own copy.
+     *
+     * @var    array<string, string>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const SECTION_BY_VIEW = [
+        'cwmcomment'      => 'comment',
+        'cwmlocation'     => 'location',
+        'cwmmediafile'    => 'mediafile',
+        'cwmmessage'      => 'message',
+        'cwmmessagetype'  => 'messagetype',
+        'cwmplaylist'     => 'playlist',
+        'cwmpodcast'      => 'podcast',
+        'cwmserie'        => 'serie',
+        'cwmserver'       => 'server',
+        'cwmteacher'      => 'teacher',
+        'cwmtemplate'     => 'template',
+        'cwmtemplatecode' => 'templatecode',
+        'cwmtopic'        => 'topic',
+    ];
+
+    /**
+     * The section governing an entity's edit view, or an empty string.
+     *
+     * @param   string  $view  A view name, such as `cwmteacher`
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function sectionForView(string $view): string
+    {
+        return self::SECTION_BY_VIEW[$view] ?? '';
+    }
+
+    /**
      * The permissions a user holds on `com_proclaim.<section>`.
      *
      * ⚠️ Use this, not `ContentHelper::getActions()`, for a section question:

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -248,6 +248,34 @@ class AssetNameContractTest extends TestCase
         );
     }
 
+    #[TestDox('every controller $aclSection is declared in access.xml')]
+    public function testControllerSectionsAreDeclaredSections(): void
+    {
+        // Built from a property, so the authorise() scan above cannot see it.
+        $declared = self::declaredSections();
+        $offences = [];
+
+        foreach (glob(self::root() . '/admin/src/Controller/*.php') as $file) {
+            $code = self::codeWithoutComments($file);
+
+            if (!preg_match('/\$aclSection\s*=\s*[\'"]([a-z_]*)[\'"]/i', $code, $match)) {
+                continue;
+            }
+
+            if (!\in_array($match[1], $declared, true)) {
+                $offences[] = basename($file) . ' -> ' . $match[1];
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offences,
+            "A controller gates create and edit on a section admin/access.xml does not declare.\n"
+            . 'The asset never resolves, so the check falls back to the component and the '
+            . 'section rule governs nothing.'
+        );
+    }
+
     #[TestDox('every asset name written by a Table is declared in access.xml')]
     public function testTableAssetNamesAreDeclaredSections(): void
     {

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -276,6 +276,48 @@ class AssetNameContractTest extends TestCase
         );
     }
 
+    #[TestDox("Cwmassets' entity section map matches the controllers' \$aclSection")]
+    public function testEntitySectionMapMatchesTheControllers(): void
+    {
+        // The edit form is gated from the map and the save from $aclSection.
+        // A mismatch gates the two on different sections.
+        $lib = self::codeWithoutComments(self::root() . '/admin/src/Lib/Cwmassets.php');
+
+        preg_match_all(
+            '/[\'"](cwm[a-z]+)[\'"]\s*=>\s*[\'"]([a-z_]+)[\'"]/i',
+            substr($lib, strpos($lib, 'SECTION_BY_VIEW')),
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $this->assertNotEmpty($matches, 'No entity section map found; the guard would be vacuous.');
+
+        $declared    = self::declaredSections();
+        $mismatches  = [];
+
+        foreach ($matches as [, $view, $section]) {
+            if (!\in_array($section, $declared, true)) {
+                $mismatches[] = "{$view}: '{$section}' is not declared in access.xml";
+            }
+
+            $file = self::root() . '/admin/src/Controller/' . ucfirst($view) . 'Controller.php';
+
+            if (!is_file($file)) {
+                $mismatches[] = $view . ' -> no such controller';
+
+                continue;
+            }
+
+            preg_match('/\$aclSection\s*=\s*[\'"]([a-z_]*)[\'"]/i', self::codeWithoutComments($file), $own);
+
+            if (($own[1] ?? null) !== $section) {
+                $mismatches[] = $view . ": map says '{$section}', controller says '" . ($own[1] ?? 'nothing') . "'";
+            }
+        }
+
+        $this->assertSame([], $mismatches, 'The edit form and its save are gated on different sections.');
+    }
+
     #[TestDox('every asset name written by a Table is declared in access.xml')]
     public function testTableAssetNamesAreDeclaredSections(): void
     {


### PR DESCRIPTION
> **Stacked on #1717.** Closes the last gap in #1653 — section rules now govern records, not just buttons.

Before this, section rules governed list affordances only. `FormController::allowAdd()` and `allowEdit()` ask `com_proclaim`, so a Manager denied `core.edit` on `com_proclaim.teacher` lost the New and Batch buttons but could still open `view=cwmteacher&layout=edit&id=123` and save it. The toolbar said one thing and the component did another.

## What this adds

`SectionAccessTrait` answers create and edit against `com_proclaim.<section>`, wired exactly like the existing `MultiCampusAccessTrait` — `use SectionAccessTrait;` plus `protected string $aclSection = 'teacher';`. Applied to all 13 entity controllers.

`DisplayController` already refused unheld edit ids, but only for `cwmmessage`. It now does so for all 13 entity views, with a section check ahead of it — because a task-less `view=` GET never reaches the entity controller, so `allowAdd()`/`allowEdit()` never run. Without that, a denied section rendered the full form and only refused on save.

## Always the section, never the item asset

`sectionAsset()` deliberately returns `com_proclaim.<section>`, not `com_proclaim.<section>.<id>`.

Item assets are parented to the component, so asking one lets any record that happens to carry an `#__assets` row escape the section rule — measured on j6-dev, where `com_proclaim.teacher.79` stayed ALLOW under a section deny. Asking the item would have left the hole open for exactly the records an administrator had singled out.

**Consequence:** a record with an explicit item-level grant is governed by the section too. Reparenting item assets beneath their section would let them refine rather than bypass; that is not done here.

`core.edit.own` is deliberately not consulted — `FormController` did not consider it either, so only the asset changes here, not the question.

## Verified as a Manager-tier user

`bccadmin` (groups 1/6/10), with `core.create` and `core.edit` denied on `com_proclaim.teacher`:

| | result |
|---|---|
| `view=cwmteacher&layout=edit&id=123` (`asset_id=0`, the common case) | **refused**, redirected to the list |
| `view=cwmteacher&layout=edit&id=79` (explicit item grants) | **refused** — the section governs it too |
| `task=cwmteacher.save` | **refused** — "Save not permitted." |
| editing a Series from its list link | unaffected |

The first of those rendered the full edit form with Save buttons before this PR.

## Where the section map lives

`Cwmassets::sectionForView()` owns which section governs which entity — that is domain knowledge, and a controller carrying its own copy is a second source that can drift. `DisplayController` keeps only the view → list redirect map, which is routing.

## Guards

Two contract tests, both mutation-validated:

| mutation | result |
|---|---|
| `$aclSection` `'teacher'` → `'teachers'` | **fails**, naming the file |
| map points `cwmteacher` at `serie` | **fails** — form and save would be gated on different sections |
| map names an undeclared section | **fails** |
| unchanged | green |

The existing scan matches `authorise()` literals and cannot see a name built from a property, which is why these are separate.

## ⚠️ Behaviour change

Any site that has already set section rules through #1717's screen will find a denied section now refuses the edit and new-record URLs, where before it only hid the buttons. That is the intent of #1653, but it is a change rather than a no-op.

## Verification

```
composer test:unit          1406 tests, 3006 assertions — OK
composer test:integration    428 tests, 3908 assertions — OK
php-cs-fixer                 0 of 622 files
```

Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
