### PR TITLE
feat: drive the book facets from the junction (#1623 step 2, tier 1)

### DIFF
--- a/admin/src/Field/BookListField.php
+++ b/admin/src/Field/BookListField.php
@@ -67,20 +67,22 @@ class BookListField extends ListField
         $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $query  = $db->createQuery();
 
-        // Driven by the studies rather than by #__bsms_books, whose bookname
-        // column holds the same language keys the scripture library already has
-        // (#1687). The studies keep the alias `s`: applyCrossFilters() below
-        // writes s.booknumber, s.series_id and s.id, so the alias is part of
-        // that helper's contract even though the table it joined has gone.
-        //
-        // booknumber > 0 is what the INNER JOIN used to do implicitly — a study
-        // with no book matched no row, so it never became an option.
-        $query->select('DISTINCT ' . $db->quoteName('s.booknumber', 'value'))
+        // Books come from the junction, so a study with more than two references
+        // offers all of them rather than the two the flat columns could hold
+        // (#1623). The studies keep the alias `s`: applyCrossFilters() below
+        // writes s.series_id and s.id, so the alias is part of that helper's
+        // contract.
+        $query->select('DISTINCT ' . $db->quoteName('sr.booknumber', 'value'))
             ->from($db->quoteName('#__bsms_studies', 's'))
-            ->where($db->quoteName('s.booknumber') . ' > 0')
+            ->join(
+                'INNER',
+                $db->quoteName('#__bsms_study_scriptures', 'sr') . ' ON '
+                . $db->quoteName('sr.study_id') . ' = ' . $db->quoteName('s.id')
+            )
+            ->where($db->quoteName('sr.booknumber') . ' > 0')
             ->whereIn($db->quoteName('s.published'), [1, 2])
             ->whereIn($db->quoteName('s.access'), $groups)
-            ->order($db->quoteName('s.booknumber') . ' ASC');
+            ->order($db->quoteName('sr.booknumber') . ' ASC');
 
         CwmfilterHelper::applyCrossFilters(
             $query,

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -508,16 +508,18 @@ class CwmproclaimHelper
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->createQuery();
 
-        // Asks the studies which books are in use, rather than asking
-        // #__bsms_books which of its rows a study points at. Same set, and the
-        // name comes from the scripture library, which holds the language keys
-        // that table stored (#1687).
-        //
-        // booknumber > 0 replaces what the INNER JOIN used to do implicitly: a
-        // study with no book selected matched no row, so it never appeared.
-        $query->select('DISTINCT ' . $db->quoteName('booknumber', 'value'))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('booknumber') . ' > 0')
+        // Books come from the junction, so a study with more than two references
+        // offers all of them rather than the two the flat columns could hold
+        // (#1623). The name comes from the scripture library, which holds the
+        // language keys #__bsms_books used to store (#1687).
+        $query->select('DISTINCT ' . $db->quoteName('sr.booknumber', 'value'))
+            ->from($db->quoteName('#__bsms_studies', 's'))
+            ->join(
+                'INNER',
+                $db->quoteName('#__bsms_study_scriptures', 'sr') . ' ON '
+                . $db->quoteName('sr.study_id') . ' = ' . $db->quoteName('s.id')
+            )
+            ->where($db->quoteName('sr.booknumber') . ' > 0')
             ->order($db->quoteName('value') . ' ASC');
 
         // Get the options.

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -584,16 +584,22 @@ class Cwmlanding
                 // scripture library already carries, so the join it needed
                 // earned nothing (#1687).
                 //
-                // booknumber > 0 is what that INNER JOIN did implicitly.
+                // Books come from the junction, so a study with more than two
+                // references contributes all of them (#1623).
                 $query->select(
-                    'DISTINCT ' . $this->db->quoteName('b.booknumber', 'id') . ', '
+                    'DISTINCT ' . $this->db->quoteName('sr.booknumber', 'id') . ', '
                     . $null . ' AS ' . $this->db->quoteName('text') . ', '
                     . '0 AS ' . $this->db->quoteName('landing_show') . ', '
                     . $null . ' AS ' . $this->db->quoteName('params') . ', '
                     . $this->db->quote('books') . ' AS ' . $this->db->quoteName('type')
                 )
                     ->from($this->db->quoteName('#__bsms_studies', 'b'))
-                    ->where($this->db->quoteName('b.booknumber') . ' > 0')
+                    ->join(
+                        'INNER',
+                        $this->db->quoteName('#__bsms_study_scriptures', 'sr') . ' ON '
+                        . $this->db->quoteName('sr.study_id') . ' = ' . $this->db->quoteName('b.id')
+                    )
+                    ->where($this->db->quoteName('sr.booknumber') . ' > 0')
                     ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                     ->where($this->db->quoteName('b.published') . ' = 1');
                 $this->addAccessFilter($query);
@@ -1126,21 +1132,26 @@ class Cwmlanding
             $order    = $this->getSortOrder($params, 'books_order');
             $language = $this->getLanguageFilter($params);
 
-            // Asks the studies which books are in use rather than asking
-            // #__bsms_books which of its rows a study points at — same set, and
-            // the name is attached afterwards from the scripture library, which
-            // holds the language keys that table stored (#1687).
+            // Books come from the junction, so a study with more than two
+            // references contributes all of them rather than the two the flat
+            // columns could hold (#1623). The name is attached afterwards from
+            // the scripture library, which holds the language keys
+            // #__bsms_books used to store (#1687).
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
-            // b.access. booknumber > 0 is what the INNER JOIN did implicitly: a
-            // study with no book matched no row, so it never became an entry.
+            // b.access.
             $query = $this->db->createQuery();
-            $query->select('DISTINCT ' . $this->db->quoteName('b.booknumber'))
+            $query->select('DISTINCT ' . $this->db->quoteName('sr.booknumber'))
                 ->from($this->db->quoteName('#__bsms_studies', 'b'))
-                ->where($this->db->quoteName('b.booknumber') . ' > 0')
+                ->join(
+                    'INNER',
+                    $this->db->quoteName('#__bsms_study_scriptures', 'sr') . ' ON '
+                    . $this->db->quoteName('sr.study_id') . ' = ' . $this->db->quoteName('b.id')
+                )
+                ->where($this->db->quoteName('sr.booknumber') . ' > 0')
                 ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                 ->where($this->db->quoteName('b.published') . ' = 1')
-                ->order($this->db->quoteName('b.booknumber') . ' ' . $order);
+                ->order($this->db->quoteName('sr.booknumber') . ' ' . $order);
 
             $this->addAccessFilter($query);
 
@@ -1715,21 +1726,26 @@ class Cwmlanding
             $order    = $this->getSortOrder($params, 'books_order');
             $language = $this->getLanguageFilter($params);
 
-            // Asks the studies which books are in use rather than asking
-            // #__bsms_books which of its rows a study points at — same set, and
-            // the name is attached afterwards from the scripture library, which
-            // holds the language keys that table stored (#1687).
+            // Books come from the junction, so a study with more than two
+            // references contributes all of them rather than the two the flat
+            // columns could hold (#1623). The name is attached afterwards from
+            // the scripture library, which holds the language keys
+            // #__bsms_books used to store (#1687).
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
-            // b.access. booknumber > 0 is what the INNER JOIN did implicitly: a
-            // study with no book matched no row, so it never became an entry.
+            // b.access.
             $query = $this->db->createQuery();
-            $query->select('DISTINCT ' . $this->db->quoteName('b.booknumber'))
+            $query->select('DISTINCT ' . $this->db->quoteName('sr.booknumber'))
                 ->from($this->db->quoteName('#__bsms_studies', 'b'))
-                ->where($this->db->quoteName('b.booknumber') . ' > 0')
+                ->join(
+                    'INNER',
+                    $this->db->quoteName('#__bsms_study_scriptures', 'sr') . ' ON '
+                    . $this->db->quoteName('sr.study_id') . ' = ' . $this->db->quoteName('b.id')
+                )
+                ->where($this->db->quoteName('sr.booknumber') . ' > 0')
                 ->where($this->db->quoteName('b.language') . ' IN (' . $language . ')')
                 ->where($this->db->quoteName('b.published') . ' = 1')
-                ->order($this->db->quoteName('b.booknumber') . ' ' . $order);
+                ->order($this->db->quoteName('sr.booknumber') . ' ' . $order);
 
             $this->addAccessFilter($query);
 

--- a/tests/integration/Admin/Helper/CwmbookFacetSourceTest.php
+++ b/tests/integration/Admin/Helper/CwmbookFacetSourceTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * The book facets are driven by the scripture junction, not by the flat
+ * columns on #__bsms_studies.
+ *
+ * Those columns hold at most two references, so a study covering three or more
+ * passages only ever offered its first two as filter options -- the rest were
+ * invisible to every book list on the site even though the junction knew about
+ * them (#1623).
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmproclaimHelper::class)]
+class CwmbookFacetSourceTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseDriver|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        try {
+            $this->db?->transactionRollback(true);
+        } catch (\Throwable) {
+            // Connection lost; nothing to roll back.
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A published study whose references live only in the junction.
+     *
+     * The flat columns are left at their defaults on purpose: a study saved
+     * after the columns are retired looks exactly like this, and the facets
+     * still have to find it.
+     *
+     * @param   int[]  $books  Proclaim book numbers, in reference order
+     *
+     * @return  int  The new study's primary key
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function studyWithReferences(array $books): int
+    {
+        $study = (object) [
+            'published'  => 1,
+            'access'     => 1,
+            'studytitle' => 'cwm1623 facet fixture',
+            'language'   => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $studyId = (int) $this->db->insertid();
+
+        foreach ($books as $ordering => $book) {
+            $row = (object) [
+                'study_id'       => $studyId,
+                'ordering'       => $ordering,
+                'booknumber'     => $book,
+                'chapter_begin'  => 1,
+                'verse_begin'    => 1,
+                'chapter_end'    => 1,
+                'verse_end'      => 5,
+                'bible_version'  => 'kjv',
+                'reference_text' => 'cwm1623 fixture reference',
+            ];
+            $this->db->insertObject('#__bsms_study_scriptures', $row);
+        }
+
+        return $studyId;
+    }
+
+    /**
+     * @return  int[]  Book numbers offered by getStudyBooks()
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function offeredBooks(): array
+    {
+        return array_map(
+            static fn ($option) => (int) $option->value,
+            CwmproclaimHelper::getStudyBooks()
+        );
+    }
+
+    /**
+     * Book numbers no study currently covers, so an assertion cannot be
+     * satisfied by real fixture content happening to use them.
+     *
+     * @param   int  $count  How many to return
+     *
+     * @return  int[]
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function unusedBooks(int $count): array
+    {
+        $free = array_values(array_diff(range(101, 166), $this->offeredBooks()));
+
+        $this->assertGreaterThanOrEqual($count, \count($free), 'No spare book numbers left in the fixture data.');
+
+        return \array_slice($free, 0, $count);
+    }
+
+    #[TestDox('a study with three references offers all three, not the two the flat columns held')]
+    public function testAllReferencesBecomeFacetOptions(): void
+    {
+        $books = $this->unusedBooks(3);
+
+        $this->studyWithReferences($books);
+
+        $after = $this->offeredBooks();
+
+        foreach ($books as $i => $book) {
+            $this->assertContains(
+                $book,
+                $after,
+                \sprintf(
+                    'Reference %d of 3 is missing from the book facet. The flat columns hold two references, '
+                    . 'so reading them drops every one after the second.',
+                    $i + 1
+                )
+            );
+        }
+    }
+
+    #[TestDox('the facet follows the junction even when the flat column says otherwise')]
+    public function testTheJunctionWinsOverTheFlatColumn(): void
+    {
+        $book    = $this->unusedBooks(1)[0];
+        $studyId = $this->studyWithReferences([$book]);
+
+        // ⚠️ booknumber is `DEFAULT '101'`, so a study nothing wrote a book to
+        // still reads as Genesis. The flat column can never say "no reference",
+        // which is half of why it is being retired.
+        $flat = (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('booknumber'))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('id') . ' = ' . $studyId)
+        )->loadResult();
+
+        $this->assertSame(101, $flat, 'The column default changed; this fixture no longer sets up the conflict.');
+        $this->assertNotSame(101, $book, 'Pick a fixture book other than the column default.');
+
+        $this->assertContains(
+            $book,
+            $this->offeredBooks(),
+            'The facet did not offer the junction\'s book, so it is still reading the flat column.'
+        );
+    }
+
+    #[TestDox('a study with no references contributes nothing')]
+    public function testStudiesWithoutReferencesAreExcluded(): void
+    {
+        $before = $this->offeredBooks();
+
+        $this->studyWithReferences([]);
+
+        $this->assertSame(
+            $before,
+            $this->offeredBooks(),
+            'A study with no scripture references gained a facet entry. The INNER JOIN is what keeps it out.'
+        );
+    }
+}

--- a/tests/integration/Admin/Helper/CwmbookFacetSourceTest.php
+++ b/tests/integration/Admin/Helper/CwmbookFacetSourceTest.php
@@ -32,6 +32,14 @@ use PHPUnit\Framework\Attributes\TestDox;
 class CwmbookFacetSourceTest extends IntegrationTestCase
 {
     /**
+     * The value of #__bsms_studies.booknumber when nobody sets one.
+     *
+     * @var int
+     * @since __DEPLOY_VERSION__
+     */
+    private const FLAT_COLUMN_DEFAULT = 101;
+
+    /**
      * @var DatabaseDriver|null
      * @since __DEPLOY_VERSION__
      */
@@ -128,6 +136,11 @@ class CwmbookFacetSourceTest extends IntegrationTestCase
      * Book numbers no study currently covers, so an assertion cannot be
      * satisfied by real fixture content happening to use them.
      *
+     * ⚠️ Never returns the column default. A well-populated database uses 101
+     * already and would never offer it, but a near-empty one — CI's — hands it
+     * straight back, and a fixture book equal to the default cannot distinguish
+     * the junction from the flat column.
+     *
      * @param   int  $count  How many to return
      *
      * @return  int[]
@@ -136,7 +149,9 @@ class CwmbookFacetSourceTest extends IntegrationTestCase
      */
     private function unusedBooks(int $count): array
     {
-        $free = array_values(array_diff(range(101, 166), $this->offeredBooks()));
+        $free = array_values(
+            array_diff(range(101, 166), $this->offeredBooks(), [self::FLAT_COLUMN_DEFAULT])
+        );
 
         $this->assertGreaterThanOrEqual($count, \count($free), 'No spare book numbers left in the fixture data.');
 
@@ -181,8 +196,11 @@ class CwmbookFacetSourceTest extends IntegrationTestCase
                 ->where($this->db->quoteName('id') . ' = ' . $studyId)
         )->loadResult();
 
-        $this->assertSame(101, $flat, 'The column default changed; this fixture no longer sets up the conflict.');
-        $this->assertNotSame(101, $book, 'Pick a fixture book other than the column default.');
+        $this->assertSame(
+            self::FLAT_COLUMN_DEFAULT,
+            $flat,
+            'The column default changed; this fixture no longer sets up the conflict.'
+        );
 
         $this->assertContains(
             $book,


### PR DESCRIPTION
> **Tier 1 of #1623 step 2.** Follows #1732, which had to land first. See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611) for the four tiers.

Five option sources answer "which books do we have messages for", and all five read `#__bsms_studies.booknumber` — a column that holds **at most two references**. A study covering three or more passages only ever offered its first two as filter options. The rest were invisible to every book list on the site, even though the junction knew about them.

| file | what it feeds |
|---|---|
| `admin/src/Field/BookListField.php:78` | site book filter dropdown |
| `admin/src/Helper/CwmproclaimHelper.php:518` | admin book list |
| `site/src/Helper/Cwmlanding.php:589` | landing page union branch |
| `site/src/Helper/Cwmlanding.php:1138` | landing page book section |
| `site/src/Helper/Cwmlanding.php:1727` | landing page book section |

All five now `INNER JOIN #__bsms_study_scriptures`, following the idiom `CwmfilterHelper::applyCrossFilters()` already uses for the **teacher** junction — no new pattern invented. Study-level filters (published, access, language) keep their existing table aliases, so `addAccessFilter()` and `applyCrossFilters()` are unaffected.

⚠️ **This is a cut-over with no flat-column fallback.** That is only safe because #1732 made the migration repeatable and self-repairing — which is exactly why it went first.

## Verification

**Old and new queries side by side, against two development sites with real content.** Identical, because neither site has a study with more than two references yet. That is the point: the conversion is faithful, and the capability for a third reference is what is new.

| site | `getStudyBooks` | `BookListField` | landing |
|---|---|---|---|
| j5-dev | 43 → 43 | 43 → 43 | 41 → 41 |
| j6-dev | 43 → 43 | 43 → 43 | 41 → 41 |

`CwmbookFacetSourceTest` — three-reference case, junction-over-flat precedence, exclusion of studies with no references. ⚠️ **Mutation-tested:** restoring the flat-column query fails two of the three.

Rendered against j6-dev. 200 everywhere, no DB errors, no untranslated `JBS_BBK_*` keys:

| view | | |
|---|---|---|
| `cwmlandingpage` | 118253 bytes | 41 distinct book links |
| `cwmsermons` | 93786 bytes | 44 select options, names resolving (Genesis, Exodus, Numbers…) |
| `cwmsermons&filter[book]=151` | 48761 bytes | filter returns the expected studies |
| `cwmseriesdisplays` | 62697 bytes | |

## ⚠️ Found while writing the fixtures

`booknumber` is declared `DEFAULT '101'` (`install.mysql.utf8.sql:473`). **A study nobody ever chose a book for has always read as Genesis.** The flat column cannot express "no reference" at all — `WHERE booknumber > 0` never excludes anything, because the default is not zero.

The junction can express it, and the `INNER JOIN` now keeps those studies out of the facet. `testStudiesWithoutReferencesAreExcluded` pins it.

## Not in this PR

Tier 2 — the filter `WHERE` clauses, `CwmfilterHelper:129` and `CwmsermonsModel:975,1020` — still reads the flat columns. `CwmsermonsModel`'s chapter-range logic with the `booknumber2` fallback is the hardest single piece in this issue and gets its own PR.

```
composer test:unit          1418 tests, 3018 assertions — OK
composer test:integration    450 tests, 4021 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
