### PR TITLE
chore(deps): allow install scripts for three packages, and dedupe fsevents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7017,7 +7017,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/playwright-core": {
@@ -7031,21 +7031,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -75,5 +75,10 @@
     "brace-expansion": "^5.0.6",
     "ws": "^8.21.0",
     "js-yaml": "^4.3.1"
+  },
+  "allowScripts": {
+    "core-js@3.50.0": true,
+    "unrs-resolver@1.12.2": true,
+    "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
Working-tree changes that have been carried uncommitted for a while. Committing them so they stop riding along with unrelated work — every branch this session had to step around them.

**`package.json`** — `allowScripts` opts three packages into running their install scripts:

```
core-js@3.50.0
unrs-resolver@1.12.2
fsevents@2.3.3
```

**`package-lock.json`** — drops the nested `playwright/node_modules/fsevents@2.3.2` in favour of the hoisted `2.3.3`, so the tree carries one copy instead of two.

`npm ls --depth=0` is clean and both files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)