### PR TITLE
feat: stop writing the legacy scripture columns (#1623 step 2, commit 5)

### DIFF
--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -243,7 +243,7 @@ class CwmcsvimportHelper
             $scriptures = self::parseScriptures($rowData['scripture']);
 
             if (!empty($scriptures)) {
-                CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
+                CwmscriptureHelper::saveScriptures($studyId, $scriptures);
             }
         }
 
@@ -339,7 +339,7 @@ class CwmcsvimportHelper
             $scriptures = self::parseScriptures($rowData['scripture']);
 
             if (!empty($scriptures)) {
-                CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
+                CwmscriptureHelper::saveScriptures($studyId, $scriptures);
             }
         }
 

--- a/admin/src/Helper/CwmscriptureHelper.php
+++ b/admin/src/Helper/CwmscriptureHelper.php
@@ -190,43 +190,19 @@ class CwmscriptureHelper extends ScriptureHelper
     }
 
     /**
-     * Save references and refresh the legacy flat columns as one unit.
-     *
-     * #__bsms_studies carries a flattened copy of the first two references.
-     * Writing the junction table and that copy separately lets them diverge if
-     * the second write never happens, and the divergence is permanent -- the
-     * flat columns keep describing the previous reference set until some later
-     * save happens to succeed. Callers that maintain both should use this.
+     * Save references. The legacy flat columns are no longer written.
      *
      * @param   int                   $studyId     Study primary key
      * @param   ScriptureReference[]  $scriptures  References to save
      *
      * @return  void
      *
-     * @since   10.5.6
+     * @since       10.5.6
+     * @deprecated  __DEPLOY_VERSION__  Use saveScriptures(); the sync half is gone.
      */
     public static function saveScripturesAndSync(int $studyId, array $scriptures): void
     {
-        $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-        $db->transactionStart(true);
-
-        try {
-            self::resetScriptureCache($studyId);
-            self::writeScriptures($db, $studyId, $scriptures);
-            self::syncLegacyColumns($studyId, $scriptures);
-            $db->transactionCommit(true);
-        } catch (\Throwable $e) {
-            try {
-                $db->transactionRollback(true);
-            } catch (\Throwable) {
-                // Nothing to roll back.
-            }
-
-            self::resetScriptureCache($studyId);
-
-            throw $e;
-        }
+        self::saveScriptures($studyId, $scriptures);
     }
 
     /**
@@ -277,12 +253,17 @@ class CwmscriptureHelper extends ScriptureHelper
     /**
      * Sync the first two scripture references back to the legacy flat columns on #__bsms_studies.
      *
+     * ⚠️ Nothing in Proclaim calls this. It still works, and is kept for one
+     * cycle in case an extension outside this repository does; it goes when the
+     * columns are dropped.
+     *
      * @param   int                    $studyId     Study primary key
      * @param   ScriptureReference[]   $scriptures  All references for the study
      *
      * @return  void
      *
-     * @since  10.1.0
+     * @since       10.1.0
+     * @deprecated  __DEPLOY_VERSION__  The columns it writes are being retired (#1623).
      */
     public static function syncLegacyColumns(int $studyId, array $scriptures): void
     {

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -582,7 +582,7 @@ class CwmmessageModel extends AdminModel
             $ordering++;
         }
 
-        CwmscriptureHelper::saveScripturesAndSync($studyId, $scriptures);
+        CwmscriptureHelper::saveScriptures($studyId, $scriptures);
     }
 
     /**

--- a/tests/integration/Admin/Helper/CwmscriptureSaveTest.php
+++ b/tests/integration/Admin/Helper/CwmscriptureSaveTest.php
@@ -25,11 +25,8 @@ use PHPUnit\Framework\Attributes\TestDox;
  * one row at a time with nothing wrapping the two. An insert failing partway
  * through left the old references gone and only some of the new ones written.
  *
- * Callers paired it with syncLegacyColumns(), which copies the first two
- * references into flat columns on #__bsms_studies. That second call never ran
- * when the first threw, so the flat columns kept describing the previous
- * reference set -- a divergence nothing reconciles until a later save happens
- * to succeed.
+ * The flat columns those callers also maintained are no longer written (#1623);
+ * what remains to protect is the delete-then-insert pair itself.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -220,27 +217,33 @@ class CwmscriptureSaveTest extends IntegrationTestCase
     // The junction table and the flat columns must not diverge
     // -------------------------------------------------------------------------
 
-    #[TestDox('Saving with sync updates both the references and the flat columns')]
-    public function testSaveAndSyncWritesBoth(): void
+    #[TestDox('Saving writes the references and leaves the legacy columns alone')]
+    public function testSaveWritesTheJunctionOnly(): void
     {
-        CwmscriptureHelper::saveScripturesAndSync($this->studyId, [$this->ref(42)]);
+        $before = $this->legacyBookNumber();
+
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(42)]);
 
         $this->assertSame(1, $this->countReferences());
-        $this->assertSame(42, $this->legacyBookNumber(), 'The flat columns must reflect the saved reference');
+        $this->assertSame(
+            $before,
+            $this->legacyBookNumber(),
+            'The flat columns are no longer written (#1623). Every reader prefers the junction, so a stale '
+            . 'value here is invisible -- but writing one would put the retirement back where it started.'
+        );
     }
 
     /**
      * The divergence this issue is really about: references written, flat
      * columns left describing the previous set.
      */
-    #[TestDox('A failed save leaves references and flat columns consistent')]
-    public function testFailedSaveAndSyncLeavesNoDivergence(): void
+    #[TestDox('A failed save restores the references it replaced')]
+    public function testFailedSaveLeavesTheJunctionIntact(): void
     {
-        CwmscriptureHelper::saveScripturesAndSync($this->studyId, [$this->ref(11)]);
-        $this->assertSame(11, $this->legacyBookNumber(), 'Precondition');
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(11)]);
 
         try {
-            CwmscriptureHelper::saveScripturesAndSync(
+            CwmscriptureHelper::saveScriptures(
                 $this->studyId,
                 [$this->ref(20), $this->ref(21, 'not-a-number')]
             );
@@ -248,12 +251,6 @@ class CwmscriptureSaveTest extends IntegrationTestCase
         } catch (\Throwable) {
             // Expected.
         }
-
-        $this->assertSame(
-            11,
-            $this->legacyBookNumber(),
-            'Flat columns must not describe a reference set that was never written — see #1573'
-        );
 
         // Assert the surviving reference, not just how many there are: a bare
         // count of 1 is satisfied both by the restored reference and by a
@@ -269,7 +266,8 @@ class CwmscriptureSaveTest extends IntegrationTestCase
         $this->assertSame(
             [11],
             $books,
-            'The junction table must still hold the reference the flat columns describe — see #1573'
+            'saveScriptures() deletes then inserts. Without a transaction around the pair, a failing '
+            . 'insert leaves the old references gone and only some of the new ones written — see #1573.'
         );
     }
 }


### PR DESCRIPTION
> **Commit 5 of #1623 step 2** — the last one. Step 3 drops the columns.

Nothing in Proclaim writes `#__bsms_studies.booknumber` and its siblings any more. Every reader prefers the junction, so the columns are now **inert**: still present, still holding whatever was last written, read only as the fallback for rows the migration has not reached.

- `saveScripturesAndSync()` no longer syncs — it delegates to `saveScriptures()`
- `CwmmessageModel` and `CwmcsvimportHelper` (2 sites) call `saveScriptures()`

## ⚠️ Kept, not deleted

Both `saveScripturesAndSync()` and `syncLegacyColumns()` are marked `@deprecated` rather than removed. They are **public static methods on a helper an extension outside this repository could be calling**, and `syncLegacyColumns()` still works if called. They go when the columns do, in step 3.

The two legacy importers, `CwmpIconvert` and `Cwmssconvert`, still write the flat columns **on purpose**: that write is the input to `CwmscriptureMigration::migrateStudy()`, which is what puts their studies into the junction at all (#1732).

`CwmmessageTable` was checked and needs nothing — it declares the columns as typed properties and casts them on bind; no logic depends on Proclaim writing them.

## Verification

The failure mode here is silent. **An unwritten column is not empty, it is stale** — the previous reference for an edited study, `DEFAULT 101` for a new one — so a reader still consulting one renders a confidently wrong reference and nothing looks broken.

Tested by making the two sources deliberately disagree on a real study and rendering it. Junction set to Romans 8; flat columns left saying book 123, Isaiah:

| | |
|---|---|
| Romans *(junction)* | **present** |
| Isaiah *(stale flat column)* | absent |

The page follows the junction. Study 300 was restored afterwards and re-checked.

`CwmscriptureSaveTest` was **rewritten rather than deleted**. Its two sync tests described behaviour that no longer exists, but the invariant underneath them — #1573, a failed save must not leave the junction half-written — still holds and is now asserted without the flat-column claims. One of them inverts: saving must leave the legacy columns **untouched**.

Render comparison across six views: **0 diff lines**, as expected while the junction and the columns still agree on existing data.

```
composer test:unit          1421 tests, 3025 assertions — OK
composer test:integration    464 tests, 4042 assertions — OK
php-cs-fixer                 clean
```

## What step 3 still has to handle

- drop the columns, and with them `syncLegacyColumns()`, `saveScripturesAndSync()`, and `Cwmlisting`'s fallback
- ⚠️ **migrate saved sort params**: `booknumber` appears as a sort/order value in `admin/forms/template.xml`, `modules/site/mod_proclaim/mod_proclaim.xml` and three `site/tmpl/*/default.xml`. Those live in users' template and module configs, so a site with "order by booknumber" saved breaks on the column drop unless the migration rewrites them.

Refs #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
