### PR TITLE
feat: prefer the junction in the last flat-column readers (#1623 step 2, tier 4b)

### DIFF
--- a/admin/src/Helper/CwmscriptureHelper.php
+++ b/admin/src/Helper/CwmscriptureHelper.php
@@ -353,11 +353,18 @@ class CwmscriptureHelper extends ScriptureHelper
     }
 
     /**
-     * Set `bookname` and `bookname2` on rows from their scripture references.
+     * Project a study's first two scripture references onto the row properties
+     * that templates read: `bookname`, `booknumber`, `chapter_begin`,
+     * `verse_begin`, `chapter_end`, `verse_end`, `bible_version`, and the `2`
+     * suffixed set for the second reference.
      *
-     * Template overrides outside this repository read these two properties, so
-     * they stay on the row. Rows that already carry `scriptures` cost nothing;
-     * the rest are batch-loaded in one query.
+     * These properties are read by template overrides outside this repository
+     * and by helpers such as Cwmshowscripture::formReference(), so they stay on
+     * the row even though the junction is the source. Rows that already carry
+     * `scriptures` cost nothing; the rest are batch-loaded in one query.
+     *
+     * ⚠️ A position with no reference is left untouched rather than zeroed, so
+     * a row that predates the junction keeps whatever its columns held.
      *
      * @param   object[]  $rows      Rows to annotate, modified in place
      * @param   string    $idColumn  Property holding the study's primary key
@@ -382,8 +389,28 @@ class CwmscriptureHelper extends ScriptureHelper
             $refs = $row->scriptures ?? ($loaded[(int) ($row->{$idColumn} ?? 0)] ?? []);
             $refs = \is_array($refs) ? array_values($refs) : [];
 
-            $row->bookname  = ScriptureHelper::getBookName((int) ($refs[0]->booknumber ?? 0));
-            $row->bookname2 = ScriptureHelper::getBookName((int) ($refs[1]->booknumber ?? 0));
+            foreach ([0 => '', 1 => '2'] as $index => $suffix) {
+                $ref = $refs[$index] ?? null;
+
+                if (!$ref instanceof ScriptureReference || $ref->booknumber <= 0) {
+                    // No junction reference here, so the legacy columns are all
+                    // this row has. bookname is still set, because callers gate
+                    // on it and an undefined property is a warning.
+                    $row->{'bookname' . $suffix} = ScriptureHelper::getBookName(
+                        (int) ($row->{'booknumber' . $suffix} ?? 0)
+                    );
+
+                    continue;
+                }
+
+                $row->{'bookname' . $suffix}      = ScriptureHelper::getBookName($ref->booknumber);
+                $row->{'booknumber' . $suffix}    = $ref->booknumber;
+                $row->{'chapter_begin' . $suffix} = $ref->chapterBegin;
+                $row->{'verse_begin' . $suffix}   = $ref->verseBegin;
+                $row->{'chapter_end' . $suffix}   = $ref->chapterEnd;
+                $row->{'verse_end' . $suffix}     = $ref->verseEnd;
+                $row->{'bible_version' . $suffix} = $ref->bibleVersion;
+            }
         }
     }
 }

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -1232,7 +1232,7 @@ class Cwmlisting
                 if ($header === 1) {
                     $data = Text::_('JBS_CMN_SCRIPTURE');
                 } else {
-                    (isset($item->booknumber) ? $data = $this->getScripture(
+                    (self::hasScripture($item, 1) ? $data = $this->getScripture(
                         $params,
                         $item,
                         $esv,
@@ -1248,7 +1248,7 @@ class Cwmlisting
                 if ($header === 1) {
                     $data = Text::_('JBS_CMN_SCRIPTURE');
                 } else {
-                    (isset($item->booknumber2) ? $data = $this->getScripture(
+                    (self::hasScripture($item, 2) ? $data = $this->getScripture(
                         $params,
                         $item,
                         $esv,
@@ -1931,6 +1931,38 @@ class Cwmlisting
             return '';
         }
 
+        $ref = self::referenceFor($row, $scripturerow);
+
+        if ($ref !== null) {
+            $bookNum      = $ref->booknumber;
+            $ch_b         = $ref->chapterBegin;
+            $ch_e         = $ref->chapterEnd;
+            $v_b          = $ref->verseBegin;
+            $v_e          = $ref->verseEnd;
+            $book         = CwmscriptureHelper::getBookName($bookNum);
+            $bibleVersion = $ref->bibleVersion;
+
+            if ($book === '' || $bookNum <= 0) {
+                return '';
+            }
+
+            return $this->renderScripture(
+                $params,
+                $elementConfig,
+                $book,
+                $bookNum,
+                $ch_b,
+                $ch_e,
+                $v_b,
+                $v_e,
+                $bibleVersion
+            );
+        }
+
+        if (self::hasJunctionReferences($row)) {
+            return '';
+        }
+
         $booknumber  = (int) ($row->booknumber ?? 0);
         $booknumber2 = (int) ($row->booknumber2 ?? 0);
 
@@ -1963,6 +1995,104 @@ class Cwmlisting
             return '';
         }
 
+        return $this->renderScripture(
+            $params,
+            $elementConfig,
+            $book,
+            $bookNum,
+            $ch_b,
+            $ch_e,
+            $v_b,
+            $v_e,
+            $bibleVersion
+        );
+    }
+
+    /**
+     * The reference a row carries at the given position, from the junction.
+     *
+     * @param   object  $row           Row that may carry `scriptures`
+     * @param   int     $scripturerow  1-based position
+     *
+     * @return  ScriptureReference|null  Null when the row predates the junction
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function referenceFor(object $row, int $scripturerow): ?ScriptureReference
+    {
+        if (empty($row->scriptures) || !\is_array($row->scriptures)) {
+            return null;
+        }
+
+        $ref = array_values($row->scriptures)[$scripturerow - 1] ?? null;
+
+        return $ref instanceof ScriptureReference && $ref->booknumber > 0 ? $ref : null;
+    }
+
+    /**
+     * Whether a row has a reference at the given position.
+     *
+     * Callers used to gate on `booknumber` and `booknumber2`, which cannot see
+     * past a study's second reference (#1623).
+     *
+     * @param   object  $row           Row to test
+     * @param   int     $scripturerow  1-based position
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function hasScripture(object $row, int $scripturerow): bool
+    {
+        if (self::hasJunctionReferences($row)) {
+            return self::referenceFor($row, $scripturerow) !== null;
+        }
+
+        $column = $scripturerow === 2 ? 'booknumber2' : 'booknumber';
+
+        return (int) ($row->{$column} ?? 0) > 0;
+    }
+
+    /**
+     * @param   object  $row  Row to test
+     *
+     * @return  bool  Whether the row carries any junction reference
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function hasJunctionReferences(object $row): bool
+    {
+        return !empty($row->scriptures) && \is_array($row->scriptures);
+    }
+
+    /**
+     * Render one reference. Shared by the junction and legacy paths.
+     *
+     * @param   Registry  $params         Item params
+     * @param   ?object   $elementConfig  Element configuration
+     * @param   string    $book           Translated book name
+     * @param   int       $bookNum        Proclaim book number
+     * @param   int       $ch_b           Chapter begin
+     * @param   int       $ch_e           Chapter end
+     * @param   int       $v_b            Verse begin
+     * @param   int       $v_e            Verse end
+     * @param   string    $bibleVersion   Bible version code
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function renderScripture(
+        Registry $params,
+        ?object $elementConfig,
+        string $book,
+        int $bookNum,
+        int $ch_b,
+        int $ch_e,
+        int $v_b,
+        int $v_e,
+        string $bibleVersion
+    ): string {
         // Check for element-specific show_verses (empty string means use global)
         // Default to 0 (chapters only) if not found in params
         $show_verses = (int) $params->get('show_verses', 0);

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -1545,7 +1545,7 @@ class Cwmmedia
         // Get scripture reference
         $listing   = new Cwmlisting();
         $scripture = '';
-        if (isset($media->booknumber) && $media->booknumber > 0) {
+        if (Cwmlisting::hasScripture($media, 1)) {
             $savedId   = $media->id ?? null;
             $media->id = $media->study_id ?? $media->id;
             $scripture = $listing->getScripture($params, $media, 0, 1);

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -93,7 +93,7 @@ class Cwmpagebuilder
         $esv          = 0;
         $scripturerow = 1;
 
-        if ($item->chapter_begin) {
+        if (Cwmlisting::hasScripture($item, 1)) {
             $page->scripture1 = $CWMElements->getScripture($params, $item, $esv, $scripturerow);
         } else {
             $page->scripture1 = '';
@@ -106,7 +106,7 @@ class Cwmpagebuilder
         // Scripture 2
         $scripturerow = 2;
 
-        if ($item->booknumber2 >= 1) {
+        if (Cwmlisting::hasScripture($item, 2)) {
             $page->scripture2 = $CWMElements->getScripture($params, $item, $esv, $scripturerow);
         } else {
             $page->scripture2 = '';

--- a/tests/integration/Site/Helper/CwmlistingScriptureSourceTest.php
+++ b/tests/integration/Site/Helper/CwmlistingScriptureSourceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * The scripture1 and scripture2 elements read the junction, not the flat pair.
+ *
+ * Once the flat columns stop being written they hold stale values rather than
+ * empty ones -- the previous reference for an edited study, and `DEFAULT 101`
+ * (Genesis) for a new one. A reader still consulting them would render
+ * confidently wrong references, which is why every one of them has to prefer
+ * the junction before the writes are removed (#1623).
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\Cwmlisting;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use CWM\Library\Scripture\Helper\ScriptureReference;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmlisting::class)]
+class CwmlistingScriptureSourceTest extends IntegrationTestCase
+{
+    /**
+     * A row whose flat columns and junction references disagree.
+     *
+     * The flat pair says Genesis 1 and Exodus 2 -- what a stale row looks like.
+     * The junction says Romans 8 and Titus 3.
+     *
+     * @param   bool  $withJunction  Whether to attach junction references
+     *
+     * @return  object
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function row(bool $withJunction): object
+    {
+        $row = (object) [
+            'id'             => 4242,
+            'booknumber'     => 101,
+            'chapter_begin'  => 1,
+            'verse_begin'    => 1,
+            'chapter_end'    => 1,
+            'verse_end'      => 2,
+            'bookname'       => 'JBS_BBK_GENESIS',
+            'bible_version'  => 'kjv',
+            'booknumber2'    => 102,
+            'chapter_begin2' => 2,
+            'verse_begin2'   => 1,
+            'chapter_end2'   => 2,
+            'verse_end2'     => 2,
+            'bookname2'      => 'JBS_BBK_EXODUS',
+            'bible_version2' => 'kjv',
+        ];
+
+        if ($withJunction) {
+            $row->scriptures = [
+                new ScriptureReference(booknumber: 145, chapterBegin: 8, verseBegin: 1, chapterEnd: 8, verseEnd: 4),
+                new ScriptureReference(booknumber: 156, chapterBegin: 3, verseBegin: 1, chapterEnd: 3, verseEnd: 5),
+            ];
+        }
+
+        return $row;
+    }
+
+    /**
+     * ⚠️ Assertions here ignore case because the book name renders as its
+     * language key ("JBS_BBK_TITUS") when this test runs alone and as the
+     * translation ("Titus") when an earlier test in the suite has loaded the
+     * language. Both contain the book, so matching case-insensitively is true
+     * either way; asserting on one spelling passes or fails by suite order.
+     *
+     * @return  Registry  Params asking for chapters only, the default.
+     * @since __DEPLOY_VERSION__
+     */
+    private function params(): Registry
+    {
+        return new Registry(['show_verses' => 0]);
+    }
+
+    #[TestDox('scripture1 renders the junction reference, not the flat column')]
+    public function testFirstReferenceComesFromTheJunction(): void
+    {
+        $rendered = (new Cwmlisting())->getScripture($this->params(), $this->row(true), 0, 1);
+
+        $this->assertStringContainsStringIgnoringCase(
+            'ROMANS',
+            $rendered,
+            'scripture1 rendered the flat column. After the writes are removed that column is stale, '
+            . 'so this would show the study\'s previous reference or Genesis.'
+        );
+        $this->assertStringNotContainsStringIgnoringCase('GENESIS', $rendered);
+    }
+
+    #[TestDox('scripture2 renders the junction reference, not the flat column')]
+    public function testSecondReferenceComesFromTheJunction(): void
+    {
+        $rendered = (new Cwmlisting())->getScripture($this->params(), $this->row(true), 0, 2);
+
+        $this->assertStringContainsStringIgnoringCase('TITUS', $rendered);
+        $this->assertStringNotContainsStringIgnoringCase('EXODUS', $rendered);
+    }
+
+    #[TestDox('a row with no junction references still renders its legacy columns')]
+    public function testLegacyRowsStillRender(): void
+    {
+        $rendered = (new Cwmlisting())->getScripture($this->params(), $this->row(false), 0, 1);
+
+        $this->assertStringContainsStringIgnoringCase(
+            'GENESIS',
+            $rendered,
+            'The fallback is what keeps studies readable until the migration has run on their site.'
+        );
+    }
+
+    #[TestDox('hasScripture reports positions from the junction and from the legacy columns')]
+    public function testHasScriptureCoversBothSources(): void
+    {
+        $this->assertTrue(Cwmlisting::hasScripture($this->row(true), 1));
+        $this->assertTrue(Cwmlisting::hasScripture($this->row(true), 2));
+        $this->assertTrue(Cwmlisting::hasScripture($this->row(false), 1));
+
+        $bare = (object) ['id' => 1];
+
+        $this->assertFalse(Cwmlisting::hasScripture($bare, 1), 'A row with neither source has no reference.');
+        $this->assertFalse(Cwmlisting::hasScripture($bare, 2));
+    }
+
+    #[TestDox('a junction row with one reference has no second position')]
+    public function testASingleJunctionReferenceHasNoSecond(): void
+    {
+        $row             = $this->row(false);
+        $row->scriptures = [new ScriptureReference(booknumber: 145, chapterBegin: 8)];
+
+        $this->assertTrue(Cwmlisting::hasScripture($row, 1));
+        $this->assertFalse(
+            Cwmlisting::hasScripture($row, 2),
+            'The junction says one reference; booknumber2 is a stale leftover and must not resurrect a second.'
+        );
+    }
+}


### PR DESCRIPTION
> **Tier 4b of #1623 step 2** — the readers tier 4 missed. This is the last thing between here and commit 5.

Tier 4 converted `bookname`. It did **not** convert the properties beside it, so these still read the flat columns directly:

| site | reads |
|---|---|
| `Cwmpodcast:399` | `$episode->chapter_begin` |
| `admin/tmpl/cwmcomments/default.php` | `$item->chapter_begin` |
| `Cwmmedia:1548` | `$media->booknumber` |
| `Cwmpagebuilder:96,109` | `$item->chapter_begin`, `$item->booknumber2` |
| `Cwmshowscripture::formReference` | chapter/verse begin and end |
| `Cwmlisting:1235,1251` | the `scripture1`/`scripture2` gates |

**Why this blocks commit 5:** removing the writes does not *empty* those columns, it **freezes** them — the previous reference for an edited study, `DEFAULT 101` (Genesis) for a new one. A reader still consulting them renders a confidently wrong reference rather than nothing, which is the worst kind of failure because nothing looks broken.

## Two changes cover all of it

- **`Cwmlisting::getScripture()`** takes its data from `$row->scriptures[n]` when present. The rendering tail moved to `renderScripture()`, shared by both paths.
- **`applyBookNames()`** now projects a reference's *whole shape* onto the row — `booknumber`, chapter and verse bounds, `bible_version`, for both positions — not just the name. Every consumer of those properties, including `formReference()` and template overrides, is fed from the junction **with no change at its call site**.

Gates go through `Cwmlisting::hasScripture($row, $n)`.

## ⚠️ A test caught a bug in this PR's own first draft

`hasScripture()` initially fell back to `booknumber2` whenever the junction had no second reference. `testASingleJunctionReferenceHasNoSecond` caught it: **a study edited down from two references to one would have kept rendering the second from the stale column.**

The rule is now what `getAllScriptures()` has always used — a row carrying *any* junction reference never consults the legacy columns, for any position. Not per-position fallback.

## Verification

`CwmlistingScriptureSourceTest` builds rows whose two sources deliberately disagree — flat says Genesis and Exodus, junction says Romans and Titus — and pins that the junction wins, that rows without junction data still render, and the one-reference case above.

⚠️ **Its assertions ignore case deliberately.** The book renders as its language key (`JBS_BBK_TITUS`) when the test runs alone, and as the translation (`Titus`) when an earlier test in the suite has loaded the language. Asserting on either spelling passes or fails by suite order. Verified both ways:

```
isolated     5 tests, 12 assertions — OK
full suite   464 tests, 4044 assertions — OK
```

Render comparison across six views, before and after: **0 diff lines**.

```
composer test:unit          1421 tests, 3025 assertions — OK
composer test:integration    464 tests, 4044 assertions — OK
php-cs-fixer                 clean
```

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
