### PR TITLE
fix: correct the three asset names that disagreed with access.xml (#1653)

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -545,6 +545,108 @@ class Cwmassets
     }
 
     /**
+     * Asset name prefixes that disagreed with access.xml, and their correction.
+     *
+     * A null target means the rows are removed rather than renamed.
+     *
+     * @var    array<string, string|null>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const LEGACY_ASSET_PREFIXES = [
+        'message_type' => 'messagetype',
+        'cwmadmin'     => 'admin',
+        'studytopics'  => null,
+    ];
+
+    /**
+     * Correct asset names written before they were bound to access.xml.
+     *
+     * Renaming is a plain column update: id, parent_id, lft and rgt are
+     * untouched, so the nested set is unaffected. `reparentItemAssets()` runs
+     * afterwards and moves the corrected rows under their section.
+     *
+     * @return  array{renamed: int, removed: int, collided: list<string>}
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function renameLegacyAssetNames(): array
+    {
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
+        $renamed  = 0;
+        $removed  = 0;
+        $collided = [];
+
+        foreach (self::LEGACY_ASSET_PREFIXES as $from => $to) {
+            $like  = 'com_proclaim.' . $from . '.%';
+            $query = $db->createQuery()
+                ->select($db->quoteName(['id', 'name']))
+                ->from($db->quoteName('#__assets'))
+                ->where($db->quoteName('name') . ' LIKE :like')
+                ->bind(':like', $like);
+
+            foreach ((array) $db->setQuery($query)->loadObjectList() as $row) {
+                $suffix = substr((string) $row->name, \strlen('com_proclaim.' . $from . '.'));
+
+                if (!ctype_digit($suffix)) {
+                    continue;
+                }
+
+                // A link row between a study and a topic is not permissionable.
+                if ($to === null) {
+                    $asset = new \Joomla\CMS\Table\Asset($db);
+
+                    if ($asset->load((int) $row->id) && $asset->delete((int) $row->id)) {
+                        $removed++;
+                    }
+
+                    continue;
+                }
+
+                $target = 'com_proclaim.' . $to . '.' . $suffix;
+
+                // `name` is unique. A row already carrying the correct name means
+                // both were minted at some point; keep it and drop the stale one.
+                $exists = $db->setQuery(
+                    $db->createQuery()
+                        ->select($db->quoteName('id'))
+                        ->from($db->quoteName('#__assets'))
+                        ->where($db->quoteName('name') . ' = :target')
+                        ->bind(':target', $target)
+                )->loadResult();
+
+                if ($exists) {
+                    $collided[] = (string) $row->name;
+                    $asset      = new \Joomla\CMS\Table\Asset($db);
+
+                    if ($asset->load((int) $row->id)) {
+                        $asset->delete((int) $row->id);
+                    }
+
+                    continue;
+                }
+
+                $id = (int) $row->id;
+                $db->setQuery(
+                    $db->createQuery()
+                        ->update($db->quoteName('#__assets'))
+                        ->set($db->quoteName('name') . ' = :target')
+                        ->where($db->quoteName('id') . ' = :id')
+                        ->bind(':target', $target)
+                        ->bind(':id', $id, ParameterType::INTEGER)
+                )->execute();
+
+                $renamed++;
+            }
+        }
+
+        if ($renamed > 0 || $removed > 0) {
+            self::clearSectionCache();
+        }
+
+        return ['renamed' => $renamed, 'removed' => $removed, 'collided' => $collided];
+    }
+
+    /**
      * Move existing item assets under their section.
      *
      * `_getAssetParentId()` handles every asset created from now on; this is for

--- a/admin/src/Table/CwmadminTable.php
+++ b/admin/src/Table/CwmadminTable.php
@@ -178,7 +178,7 @@ class CwmadminTable extends Table
     {
         $k = $this->_tbl_key;
 
-        return 'com_proclaim.cwmadmin.' . (int)$this->$k;
+        return 'com_proclaim.admin.' . (int)$this->$k;
     }
 
     /**
@@ -210,7 +210,8 @@ class CwmadminTable extends Table
     #[\Override]
     protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
+        // Parent to the section, so a rule on com_proclaim.admin reaches
+        // this record's own asset instead of being bypassed by it.
+        return Cwmassets::sectionParentId('admin');
     }
 }

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -301,7 +301,7 @@ class CwmmessagetypeTable extends Table
     {
         $k = $this->_tbl_key;
 
-        return 'com_proclaim.message_type.' . (int)$this->$k;
+        return 'com_proclaim.messagetype.' . (int)$this->$k;
     }
 
     /**

--- a/admin/src/Table/CwmstudytopicsTable.php
+++ b/admin/src/Table/CwmstudytopicsTable.php
@@ -83,6 +83,12 @@ class CwmstudytopicsTable extends Table
     public function __construct(&$db)
     {
         parent::__construct('#__bsms_studytopics', 'id', $db);
+
+        // A link row between a study and a topic is not something anyone
+        // permissions. Table enables asset tracking for any table carrying an
+        // asset_id column, which minted an asset per link for a section
+        // access.xml never declared (#1653).
+        $this->_trackAssets = false;
     }
 
     /**
@@ -111,53 +117,6 @@ class CwmstudytopicsTable extends Table
         return $result;
     }
 
-    /**
-     * Method to compute the default name of the asset.
-     * The default name is in the form `table_name.id`
-     * where id is the value of the primary key of the table.
-     *
-     * @return      string
-     *
-     * @since       1.6
-     */
-    #[\Override]
-    protected function _getAssetName(): string
-    {
-        $k = $this->_tbl_key;
 
-        return 'com_proclaim.studytopics.' . (int)$this->$k;
-    }
 
-    /**
-     * Method to return the title to use for the asset table.
-     *
-     * @return      string
-     *
-     * @since       1.6
-     */
-    #[\Override]
-    protected function _getAssetTitle(): string
-    {
-        return 'JBS StudyTopics: ' . $this->id;
-    }
-
-    /**
-     * Method to get the parent asset under which to register this one.
-     * By default, all assets are registered to the ROOT node with ID 1.
-     * The extended class can define a table and id to lookup.  If the
-     * asset does not exist it will be created.
-     *
-     * @param   ?Table  $table  A Table object for the asset parent.
-     * @param   null    $id     Id to look up
-     *
-     * @return  int
-     *
-     * @since   11.1
-     */
-    #[\Override]
-    protected function _getAssetParentId(?Table $table = null, $id = null): int
-    {
-        // Get Proclaim Root ID
-        return Cwmassets::parentId();
-    }
 }

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -675,6 +675,26 @@ class com_proclaimInstallerScript extends InstallerScript
                 Log::add('Removed undeclared section asset(s): ' . implode(', ', $removed), Log::INFO, 'com_proclaim');
             }
 
+            // Names written before they were bound to access.xml. Must run
+            // before reparenting, which keys off the corrected section name.
+            $renames = Cwmassets::renameLegacyAssetNames();
+
+            if ($renames['renamed'] > 0 || $renames['removed'] > 0) {
+                Log::add(
+                    "Corrected {$renames['renamed']} asset name(s), removed {$renames['removed']}",
+                    Log::INFO,
+                    'com_proclaim'
+                );
+            }
+
+            if ($renames['collided'] !== []) {
+                Log::add(
+                    'Dropped stale duplicate asset(s): ' . implode(', ', $renames['collided']),
+                    Log::WARNING,
+                    'com_proclaim'
+                );
+            }
+
             // Item assets written before sections existed hang off the component
             // and so ignore their section's rules.
             $reparented = Cwmassets::reparentItemAssets();

--- a/tests/integration/Admin/Lib/CwmassetsReparentTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsReparentTest.php
@@ -231,6 +231,64 @@ class CwmassetsReparentTest extends IntegrationTestCase
         );
     }
 
+    #[TestDox('legacy asset names are corrected, and link-row assets removed')]
+    public function testLegacyAssetNamesAreCorrected(): void
+    {
+        Cwmassets::seedSections();
+        $component = Cwmassets::parentId();
+
+        $this->makeAsset('com_proclaim.message_type.999996', $component);
+        $this->makeAsset('com_proclaim.cwmadmin.999995', $component);
+        $this->makeAsset('com_proclaim.studytopics.999994', $component);
+
+        $result = Cwmassets::renameLegacyAssetNames();
+
+        $this->assertGreaterThanOrEqual(2, $result['renamed'], 'The two renamable names were not corrected.');
+        $this->assertGreaterThanOrEqual(1, $result['removed'], 'The link-row asset was not removed.');
+
+        foreach (['com_proclaim.messagetype.999996', 'com_proclaim.admin.999995'] as $name) {
+            $asset = new Asset($this->db);
+            $this->assertTrue($asset->loadByName($name), "{$name} does not exist after the rename.");
+        }
+
+        foreach (['com_proclaim.message_type.999996', 'com_proclaim.cwmadmin.999995'] as $name) {
+            $asset = new Asset($this->db);
+            $this->assertFalse($asset->loadByName($name), "{$name} still exists; the old name was not replaced.");
+        }
+
+        $gone = new Asset($this->db);
+        $this->assertFalse(
+            $gone->loadByName('com_proclaim.studytopics.999994'),
+            'A study-topic link row is not permissionable and its asset must be removed, not renamed.'
+        );
+    }
+
+    #[TestDox('a rename that would collide drops the stale row instead of failing')]
+    public function testRenameCollisionDropsTheStaleRow(): void
+    {
+        Cwmassets::seedSections();
+        $component = Cwmassets::parentId();
+
+        // Both names present: the old one is stale, the correct one wins.
+        $this->makeAsset('com_proclaim.messagetype.999993', $component);
+        $this->makeAsset('com_proclaim.message_type.999993', $component);
+
+        $result = Cwmassets::renameLegacyAssetNames();
+
+        $this->assertContains(
+            'com_proclaim.message_type.999993',
+            $result['collided'],
+            'The collision was not reported. `name` is unique, so an unreported collision is a '
+            . 'failed UPDATE that would abort the whole migration.'
+        );
+
+        $kept = new Asset($this->db);
+        $this->assertTrue($kept->loadByName('com_proclaim.messagetype.999993'), 'The correct row was dropped.');
+
+        $stale = new Asset($this->db);
+        $this->assertFalse($stale->loadByName('com_proclaim.message_type.999993'), 'The stale row survived.');
+    }
+
     #[TestDox('reparenting leaves the nested set valid')]
     public function testNestedSetSurvivesReparenting(): void
     {

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -41,11 +41,9 @@ class AssetNameContractTest extends TestCase
     /**
      * Sections written to #__assets that access.xml does not declare.
      *
-     * These are real mismatches, deliberately not fixed here. Unlike the names
-     * that live only in code, each of these has already been persisted as an
-     * #__assets row on every existing site, so correcting them means renaming
-     * live rows through Joomla's nested set rather than editing a string --
-     * see #1653 items 3-5.
+     * Empty, and it must stay that way. It held three entries until #1653:
+     * `message_type` and `cwmadmin` are now written under their declared names,
+     * and `CwmstudytopicsTable` no longer tracks assets at all.
      *
      * This list must only ever shrink. Adding to it means shipping a section
      * whose permissions govern nothing.
@@ -53,11 +51,7 @@ class AssetNameContractTest extends TestCase
      * @var array<string, string>
      * @since __DEPLOY_VERSION__
      */
-    private const KNOWN_UNDECLARED = [
-        'message_type' => 'CwmmessagetypeTable writes message_type; access.xml declares messagetype (#1653)',
-        'cwmadmin'     => 'CwmadminTable writes cwmadmin; access.xml declares admin (#1653)',
-        'studytopics'  => 'CwmstudytopicsTable writes an asset for a section access.xml never declares (#1653)',
-    ];
+    private const KNOWN_UNDECLARED = [];
 
     /**
      * Section names declared in admin/access.xml.
@@ -283,9 +277,16 @@ class AssetNameContractTest extends TestCase
         // A mismatch gates the two on different sections.
         $lib = self::codeWithoutComments(self::root() . '/admin/src/Lib/Cwmassets.php');
 
+        // Bounded to the SECTION_BY_VIEW block. Scanning everything after it
+        // sweeps up any later const of the same shape.
+        $start = strpos($lib, 'SECTION_BY_VIEW');
+        $end   = strpos($lib, '];', $start === false ? 0 : $start);
+
+        $this->assertNotFalse($start, 'SECTION_BY_VIEW not found in Cwmassets.');
+
         preg_match_all(
             '/[\'"](cwm[a-z]+)[\'"]\s*=>\s*[\'"]([a-z_]+)[\'"]/i',
-            substr($lib, strpos($lib, 'SECTION_BY_VIEW')),
+            substr($lib, $start, $end - $start),
             $matches,
             PREG_SET_ORDER
         );
@@ -355,6 +356,15 @@ class AssetNameContractTest extends TestCase
     #[TestDox('the known-undeclared list only shrinks')]
     public function testKnownUndeclaredEntriesStillApply(): void
     {
+        // Asserted rather than looped, because a loop over an empty list passes
+        // without checking anything -- and the list is empty now.
+        $this->assertSame(
+            [],
+            self::KNOWN_UNDECLARED,
+            'A Table is writing an asset name access.xml does not declare. The list was emptied '
+            . 'in #1653; a new entry means shipping a section whose permissions govern nothing.'
+        );
+
         $declared = self::declaredSections();
 
         foreach (self::KNOWN_UNDECLARED as $section => $why) {


### PR DESCRIPTION
> Stacked on `development`. The last item from the phase 0 audit — closes #1653.

Three Tables wrote asset names no section declares, so the check fell back to the component and the section rule governed nothing. After #1721 reparented item assets, these were the only entities still hanging off the component.

| Table | wrote | now |
|---|---|---|
| `CwmmessagetypeTable` | `com_proclaim.message_type.<id>` | `com_proclaim.messagetype.<id>` |
| `CwmadminTable` | `com_proclaim.cwmadmin.<id>` | `com_proclaim.admin.<id>` |
| `CwmstudytopicsTable` | `com_proclaim.studytopics.<id>` | *no asset at all* |

**`message_type` was a genuine write-vs-check mismatch** — `CwmmessagetypeModel:49` and the list view both authorise against `com_proclaim.messagetype`, which nothing was writing.

**⚠️ For `cwmadmin`, only the ACL name changed.** `com_proclaim.cwmadmin` is also the UCM `$typeAlias`, a `setUserState()` key, and the prefix of ~18 web asset names (`com_proclaim.cwmadmin-batch-footer` and friends). Those are unrelated namespaces that share the string and must keep it — the phase 0 audit flagged exactly this trap.

**`studytopics` is a link row** between a study and a topic. Nobody permissions one; it only had assets because `Table` enables tracking for any table carrying an `asset_id` column. Tracking is now off, and the three asset hooks are removed rather than left implying an asset still exists.

## Migration

`Cwmassets::renameLegacyAssetNames()` corrects rows already written, running **before** `reparentItemAssets()` because that keys off the corrected section name.

Renaming is a plain column update — `id`, `parent_id`, `lft` and `rgt` are untouched, so the nested set is unaffected; the reparent pass then moves the corrected rows under their section.

**⚠️ `#__assets.name` is unique.** A site carrying both the old and the correct name would abort the whole migration on a duplicate key. The stale row is dropped and reported instead. Mutation-validated: removing that check turns the test into a duplicate-key **error** — exactly the failure it prevents.

## Two vacuity traps closed

- `KNOWN_UNDECLARED` is now empty, and its guard *looped over the list* — an empty list would have passed while checking nothing. It now asserts emptiness directly.
- The entity-map contract scan was unbounded from `SECTION_BY_VIEW` onward, so it swept up the new `LEGACY_ASSET_PREFIXES` const, which has the same `'cwmx' => 'y'` shape. Now bounded to the block.

## Verified

On j6-dev with one row of each legacy shape staged, as an upgraded site would have:

```
renamed=2  removed=1  collided=none
reparented=2  skipped=com_proclaim.playlist.0
  com_proclaim.admin.900002        parent=com_proclaim.admin
  com_proclaim.messagetype.900001  parent=com_proclaim.messagetype
  com_proclaim.teacher.79          parent=com_proclaim.teacher
com_proclaim span: 195..1140 -> 195..1138   (down by the one removed node)
lft>=rgt: 0   dup lft: 0
```

```
composer test:unit          1406 tests, 3005 assertions — OK
composer test:integration    440 tests, 3993 assertions — OK
php-cs-fixer                 0 of 629 files
```

Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
