### PR TITLE
fix: seed the study_teachers junction so no install starts out unmigrated (#1731 commit 0)

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -579,6 +579,17 @@ CREATE TABLE IF NOT EXISTS `#__bsms_study_teachers` (
     KEY `idx_study_ordering` (`study_id`, `ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Dump of table #__bsms_study_teachers
+-- ------------------------------------------------------------
+--
+-- The seeded study's teacher. It lived only in #__bsms_studies.teacher_id, and
+-- populateStudyTeachers() runs on update, so a fresh install started life with
+-- this study unmigrated and leaning on the flat-column fallback (#1731).
+
+INSERT IGNORE INTO `#__bsms_study_teachers` (`id`, `study_id`, `teacher_id`, `ordering`)
+VALUES (1, 1, 1, 0);
+
 -- --------------------------------------------------------
 
 --


### PR DESCRIPTION
> Commit 0 of #1731, and the answer to its blocking question. Full inventory in the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1731#issuecomment-5270134079).

## The blocking question is answered: this migration is already safe

#1623 was blocked by a migration that could only ever run once. `populateStudyTeachers()` is **not** in that state:

```sql
INSERT IGNORE INTO `#__bsms_study_teachers` (study_id, teacher_id, ordering)
SELECT id, teacher_id, 0 FROM `#__bsms_studies` WHERE teacher_id > 0
```

No table-wide `COUNT(*)` guard, and the junction carries `UNIQUE KEY idx_study_teacher (study_id, teacher_id)`, so `INSERT IGNORE` genuinely dedupes. Repeatable and resumable as written.

## The one gap

It runs on **update** only, and the install SQL seeds `teacher_id = 1` with no junction row:

| site | with teacher | junction | unmigrated |
|---|---|---|---|
| j5-dev | 825 | 825 | 0 |
| j6-dev | 824 | 824 | 0 |
| **j62-dev** | 1 | 0 | **1** ← clean install |
| **j70-dev** | 1 | 0 | **1** ← clean install |

Exactly the shape #1623 found for scripture, invisible for the same reason — every reader falls back to the column. It stops being invisible the moment the readers are converted, so it goes first.

⚠️ Worth recording: the docblock two methods below `populateStudyTeachers()` already says *"the seed data (INSERT IGNORE) from SQL update files is NOT executed by Joomla's ChangeSet (it only runs DDL)"*. That is the same behaviour behind the data loss fixed in #1744 — it was known here and never connected to the migration design.

## Verification

Imported `install.mysql.utf8.sql` into a scratch schema: 26 tables, one study, one `study_scriptures` row, one `study_teachers` row (study 1, teacher 1, ordering 0). The two clean-install dev sites were backfilled the way an update would have.

```
composer test:unit          1741 tests, 3345 assertions — OK
composer test:integration    466 tests, 4035 assertions — OK
```

Refs #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)