### PR TITLE
feat: parent item assets to their section, so section rules reach them (#1653)

### DIFF
--- a/admin/src/Controller/CwmcommentController.php
+++ b/admin/src/Controller/CwmcommentController.php
@@ -119,6 +119,6 @@ class CwmcommentController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 }

--- a/admin/src/Controller/CwmlocationController.php
+++ b/admin/src/Controller/CwmlocationController.php
@@ -97,7 +97,7 @@ class CwmlocationController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -140,7 +140,7 @@ class CwmmediafileController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmmessageController.php
+++ b/admin/src/Controller/CwmmessageController.php
@@ -392,6 +392,6 @@ class CwmmessageController extends FormController
         }
 
         // Since there is no asset tracking, revert to the component permissions.
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 }

--- a/admin/src/Controller/CwmmessagetypeController.php
+++ b/admin/src/Controller/CwmmessagetypeController.php
@@ -87,7 +87,7 @@ class CwmmessagetypeController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmplaylistController.php
+++ b/admin/src/Controller/CwmplaylistController.php
@@ -80,7 +80,7 @@ class CwmplaylistController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmpodcastController.php
+++ b/admin/src/Controller/CwmpodcastController.php
@@ -76,7 +76,7 @@ class CwmpodcastController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmserieController.php
+++ b/admin/src/Controller/CwmserieController.php
@@ -139,6 +139,6 @@ class CwmserieController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 }

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -123,7 +123,7 @@ class CwmserverController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmteacherController.php
+++ b/admin/src/Controller/CwmteacherController.php
@@ -126,7 +126,7 @@ class CwmteacherController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmtemplateController.php
+++ b/admin/src/Controller/CwmtemplateController.php
@@ -105,7 +105,7 @@ class CwmtemplateController extends FormController
             }
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 
     /**

--- a/admin/src/Controller/CwmtemplatecodeController.php
+++ b/admin/src/Controller/CwmtemplatecodeController.php
@@ -134,6 +134,6 @@ class CwmtemplatecodeController extends FormController
             }
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 }

--- a/admin/src/Controller/CwmtopicController.php
+++ b/admin/src/Controller/CwmtopicController.php
@@ -85,6 +85,6 @@ class CwmtopicController extends FormController
             return false;
         }
 
-        return $this->allowSectionEdit();
+        return $this->allowSectionEdit((int) ($data[$key] ?? 0));
     }
 }

--- a/admin/src/Controller/Trait/SectionAccessTrait.php
+++ b/admin/src/Controller/Trait/SectionAccessTrait.php
@@ -17,6 +17,8 @@ namespace CWM\Component\Proclaim\Administrator\Controller\Trait;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 /**
  * Answers create and edit against `com_proclaim.<section>` rather than the component.
@@ -43,18 +45,59 @@ trait SectionAccessTrait
     /**
      * The asset create and edit are authorised against.
      *
-     * Always the section, never `com_proclaim.<section>.<id>`. Item assets are
-     * parented to the component, so asking one lets any record that happens to
-     * carry an `#__assets` row escape the section rule entirely. Records with an
-     * explicit item grant are therefore governed by the section too.
+     * The record's own asset when it has one — those are parented to the section
+     * now, so its rules are inherited and an item rule refines within them
+     * rather than escaping them. A deny on the section still wins, because
+     * `Rule::mergeIdentity()` merges root-first and an explicit deny survives
+     * every later merge.
+     *
+     * ⚠️ Only when `asset_id > 0`. Joomla resolves an unknown
+     * `com_proclaim.teacher.5` to everything before the **first** dot, so a
+     * row-less record would fall back to `com_proclaim` and skip the section.
+     *
+     * @param   int  $recordId  The record being edited, 0 when creating
      *
      * @return  string
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function sectionAsset(): string
+    protected function sectionAsset(int $recordId = 0): string
     {
-        return isset($this->aclSection) ? 'com_proclaim.' . $this->aclSection : 'com_proclaim';
+        if (!isset($this->aclSection)) {
+            return 'com_proclaim';
+        }
+
+        $section = 'com_proclaim.' . $this->aclSection;
+
+        return $recordId > 0 && $this->recordHasAsset($recordId) ? $section . '.' . $recordId : $section;
+    }
+
+    /**
+     * Whether a record carries an `#__assets` row of its own.
+     *
+     * Most do not: Proclaim strips an item asset again when its rules are empty,
+     * so one exists only where per-record permissions were actually set.
+     *
+     * @param   int  $recordId  The record primary key
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function recordHasAsset(int $recordId): bool
+    {
+        if (!isset($this->accessTable)) {
+            return false;
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()
+            ->select($db->quoteName('asset_id'))
+            ->from($db->quoteName($this->accessTable))
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $recordId, ParameterType::INTEGER);
+
+        return (int) $db->setQuery($query)->loadResult() > 0;
     }
 
     /**
@@ -83,8 +126,8 @@ trait SectionAccessTrait
      * @throws  \Exception
      * @since   __DEPLOY_VERSION__
      */
-    protected function allowSectionEdit(): bool
+    protected function allowSectionEdit(int $recordId = 0): bool
     {
-        return Factory::getApplication()->getIdentity()->authorise('core.edit', $this->sectionAsset());
+        return Factory::getApplication()->getIdentity()->authorise('core.edit', $this->sectionAsset($recordId));
     }
 }

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -545,6 +545,112 @@ class Cwmassets
     }
 
     /**
+     * Move existing item assets under their section.
+     *
+     * `_getAssetParentId()` handles every asset created from now on; this is for
+     * rows written before that, which hang off `com_proclaim` and so ignore
+     * their section's rules.
+     *
+     * ⚠️ Uses `moveByReference()`, not `setLocation()` + `store()`: store() on a
+     * loaded nested row rewrites lft/rgt from values that may be stale if
+     * anything else moved the tree first.
+     *
+     * `<section>.0` rows are skipped — they belong to no record and are reported
+     * for `fixAllAssets()` to clean rather than silently relocated.
+     *
+     * @return  array{moved: int, skipped: list<string>}
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function reparentItemAssets(): array
+    {
+        $db      = Factory::getContainer()->get(DatabaseInterface::class);
+        $moved   = 0;
+        $skipped = [];
+
+        foreach (self::declaredSections() as $section) {
+            $sectionId = self::sectionId($section);
+
+            if ($sectionId < 1) {
+                continue;
+            }
+
+            $like  = 'com_proclaim.' . $section . '.%';
+            $query = $db->createQuery()
+                ->select($db->quoteName(['id', 'name']))
+                ->from($db->quoteName('#__assets'))
+                ->where($db->quoteName('name') . ' LIKE :like')
+                ->where($db->quoteName('parent_id') . ' <> :section')
+                ->bind(':like', $like)
+                ->bind(':section', $sectionId, ParameterType::INTEGER);
+
+            foreach ((array) $db->setQuery($query)->loadObjectList() as $row) {
+                $suffix = substr((string) $row->name, \strlen('com_proclaim.' . $section . '.'));
+
+                // Only ever move com_proclaim.<section>.<id>; a further dot means
+                // something this method does not understand.
+                if (!ctype_digit($suffix)) {
+                    continue;
+                }
+
+                if ((int) $suffix === 0) {
+                    $skipped[] = (string) $row->name;
+
+                    continue;
+                }
+
+                $asset = new \Joomla\CMS\Table\Asset($db);
+
+                if (!$asset->load((int) $row->id)) {
+                    continue;
+                }
+
+                if ($asset->moveByReference($sectionId, 'last-child', (int) $row->id)) {
+                    $moved++;
+                } else {
+                    Log::add("Could not reparent '{$row->name}': " . $asset->getError(), Log::WARNING, 'com_proclaim');
+                }
+            }
+        }
+
+        if ($moved > 0) {
+            self::clearSectionCache();
+        }
+
+        return ['moved' => $moved, 'skipped' => $skipped];
+    }
+
+    /**
+     * The asset a section's item rows should hang from.
+     *
+     * Item assets used to be parented to `com_proclaim`, which meant a rule on
+     * `com_proclaim.<section>` never reached them — a record with per-record
+     * permissions escaped its section entirely (#1653).
+     *
+     * Falls back to the component for a section access.xml does not declare, so
+     * `message_type`, `cwmadmin` and `studytopics` keep their old parent until
+     * their names are corrected.
+     *
+     * @param   string  $section  Section name as declared in access.xml
+     *
+     * @return  int  Section asset id, or the component asset id
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function sectionParentId(string $section): int
+    {
+        if (\in_array($section, self::declaredSections(), true)) {
+            $id = self::sectionId($section);
+
+            if ($id > 0) {
+                return $id;
+            }
+        }
+
+        return self::parentId();
+    }
+
+    /**
      * Get the com_proclaim parent asset ID, creating it if missing.
      *
      * CRITICAL: This method MUST never return 0.  All 14 Table classes call

--- a/admin/src/Table/CwmcommentTable.php
+++ b/admin/src/Table/CwmcommentTable.php
@@ -307,7 +307,8 @@ class CwmcommentTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.comment reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('comment');
     }
 }

--- a/admin/src/Table/CwmlocationTable.php
+++ b/admin/src/Table/CwmlocationTable.php
@@ -287,7 +287,8 @@ class CwmlocationTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.location reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('location');
     }
 }

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -586,7 +586,8 @@ class CwmmediafileTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.mediafile reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('mediafile');
     }
 }

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -980,7 +980,8 @@ class CwmmessageTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.message reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('message');
     }
 }

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -333,7 +333,8 @@ class CwmmessagetypeTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.messagetype reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('messagetype');
     }
 }

--- a/admin/src/Table/CwmplaylistTable.php
+++ b/admin/src/Table/CwmplaylistTable.php
@@ -385,7 +385,8 @@ class CwmplaylistTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.playlist reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('playlist');
     }
 }

--- a/admin/src/Table/CwmpodcastTable.php
+++ b/admin/src/Table/CwmpodcastTable.php
@@ -752,7 +752,8 @@ class CwmpodcastTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.podcast reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('podcast');
     }
 }

--- a/admin/src/Table/CwmserieTable.php
+++ b/admin/src/Table/CwmserieTable.php
@@ -404,7 +404,8 @@ class CwmserieTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.serie reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('serie');
     }
 }

--- a/admin/src/Table/CwmserverTable.php
+++ b/admin/src/Table/CwmserverTable.php
@@ -329,7 +329,8 @@ class CwmserverTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.server reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('server');
     }
 }

--- a/admin/src/Table/CwmteacherTable.php
+++ b/admin/src/Table/CwmteacherTable.php
@@ -392,7 +392,8 @@ class CwmteacherTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get to Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.teacher reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('teacher');
     }
 }

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -331,7 +331,8 @@ class CwmtemplateTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.template reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('template');
     }
 }

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -395,7 +395,8 @@ class CwmtemplatecodeTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get to Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.templatecode reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('templatecode');
     }
 }

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -324,7 +324,8 @@ class CwmtopicTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.topic reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('topic');
     }
 }

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -674,6 +674,23 @@ class com_proclaimInstallerScript extends InstallerScript
             if ($removed !== []) {
                 Log::add('Removed undeclared section asset(s): ' . implode(', ', $removed), Log::INFO, 'com_proclaim');
             }
+
+            // Item assets written before sections existed hang off the component
+            // and so ignore their section's rules.
+            $reparented = Cwmassets::reparentItemAssets();
+
+            if ($reparented['moved'] > 0) {
+                Log::add("Reparented {$reparented['moved']} item asset(s) under their section", Log::INFO, 'com_proclaim');
+            }
+
+            if ($reparented['skipped'] !== []) {
+                Log::add(
+                    'Left item asset(s) belonging to no record: ' . implode(', ', $reparented['skipped'])
+                    . ' — run Database Maintenance to clean them',
+                    Log::WARNING,
+                    'com_proclaim'
+                );
+            }
         } catch (\Throwable $e) {
             // Must not take down an otherwise successful install.
             Log::add('Could not reconcile section assets: ' . $e->getMessage(), Log::WARNING, 'com_proclaim');

--- a/tests/integration/Admin/Lib/CwmassetsReparentTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsReparentTest.php
@@ -1,0 +1,271 @@
+<?php
+
+/**
+ * Item assets must hang from their section, not the component (#1653).
+ *
+ * While they were parented to `com_proclaim`, a rule on `com_proclaim.teacher`
+ * never reached `com_proclaim.teacher.79` — so the records an administrator had
+ * singled out for per-record permissions were the ones that escaped the section
+ * rule. Measured on a development site before the change: the section denied
+ * core.edit and the item asset still answered ALLOW.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Access\Access;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Asset;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsReparentTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * Asset ids this test created, removed again in tearDown.
+     *
+     * @var list<int>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $created = [];
+
+    /**
+     * Section rules on the way in, so a deny written here is undone.
+     *
+     * @var array<int, string>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $savedRules = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if (!\in_array('teacher', Cwmassets::declaredSections(), true)) {
+            $this->markTestSkipped('access.xml is not readable from this install path.');
+        }
+    }
+
+    /**
+     * Remove only what this test created, and restore any rules it wrote.
+     *
+     * Not a transaction: nested-set writes take table locks, which are an
+     * implicit COMMIT in MySQL.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->savedRules as $id => $rules) {
+            $this->db->setQuery(
+                $this->db->createQuery()
+                    ->update($this->db->quoteName('#__assets'))
+                    ->set($this->db->quoteName('rules') . ' = ' . $this->db->quote($rules))
+                    ->where($this->db->quoteName('id') . ' = ' . (int) $id)
+            )->execute();
+        }
+
+        foreach (array_reverse($this->created) as $id) {
+            $asset = new Asset($this->db);
+
+            if ($asset->load($id)) {
+                $asset->delete($id);
+            }
+        }
+
+        Cwmassets::clearSectionCache();
+        Access::clearStatics();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create an asset under a given parent, tracked for cleanup.
+     *
+     * @param   string  $name      Asset name
+     * @param   int     $parentId  Parent asset id
+     * @param   string  $rules     JSON rule set
+     *
+     * @return  int
+     * @since __DEPLOY_VERSION__
+     */
+    private function makeAsset(string $name, int $parentId, string $rules = '{}'): int
+    {
+        $asset = new Asset($this->db);
+        $asset->setLocation($parentId, 'last-child');
+        $asset->name  = $name;
+        $asset->title = $name;
+        $asset->rules = $rules;
+
+        $this->assertTrue($asset->check() && $asset->store(), "Could not create {$name}");
+        $this->created[] = (int) $asset->id;
+
+        return (int) $asset->id;
+    }
+
+    /**
+     * The name of an asset's parent.
+     *
+     * @param   string  $name  Asset name
+     *
+     * @return  string
+     * @since __DEPLOY_VERSION__
+     */
+    private function parentNameOf(string $name): string
+    {
+        return (string) $this->db->setQuery(
+            'SELECT p.name FROM ' . $this->db->quoteName('#__assets', 'a')
+            . ' INNER JOIN ' . $this->db->quoteName('#__assets', 'p') . ' ON p.id = a.parent_id'
+            . ' WHERE a.name = ' . $this->db->quote($name)
+        )->loadResult();
+    }
+
+    #[TestDox('a section rule reaches an item asset once it is reparented')]
+    public function testSectionDenyReachesAReparentedItemAsset(): void
+    {
+        Cwmassets::seedSections();
+        $sectionId = Cwmassets::sectionId('teacher');
+        $component = Cwmassets::parentId();
+
+        $this->assertGreaterThan(0, $sectionId);
+        $this->assertNotSame($sectionId, $component, 'Section and component must be distinct assets.');
+
+        // The old shape: an item asset on the component, carrying an explicit
+        // allow. This is the record that used to escape its section.
+        $group = (int) $this->db->setQuery(
+            'SELECT id FROM ' . $this->db->quoteName('#__usergroups') . ' ORDER BY id LIMIT 1'
+        )->loadResult();
+
+        $itemId = $this->makeAsset(
+            'com_proclaim.teacher.999998',
+            $component,
+            json_encode(['core.edit' => [(string) $group => 1]], \JSON_THROW_ON_ERROR)
+        );
+
+        $moved = Cwmassets::reparentItemAssets();
+        Access::clearStatics();
+
+        $this->assertGreaterThanOrEqual(1, $moved['moved'], 'Nothing was reparented.');
+        $this->assertSame(
+            'com_proclaim.teacher',
+            $this->parentNameOf('com_proclaim.teacher.999998'),
+            'The item asset is still on the component, so section rules cannot reach it.'
+        );
+
+        // Deny at the section. Rule::mergeIdentity() merges root-first and an
+        // explicit deny survives every later merge, so the item's own allow
+        // must not win.
+        $this->savedRules[$sectionId] = (string) $this->db->setQuery(
+            'SELECT rules FROM ' . $this->db->quoteName('#__assets') . ' WHERE id = ' . $sectionId
+        )->loadResult();
+
+        $this->db->setQuery(
+            $this->db->createQuery()
+                ->update($this->db->quoteName('#__assets'))
+                ->set($this->db->quoteName('rules') . ' = ' . $this->db->quote(
+                    json_encode(['core.edit' => [(string) $group => 0]], \JSON_THROW_ON_ERROR)
+                ))
+                ->where($this->db->quoteName('id') . ' = ' . $sectionId)
+        )->execute();
+
+        Access::clearStatics();
+
+        $this->assertFalse(
+            Access::checkGroup($group, 'core.edit', 'com_proclaim.teacher.999998'),
+            'A deny on the section did not reach the item asset. The records an administrator '
+            . 'singled out are exactly the ones escaping the section rule.'
+        );
+        $this->assertFalse(
+            Access::checkGroup($group, 'core.edit', 'com_proclaim.teacher'),
+            'Baseline: the section itself must deny.'
+        );
+    }
+
+    #[TestDox('an asset for record 0 is reported rather than reparented')]
+    public function testRecordZeroAssetIsSkipped(): void
+    {
+        Cwmassets::seedSections();
+        $component = Cwmassets::parentId();
+
+        $this->makeAsset('com_proclaim.teacher.0', $component);
+
+        $result = Cwmassets::reparentItemAssets();
+
+        $this->assertContains(
+            'com_proclaim.teacher.0',
+            $result['skipped'],
+            'An asset naming record 0 belongs to no record and must be reported, not relocated '
+            . 'under a section where it would look legitimate.'
+        );
+        $this->assertSame(
+            'com_proclaim',
+            $this->parentNameOf('com_proclaim.teacher.0'),
+            'The record-0 asset was moved despite being reported as skipped.'
+        );
+    }
+
+    #[TestDox('reparenting leaves the nested set valid')]
+    public function testNestedSetSurvivesReparenting(): void
+    {
+        Cwmassets::seedSections();
+        $component = Cwmassets::parentId();
+
+        $spanBefore = (array) $this->db->setQuery(
+            'SELECT lft, rgt FROM ' . $this->db->quoteName('#__assets') . ' WHERE id = ' . $component
+        )->loadAssoc();
+
+        $this->makeAsset('com_proclaim.serie.999997', $component);
+        Cwmassets::reparentItemAssets();
+
+        $spanAfter = (array) $this->db->setQuery(
+            'SELECT lft, rgt FROM ' . $this->db->quoteName('#__assets') . ' WHERE id = ' . $component
+        )->loadAssoc();
+
+        $this->assertSame(
+            (int) $spanBefore['rgt'] - (int) $spanBefore['lft'] + 2,
+            (int) $spanAfter['rgt'] - (int) $spanAfter['lft'],
+            'The component span changed by more than the one asset added; a move within a '
+            . 'subtree must not alter the parent span.'
+        );
+        $this->assertSame(
+            0,
+            (int) $this->db->setQuery('SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets') . ' WHERE lft >= rgt')->loadResult(),
+            'The nested set has rows where lft >= rgt.'
+        );
+        $this->assertSame(
+            0,
+            (int) $this->db->setQuery(
+                'SELECT COUNT(*) FROM (SELECT lft FROM ' . $this->db->quoteName('#__assets')
+                . ' GROUP BY lft HAVING COUNT(*) > 1) t'
+            )->loadResult(),
+            'The nested set has duplicate lft values.'
+        );
+    }
+}

--- a/tests/integration/Admin/Lib/CwmassetsSectionTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsSectionTest.php
@@ -211,14 +211,24 @@ class CwmassetsSectionTest extends IntegrationTestCase
         Cwmassets::seedSections();
         $this->rememberCreated($existing);
 
-        foreach ($this->created as $id) {
-            $asset = new Asset($this->db);
-            $asset->load($id);
+        // Asserted over every declared section, not just the ones this test
+        // created: another test in the same run may have seeded them already,
+        // in which case $this->created is empty and the loop asserts nothing.
+        $sections = Cwmassets::declaredSections();
 
+        $this->assertNotEmpty($sections, 'No sections declared; the assertion would be vacuous.');
+
+        foreach ($sections as $section) {
+            $asset = new Asset($this->db);
+
+            $this->assertTrue(
+                $asset->loadByName('com_proclaim.' . $section),
+                "Section asset com_proclaim.{$section} does not exist after seeding."
+            );
             $this->assertSame(
                 '{}',
                 (string) $asset->rules,
-                "Section asset {$asset->name} was created with rules other than '{}'. "
+                "Section asset {$asset->name} carries rules other than '{}'. "
                 . 'Empty rules are what make seeding inert.'
             );
         }


### PR DESCRIPTION
> Stacked on `development`. Removes the tradeoff #1718 had to make.

Item assets were parented to `com_proclaim`, so a rule on `com_proclaim.teacher` never reached `com_proclaim.teacher.79`. The records an administrator had singled out for per-record permissions were exactly the ones escaping the section rule.

Measured on j6-dev, same record, before and after:

| | `com_proclaim` | `com_proclaim.teacher` | `com_proclaim.teacher.79` |
|---|---|---|---|
| before | ALLOW | **deny** | **ALLOW** ← escaped |
| after | ALLOW | **deny** | **deny** |

`teacher.79` carries an explicit `core.edit` *allow* for that group, and still denies — because `Rule::mergeIdentity()` merges root-first and *"Explicit deny always wins a merge."* That gives the semantics we want for free: a section deny cascades and cannot be repaired at the item, while a section allow can still be refined by an item-level deny.

## What changed

- **`Cwmassets::sectionParentId()`**, used by all 13 entity tables' `_getAssetParentId()`. `CwmadminTable` stays on the component (it *is* the component-level screen); `CwmstudytopicsTable` has no declared section.
- **`Cwmassets::reparentItemAssets()`** moves rows written before this, from the same postflight as seeding. Uses `moveByReference()` rather than `setLocation()` + `store()` — the latter rewrites `lft`/`rgt` from values that may be stale if anything else moved the tree first.
- **`SectionAccessTrait::sectionAsset()`** can now safely ask the record's own asset, which is what #1718 had to forgo.

## ⚠️ Only when the record actually has an asset

Joomla resolves an unknown `com_proclaim.teacher.5` to everything before the **first** dot, so a row-less record falls back to `com_proclaim` and would skip the section entirely. The item branch is therefore gated on `asset_id > 0`.

That is the exception, not the rule: `Table::store()` creates an item asset, and Proclaim's own `stripEmptyAssetRow()` deletes it again unless it carries real rules. j6-dev has ~900 messages and two item assets. So the migration is small by construction on any site — this is not a per-record backfill.

## Record-0 assets

`com_proclaim.playlist.0` exists on j6-dev. It belongs to no record, and `_getAssetName()` can still mint one — a separate bug. The migration **reports** these for Database Maintenance rather than relocating them under a section where they would look legitimate.

## Three entities unaffected

`message_type`, `cwmadmin` and `studytopics` keep the component as parent, because their asset names disagree with access.xml (the `KNOWN_UNDECLARED` set). They stay on the old behaviour until that rename migration lands. Stated rather than silently degraded.

## Verified

Migration on j6-dev: 1 moved, 1 reported, `com_proclaim` span unchanged at `195..1134` (a move within a subtree must not alter the parent's span), no `lft >= rgt`, no duplicate `lft`.

Tests assert the deny reaches a reparented item, that a record-0 asset is reported and not moved, and that the nested set survives. Both mutations fail: not moving, and not skipping `.0`.

Also fixes `testSectionAssetsCarryEmptyRules`, which asserted only over assets it had created itself — once another test seeds the sections first that set is empty and it ran **zero assertions**. It now asserts over every declared section.

```
composer test:unit          1406 tests, 3006 assertions — OK
composer test:integration    438 tests, 3976 assertions — OK
php-cs-fixer                 0 of 629 files
```

Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
