### PR TITLE
fix: make the scripture migration repeatable so stranded studies can be repaired (#1623)

### DIFF
--- a/admin/src/Lib/CwmpIconvert.php
+++ b/admin/src/Lib/CwmpIconvert.php
@@ -573,6 +573,11 @@ class CwmpIconvert
                     $newid              = $datastudies->id;
                     $oldid              = $pi->id;
                     $this->studiesids[] = ['newid' => $newid, 'oldid' => $oldid];
+
+                    // The columns written above are the legacy pair. The junction
+                    // is the read path, so populate it here rather than leaving
+                    // the study for a migration that may already have run (#1623).
+                    CwmscriptureMigration::migrateStudy((int) $newid);
                 }
 
                 // Create the mediafiles

--- a/admin/src/Lib/CwmscriptureMigration.php
+++ b/admin/src/Lib/CwmscriptureMigration.php
@@ -24,7 +24,11 @@ use Joomla\Database\DatabaseInterface;
  * Migrates legacy flat scripture columns from #__bsms_studies into the new
  * #__bsms_study_scriptures junction table.
  *
- * Called once from proclaim.script.php postflight on update.
+ * Called from proclaim.script.php postflight on update, from the Backup and
+ * Restore screens, and from the control panel's data fixes. Every caller may
+ * run it repeatedly: it selects only studies that have legacy values and no
+ * junction rows, so migrated studies are skipped and an interrupted run resumes
+ * where it stopped.
  *
  * @since  10.1.0
  */
@@ -39,7 +43,7 @@ class CwmscriptureMigration
     private const BATCH_SIZE = 100;
 
     /**
-     * Run the migration. Idempotent — checks for existing data before inserting.
+     * Run the migration over every study that still needs it.
      *
      * @return  int  Number of studies migrated
      *
@@ -49,55 +53,16 @@ class CwmscriptureMigration
     {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        // Check if table exists
-        $tables    = $db->getTableList();
-        $prefix    = $db->getPrefix();
-        $tableName = $prefix . 'bsms_study_scriptures';
-
-        if (!\in_array($tableName, $tables, true)) {
+        if (!self::junctionTableExists($db)) {
             Log::add('Scripture junction table not found, skipping migration.', Log::INFO, 'com_proclaim');
 
             return 0;
         }
 
-        // Check if already migrated (junction table has rows)
-        $query = $db->createQuery()
-            ->select('COUNT(*)')
-            ->from($db->quoteName('#__bsms_study_scriptures'));
-        $db->setQuery($query);
-        $existingCount = (int) $db->loadResult();
-
-        if ($existingCount > 0) {
-            Log::add('Scripture migration already completed (' . $existingCount . ' rows exist).', Log::INFO, 'com_proclaim');
-
-            return 0;
-        }
-
-        // Query all studies with at least one book reference
-        $query = $db->createQuery()
-            ->select([
-                $db->quoteName('id'),
-                $db->quoteName('booknumber'),
-                $db->quoteName('chapter_begin'),
-                $db->quoteName('verse_begin'),
-                $db->quoteName('chapter_end'),
-                $db->quoteName('verse_end'),
-                $db->quoteName('bible_version'),
-                $db->quoteName('booknumber2'),
-                $db->quoteName('chapter_begin2'),
-                $db->quoteName('verse_begin2'),
-                $db->quoteName('chapter_end2'),
-                $db->quoteName('verse_end2'),
-                $db->quoteName('bible_version2'),
-            ])
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where('(' . $db->quoteName('booknumber') . ' > 0 OR '
-                . $db->quoteName('booknumber2') . ' IS NOT NULL AND ' . $db->quoteName('booknumber2') . ' > 0)');
-        $db->setQuery($query);
-        $studies = $db->loadObjectList();
+        $studies = self::loadPending($db);
 
         if (empty($studies)) {
-            Log::add('No studies with scripture references found.', Log::INFO, 'com_proclaim');
+            Log::add('No studies with unmigrated scripture references found.', Log::INFO, 'com_proclaim');
 
             return 0;
         }
@@ -106,65 +71,15 @@ class CwmscriptureMigration
         $batch    = [];
 
         foreach ($studies as $study) {
-            $bn1 = (int) ($study->booknumber ?? 0);
-            $bn2 = (int) ($study->booknumber2 ?? 0);
-
-            // Primary reference
-            if ($bn1 > 0) {
-                $refText = CwmscriptureHelper::formatReference(
-                    $bn1,
-                    (int) ($study->chapter_begin ?? 0),
-                    (int) ($study->verse_begin ?? 0),
-                    (int) ($study->chapter_end ?? 0),
-                    (int) ($study->verse_end ?? 0)
-                );
-
-                $batch[] = implode(', ', [
-                    (int) $study->id,
-                    0,
-                    $bn1,
-                    (int) ($study->chapter_begin ?? 0),
-                    (int) ($study->verse_begin ?? 0),
-                    (int) ($study->chapter_end ?? 0),
-                    (int) ($study->verse_end ?? 0),
-                    $db->quote((string) ($study->bible_version ?? '')),
-                    $db->quote($refText),
-                ]);
-            }
-
-            // Secondary reference
-            if ($bn2 > 0) {
-                $refText2 = CwmscriptureHelper::formatReference(
-                    $bn2,
-                    (int) ($study->chapter_begin2 ?? 0),
-                    (int) ($study->verse_begin2 ?? 0),
-                    (int) ($study->chapter_end2 ?? 0),
-                    (int) ($study->verse_end2 ?? 0)
-                );
-
-                $batch[] = implode(', ', [
-                    (int) $study->id,
-                    1,
-                    $bn2,
-                    (int) ($study->chapter_begin2 ?? 0),
-                    (int) ($study->verse_begin2 ?? 0),
-                    (int) ($study->chapter_end2 ?? 0),
-                    (int) ($study->verse_end2 ?? 0),
-                    $db->quote((string) ($study->bible_version2 ?? '')),
-                    $db->quote($refText2),
-                ]);
-            }
-
+            $batch = array_merge($batch, self::rowToValues($db, $study));
             $migrated++;
 
-            // Flush batch
             if (\count($batch) >= self::BATCH_SIZE) {
                 self::insertBatch($db, $batch);
                 $batch = [];
             }
         }
 
-        // Flush remaining
         if (!empty($batch)) {
             self::insertBatch($db, $batch);
         }
@@ -172,6 +87,143 @@ class CwmscriptureMigration
         Log::add('Scripture migration completed: ' . $migrated . ' studies migrated.', Log::INFO, 'com_proclaim');
 
         return $migrated;
+    }
+
+    /**
+     * Migrate one study, for importers that write the legacy columns directly.
+     *
+     * @param   int  $studyId  Study primary key
+     *
+     * @return  int  1 if the study was migrated, 0 if it had nothing to migrate
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function migrateStudy(int $studyId): int
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if (!self::junctionTableExists($db)) {
+            return 0;
+        }
+
+        $studies = self::loadPending($db, $studyId);
+
+        if (empty($studies)) {
+            return 0;
+        }
+
+        self::insertBatch($db, self::rowToValues($db, $studies[0]));
+
+        return 1;
+    }
+
+    /**
+     * Studies holding legacy values that have no junction rows yet.
+     *
+     * ⚠️ The `NOT EXISTS` is what makes every caller safe to run repeatedly.
+     * This used to be a table-wide `COUNT(*) > 0` check, which switched the
+     * migration off permanently the first time any study was saved through the
+     * editor — leaving studies written by the PreachIT and Sermon Speaker
+     * importers in the flat columns with no way to repair them (#1623).
+     *
+     * @param   DatabaseInterface  $db       Database driver
+     * @param   int|null           $studyId  Limit to one study, or null for all
+     *
+     * @return  object[]
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function loadPending(DatabaseInterface $db, ?int $studyId = null): array
+    {
+        $bn1 = $db->quoteName('s.booknumber');
+        $bn2 = $db->quoteName('s.booknumber2');
+
+        $query = $db->createQuery()
+            ->select([
+                $db->quoteName('s.id'),
+                $bn1,
+                $db->quoteName('s.chapter_begin'),
+                $db->quoteName('s.verse_begin'),
+                $db->quoteName('s.chapter_end'),
+                $db->quoteName('s.verse_end'),
+                $db->quoteName('s.bible_version'),
+                $bn2,
+                $db->quoteName('s.chapter_begin2'),
+                $db->quoteName('s.verse_begin2'),
+                $db->quoteName('s.chapter_end2'),
+                $db->quoteName('s.verse_end2'),
+                $db->quoteName('s.bible_version2'),
+            ])
+            ->from($db->quoteName('#__bsms_studies', 's'))
+            ->where('(' . $bn1 . ' > 0 OR (' . $bn2 . ' IS NOT NULL AND ' . $bn2 . ' > 0))')
+            ->where(
+                'NOT EXISTS (SELECT 1 FROM ' . $db->quoteName('#__bsms_study_scriptures', 'j')
+                . ' WHERE ' . $db->quoteName('j.study_id') . ' = ' . $db->quoteName('s.id') . ')'
+            );
+
+        if ($studyId !== null) {
+            $query->where($db->quoteName('s.id') . ' = ' . $studyId);
+        }
+
+        $db->setQuery($query);
+
+        return $db->loadObjectList() ?: [];
+    }
+
+    /**
+     * Turn one study's flat columns into junction row value strings.
+     *
+     * @param   DatabaseInterface  $db     Database driver
+     * @param   object             $study  Row from loadPending()
+     *
+     * @return  string[]  Zero, one or two value strings
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function rowToValues(DatabaseInterface $db, object $study): array
+    {
+        $values = [];
+
+        foreach ([['', 0], ['2', 1]] as [$suffix, $ordering]) {
+            $book = (int) ($study->{'booknumber' . $suffix} ?? 0);
+
+            if ($book < 1) {
+                continue;
+            }
+
+            $chapterBegin = (int) ($study->{'chapter_begin' . $suffix} ?? 0);
+            $verseBegin   = (int) ($study->{'verse_begin' . $suffix} ?? 0);
+            $chapterEnd   = (int) ($study->{'chapter_end' . $suffix} ?? 0);
+            $verseEnd     = (int) ($study->{'verse_end' . $suffix} ?? 0);
+
+            $values[] = implode(', ', [
+                (int) $study->id,
+                $ordering,
+                $book,
+                $chapterBegin,
+                $verseBegin,
+                $chapterEnd,
+                $verseEnd,
+                $db->quote((string) ($study->{'bible_version' . $suffix} ?? '')),
+                $db->quote(
+                    CwmscriptureHelper::formatReference($book, $chapterBegin, $verseBegin, $chapterEnd, $verseEnd)
+                ),
+            ]);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param   DatabaseInterface  $db  Database driver
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function junctionTableExists(DatabaseInterface $db): bool
+    {
+        return \in_array($db->getPrefix() . 'bsms_study_scriptures', $db->getTableList(), true);
     }
 
     /**
@@ -186,6 +238,10 @@ class CwmscriptureMigration
      */
     private static function insertBatch(DatabaseInterface $db, array $batch): void
     {
+        if (empty($batch)) {
+            return;
+        }
+
         $columns = $db->quoteName([
             'study_id', 'ordering', 'booknumber', 'chapter_begin', 'verse_begin',
             'chapter_end', 'verse_end', 'bible_version', 'reference_text',

--- a/admin/src/Lib/Cwmssconvert.php
+++ b/admin/src/Lib/Cwmssconvert.php
@@ -261,6 +261,11 @@ class Cwmssconvert
 
         $db->insertObject('#__bsms_studies', $data, 'id');
 
+        // The columns written above are the legacy pair. The junction is the read
+        // path, so populate it here rather than leaving the study for a migration
+        // that may already have run (#1623).
+        CwmscriptureMigration::migrateStudy((int) $data->id);
+
         $data1              = new \stdClass();
         $data1->study_id    = $data->id;
         $data1->server_id   = $this->serverid;

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1667,47 +1667,51 @@ class com_proclaimInstallerScript extends InstallerScript
             }
         }
 
-        // Legacy data migrations run on UPGRADES only. A fresh install's SQL
-        // already creates the current schema, so there is nothing to migrate —
-        // running these against freshly seeded default rows only produces
-        // spurious warnings (e.g. the podcast-link "could not be matched" notice)
-        // and, historically, fatals when a moved helper no longer exists.
-        if ($type === 'update') {
-            // Migrate legacy scripture columns to junction table
-            try {
-                $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
+        // ⚠️ The scripture migration is the one that also runs on a fresh install.
+        // install.mysql.utf8.sql seeds the sample study with legacy flat columns
+        // and no junction row, so an install that skipped this shipped a study
+        // whose reference the junction never knew about (#1623).
+        try {
+            $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
 
-                if (file_exists($migrationPath)) {
-                    require_once $migrationPath;
-                    // These helpers moved to lib_cwmscripture in 10.3.0 and the
-                    // migration autoloads the library class via the namespace
-                    // registered in preflight(). Only require a legacy in-component
-                    // copy if one is still present — a bare require_once of the
-                    // (now missing) file is a fatal that the catch below can't trap.
-                    $helperDir = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/';
+            if (file_exists($migrationPath)) {
+                require_once $migrationPath;
+                // These helpers moved to lib_cwmscripture in 10.3.0 and the
+                // migration autoloads the library class via the namespace
+                // registered in preflight(). Only require a legacy in-component
+                // copy if one is still present — a bare require_once of the
+                // (now missing) file is a fatal that the catch below can't trap.
+                $helperDir = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/';
 
-                    foreach (['ScriptureReference.php', 'CwmscriptureHelper.php'] as $legacyHelper) {
-                        if (is_file($helperDir . $legacyHelper)) {
-                            require_once $helperDir . $legacyHelper;
-                        }
-                    }
-
-                    $migrated = CwmscriptureMigration::migrate();
-
-                    if ($migrated > 0) {
-                        Factory::getApplication()->enqueueMessage(
-                            $migrated . ' study scripture reference(s) migrated to new format.',
-                            'message'
-                        );
+                foreach (['ScriptureReference.php', 'CwmscriptureHelper.php'] as $legacyHelper) {
+                    if (is_file($helperDir . $legacyHelper)) {
+                        require_once $helperDir . $legacyHelper;
                     }
                 }
-            } catch (\Exception $e) {
-                Factory::getApplication()->enqueueMessage(
-                    'Scripture migration notice: ' . $e->getMessage(),
-                    'warning'
-                );
-            }
 
+                $migrated = CwmscriptureMigration::migrate();
+
+                if ($migrated > 0 && $type === 'update') {
+                    Factory::getApplication()->enqueueMessage(
+                        $migrated . ' study scripture reference(s) migrated to new format.',
+                        'message'
+                    );
+                }
+            }
+        } catch (\Exception $e) {
+            Factory::getApplication()->enqueueMessage(
+                'Scripture migration notice: ' . $e->getMessage(),
+                'warning'
+            );
+        }
+
+        // The remaining legacy data migrations run on UPGRADES only. A fresh
+        // install's SQL already creates the current schema, so there is nothing
+        // to migrate — running these against freshly seeded default rows only
+        // produces spurious warnings (e.g. the podcast-link "could not be
+        // matched" notice) and, historically, fatals when a moved helper no
+        // longer exists.
+        if ($type === 'update') {
             // Fix legacy image paths in mediafile params (images/biblestudy/ -> media/com_proclaim/images/)
             try {
                 CwmmigrationHelper::fixMediafileLegacyPaths();

--- a/tests/integration/Admin/Lib/CwmscriptureMigrationTest.php
+++ b/tests/integration/Admin/Lib/CwmscriptureMigrationTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * The scripture migration has to be safe to run more than once, and has to
+ * still find work when the junction table is already partly populated.
+ *
+ * It used to guard on `SELECT COUNT(*) FROM #__bsms_study_scriptures > 0` and
+ * report "already completed". That is table-wide, so the first study saved
+ * through the editor switched the migration off for the whole site. Studies
+ * written by the PreachIT and Sermon Speaker importers -- which populate the
+ * flat columns and nothing else -- were then stranded with no way to repair
+ * them, and an interrupted run could never resume (#1623).
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmscriptureMigration::class)]
+class CwmscriptureMigrationTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseDriver|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var int[]
+     * @since __DEPLOY_VERSION__
+     */
+    private array $studyIds = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        try {
+            $this->db?->transactionRollback(true);
+        } catch (\Throwable) {
+            // Connection lost; nothing to roll back.
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A study carrying legacy flat values and no junction rows.
+     *
+     * @param   int       $book   Proclaim book number for the primary reference
+     * @param   int|null  $book2  Book number for the secondary reference, if any
+     *
+     * @return  int  The new study's primary key
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function legacyStudy(int $book = 101, ?int $book2 = null): int
+    {
+        $study = (object) [
+            'published'      => 0,
+            'studytitle'     => 'cwm1623 migration fixture',
+            'booknumber'     => $book,
+            'chapter_begin'  => 1,
+            'verse_begin'    => 1,
+            'chapter_end'    => 1,
+            'verse_end'      => 5,
+            'bible_version'  => 'kjv',
+            'booknumber2'    => $book2,
+            'chapter_begin2' => $book2 === null ? null : 2,
+            'verse_begin2'   => $book2 === null ? null : 3,
+            'chapter_end2'   => $book2 === null ? null : 2,
+            'verse_end2'     => $book2 === null ? null : 9,
+            'language'       => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+
+        $id               = (int) $this->db->insertid();
+        $this->studyIds[] = $id;
+
+        return $id;
+    }
+
+    /**
+     * @param   int  $studyId  Study primary key
+     *
+     * @return  int  Junction rows belonging to that study
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function junctionRows(int $studyId): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_study_scriptures'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $studyId)
+        )->loadResult();
+    }
+
+    #[TestDox('a study already holding junction rows does not stop a later one being migrated')]
+    public function testAPopulatedJunctionDoesNotDisableTheMigration(): void
+    {
+        // Stands in for any study saved through the editor: it has junction rows
+        // already, which is what the old table-wide COUNT(*) guard tripped on.
+        $saved = $this->legacyStudy(102);
+        CwmscriptureMigration::migrateStudy($saved);
+        $this->assertGreaterThan(0, $this->junctionRows($saved), 'Fixture did not migrate.');
+
+        $stranded = $this->legacyStudy(103);
+
+        CwmscriptureMigration::migrate();
+
+        $this->assertSame(
+            1,
+            $this->junctionRows($stranded),
+            'The migration reported nothing to do because some other study already had junction rows. '
+            . 'That is the defect: one saved study strands every importer-written study on the site.'
+        );
+    }
+
+    #[TestDox('running the migration twice does not duplicate rows')]
+    public function testMigrationIsIdempotent(): void
+    {
+        $study = $this->legacyStudy(104, 105);
+
+        CwmscriptureMigration::migrate();
+        $afterFirst = $this->junctionRows($study);
+
+        CwmscriptureMigration::migrate();
+
+        $this->assertSame(2, $afterFirst, 'Both flat references should have become junction rows.');
+        $this->assertSame(
+            $afterFirst,
+            $this->junctionRows($study),
+            'The second run migrated the same study again. Rerunning is normal — Backup, Restore and the '
+            . 'control panel data fixes all call this.'
+        );
+    }
+
+    #[TestDox('a run that stopped part way is picked up by the next one')]
+    public function testAnInterruptedRunResumes(): void
+    {
+        $done    = $this->legacyStudy(106);
+        $pending = $this->legacyStudy(107);
+
+        // What an insertBatch() failure leaves behind: some studies migrated,
+        // the rest still holding only flat values.
+        CwmscriptureMigration::migrateStudy($done);
+
+        $this->assertSame(1, CwmscriptureMigration::migrate(), 'Only the unmigrated study should be picked up.');
+        $this->assertSame(1, $this->junctionRows($pending), 'The stranded study was never resumed.');
+        $this->assertSame(1, $this->junctionRows($done), 'The already-migrated study was migrated a second time.');
+    }
+
+    #[TestDox('a study with no legacy values is left alone')]
+    public function testStudiesWithoutLegacyValuesAreSkipped(): void
+    {
+        $empty = $this->legacyStudy(0);
+
+        CwmscriptureMigration::migrate();
+
+        $this->assertSame(0, $this->junctionRows($empty));
+        $this->assertSame(0, CwmscriptureMigration::migrateStudy($empty));
+    }
+
+    #[TestDox('migrateStudy only touches the study it was given')]
+    public function testMigrateStudyIsScopedToOneStudy(): void
+    {
+        $target = $this->legacyStudy(108);
+        $other  = $this->legacyStudy(109);
+
+        $this->assertSame(1, CwmscriptureMigration::migrateStudy($target));
+
+        $this->assertSame(1, $this->junctionRows($target));
+        $this->assertSame(
+            0,
+            $this->junctionRows($other),
+            'The importers call this per study as they insert. Migrating anything else would be a full-table '
+            . 'scan on every imported row.'
+        );
+    }
+}

--- a/tests/integration/Admin/Lib/CwmscriptureMigrationTest.php
+++ b/tests/integration/Admin/Lib/CwmscriptureMigrationTest.php
@@ -176,11 +176,21 @@ class CwmscriptureMigrationTest extends IntegrationTestCase
         $done    = $this->legacyStudy(106);
         $pending = $this->legacyStudy(107);
 
+        // Stands in for the rest of the site. A freshly installed database has
+        // one of these for real — the seeded study — so without it this test
+        // passes locally and fails on CI.
+        $this->legacyStudy(110);
+
         // What an insertBatch() failure leaves behind: some studies migrated,
         // the rest still holding only flat values.
         CwmscriptureMigration::migrateStudy($done);
 
-        $this->assertSame(1, CwmscriptureMigration::migrate(), 'Only the unmigrated study should be picked up.');
+        // ⚠️ Assert on the fixtures, never on migrate()'s return count. It works
+        // over the whole table, and a freshly installed database carries the
+        // seeded study from install.mysql.utf8.sql — which is itself unmigrated,
+        // and is the very defect under test.
+        CwmscriptureMigration::migrate();
+
         $this->assertSame(1, $this->junctionRows($pending), 'The stranded study was never resumed.');
         $this->assertSame(1, $this->junctionRows($done), 'The already-migrated study was migrated a second time.');
     }


### PR DESCRIPTION
> **Commit 0 of #1623 step 2.** Blocks the reader conversions — see the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611).

`CwmscriptureMigration::migrate()` guarded on a table-wide count:

```php
SELECT COUNT(*) FROM #__bsms_study_scriptures
if ($existingCount > 0) { return 0; }   // "already completed"
```

One junction row **anywhere** switched the migration off for the whole site.

## Three consequences

**Nothing was resumable.** `insertBatch()` throwing halfway left the table partly filled, and every later run saw a non-zero count and reported success.

**Every clean install ships a stranded study.** `install.mysql.utf8.sql:862` seeds study 1 with `booknumber = 151` (Colossians 3:5-11). `#__bsms_study_scriptures` is created at `:549` and never seeded — and the install script only ran the migration for `$type === 'update'`.

**Two of the three importers write the flat columns only:**

| importer | writes junction? |
|---|---|
| `CwmcsvimportHelper` | ✅ `saveScripturesAndSync()` |
| `CwmpIconvert` (PreachIT) | ❌ `insertObject()` at `:568` |
| `Cwmssconvert` (Sermon Speaker) | ❌ `insertObject()` at `:262` |

## The ordinary lifecycle strands data

Install → save one study → update later. By the update, the guard has already tripped. Demonstrated against j62-dev inside a rolled-back transaction:

```
fresh clean install       old guard: runs     new predicate: 1 pending
admin saves one study     old guard: BAILS    new predicate: 1 pending
site updates              old guard: returns 0, study 1 stays flat forever
```

Nobody has hit this because `Cwmlisting::getAllScriptures()` falls back to the flat columns. **#1623 removes that cover, and its final step drops the columns — which would delete the data outright.** Hence commit 0.

## Changes

- **`loadPending()`** replaces the table-wide guard with a per-study `NOT EXISTS` against the junction. Every caller — postflight, Backup, Restore, control-panel data fixes — is now safe to run repeatedly, and an interrupted run resumes where it stopped.
- **`migrateStudy()`** migrates a single study. `CwmpIconvert` and `Cwmssconvert` call it as they insert, so imported studies no longer depend on a migration that may already have run.
- **The scripture migration now runs on fresh installs too** — the one exception to the update-only rule, because the install SQL itself seeds legacy values. The other legacy migrations stay update-only for the reasons already recorded there.
- **`rowToValues()`** folds the duplicated primary/secondary reference blocks into one loop, shared by both entry points.

No schema change. Existing sites repair themselves at their next update.

## Verification

`CwmscriptureMigrationTest` — populated-junction case, idempotency, resumption, skip-when-nothing-to-do, `migrateStudy()` scoping.

⚠️ **Mutation-tested.** Restoring the old `COUNT(*)` guard fails three of the five:

```
1) testAPopulatedJunctionDoesNotDisableTheMigration   Failed asserting that 0 is identical to 1
2) testMigrationIsIdempotent                          Failed asserting that 0 is identical to 2
3) testAnInterruptedRunResumes                        Failed asserting that 0 is identical to 1
```

The new predicate against the real dev sites — finds the stranded studies, no false positives on an already-migrated one:

| site | junction rows | pending | |
|---|---|---|---|
| j62-dev | 0 | **1** | `id=1 book=151 3:5-3:11` |
| j70-dev | 0 | **1** | `id=1 book=151 3:5-3:11` |
| j5-dev | 441 | 0 | already migrated |

```
composer test:unit          1418 tests, 3018 assertions — OK
composer test:integration    447 tests, 4011 assertions — OK
php-cs-fixer                 0 of 634 files
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
