### PR TITLE
feat: score and index every scripture reference, not just the first (#1623 step 2, tier 3)

### DIFF
--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -530,43 +530,28 @@ final class Proclaim extends Adapter implements SubscriberInterface
             }
         }
 
-        // Add Scripture/Book
-        if (!empty($item->booknumber)) {
-            // From the scripture library rather than #__bsms_books, which stores
-            // the same language keys against the same numbers and was costing a
-            // query per indexed item to fetch one (#1687). getBookName()
-            // translates on the way out, so no Text::_() call is needed here.
-            $bookname = ScriptureHelper::getBookName((int) $item->booknumber);
+        // Add Scripture/Book: one Scripter taxonomy per reference (#1623).
+        try {
+            foreach (CwmscriptureHelper::getScripturesForStudy((int) $item->id) as $ref) {
+                // Not the stored reference_text, which is frozen in whatever
+                // language was active at save time.
+                $reference = ScriptureHelper::formatReference(
+                    $ref->booknumber,
+                    $ref->chapterBegin,
+                    $ref->verseBegin,
+                    $ref->chapterEnd,
+                    $ref->verseEnd
+                );
 
-            if ($bookname) {
-
-                // Construct reference string
-                $reference = $bookname . ' ' . $item->chapter_begin;
-                if ($item->verse_begin !== '0') {
-                    $reference .= ':' . $item->verse_begin;
-                }
-
-                if ($item->verse_end !== '0') {
-                    $reference .= '-' . $item->verse_end;
+                if ($reference === '') {
+                    continue;
                 }
 
                 if (\in_array('scripter', $taxonomies, true)) {
                     $item->addTaxonomy('Scripter', $reference);
                 }
 
-                // Add to body
                 $item->body .= ' ' . $reference;
-            }
-        }
-
-        // Also index all references from the junction table
-        try {
-            $scriptures = CwmscriptureHelper::getScripturesForStudy((int) $item->id);
-
-            foreach ($scriptures as $ref) {
-                if ($ref->referenceText !== '') {
-                    $item->body .= ' ' . $ref->referenceText;
-                }
             }
         } catch (\Exception $e) {
             // Junction table may not exist yet during migration
@@ -601,7 +586,6 @@ final class Proclaim extends Adapter implements SubscriberInterface
             ->select($db->quoteName('a.language'))
             ->select($db->quoteName('a.access') . ', ' . $db->quoteName('a.ordering') . ', ' . $db->quoteName('a.params'))
             ->select($db->quoteName('a.publish_up', 'publish_start_date') . ', ' . $db->quoteName('a.publish_down', 'publish_end_date'))
-            ->select($db->quoteName(['a.booknumber', 'a.chapter_begin', 'a.verse_begin', 'a.chapter_end', 'a.verse_end']))
             ->select($db->quoteName('s.series_text', 'series') . ', ' . $db->quoteName('s.published', 'series_state') . ', ' . $db->quoteName('s.access', 'series_access'));
 
         // Handle the alias CASE WHEN portion of the query

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -222,8 +222,6 @@ class Cwmrelatedstudies
     /**
      * Score studies by scripture book overlap (1 point per shared book).
      *
-     * Checks both junction table and legacy booknumber field.
-     *
      * @param   object  $db       Database driver
      * @param   int     $studyId  Current study ID
      * @param   array   $groups   Authorised view levels
@@ -234,19 +232,11 @@ class Cwmrelatedstudies
      */
     private function scoreByBooks(object $db, int $studyId, array $groups): void
     {
-        // Collect book numbers from both junction table and legacy column in one query
         $query = $db->createQuery()
             ->select('DISTINCT ' . $db->quoteName('booknumber'))
             ->from($db->quoteName('#__bsms_study_scriptures'))
             ->where($db->quoteName('study_id') . ' = ' . $studyId)
-            ->where($db->quoteName('booknumber') . ' > 0')
-            ->union(
-                $db->createQuery()
-                    ->select($db->quoteName('booknumber'))
-                    ->from($db->quoteName('#__bsms_studies'))
-                    ->where($db->quoteName('id') . ' = ' . $studyId)
-                    ->where($db->quoteName('booknumber') . ' > 0')
-            );
+            ->where($db->quoteName('booknumber') . ' > 0');
 
         $db->setQuery($query);
         $bookNumbers = array_unique(array_filter(array_map('intval', $db->loadColumn() ?: [])));
@@ -257,7 +247,6 @@ class Cwmrelatedstudies
 
         $bookList = implode(',', $bookNumbers);
 
-        // Find matches via junction table
         $query = $db->createQuery()
             ->select($db->quoteName('ss.study_id'))
             ->select('COUNT(DISTINCT ' . $db->quoteName('ss.booknumber') . ') AS ' . $db->quoteName('overlap'))
@@ -277,22 +266,6 @@ class Cwmrelatedstudies
 
         foreach ($rows as $r) {
             $this->addScore((int) $r->study_id, (int) $r->overlap);
-        }
-
-        // Also match via legacy booknumber column
-        $query = $db->createQuery()
-            ->select($db->quoteName('id'))
-            ->from($db->quoteName('#__bsms_studies'))
-            ->where($db->quoteName('booknumber') . ' IN (' . $bookList . ')')
-            ->where($db->quoteName('id') . ' != ' . $studyId)
-            ->where($db->quoteName('published') . ' = 1')
-            ->where($db->quoteName('access') . ' IN (' . implode(',', $groups) . ')');
-
-        $db->setQuery($query);
-        $ids = $db->loadColumn();
-
-        foreach ($ids as $id) {
-            $this->addScore((int) $id, 1);
         }
     }
 


### PR DESCRIPTION
> **Tier 3 of #1623 step 2.** See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611).

Both remaining consumers layered a junction read on top of a flat-column read — and in both, the flat half quietly **privileged a study's first reference**.

## Related studies

`scoreByBooks()` collected the source study's books from the junction `UNION` the flat column, then scored candidates twice:

1. one point per shared book, from the junction
2. **plus a further point** whenever the candidate's flat `booknumber` matched

That column holds the candidate's *first* reference, so bonus (2) reached only studies matching on that one. A study matching on its second or third reference scored a point less than an equally relevant result and sorted below it.

Both flat halves are gone. One point per shared book, once.

## Smart Search

The indexer built its reference string from the flat columns and added a single `Scripter` taxonomy from it, then *separately* appended junction `reference_text` values to the body. So every reference was searchable as free text, but **only the first became a taxonomy** — the facet users actually browse by.

Now one taxonomy and one body entry per reference, built with `ScriptureHelper::formatReference()` rather than the stored `reference_text`, which is frozen in whatever language was active when the study was saved. The five flat columns leave the adapter's `SELECT` with nothing reading them.

⚠️ **Existing Smart Search entries are stale until reindexed.** Studies with more than one reference gain their extra taxonomy terms only when their index entry is rebuilt (Smart Search → Index → Index).

## Verification

Measured on j6-dev across 120 studies that have references. ⚠️ **These figures are the book dimension in isolation**, not the rendered list:

| | |
|---|---|
| scores differ | 116 of 120 |
| top 5 *by book score* differs | 10 of 120 |
| candidate set differs | **0 of 120** |

No study enters or leaves consideration; only relative order moves. Mechanism confirmed on study 507, whose candidates all share book 120:

| id | junction | flat +1 | total | flat `booknumber` |
|---|---|---|---|---|
| 511 | 1 | 1 | 2 | 120 |
| **536** | 1 | **0** | **1** | 105 ← matches on a later reference |
| 596 | 1 | 1 | 2 | 120 |

536 scored one less for no reason other than *which* reference matched.

**End to end** — rendering eight sermon pages before and after. Book overlap is the lowest-weighted dimension (1 point, against 3 for series and 2 each for teacher and topic), so most lists do not move:

```
5 of 8 unchanged
3 of 8 changed — every one of them by "Committed! Are You?" (536) entering the list
```

The predicted study, and only that study, surfaces. That is the correction this PR is for.

```
composer test:unit          1421 tests, 3025 assertions — OK
composer test:integration    459 tests, 4032 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
