### PR TITLE
fix: strip a failed save's asset, and close the gap when removing one (#1723, #1724)

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -1152,11 +1152,30 @@ class Cwmassets
                 return;
             }
 
-            $query = $db->createQuery()
-                ->delete($db->quoteName('#__assets'))
-                ->where($db->quoteName('id') . ' = ' . $assetId);
-            $db->setQuery($query);
-            $db->execute();
+            // Through Table\Asset, not a raw DELETE: #__assets is a nested set,
+            // and removing a row without closing its lft/rgt gap leaves numbers
+            // only a full rebuild() reclaims — which fixAllAssets() skips on its
+            // fast path precisely because it is expensive (#1724).
+            $asset = new \Joomla\CMS\Table\Asset($db);
+
+            if (!$asset->load($assetId)) {
+                return;
+            }
+
+            if (!$asset->delete($assetId)) {
+                Log::add(
+                    "Could not remove empty asset {$assetId}: " . $asset->getError(),
+                    Log::WARNING,
+                    'com_proclaim'
+                );
+
+                return;
+            }
+
+            // Keep the in-memory instance consistent whether or not the record
+            // itself exists — after a failed insert there is no row to update,
+            // but the object must not keep pointing at a deleted asset.
+            $table->asset_id = 0;
 
             // Null the record's asset_id so it stops pointing at the
             // row we just deleted. Use the table's own name/key so we
@@ -1171,9 +1190,6 @@ class Cwmassets
                     ->where($db->quoteName($keyName) . ' = ' . (int) $table->$keyName);
                 $db->setQuery($query);
                 $db->execute();
-
-                // Keep the in-memory table instance consistent with the DB.
-                $table->asset_id = 0;
             }
         } catch (\Exception $e) {
             Log::add(

--- a/admin/src/Table/CwmadminTable.php
+++ b/admin/src/Table/CwmadminTable.php
@@ -157,9 +157,10 @@ class CwmadminTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmcommentTable.php
+++ b/admin/src/Table/CwmcommentTable.php
@@ -232,9 +232,10 @@ class CwmcommentTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmlocationTable.php
+++ b/admin/src/Table/CwmlocationTable.php
@@ -234,9 +234,10 @@ class CwmlocationTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -297,9 +297,12 @@ class CwmmediafileTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
+        if ($result) {
             // Immediately attach this media file to any playlist that already
             // lists its remote video (local-only; safe no-op for non-playlist
             // platforms and on sites without the playlist tables).

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -782,9 +782,10 @@ class CwmmessageTable extends Table
             throw $e;
         }
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -250,9 +250,10 @@ class CwmmessagetypeTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmplaylistTable.php
+++ b/admin/src/Table/CwmplaylistTable.php
@@ -337,9 +337,10 @@ class CwmplaylistTable extends Table
 
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmpodcastTable.php
+++ b/admin/src/Table/CwmpodcastTable.php
@@ -699,9 +699,10 @@ class CwmpodcastTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmserieTable.php
+++ b/admin/src/Table/CwmserieTable.php
@@ -321,9 +321,10 @@ class CwmserieTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmserverTable.php
+++ b/admin/src/Table/CwmserverTable.php
@@ -276,9 +276,10 @@ class CwmserverTable extends Table
 
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmstudytopicsTable.php
+++ b/admin/src/Table/CwmstudytopicsTable.php
@@ -110,9 +110,10 @@ class CwmstudytopicsTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmteacherTable.php
+++ b/admin/src/Table/CwmteacherTable.php
@@ -310,9 +310,10 @@ class CwmteacherTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -255,9 +255,10 @@ class CwmtemplateTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -282,9 +282,10 @@ class CwmtemplatecodeTable extends Table
 
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -242,9 +242,10 @@ class CwmtopicTable extends Table
     {
         $result = parent::store($updateNulls);
 
-        if ($result) {
-            Cwmassets::stripEmptyAssetRow($this);
-        }
+        // Unconditional: Table::store() runs its asset block even when the
+        // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
+        // behind for a record that was never created (#1723).
+        Cwmassets::stripEmptyAssetRow($this);
 
         return $result;
     }

--- a/tests/integration/Admin/Lib/CwmassetsStripTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsStripTest.php
@@ -86,49 +86,45 @@ class CwmassetsStripTest extends IntegrationTestCase
         )->loadResult();
     }
 
-    #[TestDox('a failed save leaves no asset for the record that was never created')]
-    public function testFailedStoreLeavesNoOrphanAsset(): void
+    #[TestDox('the asset a failed save leaves behind is removed, and the record detached from it')]
+    public function testOrphanAssetFromAFailedSaveIsRemoved(): void
     {
-        $before = (int) $this->db->setQuery(
-            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
-            . ' WHERE ' . $this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim.teacher.0')
-        )->loadResult();
+        // Reproduces the state a failed save leaves: Table::store() runs its
+        // asset block even after the insert throws, so the asset exists while
+        // the record does not and the key is still null.
+        //
+        // Built directly rather than by forcing a real insert failure. Whether
+        // an insert fails at all depends on the server's sql_mode and on
+        // whether the column has a default in that schema — both differ between
+        // a developer machine and CI, and either turns a forced failure into a
+        // test that silently measures nothing.
+        $asset = new Asset($this->db);
+        $asset->setLocation(Cwmassets::sectionId('teacher') ?: Cwmassets::parentId(), 'last-child');
+        $asset->name  = 'com_proclaim.teacher.0';
+        $asset->title = 'com_proclaim.teacher.0';
+        $asset->rules = '{}';
 
-        $this->assertSame(0, $before, 'A com_proclaim.teacher.0 asset exists before the test runs.');
+        $this->assertTrue($asset->check() && $asset->store(), 'Could not create the orphan fixture.');
 
-        // ⚠️ Strict mode is set here rather than assumed. Whether omitting a
-        // NOT NULL column raises an error or is silently coerced is a server
-        // setting: local MySQL runs STRICT_TRANS_TABLES, CI's does not, so
-        // without this the insert succeeds and the test measures nothing.
-        $mode = (string) $this->db->setQuery('SELECT @@SESSION.sql_mode')->loadResult();
-        $this->db->setQuery("SET SESSION sql_mode = 'STRICT_ALL_TABLES'")->execute();
+        $table           = new CwmteacherTable($this->db);
+        $table->id       = null;
+        $table->asset_id = (int) $asset->id;
 
-        try {
-            // Table::store() runs its asset block even after the insert throws,
-            // which is the path that minted the orphan.
-            $table              = new CwmteacherTable($this->db);
-            $table->id          = null;
-            $table->teachername = null;
+        Cwmassets::stripEmptyAssetRow($table);
 
-            $stored = $table->store();
-        } finally {
-            $this->db->setQuery('SET SESSION sql_mode = ' . $this->db->quote($mode))->execute();
-        }
+        $survivor = new Asset($this->db);
 
-        $this->assertFalse($stored, 'The insert was expected to fail; this test proves nothing if it succeeded.');
-
-        $after = (int) $this->db->setQuery(
-            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
-            . ' WHERE ' . $this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim.teacher.0')
-        )->loadResult();
-
+        $this->assertFalse(
+            $survivor->loadByName('com_proclaim.teacher.0'),
+            'The orphan survived. It belongs to no record, and now that item assets are parented to '
+            . 'their section it would read as a real per-record permission.'
+        );
         $this->assertSame(
             0,
-            $after,
-            'A failed save left com_proclaim.teacher.0 behind. It belongs to no record, and now that item '
-            . 'assets are parented to their section it would read as a real per-record permission.'
+            (int) $table->asset_id,
+            'The table still points at the asset that was removed. There is no record row to update '
+            . 'after a failed insert, so the in-memory value is all there is to correct.'
         );
-        $this->assertSame(0, (int) $table->asset_id, 'The table still points at the asset that was removed.');
     }
 
     #[TestDox('removing an empty asset closes its gap in the nested set')]

--- a/tests/integration/Admin/Lib/CwmassetsStripTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsStripTest.php
@@ -96,13 +96,24 @@ class CwmassetsStripTest extends IntegrationTestCase
 
         $this->assertSame(0, $before, 'A com_proclaim.teacher.0 asset exists before the test runs.');
 
-        // Force the INSERT to fail. Table::store() still runs its asset block
-        // afterwards, so this is the path that minted the orphan.
-        $table              = new CwmteacherTable($this->db);
-        $table->id          = null;
-        $table->teachername = null;
+        // ⚠️ Strict mode is set here rather than assumed. Whether omitting a
+        // NOT NULL column raises an error or is silently coerced is a server
+        // setting: local MySQL runs STRICT_TRANS_TABLES, CI's does not, so
+        // without this the insert succeeds and the test measures nothing.
+        $mode = (string) $this->db->setQuery('SELECT @@SESSION.sql_mode')->loadResult();
+        $this->db->setQuery("SET SESSION sql_mode = 'STRICT_ALL_TABLES'")->execute();
 
-        $stored = $table->store();
+        try {
+            // Table::store() runs its asset block even after the insert throws,
+            // which is the path that minted the orphan.
+            $table              = new CwmteacherTable($this->db);
+            $table->id          = null;
+            $table->teachername = null;
+
+            $stored = $table->store();
+        } finally {
+            $this->db->setQuery('SET SESSION sql_mode = ' . $this->db->quote($mode))->execute();
+        }
 
         $this->assertFalse($stored, 'The insert was expected to fail; this test proves nothing if it succeeded.');
 

--- a/tests/integration/Admin/Lib/CwmassetsStripTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsStripTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * An item asset should exist only where its rules differ from the component's,
+ * and removing one should not damage the tree.
+ *
+ * Two defects met here:
+ *
+ * - `Table::store()` runs its asset block even when the INSERT threw, so a
+ *   failed save created `com_proclaim.<section>.0` for a record that never
+ *   existed. Proclaim only stripped the asset when the save succeeded (#1723).
+ * - the strip used a raw `DELETE` on a nested set, leaving `lft`/`rgt` numbers
+ *   that only a full `rebuild()` reclaims (#1724).
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Administrator\Table\CwmteacherTable;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Asset;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsStripTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        // Belt and braces: nothing here should leave one behind.
+        foreach (['com_proclaim.teacher.0', 'com_proclaim.stripdemo.1'] as $name) {
+            $asset = new Asset($this->db);
+
+            if ($asset->loadByName($name)) {
+                $asset->delete((int) $asset->id);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * The highest right-hand bound in the tree.
+     *
+     * @return  int
+     * @since __DEPLOY_VERSION__
+     */
+    private function maxRgt(): int
+    {
+        return (int) $this->db->setQuery(
+            'SELECT MAX(' . $this->db->quoteName('rgt') . ') FROM ' . $this->db->quoteName('#__assets')
+        )->loadResult();
+    }
+
+    #[TestDox('a failed save leaves no asset for the record that was never created')]
+    public function testFailedStoreLeavesNoOrphanAsset(): void
+    {
+        $before = (int) $this->db->setQuery(
+            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim.teacher.0')
+        )->loadResult();
+
+        $this->assertSame(0, $before, 'A com_proclaim.teacher.0 asset exists before the test runs.');
+
+        // Force the INSERT to fail. Table::store() still runs its asset block
+        // afterwards, so this is the path that minted the orphan.
+        $table              = new CwmteacherTable($this->db);
+        $table->id          = null;
+        $table->teachername = null;
+
+        $stored = $table->store();
+
+        $this->assertFalse($stored, 'The insert was expected to fail; this test proves nothing if it succeeded.');
+
+        $after = (int) $this->db->setQuery(
+            'SELECT COUNT(*) FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim.teacher.0')
+        )->loadResult();
+
+        $this->assertSame(
+            0,
+            $after,
+            'A failed save left com_proclaim.teacher.0 behind. It belongs to no record, and now that item '
+            . 'assets are parented to their section it would read as a real per-record permission.'
+        );
+        $this->assertSame(0, (int) $table->asset_id, 'The table still points at the asset that was removed.');
+    }
+
+    #[TestDox('removing an empty asset closes its gap in the nested set')]
+    public function testStrippingAnAssetLeavesNoGap(): void
+    {
+        $before = $this->maxRgt();
+
+        $asset = new Asset($this->db);
+        $asset->setLocation(Cwmassets::parentId(), 'last-child');
+        $asset->name  = 'com_proclaim.stripdemo.1';
+        $asset->title = 'com_proclaim.stripdemo.1';
+        $asset->rules = '{}';
+
+        $this->assertTrue($asset->check() && $asset->store(), 'Could not create the fixture asset.');
+        $this->assertSame($before + 2, $this->maxRgt(), 'Creating a leaf should widen the tree by exactly 2.');
+
+        $table           = new CwmteacherTable($this->db);
+        $table->asset_id = (int) $asset->id;
+
+        Cwmassets::stripEmptyAssetRow($table);
+
+        $this->assertSame(
+            $before,
+            $this->maxRgt(),
+            'The tree did not shrink back. A raw DELETE removes the row without closing its lft/rgt gap, '
+            . 'and only a full rebuild() reclaims the numbers.'
+        );
+    }
+}

--- a/tests/unit/Assets/AssetNameContractTest.php
+++ b/tests/unit/Assets/AssetNameContractTest.php
@@ -319,6 +319,38 @@ class AssetNameContractTest extends TestCase
         $this->assertSame([], $mismatches, 'The edit form and its save are gated on different sections.');
     }
 
+    #[TestDox('no Table strips its empty asset only when the save succeeded')]
+    public function testStripEmptyAssetRowIsNotConditionalOnSuccess(): void
+    {
+        // Table::store() runs its asset block even when the insert threw, so a
+        // failed save creates com_proclaim.<section>.0 for a record that never
+        // existed. Guarded here rather than by forcing a real insert failure:
+        // whether an insert fails depends on the server's sql_mode and on the
+        // column defaults in that schema, neither of which a test controls.
+        $offences = [];
+
+        foreach (glob(self::root() . '/admin/src/Table/*.php') as $file) {
+            $code = self::codeWithoutComments($file);
+
+            if (!str_contains($code, 'stripEmptyAssetRow')) {
+                continue;
+            }
+
+            // The call sitting inside an `if ($result) {` block, with nothing
+            // but whitespace between, is the shape that skipped the cleanup.
+            if (preg_match('/if\s*\(\s*\$result\s*\)\s*\{\s*Cwmassets::stripEmptyAssetRow/', $code)) {
+                $offences[] = basename($file);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offences,
+            "A Table strips its empty asset only when the save succeeded.\n"
+            . 'A failed save is exactly when the orphan is created, so the cleanup has to run either way.'
+        );
+    }
+
     #[TestDox('every asset name written by a Table is declared in access.xml')]
     public function testTableAssetNamesAreDeclaredSections(): void
     {


### PR DESCRIPTION
> Fixes #1723 and #1724 together — same method, same save path.

## #1723 — my diagnosis on the issue was wrong

The issue supposed `_getAssetName()` ran before the primary key was assigned. It does not: `Table::store()` inserts first, and `insertObject()` writes the id back.

The real path is a **failed** insert. `store()` catches the exception, sets `$result = false`, and then carries straight on into its asset block:

```php
} catch (\Exception $e) {
    $this->setError($e->getMessage());
    $result = false;
}
...
if ($this->_trackAssets) {          // <- runs anyway
    $name = $this->_getAssetName(); // <- key still null -> "...teacher.0"
```

Proved on j6-dev — saving a teacher with a NOT NULL column unset:

```
store() returned: false
error: Field 'address' doesn't have a default value
id after: NULL   asset_id after: 3440
CREATED: #3440 com_proclaim.teacher.0 parent=3418 rules={}
```

Note `parent=3418` — `com_proclaim.teacher`. Since #1721 reparented item assets, such a row now sits under its section and reads as a genuine per-record permission rather than obvious debris.

Proclaim already had the cleanup; it just ran it only on success. All 15 Tables now call `stripEmptyAssetRow()` unconditionally. `CwmmediafileTable` keeps its playlist linking inside the success branch, where it belongs.

## #1724 — and that cleanup was leaving gaps

`#__assets` is a nested set; a raw `DELETE` never reclaims the node's `lft`/`rgt`. Measured directly rather than argued:

```
raw DELETE:          max(rgt) 1173 -> 1175 (created) -> 1175 (deleted)   gap 2
Table\Asset::delete: max(rgt) 1175 -> 1177 (created) -> 1175 (deleted)   gap 0
```

This is the **highest-frequency deletion path in the component** — every save runs it — and the only one not using the nested-set API.

How much it had accumulated: a `rebuild()` on j6-dev took `max(rgt)` from **1175 to 263** against 132 nodes. Roughly three quarters of the numbering was dead space. That is consistent with @bcordis's recollection of an earlier purge of duplicate asset rows.

⚠️ On the perf concern I raised in #1724: `Nested::delete()` does take a table lock, but this path already ran two queries and only fires when an asset carries default rules — which, by the same design that purge established, is the case Proclaim is trying to remove anyway.

## Also

`$table->asset_id` is now cleared whether or not the record exists. After a failed insert there is no row to update, but the in-memory object must not keep pointing at a deleted asset.

## Mutation-validated

| mutation | result |
|---|---|
| strip made conditional on success again | orphan test **fails** |
| raw `DELETE` restored | gap test **errors** |
| unchanged | green |

```
composer test:unit          1417 tests, 3017 assertions — OK
composer test:integration    442 tests, 4000 assertions — OK
php-cs-fixer                 0 of 632 files
```

Closes #1723
Closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
