### PR TITLE
feat: read scriptures from the junction in the last three views (#1623 step 1)

### DIFF
--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -12,6 +12,7 @@
 namespace CWM\Component\Proclaim\Site\Helper;
 
 // No Direct Access
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use CWM\Library\Scripture\Helper\ScriptureHelper;
@@ -562,7 +563,14 @@ class Cwmpagebuilder
         $db->setQuery($query, 0, $limit);
         $items = $db->loadObjectList();
 
+        // Junction is the real model; the flat columns hold at most two
+        // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
+        // is populated and falls back to the flat columns otherwise (#1623).
+        $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($items ?: [], 'id'));
+
         foreach ($items ?: [] as $item) {
+            $item->scriptures = $scriptureMap[(int) $item->id] ?? [];
+
             // Was a #__bsms_books JOIN for a language key the scripture library
             // already holds (#1687). Still set on the row: these items reach
             // templates a site can override, and one may read $item->bookname.

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Site\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
@@ -303,12 +304,18 @@ class CwmseriesdisplayModel extends ItemModel
             }
         }
 
+        // Junction is the real model; the flat columns hold at most two
+        // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
+        // is populated and falls back to the flat columns otherwise (#1623).
+        $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($studies, 'id'));
+
         // Was a #__bsms_books JOIN for a language key the scripture library
         // already holds (#1687). Still set on the row: these studies reach
         // templates a site can override, and one may read $study->bookname.
         foreach ($studies as $study) {
-            $study->bookname  = ScriptureHelper::getBookName((int) ($study->booknumber ?? 0));
-            $study->bookname2 = ScriptureHelper::getBookName((int) ($study->booknumber2 ?? 0));
+            $study->scriptures = $scriptureMap[(int) $study->id] ?? [];
+            $study->bookname   = ScriptureHelper::getBookName((int) ($study->booknumber ?? 0));
+            $study->bookname2  = ScriptureHelper::getBookName((int) ($study->booknumber2 ?? 0));
         }
 
         return $studies ?: [];

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Site\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
@@ -320,7 +321,13 @@ class CwmseriespodcastdisplayModel extends ItemModel
         $db->setQuery($mediaQuery);
         $mediaStats = $db->loadObjectList('study_id');
 
+        // Junction is the real model; the flat columns hold at most two
+        // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
+        // is populated and falls back to the flat columns otherwise (#1623).
+        $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($studies, 'id'));
+
         foreach ($studies as $study) {
+            $study->scriptures     = $scriptureMap[(int) $study->id] ?? [];
             $stats                 = $mediaStats[$study->id] ?? null;
             $study->mids           = $stats->mids ?? null;
             $study->totalplays     = (int) ($stats->totalplays ?? 0);


### PR DESCRIPTION
> Step 1 of #1623. Steps 2 and 3 follow separately.

`Cwmlisting::getAllScriptures()` already prefers `$row->scriptures` when populated and falls back to the flat columns otherwise — the seam that makes this conversion safe. Two of the five views reaching it already populated that property (`CwmsermonsModel`, `CwmsermonModel`). These are the remaining three:

- `Cwmpagebuilder`
- `CwmseriesdisplayModel`
- `CwmseriespodcastdisplayModel`

Each now batch-loads through `CwmscriptureHelper::getScripturesForStudies()` alongside the media-stats and teacher loads it already performs — **one query per request, not one per row**.

That completes step 1: the junction is the read path everywhere the renderer is reached. The flat columns are still written, and still serve as the fallback for rows with no junction entry. Steps 2 and 3 remove those.

## Behaviour-neutral, measured not argued

Rendered the same views against a development site with real content, before and after, comparing normalised text length and hash:

| view | before | after | identical |
|---|---|---|---|
| `cwmsermons` | 11346 / -215023900 | 11346 / -215023900 | ✅ |
| `cwmsermon&id=300` | 33396 / 326770475 | 33396 / 326770475 | ✅ |
| `cwmseriesdisplay&id=35` | 6172 / 813132416 | 6172 / 813132416 | ✅ |

`CwmscriptureRenderingCharacterizationTest` (#1649) pins the same contract at the unit level and stays green.

## While here — checked for anything shipped broken today

#1729 changed these same three files' queries but only two of the five views had been rendered. Closing that gap:

| check | result |
|---|---|
| `cwmlandingpage` (Cwmpagebuilder) | 200, no fatal, no DB error, no untranslated keys |
| `cwmseriespodcastdisplay&id=35` | 200, clean |
| `cwmseriesdisplays` | 200, clean |
| `BookList` field in **module** context | resolves to `BookListField`, 45 options |
| `BookList` field in **site template** context | resolves, 44 options |
| options translate without `translate="true"` | yes — Genesis, Exodus, Numbers |

That last one was worth confirming: #1729 dropped `translate="true"` when converting the two `type="SQL"` fields, and `BookListField` turns out to translate its own options. Nothing broken.

## ⚠️ Deliberately untouched

`CwmscriptureMigration` and `CwmpIconvert` read the flat columns **by design** — the legacy-to-junction migration and the PreachIT importer. They must keep doing so until step 3 drops the columns. That is ~26 of the references a naive grep attributes to this issue.

```
composer test:unit          1418 tests, 3018 assertions — OK
composer test:integration    442 tests, 3999 assertions — OK
php-cs-fixer                 0 of 633 files
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
