### PR TITLE
feat: match the sermons book filter against the junction (#1623 step 2, tier 2b)

### DIFF
--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -952,8 +952,8 @@ class CwmsermonsModel extends ListModel
     /**
      * Apply book number filter with chapter-range support.
      *
-     * Multi-value params use a simple IN clause. Single-value params and
-     * user-selected filters use chapter-range logic with booknumber2 fallback.
+     * A set of books from a menu or template param matches any of them. A single
+     * book, from either source, also honours the chapter range.
      *
      * @param   QueryInterface  $query        Active query builder
      * @param   object          $db           Database driver
@@ -972,36 +972,72 @@ class CwmsermonsModel extends ListModel
     ): void {
         $first    = $paramValues[0] ?? '-1';
         $hasParam = $paramValues !== null && $first !== '-1' && $first !== '' && $first !== null;
-        $col      = $db->quoteName('study.booknumber');
 
-        if ($hasParam && $filterValue < 1) {
+        // A menu or template may pin the list to a set of books, and the visitor
+        // may narrow it further. Both constraints apply when both are present.
+        if ($hasParam) {
             $intValues = array_map('intval', $paramValues);
 
             if (\count($intValues) > 1) {
-                $query->where($col . ' IN (' . implode(',', $intValues) . ')');
+                $query->where($this->referenceExists($db, $intValues));
             } else {
                 $this->addBookChapterWhere($query, $db, $intValues[0]);
             }
-        } elseif ($hasParam && $filterValue >= 1) {
-            $intValues = array_map('intval', $paramValues);
+        }
 
-            if (\count($intValues) > 1) {
-                $query->where($col . ' IN (' . implode(',', $intValues) . ')');
-            } else {
-                $this->addBookChapterWhere($query, $db, $intValues[0]);
-            }
-
-            $this->addBookChapterWhere($query, $db, $filterValue);
-        } elseif ($filterValue >= 1) {
+        if ($filterValue >= 1) {
             $this->addBookChapterWhere($query, $db, $filterValue);
         }
     }
 
     /**
-     * Add WHERE clause for a single book number with optional chapter range.
+     * A correlated EXISTS over a study's scripture references.
      *
-     * Also checks booknumber2 (secondary scripture reference) as a fallback.
-     * Chapter range bounds come from the request input (minChapt, maxChapt).
+     * Self-contained, so it can be ANDed with anything without the bracketing
+     * hazard a bare disjunction carries (#1735).
+     *
+     * @param   object    $db            Database driver
+     * @param   int[]     $books         Book numbers, any of which may match
+     * @param   ?int      $chapterBegin  Lower chapter bound, or null
+     * @param   ?int      $chapterEnd    Upper chapter bound, or null
+     *
+     * @return  string  An `EXISTS (...)` fragment
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function referenceExists(
+        object $db,
+        array $books,
+        ?int $chapterBegin = null,
+        ?int $chapterEnd = null,
+    ): string {
+        $sub = $db->createQuery()
+            ->select('1')
+            ->from($db->quoteName('#__bsms_study_scriptures', 'bf'))
+            ->where($db->quoteName('bf.study_id') . ' = ' . $db->quoteName('study.id'))
+            ->where(
+                \count($books) > 1
+                    ? $db->quoteName('bf.booknumber') . ' IN (' . implode(',', $books) . ')'
+                    : $db->quoteName('bf.booknumber') . ' = ' . $books[0]
+            );
+
+        if ($chapterBegin) {
+            $sub->where($db->quoteName('bf.chapter_begin') . ' >= ' . $chapterBegin);
+        }
+
+        if ($chapterEnd) {
+            $sub->where($db->quoteName('bf.chapter_end') . ' <= ' . $chapterEnd);
+        }
+
+        return 'EXISTS (' . $sub . ')';
+    }
+
+    /**
+     * Add WHERE clause matching a book, with the optional chapter range.
+     *
+     * A study matches when any of its references is in that book, and the range
+     * constrains whichever reference matched. Chapter bounds come from the
+     * request input (minChapt, maxChapt).
      *
      * @param   QueryInterface  $query  Active query builder
      * @param   object          $db     Database driver
@@ -1014,28 +1050,14 @@ class CwmsermonsModel extends ListModel
     private function addBookChapterWhere(QueryInterface $query, object $db, int $book): void
     {
         $appInput = Factory::getApplication()->getInput();
-        $chb      = $appInput->get('minChapt', 0, 'int');
-        $che      = $appInput->get('maxChapt', 0, 'int');
 
-        $bn  = $db->quoteName('study.booknumber');
-        $bn2 = $db->quoteName('study.booknumber2');
-        $cb  = $db->quoteName('study.chapter_begin');
-        $ce  = $db->quoteName('study.chapter_end');
-
-        $primary = $bn . ' = ' . $book;
-
-        if ($chb) {
-            $primary .= ' AND ' . $cb . ' >= ' . $chb;
-        }
-
-        if ($che) {
-            $primary .= ' AND ' . $ce . ' <= ' . $che;
-        }
-
-        // ⚠️ The whole disjunction must be bracketed. where() appends the string
-        // and glues it with AND, adding no brackets of its own, so an unbracketed
-        // `... OR bn2 = X` binds looser than every condition before it and lets a
-        // secondary-reference match escape published, access and language.
-        $query->where('((' . $primary . ') OR ' . $bn2 . ' = ' . $book . ')');
+        $query->where(
+            $this->referenceExists(
+                $db,
+                [$book],
+                $appInput->get('minChapt', 0, 'int'),
+                $appInput->get('maxChapt', 0, 'int')
+            )
+        );
     }
 }

--- a/tests/integration/Site/Model/CwmsermonsBookFilterScopeTest.php
+++ b/tests/integration/Site/Model/CwmsermonsBookFilterScopeTest.php
@@ -91,28 +91,47 @@ class CwmsermonsBookFilterScopeTest extends IntegrationTestCase
     }
 
     /**
-     * @param   array<string, mixed>  $overrides  Column values for the fixture
+     * A study, plus the scripture references the filter now matches on.
+     *
+     * ⚠️ The references must be real junction rows. A study with none can never
+     * match, so a fixture without them makes the two exclusion tests below pass
+     * whatever the filter does.
+     *
+     * @param   array<string, mixed>       $overrides   Column values for the study
+     * @param   array<int, array{int,int}> $references  [book, chapter] per reference
      *
      * @return  int  The new study's primary key
      *
      * @since __DEPLOY_VERSION__
      */
-    private function study(array $overrides): int
+    private function study(array $overrides = [], array $references = [[self::BOOK, 100]]): int
     {
         $study = (object) array_merge([
-            'studytitle'    => 'cwm1623 scope fixture',
-            'published'     => 1,
-            'access'        => 1,
-            'language'      => '*',
-            'booknumber'    => 999,
-            'booknumber2'   => 0,
-            'chapter_begin' => 1,
-            'chapter_end'   => 1,
+            'studytitle' => 'cwm1623 scope fixture',
+            'published'  => 1,
+            'access'     => 1,
+            'language'   => '*',
         ], $overrides);
 
         $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $studyId = (int) $this->db->insertid();
 
-        return (int) $this->db->insertid();
+        foreach ($references as $ordering => [$book, $chapter]) {
+            // insertObject() takes its object by reference, so this cannot be inlined.
+            $reference = (object) [
+                'study_id'       => $studyId,
+                'ordering'       => $ordering,
+                'booknumber'     => $book,
+                'chapter_begin'  => $chapter,
+                'chapter_end'    => $chapter,
+                'bible_version'  => 'kjv',
+                'reference_text' => 'cwm1623 fixture reference',
+            ];
+
+            $this->db->insertObject('#__bsms_study_scriptures', $reference);
+        }
+
+        return $studyId;
     }
 
     /**
@@ -145,10 +164,10 @@ class CwmsermonsBookFilterScopeTest extends IntegrationTestCase
         return array_map('intval', $this->db->setQuery($query)->loadColumn() ?: []);
     }
 
-    #[TestDox('an unpublished study does not escape through its secondary reference')]
+    #[TestDox('an unpublished study does not escape through a matching reference')]
     public function testUnpublishedStudiesStayHidden(): void
     {
-        $hidden = $this->study(['published' => 0, 'booknumber2' => self::BOOK]);
+        $hidden = $this->study(['published' => 0]);
 
         $this->assertNotContains(
             $hidden,
@@ -158,11 +177,11 @@ class CwmsermonsBookFilterScopeTest extends IntegrationTestCase
         );
     }
 
-    #[TestDox('a study above the visitor\'s view level does not escape through its secondary reference')]
+    #[TestDox('a study above the visitor\'s view level does not escape through a matching reference')]
     public function testRestrictedStudiesStayHidden(): void
     {
         // 6 is Super Users on a stock Joomla install; the query asks for 1 and 5.
-        $restricted = $this->study(['access' => 6, 'booknumber2' => self::BOOK]);
+        $restricted = $this->study(['access' => 6]);
 
         $this->assertNotContains(
             $restricted,
@@ -171,24 +190,48 @@ class CwmsermonsBookFilterScopeTest extends IntegrationTestCase
         );
     }
 
-    #[TestDox('a published, public study still matches on its secondary reference')]
-    public function testSecondaryReferenceStillMatches(): void
+    #[TestDox('a published, public study matches on a reference other than its first')]
+    public function testANonFirstReferenceStillMatches(): void
     {
-        // The clause exists to find these; bracketing must not cost it.
-        $allowed = $this->study(['booknumber2' => self::BOOK]);
+        // The filter must not privilege the first reference. Under the flat
+        // columns this was the booknumber2 case, and anything past it was
+        // unreachable; there is no such distinction now.
+        $allowed = $this->study([], [[101, 100], [102, 100], [self::BOOK, 100]]);
 
         $this->assertContains(
             $allowed,
             $this->visibleToGuest(99),
-            'Bracketing the disjunction stopped the secondary reference matching at all.'
+            'A study matching on its third reference was not returned.'
         );
     }
 
-    #[TestDox('the chapter range still constrains the primary reference')]
+    #[TestDox('a multi-book menu param matches a study referencing any one of them')]
+    public function testMultiBookParamMatchesAnyOfThem(): void
+    {
+        $second = $this->study([], [[161, 1]]);
+        $none   = $this->study([], [[162, 1]]);
+
+        $query = $this->db->createQuery()
+            ->select($this->db->quoteName('study.id'))
+            ->from($this->db->quoteName('#__bsms_studies', 'study'))
+            ->where($this->db->quoteName('study.published') . ' = 1');
+
+        // The menu/template param path: several books, no user filter.
+        $model  = (new \ReflectionClass(CwmsermonsModel::class))->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod(CwmsermonsModel::class, 'addBookFilter');
+        $method->invoke($model, $query, $this->db, [160, 161], 0);
+
+        $visible = array_map('intval', $this->db->setQuery($query)->loadColumn() ?: []);
+
+        $this->assertContains($second, $visible, 'A study referencing the second of the listed books was dropped.');
+        $this->assertNotContains($none, $visible, 'A study referencing none of the listed books was returned.');
+    }
+
+    #[TestDox('the chapter range constrains whichever reference matched')]
     public function testChapterRangeStillApplies(): void
     {
-        $inRange  = $this->study(['booknumber' => self::BOOK, 'chapter_begin' => 100]);
-        $tooEarly = $this->study(['booknumber' => self::BOOK, 'chapter_begin' => 1]);
+        $inRange  = $this->study([], [[self::BOOK, 100]]);
+        $tooEarly = $this->study([], [[self::BOOK, 1]]);
 
         $visible = $this->visibleToGuest(99);
 

--- a/tests/unit/Site/Model/CwmsermonsFilterTest.php
+++ b/tests/unit/Site/Model/CwmsermonsFilterTest.php
@@ -104,8 +104,16 @@ class CwmsermonsFilterTest extends ProclaimTestCase
 
             public function getQuery(bool $new = false): object
             {
-                // Return a minimal object for subquery building in addTeacherFilter
+                // A subquery double for the EXISTS clauses in addTeacherFilter and
+                // addBookFilter. It records what it is given and renders it, so a
+                // test can assert on the conditions rather than on a placeholder.
                 return new class () {
+                    /** @var string */
+                    private string $from = '';
+
+                    /** @var string[] */
+                    private array $conditions = [];
+
                     public function select($columns): static
                     {
                         return $this;
@@ -113,22 +121,31 @@ class CwmsermonsFilterTest extends ProclaimTestCase
 
                     public function from($tables, $subQueryAlias = null): static
                     {
+                        $this->from = \is_array($tables) ? implode(', ', $tables) : (string) $tables;
+
                         return $this;
                     }
 
                     public function where($condition): static
                     {
+                        $this->conditions[] = \is_array($condition)
+                            ? implode(' AND ', $condition)
+                            : (string) $condition;
+
                         return $this;
                     }
 
                     public function whereIn(string $keyName, array $keyValues, $dataType = 'int'): static
                     {
+                        $this->conditions[] = $keyName . ' IN (' . implode(',', $keyValues) . ')';
+
                         return $this;
                     }
 
                     public function __toString(): string
                     {
-                        return 'EXISTS (SELECT 1)';
+                        return 'SELECT 1 FROM ' . $this->from
+                            . ($this->conditions ? ' WHERE ' . implode(' AND ', $this->conditions) : '');
                     }
                 };
             }
@@ -395,17 +412,24 @@ class CwmsermonsFilterTest extends ProclaimTestCase
         $this->assertEmpty($this->whereCalls, '[null] should not filter by book');
     }
 
-    #[TestDox('addBookFilter: multiple values adds IN clause')]
+    #[TestDox('addBookFilter: multiple values adds one EXISTS clause over the junction')]
     public function testAddBookFilterMultipleValues(): void
     {
         $query = $this->createMockQuery();
         $db    = $this->createMockDb();
 
-        // Multi-value params use a plain IN clause and bypass the chapter-range
-        // path (addBookChapterWhere), so no application bootstrap is required.
+        // Multi-value params bypass the chapter-range path
+        // (addBookChapterWhere), so no application bootstrap is required.
         $this->invokeFilter('addBookFilter', [$query, $db, ['5', '10'], 0]);
 
-        $this->assertCount(1, $this->whereCalls, 'Multiple book numbers use a single IN clause');
+        $this->assertCount(1, $this->whereCalls, 'Multiple book numbers use a single clause');
+        $this->assertStringContainsString('EXISTS', $this->whereCalls[0]);
+        $this->assertStringContainsString('#__bsms_study_scriptures', $this->whereCalls[0]);
         $this->assertStringContainsString('IN (5,10)', $this->whereCalls[0]);
+        $this->assertStringNotContainsString(
+            'study.booknumber',
+            $this->whereCalls[0],
+            'The filter is still reading the flat column instead of the junction.'
+        );
     }
 }


### PR DESCRIPTION
> **Tier 2b of #1623 step 2** — the last flat-column reader in the filter path. See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611).

Two readers, both now one correlated `EXISTS` over `#__bsms_study_scriptures` via a new `referenceExists()`:

| | was | reachable references |
|---|---|---|
| `addBookChapterWhere()` | `booknumber = X` + `booknumber2 = X` fallback | first two only |
| `addBookFilter()` multi-book branch | `booknumber IN (…)` | **first only** |

## ⚠️ Behaviour change, as agreed

**The chapter range now constrains whichever reference matched.** Previously it applied only to the primary one — `... OR booknumber2 = X` carried no chapter condition at all, so a secondary match ignored `minChapt`/`maxChapt` entirely. With every reference equal, that asymmetry has nothing to stand on.

Measured across both dev sites, old bracketed flat form vs new, for every book:

| | books | differing | gained | lost |
|---|---|---|---|---|
| no chapter range | 41 | **0** | 0 | 0 |
| `minChapt=1` | 41 | **0** | 0 | 0 |
| `minChapt=3` | 41 | 2 | 0 | 2 |
| `maxChapt=5` | 37 | 1 | 0 | 1 |

**Nothing is ever gained, and the no-range case is untouched.** Both losses on j6-dev are the change itself, not a side effect:

```
book 109  id=511  references 120:22 and 109:1   minChapt=3 -> 109:1 out of range
book 151  id=726  references 146:12 and 151:1   minChapt=3 -> 151:1 out of range
```

Each matched before only because the secondary clause was unconstrained.

## Also simplified

`addBookFilter()` had three branches whose first two bodies were identical. They collapse to "apply the param constraint if there is one, then the user filter if there is one" — which is what the three added up to.

`referenceExists()` returns a self-contained `EXISTS`, so it can be ANDed with anything. **The bracketing hazard behind #1735 cannot recur in this path.**

## Verification

`CwmsermonsBookFilterScopeTest` is now five tests, with fixtures rewritten to write junction rows.

⚠️ **That rewrite was necessary, not cosmetic.** The two exclusion tests from #1735 would otherwise have passed **vacuously** — their fixtures wrote only flat columns, and a study with no junction row can never match, so the filter could have done anything and they would still have been green. Confirmed by removing the published and access conditions from the test query: both tests fail, so the fixtures do reach the filter.

The unit-level mock query object recorded nothing and stringified to a fixed `'EXISTS (SELECT 1)'` (which is why it produced `EXISTS (EXISTS (SELECT 1))`). It now records its FROM and conditions and renders them, so `testAddBookFilterMultipleValues` asserts the real clause **and** that `study.booknumber` is gone. The teacher tests assert only that `EXISTS` appears, so they are unaffected.

Rendered against j6-dev, no DB errors:

| request | items | bytes |
|---|---|---|
| *(no filter)* | 20 | 93786 |
| `book=151` | 4 | 48761 |
| `book=151&minChapt=1` | 4 | 48808 |
| `book=151&minChapt=3` | **2** | 43360 |
| `book=146` | 15 | 75308 |

The 4 → 2 drop is exactly the two studies identified above.

```
composer test:unit          1418 tests, 3021 assertions — OK
composer test:integration    459 tests, 4032 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
