### PR TITLE
feat: derive bookname from the junction, and fix comment search (#1623 step 2, tier 4)

### DIFF
--- a/admin/src/Helper/CwmscriptureHelper.php
+++ b/admin/src/Helper/CwmscriptureHelper.php
@@ -351,4 +351,39 @@ class CwmscriptureHelper extends ScriptureHelper
         $db->setQuery($query);
         $db->execute();
     }
+
+    /**
+     * Set `bookname` and `bookname2` on rows from their scripture references.
+     *
+     * Template overrides outside this repository read these two properties, so
+     * they stay on the row. Rows that already carry `scriptures` cost nothing;
+     * the rest are batch-loaded in one query.
+     *
+     * @param   object[]  $rows      Rows to annotate, modified in place
+     * @param   string    $idColumn  Property holding the study's primary key
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function applyBookNames(array $rows, string $idColumn = 'id'): void
+    {
+        $missing = [];
+
+        foreach ($rows as $row) {
+            if (!isset($row->scriptures) && !empty($row->{$idColumn})) {
+                $missing[] = (int) $row->{$idColumn};
+            }
+        }
+
+        $loaded = $missing === [] ? [] : self::getScripturesForStudies(array_unique($missing));
+
+        foreach ($rows as $row) {
+            $refs = $row->scriptures ?? ($loaded[(int) ($row->{$idColumn} ?? 0)] ?? []);
+            $refs = \is_array($refs) ? array_values($refs) : [];
+
+            $row->bookname  = ScriptureHelper::getBookName((int) ($refs[0]->booknumber ?? 0));
+            $row->bookname2 = ScriptureHelper::getBookName((int) ($refs[1]->booknumber ?? 0));
+        }
+    }
 }

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -17,7 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\DatabaseInterface;
@@ -209,7 +209,19 @@ class CwmcommentsModel extends ListModel
                 $query->where($db->quoteName('comment.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                $query->where('(' . $db->quoteName('study.studytitle') . ' LIKE ' . $search . ' OR ' . $db->quoteName('book.bookname') . ' LIKE ' . $search . ')');
+                // ⚠️ Searched `book.bookname` until #1687 dropped the
+                // #__bsms_books join that supplied the alias, which left every
+                // search on this list throwing "Unknown column".
+                $reference = $db->createQuery()
+                    ->select('1')
+                    ->from($db->quoteName('#__bsms_study_scriptures', 'csr'))
+                    ->where($db->quoteName('csr.study_id') . ' = ' . $db->quoteName('comment.study_id'))
+                    ->where($db->quoteName('csr.reference_text') . ' LIKE ' . $search);
+
+                $query->where(
+                    '(' . $db->quoteName('study.studytitle') . ' LIKE ' . $search
+                    . ' OR EXISTS (' . $reference . '))'
+                );
             }
         }
 
@@ -217,7 +229,7 @@ class CwmcommentsModel extends ListModel
         $query->select($db->quoteName('study.studytitle', 'studytitle'));
         $query->select($db->quoteName('study.chapter_begin'));
         $query->select($db->quoteName('study.studydate'));
-        $query->select($db->quoteName('study.booknumber'));
+        $query->select($db->quoteName('comment.study_id'));
         $query->join(
             'LEFT',
             $db->quoteName('#__bsms_studies', 'study') . ' ON ' . $db->quoteName('study.id') . ' = ' . $db->quoteName('comment.study_id')
@@ -302,9 +314,7 @@ class CwmcommentsModel extends ListModel
             return $items;
         }
 
-        foreach ($items as $item) {
-            $item->bookname = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
-        }
+        CwmscriptureHelper::applyBookNames($items, 'study_id');
 
         return $items;
     }

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -15,7 +15,6 @@ namespace CWM\Component\Proclaim\Site\Helper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -563,20 +562,13 @@ class Cwmpagebuilder
         $db->setQuery($query, 0, $limit);
         $items = $db->loadObjectList();
 
-        // Junction is the real model; the flat columns hold at most two
-        // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
-        // is populated and falls back to the flat columns otherwise (#1623).
         $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($items ?: [], 'id'));
 
         foreach ($items ?: [] as $item) {
             $item->scriptures = $scriptureMap[(int) $item->id] ?? [];
-
-            // Was a #__bsms_books JOIN for a language key the scripture library
-            // already holds (#1687). Still set on the row: these items reach
-            // templates a site can override, and one may read $item->bookname.
-            $item->bookname  = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
-            $item->bookname2 = ScriptureHelper::getBookName((int) ($item->booknumber2 ?? 0));
         }
+
+        CwmscriptureHelper::applyBookNames($items ?: []);
 
         // Batch-load all teachers for teachers-list element
         if (!empty($items)) {

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -22,8 +22,8 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmmime;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmpodcastTrackHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmschemaorgHelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeQuota;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Factory;
@@ -1125,13 +1125,9 @@ class Cwmpodcast
             $e->params   = new Registry($e->params);
             $e->srparams = new Registry($e->srparams);
 
-            // Was a #__bsms_books JOIN, which fetched the same language keys the
-            // scripture library already holds against the same numbers (#1687).
-            // Still set on the row rather than resolved at the point of use: an
-            // episode reaches template overrides outside this repository, and
-            // one of those may read $episode->bookname.
-            $e->bookname = ScriptureHelper::getBookName((int) ($e->booknumber ?? 0));
         }
+
+        CwmscriptureHelper::applyBookNames($episodes, 'study_id');
 
         return $episodes;
     }

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -16,8 +16,8 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
@@ -264,11 +264,9 @@ class Cwmserieslist extends Cwmlisting
             // Concat topic_text and concat topic_params do not fit, so translate individually
             $item->topics_text = Cwmtranslated::getConcatTopicItemTranslated($item);
 
-            // Was a #__bsms_books JOIN for a language key the scripture library
-            // already holds (#1687). Still set on the row: these items reach
-            // templates a site can override, and one may read $item->bookname.
-            $item->bookname = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
         }
+
+        CwmscriptureHelper::applyBookNames($items);
 
         return $items;
     }

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -18,7 +18,6 @@ namespace CWM\Component\Proclaim\Site\Model;
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -304,19 +303,13 @@ class CwmseriesdisplayModel extends ItemModel
             }
         }
 
-        // Junction is the real model; the flat columns hold at most two
-        // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
-        // is populated and falls back to the flat columns otherwise (#1623).
         $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($studies, 'id'));
 
-        // Was a #__bsms_books JOIN for a language key the scripture library
-        // already holds (#1687). Still set on the row: these studies reach
-        // templates a site can override, and one may read $study->bookname.
         foreach ($studies as $study) {
             $study->scriptures = $scriptureMap[(int) $study->id] ?? [];
-            $study->bookname   = ScriptureHelper::getBookName((int) ($study->booknumber ?? 0));
-            $study->bookname2  = ScriptureHelper::getBookName((int) ($study->booknumber2 ?? 0));
         }
+
+        CwmscriptureHelper::applyBookNames($studies);
 
         return $studies ?: [];
     }

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -18,7 +18,6 @@ namespace CWM\Component\Proclaim\Site\Model;
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -333,13 +332,9 @@ class CwmseriespodcastdisplayModel extends ItemModel
             $study->totalplays     = (int) ($stats->totalplays ?? 0);
             $study->totaldownloads = (int) ($stats->totaldownloads ?? 0);
             $study->study_id       = (int) $study->id;
-
-            // Was a #__bsms_books JOIN for a language key the scripture library
-            // already holds (#1687). Still set on the row: these studies reach
-            // templates a site can override, and one may read $study->bookname.
-            $study->bookname  = ScriptureHelper::getBookName((int) ($study->booknumber ?? 0));
-            $study->bookname2 = ScriptureHelper::getBookName((int) ($study->booknumber2 ?? 0));
         }
+
+        CwmscriptureHelper::applyBookNames($studies);
 
         return $studies;
     }

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -19,7 +19,6 @@ namespace CWM\Component\Proclaim\Site\Model;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
@@ -216,11 +215,7 @@ class CwmsermonModel extends FormModel
                     return null;
                 }
 
-                // Was a #__bsms_books JOIN for a language key the scripture library
-                // already holds (#1687). Still set on the row: this item reaches
-                // templates a site can override, and one may read $data->bookname.
-                $data->bookname  = ScriptureHelper::getBookName((int) ($data->booknumber ?? 0));
-                $data->bookname2 = ScriptureHelper::getBookName((int) ($data->booknumber2 ?? 0));
+                CwmscriptureHelper::applyBookNames([$data]);
 
                 // Load media stats in a separate query to avoid Cartesian product with topics
                 $mediaQuery = $db->createQuery()

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -16,7 +16,6 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
-use CWM\Library\Scripture\Helper\ScriptureHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -751,14 +750,6 @@ class CwmsermonsModel extends ListModel
             return [];
         }
 
-        foreach ($items as $item) {
-            // Was a #__bsms_books JOIN for a language key the scripture library
-            // already holds (#1687). Still set on the row: these items reach
-            // templates a site can override, and one may read $item->bookname.
-            $item->bookname  = ScriptureHelper::getBookName((int) ($item->booknumber ?? 0));
-            $item->bookname2 = ScriptureHelper::getBookName((int) ($item->booknumber2 ?? 0));
-        }
-
         // Collect study IDs for batch loading
         $studyIds = [];
 
@@ -797,6 +788,8 @@ class CwmsermonsModel extends ListModel
             // Teachers
             $item->teachers = $teacherMap[$sid] ?? [];
         }
+
+        CwmscriptureHelper::applyBookNames($items);
 
         return $items;
     }


### PR DESCRIPTION
> **Tier 4 of #1623 step 2.** See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1623#issuecomment-5257522611).

Tier 4 was scoped as *"ride-along SELECTs — several may just be droppable."* **None were droppable.**

Every one feeds `$row->bookname` / `$row->bookname2`, which **eight** call sites set with a comment saying template overrides outside this repository read them. That is a contract, and dropping the columns in step 3 would break it.

So rather than deleting the reads, this **decouples the contract from the columns**. `CwmscriptureHelper::applyBookNames()` sets both properties from a study's junction references — one place instead of eight. Rows that already carry `scriptures` cost nothing; the rest batch-load in a single query.

Converted: `CwmsermonsModel`, `CwmsermonModel`, `CwmseriesdisplayModel`, `CwmseriespodcastdisplayModel`, `Cwmpagebuilder`, `Cwmserieslist`, `Cwmpodcast`, `CwmcommentsModel`.

Two left alone on purpose:

- **`Cwmlanding::nameBooks()`** works on *facet* rows, where `booknumber` is the book itself, not a study's flat column.
- **`Cwmlisting`'s SELECT** still feeds `getAllScriptures()`'s fallback for rows with no junction entry. That fallback and those columns go together in step 3.

## ⚠️ Also fixes a shipped bug

The admin Comments list search read `book.bookname`:

```php
(study.studytitle LIKE ... OR book.bookname LIKE ...)
```

**#1687 removed the `#__bsms_books` join that supplied the `book` alias and left this clause behind.** Every search on that list threw `Unknown column 'book.bookname' in 'where clause'`. Confirmed against j6-dev.

It now matches the junction's `reference_text` through `EXISTS`, which restores the capability and widens it — the old clause could only ever match a study's *first* reference:

```
search "Philippians"  -> 2 comments
search "zzznope"      -> 0 comments
```

## ⚠️ The verification harness was broken first

Hashing each page and diffing reported changes on **every** view even with no code change at all. Two causes, both unrelated to Proclaim: Joomla re-stamps its asset cache-busters (`?c73d02`) per request, and WebAuthn emits a random element id.

Normalising those two, the same code produces byte-identical output across two runs — **and only then is a comparison worth reading**. Earlier in this stack I reported hash equality from this harness; that result happened to be right, but the method was not sound, and this is the corrected one.

With the fixed harness, `bookname` from the flat columns versus from the junction:

| view | |
|---|---|
| `cwmsermons` | ✅ |
| `cwmsermon&id=300` | ✅ |
| `cwmseriesdisplay&id=35` | ✅ |
| `cwmseriesdisplays` | ✅ |
| `cwmlandingpage` | ✅ |
| `cwmseriespodcastdisplay&id=35` | ✅ |

**0 diff lines across all six.**

```
composer test:unit          1421 tests, 3025 assertions — OK
composer test:integration    459 tests, 4032 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
