### PR TITLE
fix: stop relying on where()'s glue argument, and pin both where() traps in a test

### DIFF
--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -337,10 +337,10 @@ class CwmmigrationHelper
                 . '), ' . $db->quote("'") . ', ' . $db->quote('')
                 . '), ' . $db->quote('"') . ', ' . $db->quote('') . '))'
             )
-            ->where([
-                $db->quoteName('alias') . ' = ' . $db->quote(''),
-                $db->quoteName('alias') . ' IS NULL',
-            ], 'OR');
+            ->where(
+                '(' . $db->quoteName('alias') . ' = ' . $db->quote('')
+                . ' OR ' . $db->quoteName('alias') . ' IS NULL)'
+            );
         $db->setQuery($query);
         $db->execute();
         $fixed += $db->getAffectedRows();

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -1012,7 +1012,7 @@ class CwminstallModel extends ListModel
                 $conditions = CwmmigrationHelper::rmoldurl();
                 $query      = $this->getDatabase()->createQuery();
                 $query->delete($this->getDatabase()->quoteName('#__update_sites'));
-                $query->where($conditions, $glue = 'OR');
+                $query->where('(' . implode(' OR ', $conditions) . ')');
                 $this->getDatabase()->setQuery($query);
                 $this->getDatabase()->execute();
                 $this->running = 'Remove Old Update URL\'s';
@@ -1033,7 +1033,7 @@ class CwminstallModel extends ListModel
                 ];
                 $query      = $this->getDatabase()->createQuery();
                 $query->delete($this->getDatabase()->quoteName('#__update_sites'));
-                $query->where($conditions, $glue = 'OR');
+                $query->where('(' . implode(' OR ', $conditions) . ')');
                 $this->getDatabase()->setQuery($query);
                 $this->getDatabase()->execute();
 
@@ -1043,7 +1043,7 @@ class CwminstallModel extends ListModel
                 ];
                 $query      = $this->getDatabase()->createQuery();
                 $query->delete($this->getDatabase()->quoteName('#__update_sites_extensions'));
-                $query->where($conditions, $glue = 'OR');
+                $query->where('(' . implode(' OR ', $conditions) . ')');
                 $this->getDatabase()->setQuery($query);
                 $this->getDatabase()->execute();
 

--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,9 @@
 		<testsuite name="Asset Contract Tests">
 			<directory>tests/unit/Assets</directory>
 		</testsuite>
+		<testsuite name="Query Contract Tests">
+			<directory>tests/unit/Query</directory>
+		</testsuite>
 		<testsuite name="Migration SQL Contract Tests">
 			<directory>tests/unit/Sql</directory>
 		</testsuite>

--- a/tests/unit/Query/WhereClauseContractTest.php
+++ b/tests/unit/Query/WhereClauseContractTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * Two ways `QueryInterface::where()` does not behave the way its call site
+ * reads. Both have bitten this codebase; neither is visible in review.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Unit\Query;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class WhereClauseContractTest extends TestCase
+{
+    /**
+     * Source trees whose queries reach a database.
+     *
+     * @var string[]
+     * @since __DEPLOY_VERSION__
+     */
+    private const ROOTS = ['admin', 'site', 'api', 'components', 'modules', 'plugins', 'libraries/lib_cwmscripture'];
+
+    /**
+     * @var string[]
+     * @since __DEPLOY_VERSION__
+     */
+    private const SKIP = ['vendor', 'node_modules', 'tests', 'scripturelinks/libraries'];
+
+    /**
+     * @return  string[]  Absolute paths of every PHP file to inspect
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function sourceFiles(): array
+    {
+        $base  = \dirname(__DIR__, 3);
+        $files = [];
+
+        foreach (self::ROOTS as $root) {
+            if (!is_dir($base . '/' . $root)) {
+                continue;
+            }
+
+            $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($base . '/' . $root));
+
+            foreach ($it as $file) {
+                $path = $file->getPathname();
+
+                if (!str_ends_with($path, '.php')) {
+                    continue;
+                }
+
+                foreach (self::SKIP as $skip) {
+                    if (str_contains($path, $skip)) {
+                        continue 2;
+                    }
+                }
+
+                $files[] = $path;
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * The string literals a where() argument concatenates, with PHP
+     * expressions replaced by a placeholder.
+     *
+     * @param   string  $argument  Raw PHP source of the argument
+     *
+     * @return  string
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function reconstructSql(string $argument): string
+    {
+        preg_match_all("/'([^']*)'/", $argument, $matches);
+
+        return trim((string) preg_replace('/\s+/', ' ', implode(' X ', $matches[1])));
+    }
+
+    /**
+     * Whether an OR appears outside every bracket in a reconstructed fragment.
+     *
+     * @param   string  $sql  Reconstructed SQL fragment
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function hasTopLevelOr(string $sql): bool
+    {
+        $depth = 0;
+
+        foreach (preg_split('/(\(|\)|\bOR\b)/', $sql, -1, PREG_SPLIT_DELIM_CAPTURE) as $token) {
+            $token = trim($token);
+
+            if ($token === '(') {
+                $depth++;
+            } elseif ($token === ')') {
+                $depth--;
+            } elseif ($token === 'OR' && $depth <= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Every bare where()/having() argument in the codebase, as
+     * [file, line, reconstructed SQL].
+     *
+     * @return  array<int, array{0: string, 1: int, 2: string}>
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function whereArguments(): array
+    {
+        $found = [];
+
+        foreach (self::sourceFiles() as $path) {
+            $lines = explode("\n", (string) file_get_contents($path));
+            $i     = 0;
+
+            while ($i < \count($lines)) {
+                $isBare = preg_match('/->(where|having)\s*\(/', $lines[$i])
+                    && !preg_match('/->(extendWhere|whereIn|whereNotIn|orWhere|andWhere)\s*\(/', $lines[$i]);
+
+                if (!$isBare) {
+                    $i++;
+                    continue;
+                }
+
+                $depth = 0;
+                $chunk = [];
+                $j     = $i;
+
+                while ($j < \count($lines) && $j < $i + 25) {
+                    $chunk[] = $lines[$j];
+                    $depth += substr_count($lines[$j], '(') - substr_count($lines[$j], ')');
+
+                    if ($depth <= 0) {
+                        break;
+                    }
+
+                    $j++;
+                }
+
+                $blob = implode("\n", $chunk);
+
+                if (preg_match('/->(?:where|having)\s*\((.*)\)\s*[;,)]?\s*$/s', $blob, $m)) {
+                    $found[] = [$path, $i + 1, self::reconstructSql($m[1])];
+                }
+
+                $i = $j + 1;
+            }
+        }
+
+        return $found;
+    }
+
+    #[TestDox('no where() condition contains an OR outside its own brackets')]
+    public function testNoUnbracketedOrInAWhereCondition(): void
+    {
+        $offenders = [];
+
+        foreach (self::whereArguments() as [$path, $line, $sql]) {
+            if ($sql !== '' && self::hasTopLevelOr($sql)) {
+                $offenders[] = \sprintf('%s:%d  %s', basename($path), $line, $sql);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "where() appends its argument and glues it with AND, adding no brackets of its own, so an OR at\n"
+            . "the top level of the string binds looser than every condition before it and overrides them --\n"
+            . "including published, access and language. Wrap the whole disjunction in its own brackets.\n\n"
+            . implode("\n", $offenders)
+        );
+    }
+
+    #[TestDox('the detector still recognises the shape it was written for')]
+    public function testTheDetectorWorks(): void
+    {
+        // Guards the test above: a scan that finds nothing proves nothing unless
+        // it is known to find something. This is the clause from #1735.
+        $this->assertTrue(
+            self::hasTopLevelOr("( X = X AND X >= X ) OR X ="),
+            'The detector no longer recognises the unbracketed clause it was written for.'
+        );
+
+        $this->assertFalse(
+            self::hasTopLevelOr("(( X = X AND X >= X ) OR X = X )"),
+            'The detector reports a correctly bracketed clause as an offender.'
+        );
+    }
+
+    #[TestDox('no call relies on where()\'s glue argument')]
+    public function testNoCallReliesOnTheGlueArgument(): void
+    {
+        $offenders = [];
+
+        foreach (self::sourceFiles() as $path) {
+            foreach (explode("\n", (string) file_get_contents($path)) as $n => $line) {
+                if (preg_match('/->where\s*\(.*,\s*(\$\w+\s*=\s*)?[\'"](OR|XOR)[\'"]\s*\)/', $line)) {
+                    $offenders[] = \sprintf('%s:%d  %s', basename($path), $n + 1, trim($line));
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "where(\$conditions, 'OR') honours the glue ONLY when it is the first where() on the query --\n"
+            . "every later call goes through append(), which keeps the existing AND and discards the glue\n"
+            . "silently. Adding an earlier where() then changes this call's meaning with no edit to it.\n"
+            . "Join and bracket the conditions instead: where('(' . implode(' OR ', \$conditions) . ')').\n\n"
+            . implode("\n", $offenders)
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #1735, which fixed one way `QueryInterface::where()` does not read the way it behaves. The sweep for that fix turned up a second way.

## The glue is honoured only on the first call

```php
public function where($conditions, $glue = 'AND')
{
    if ($this->where === null) {
        $this->where = new QueryElement('WHERE', $conditions, " $glue ");  // used
    } else {
        $this->where->append($conditions);                                 // DISCARDED
    }
}
```

`where([...], 'OR')` means OR **only while it is the first `where()` on the query**. Every later call goes through `append()`, which keeps the existing `AND` and drops the glue with no error.

All four uses in this codebase were first calls, so all four were correct. But each is **one edit away from silently inverting** — adding a `where()` above any of them turns a disjunction into a conjunction, at a line nobody touched:

| site | query | what AND would do |
|---|---|---|
| `CwminstallModel.php:1015,1036,1046` | `DELETE FROM #__update_sites` | matches nothing — old update URLs stay behind |
| `CwmmigrationHelper.php:340` | `UPDATE #__bsms_teachers` | `alias = '' AND alias IS NULL` is never true — no alias ever generated |

All four now join and bracket their conditions, which means the same thing wherever the call sits.

⚠️ `extendWhere()` is **not** an option here — it replaces the existing WHERE with itself as a child, so it fatals when there is no WHERE yet, which is exactly the case all four are.

## Both traps are now pinned

`WhereClauseContractTest` walks every `where()`/`having()` call across the source trees — **1140 sites in 579 files** — and fails on either shape:

- an `OR` at bracket depth zero in a condition string (the #1735 defect)
- any reliance on the glue argument (this one)

The failure messages explain the trap, so whoever trips it doesn't have to rediscover it.

⚠️ **The detector carries its own test.** A scan that finds nothing proves nothing until it is known to find something — so `testTheDetectorWorks()` feeds it the #1735 clause and asserts it fires, then the bracketed version and asserts it doesn't. Without that, the contract test would silently degrade into a no-op.

**Mutation-tested:**

```
restore where($conditions, 'OR')   -> 2 of 3 fail
unbracket the #1735 clause         -> 1 of 3 fail
```

## Note for reviewers

`tests/unit/Query` is a new directory, and a new test directory does not run at all without its own suite entry — so `phpunit.xml` and the `composer test:unit` list both gained **"Query Contract Tests"**. Worth confirming the count moved: unit tests went 1418 → 1421.

```
composer test:unit          1421 tests, 3022 assertions — OK
composer test:integration    458 tests, 4030 assertions — OK
php-cs-fixer                 clean
```

Refs #1735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
