### PR TITLE
feat: match the Book cross-filter against the junction (#1623 step 2, tier 2a)

### DIFF
--- a/admin/src/Helper/CwmfilterHelper.php
+++ b/admin/src/Helper/CwmfilterHelper.php
@@ -125,10 +125,15 @@ abstract class CwmfilterHelper
             $book = (int) self::getFilterValue('book', $context);
 
             if ($book > 0) {
-                $query->where(
-                    '(' . $db->quoteName('s.booknumber') . ' = ' . $book
-                    . ' OR ' . $db->quoteName('s.booknumber2') . ' = ' . $book . ')'
-                );
+                // Use junction table for unlimited scripture references. The flat
+                // pair could only answer for a study's first two, so filtering on
+                // a third reference found nothing (#1623).
+                $query->join(
+                    'INNER',
+                    $db->quoteName('#__bsms_study_scriptures', 'xf_ss') . ' ON '
+                    . $db->quoteName('xf_ss.study_id') . ' = ' . $db->quoteName('s.id')
+                )
+                    ->where($db->quoteName('xf_ss.booknumber') . ' = ' . $book);
             }
         }
 

--- a/tests/integration/Admin/Helper/CwmfilterBookJunctionTest.php
+++ b/tests/integration/Admin/Helper/CwmfilterBookJunctionTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * The cross-filter for Book matches against the scripture junction.
+ *
+ * It used to compare the two flat columns:
+ *
+ *     (s.booknumber = X OR s.booknumber2 = X)
+ *
+ * which can only answer for a study's first two references. Filtering on a
+ * study's third book found nothing, and every dropdown that cross-filters --
+ * Teacher, Series, Location, Topic, Year, Message Type -- inherited the gap
+ * (#1623).
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmfilterHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmfilterHelper::class)]
+class CwmfilterBookJunctionTest extends IntegrationTestCase
+{
+    /**
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    private const CONTEXT = 'com_proclaim.cwm1623.list';
+
+    /**
+     * @var DatabaseDriver|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $realApplication = null;
+
+    /**
+     * Filter values the stub application hands back, keyed by state key.
+     *
+     * @var array<string, mixed>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $filterState = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        // The test harness runs a ConsoleApplication, which has no user state
+        // at all, and applyCrossFilters() reads its values through
+        // getUserStateFromRequest(). Standing up a real SiteApplication needs a
+        // session and an input; supplying just that one method is enough to
+        // drive the code under test, and Factory::$application is a plain
+        // untyped static, so it can be put back afterwards.
+        $this->realApplication = Factory::$application;
+        $state                 = &$this->filterState;
+
+        Factory::$application = new class ($state) {
+            /**
+             * @param   array  $state  Filter values by state key
+             */
+            public function __construct(private array &$state)
+            {
+            }
+
+            /**
+             * @param   string  $key      State key
+             * @param   string  $request  Request variable name, unused here
+             * @param   mixed   $default  Value when nothing is set
+             * @param   string  $type     Filter type, unused here
+             *
+             * @return  mixed
+             */
+            public function getUserStateFromRequest($key, $request, $default = null, $type = 'none'): mixed
+            {
+                return $this->state[$key] ?? $default;
+            }
+        };
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        Factory::$application = $this->realApplication;
+
+        try {
+            $this->db?->transactionRollback(true);
+        } catch (\Throwable) {
+            // Connection lost; nothing to roll back.
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A study whose references live in the junction, in the order given.
+     *
+     * The flat columns are deliberately left alone. They can hold the first two
+     * of these and nothing else, which is the whole point.
+     *
+     * @param   int[]  $books  Proclaim book numbers, in reference order
+     *
+     * @return  int  The new study's primary key
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function studyWithReferences(array $books): int
+    {
+        $study = (object) [
+            'published'  => 1,
+            'access'     => 1,
+            'studytitle' => 'cwm1623 filter fixture',
+            'language'   => '*',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $studyId = (int) $this->db->insertid();
+
+        foreach ($books as $ordering => $book) {
+            $row = (object) [
+                'study_id'       => $studyId,
+                'ordering'       => $ordering,
+                'booknumber'     => $book,
+                'chapter_begin'  => 1,
+                'verse_begin'    => 1,
+                'chapter_end'    => 1,
+                'verse_end'      => 5,
+                'bible_version'  => 'kjv',
+                'reference_text' => 'cwm1623 fixture reference',
+            ];
+            $this->db->insertObject('#__bsms_study_scriptures', $row);
+        }
+
+        return $studyId;
+    }
+
+    /**
+     * Study ids surviving the Book cross-filter.
+     *
+     * Mirrors what a *ListField does: build a query over the studies aliased
+     * `s`, then hand it to applyCrossFilters().
+     *
+     * @param   int  $book  Book number to filter on
+     *
+     * @return  int[]
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function filteredStudyIds(int $book): array
+    {
+        $this->filterState[self::CONTEXT . '.filter.book'] = $book;
+
+        $query = $this->db->createQuery()
+            ->select('DISTINCT ' . $this->db->quoteName('s.id'))
+            ->from($this->db->quoteName('#__bsms_studies', 's'));
+
+        CwmfilterHelper::applyCrossFilters($query, 'teacher', self::CONTEXT);
+
+        return array_map('intval', $this->db->setQuery($query)->loadColumn() ?: []);
+    }
+
+    #[TestDox('filtering on a study\'s third book finds it')]
+    public function testTheThirdReferenceIsFilterable(): void
+    {
+        // 170-172 are deuterocanonical numbers the sample content never uses,
+        // so a match can only come from this fixture.
+        $studyId = $this->studyWithReferences([170, 171, 172]);
+
+        $this->assertContains(
+            $studyId,
+            $this->filteredStudyIds(172),
+            'Filtering on the third reference found nothing. The flat pair holds two, so everything after '
+            . 'the second was unreachable from every dropdown that cross-filters.'
+        );
+    }
+
+    #[TestDox('the first two references still filter as they always did')]
+    public function testTheFirstTwoReferencesStillMatch(): void
+    {
+        $studyId = $this->studyWithReferences([170, 171, 172]);
+
+        $this->assertContains($studyId, $this->filteredStudyIds(170), 'The primary reference stopped matching.');
+        $this->assertContains($studyId, $this->filteredStudyIds(171), 'The secondary reference stopped matching.');
+    }
+
+    #[TestDox('a book the study does not reference does not match it')]
+    public function testUnrelatedBooksDoNotMatch(): void
+    {
+        $studyId = $this->studyWithReferences([170, 171, 172]);
+
+        $this->assertNotContains(
+            $studyId,
+            $this->filteredStudyIds(169),
+            'The join matched a book the study has no reference to.'
+        );
+    }
+
+    #[TestDox('the filter is skipped entirely when the caller excludes it')]
+    public function testExcludingBookSkipsTheJoin(): void
+    {
+        $studyId = $this->studyWithReferences([170]);
+
+        $this->filterState[self::CONTEXT . '.filter.book'] = 169;
+
+        $query = $this->db->createQuery()
+            ->select('DISTINCT ' . $this->db->quoteName('s.id'))
+            ->from($this->db->quoteName('#__bsms_studies', 's'))
+            ->where($this->db->quoteName('s.id') . ' = ' . $studyId);
+
+        // What BookListField itself passes, so its own dropdown does not
+        // self-filter down to the option already chosen.
+        CwmfilterHelper::applyCrossFilters($query, 'book', self::CONTEXT);
+
+        $this->assertSame(
+            [$studyId],
+            array_map('intval', $this->db->setQuery($query)->loadColumn() ?: []),
+            'Excluding the book filter still constrained the query, so BookListField would only ever offer '
+            . 'the book already selected.'
+        );
+    }
+}


### PR DESCRIPTION
> **Tier 2a of #1623 step 2.** Follows #1733. See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611).

`CwmfilterHelper::applyCrossFilters()` compared the flat pair:

```php
(s.booknumber = X OR s.booknumber2 = X)
```

That can only answer for a study's **first two** references. Filtering on a study's third book found nothing — and all seven dropdowns that cross-filter (Teacher, Series, Location, Topic, Year, Message Type, Book) inherited the gap.

It now `INNER JOIN`s `#__bsms_study_scriptures` — the same shape the **teacher** branch directly above it already uses for `#__bsms_study_teachers`. No new pattern.

Two things checked before making it a join:

- all six other dropdown fields `SELECT DISTINCT`, so the join cannot duplicate options
- `BookListField` passes `exclude = 'book'`, so it never joins the junction twice (it has its own `sr` join from #1733)

## Verification

**Old and new predicates compared for every book, on two development sites with real content.** Identical, study id for study id:

| site | books with matches | differing | matched rows old → new |
|---|---|---|---|
| j5-dev | 43 | **0** | 436 → 436 |
| j6-dev | 43 | **0** | 435 → 435 |

`CwmfilterBookJunctionTest` — the third reference, the first two still matching, an unrelated book not matching, and `exclude` skipping the join entirely. ⚠️ **Mutation-tested:** restoring the flat predicate fails two of the four.

Rendered against j6-dev with the filter active. Cross-filtering visibly at work, and Book correctly not self-filtering:

```
cwmsermons&filter[book]=151   48761 bytes, no DB errors
  teacher 5 options   series 1   messagetype 2   book 44 (unfiltered)
```

## ⚠️ On the test harness

The integration harness runs a `ConsoleApplication`, which has no user state at all, and `applyCrossFilters()` reads filter values through `getUserStateFromRequest()`. The test swaps `Factory::$application` for an object supplying just that one method and restores it in `tearDown()`. Standing up a real `SiteApplication` would need a session and an input for no extra coverage.

## Not in this PR

Tier 2b — `CwmsermonsModel:975,1020`, the chapter-range logic with the `booknumber2` fallback — is the hardest single piece in this issue and gets its own PR.

```
composer test:unit          1418 tests, 3018 assertions — OK
composer test:integration    454 tests, 4025 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
