### PR TITLE
feat: read teachers from the junction only (#1731 reader conversions)

### DIFF
--- a/admin/src/Helper/CwmyoutubeHelper.php
+++ b/admin/src/Helper/CwmyoutubeHelper.php
@@ -139,7 +139,7 @@ class CwmyoutubeHelper
                 . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                 . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
             ->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')')
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
             ->where('LOWER(' . $db->quoteName('s.studytitle') . ') LIKE LOWER(' . $searchTitle . ')')
             ->where($db->quoteName('s.published') . ' = 1');
 
@@ -203,7 +203,7 @@ class CwmyoutubeHelper
                 . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                 . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
             ->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')')
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
             ->where($db->quoteName('m.params') . ' LIKE ' . $searchId)
             ->where($db->quoteName('s.published') . ' = 1')
             ->whereIn($db->quoteName('m.published'), [1, 2])
@@ -333,7 +333,7 @@ class CwmyoutubeHelper
                     . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                     . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
                 ->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-                    . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')')
+                    . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
                 ->where('LOWER(' . $db->quoteName('s.studytitle') . ') LIKE LOWER(' . $searchTitle . ')')
                 ->where($db->quoteName('s.published') . ' = 1')
                 ->order($db->quoteName('s.studydate') . ' DESC')

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -257,7 +257,7 @@ class CwmmessagesModel extends ListModel
         $query->join(
             'LEFT',
             $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id')
-            . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')'
+            . ' = ' . $db->quoteName('stj.teacher_id')
         );
 
         // Join over Series

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -681,7 +681,7 @@ class CwmserieModel extends AdminModel
         $query->join(
             'LEFT',
             $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id')
-            . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')'
+            . ' = ' . $db->quoteName('stj.teacher_id')
         );
 
         // Join over Location

--- a/admin/src/Model/CwmteacherModel.php
+++ b/admin/src/Model/CwmteacherModel.php
@@ -816,14 +816,13 @@ class CwmteacherModel extends AdminModel
             $db->quoteName('#__bsms_locations', 'loc') . ' ON ' . $db->quoteName('loc.id') . ' = ' . $db->quoteName('study.location_id')
         );
 
-        // Filter by teacher via junction table OR legacy teacher_id
         $query->where(
-            '(' . $db->quoteName('study.id') . ' IN ('
+            $db->quoteName('study.id') . ' IN ('
             . $db->createQuery()
                 ->select($db->quoteName('st.study_id'))
                 ->from($db->quoteName('#__bsms_study_teachers', 'st'))
                 ->where($db->quoteName('st.teacher_id') . ' = ' . (int) $item->id)
-            . ') OR ' . $db->quoteName('study.teacher_id') . ' = ' . (int) $item->id . ')'
+            . ')'
         );
 
         // Restrict non-admin users to their authorised view levels

--- a/build/seed-dev-data.php
+++ b/build/seed-dev-data.php
@@ -1,0 +1,495 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Seed a development site with content worth looking at, and content worth
+ * breaking.
+ *
+ * Two modes, because they want opposite things:
+ *
+ *   --demo       clean, fully-populated, everything published. What a site
+ *                should look like when someone is shown it.
+ *   --scenarios  the awkward cases -- unpublished, access-restricted, no
+ *                teacher, no scripture, four references, three teachers, a
+ *                title full of entities. Useful, and it makes a site look
+ *                broken, which is why it is separate.
+ *
+ * Everything written carries the `cwmseed-` alias prefix and is removable with
+ * --remove, so a dev site can be put back exactly as it was.
+ *
+ * ⚠️ Deliberately not a fixture library for automated tests. Those build and
+ * roll back their own rows; this is for looking at pages and for exercising
+ * paths that only a browser reaches -- the player, podcast feeds, Smart Search.
+ *
+ * Usage:
+ *   php build/seed-dev-data.php --site=j6-dev --demo
+ *   php build/seed-dev-data.php --site=j5-dev --scenarios
+ *   php build/seed-dev-data.php --site=j5-dev --remove
+ *   php build/seed-dev-data.php --site=j6-dev --list
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+const SEED_PREFIX = 'cwmseed-';
+const SITES_ROOT  = '/Volumes/BCCExt_APFS_Extreme_Pro/Sites';
+
+/**
+ * Read a site's database settings out of its configuration.php.
+ *
+ * @param   string  $site  Site directory name
+ *
+ * @return  array{host: string, user: string, password: string, db: string, prefix: string}
+ */
+function siteConfig(string $site): array
+{
+    $path = SITES_ROOT . '/' . $site . '/configuration.php';
+
+    if (!is_file($path)) {
+        fwrite(STDERR, "No configuration.php for '{$site}' under " . SITES_ROOT . "\n");
+        exit(1);
+    }
+
+    $source = (string) file_get_contents($path);
+    $config = [];
+
+    foreach (['host', 'user', 'password', 'db', 'dbprefix'] as $key) {
+        preg_match('/public \$' . $key . "\s*=\s*'(.*?)';/", $source, $match);
+        $config[$key] = $match[1] ?? '';
+    }
+
+    return [
+        // MAMP writes host:port; mysqli wants them apart.
+        'host'     => explode(':', $config['host'])[0] ?: 'localhost',
+        'port'     => (int) (explode(':', $config['host'])[1] ?? 3306),
+        'user'     => $config['user'],
+        'password' => $config['password'],
+        'db'       => $config['db'],
+        'prefix'   => $config['dbprefix'],
+    ];
+}
+
+/**
+ * @param   array  $cfg  Site config from siteConfig()
+ *
+ * @return  mysqli
+ */
+function connect(array $cfg): mysqli
+{
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+    return new mysqli($cfg['host'], $cfg['user'], $cfg['password'], $cfg['db'], $cfg['port']);
+}
+
+/**
+ * Insert a row and return its id.
+ *
+ * @param   mysqli  $db     Connection
+ * @param   string  $table  Prefixed table name
+ * @param   array   $row    Column => value
+ *
+ * @return  int
+ */
+function insert(mysqli $db, string $table, array $row): int
+{
+    $cols = implode(', ', array_map(static fn ($c) => "`$c`", array_keys($row)));
+    $vals = implode(', ', array_map(
+        static fn ($v) => $v === null ? 'NULL' : "'" . $db->real_escape_string((string) $v) . "'",
+        array_values($row)
+    ));
+
+    $db->query("INSERT INTO `$table` ($cols) VALUES ($vals)");
+
+    return (int) $db->insert_id;
+}
+
+/**
+ * Columns every #__bsms_studies row needs, whatever the scenario.
+ *
+ * @return  array
+ */
+function studyDefaults(): array
+{
+    return [
+        'studydate'   => '2026-02-01 10:00:00',
+        'published'   => 1,
+        'access'      => 1,
+        'language'    => '*',
+        'ordering'    => 0,
+        'params'      => '{}',
+        'messagetype' => 1,
+        'location_id' => 1,
+        'series_id'   => 0,
+        'hits'        => 0,
+        'comments'    => 1,
+        'user_id'     => 0,
+        'show_level'  => '0',
+    ];
+}
+
+/**
+ * @param   mysqli  $db      Connection
+ * @param   string  $p       Table prefix
+ * @param   string  $name    Teacher name
+ * @param   string  $title   Teacher title
+ * @param   bool    $images  Reuse an existing teacher's images so the page is not full of broken thumbnails
+ *
+ * @return  int
+ */
+function seedTeacher(mysqli $db, string $p, string $name, string $title, bool $images = true): int
+{
+    $slug = SEED_PREFIX . strtolower(str_replace(' ', '-', $name));
+
+    return insert($db, $p . 'bsms_teachers', [
+        'teachername' => $name,
+        'alias'       => $slug,
+        'title'       => $title,
+        'short'       => '<p>' . $name . ' teaches regularly and is here to give the templates '
+            . 'something to render.</p>',
+        'information'       => '<p>A longer biography, so the teacher detail page has a body.</p>',
+        'address'           => '',
+        'phone'             => '',
+        'website'           => '',
+        'email'             => '',
+        'image'             => $images ? 'images/biblestudy/teachers/melvin-santos-2/melvin-santos.jpg' : '',
+        'teacher_thumbnail' => $images ? 'images/biblestudy/teachers/melvin-santos-2/thumb_melvin-santos.jpg' : '',
+        'published'         => 1,
+        'access'            => 1,
+        'language'          => '*',
+        'ordering'          => 0,
+    ]);
+}
+
+/**
+ * @param   mysqli  $db     Connection
+ * @param   string  $p      Table prefix
+ * @param   string  $title  Series title
+ * @param   string  $desc   Series description
+ *
+ * @return  int
+ */
+function seedSeries(mysqli $db, string $p, string $title, string $desc): int
+{
+    return insert($db, $p . 'bsms_series', [
+        'series_text'      => $title,
+        'alias'            => SEED_PREFIX . strtolower(str_replace([' ', ','], ['-', ''], $title)),
+        'description'      => '<p>' . $desc . '</p>',
+        'series_thumbnail' => 'images/biblestudy/series/worship-series-1/thumb_worship-series.jpg',
+        'published'        => 1,
+        'access'           => 1,
+        'language'         => '*',
+        'ordering'         => 0,
+    ]);
+}
+
+/**
+ * Write a study plus everything hanging off it.
+ *
+ * @param   mysqli  $db    Connection
+ * @param   string  $p     Table prefix
+ * @param   array   $spec  title, teachers[], scriptures[[book,ch,vs,chEnd,vsEnd]], topics[], media, overrides
+ *
+ * @return  int  Study id
+ */
+function seedStudy(mysqli $db, string $p, array $spec): int
+{
+    $title = $spec['title'];
+    $slug  = SEED_PREFIX . substr(preg_replace('/[^a-z0-9]+/', '-', strtolower($title)) ?? '', 0, 60);
+
+    $studyId = insert($db, $p . 'bsms_studies', array_merge(studyDefaults(), [
+        'studytitle' => $title,
+        'alias'      => $slug,
+        'studyintro' => $spec['intro'] ?? '<p>A short introduction, so listings have something to show.</p>',
+        'studytext'  => $spec['body'] ?? '<p>The body of the message.</p>',
+        'thumbnailm' => 'images/biblestudy/series/worship-series-1/thumb_worship-series.jpg',
+        'image'      => 'images/biblestudy/series/worship-series-1/thumb_worship-series.jpg',
+    ], $spec['overrides'] ?? []));
+
+    foreach ($spec['teachers'] ?? [] as $ordering => $teacherId) {
+        insert($db, $p . 'bsms_study_teachers', [
+            'study_id'   => $studyId,
+            'teacher_id' => $teacherId,
+            'ordering'   => $ordering,
+        ]);
+    }
+
+    foreach ($spec['scriptures'] ?? [] as $ordering => $ref) {
+        [$book, $chapterBegin, $verseBegin, $chapterEnd, $verseEnd] = array_pad($ref, 5, 0);
+
+        insert($db, $p . 'bsms_study_scriptures', [
+            'study_id'      => $studyId,
+            'ordering'      => $ordering,
+            'booknumber'    => $book,
+            'chapter_begin' => $chapterBegin,
+            'verse_begin'   => $verseBegin,
+            'chapter_end'   => $chapterEnd ?: $chapterBegin,
+            'verse_end'     => $verseEnd ?: $verseBegin,
+            'bible_version' => 'kjv',
+            // Left empty on purpose: postflight and the control panel data fixes
+            // fill it, and seeing that happen is part of what this is for.
+            'reference_text' => '',
+        ]);
+    }
+
+    foreach ($spec['topics'] ?? [] as $topicId) {
+        insert($db, $p . 'bsms_studytopics', ['study_id' => $studyId, 'topic_id' => $topicId]);
+    }
+
+    if ($spec['media'] ?? true) {
+        // Real, public URLs. A made-up path renders a broken player, which
+        // defeats the point of having media at all.
+        insert($db, $p . 'bsms_mediafiles', [
+            'study_id'   => $studyId,
+            'server_id'  => 5,
+            'metadata'   => '[]',
+            'language'   => '*',
+            'access'     => 1,
+            'published'  => 1,
+            'ordering'   => 0,
+            'createdate' => '2026-02-01 10:00:00',
+            'params'     => json_encode([
+                'filename'    => 'youtu.be/0LROzQHy140',
+                'mime_type'   => 'video/mp4',
+                'size'        => 0,
+                'media_image' => 1,
+            ]),
+        ]);
+    }
+
+    return $studyId;
+}
+
+/**
+ * Clean, presentable content. Everything published, every field filled.
+ *
+ * @param   mysqli  $db  Connection
+ * @param   string  $p   Table prefix
+ *
+ * @return  int  Studies written
+ */
+function seedDemo(mysqli $db, string $p): int
+{
+    $ruth   = seedTeacher($db, $p, 'Ruth Delacroix', 'Senior Pastor');
+    $samuel = seedTeacher($db, $p, 'Samuel Oyelaran', 'Associate Pastor');
+    $hana   = seedTeacher($db, $p, 'Hana Petrova', 'Guest Speaker');
+
+    $mount   = seedSeries($db, $p, 'The Sermon on the Mount', 'Four messages through Matthew 5 to 7.');
+    $letters = seedSeries($db, $p, 'Letters to the Churches', 'Three messages from the epistles.');
+
+    $topics = array_column(
+        $db->query("SELECT id FROM {$p}bsms_topics WHERE published = 1 LIMIT 3")->fetch_all(MYSQLI_ASSOC),
+        'id'
+    );
+
+    // book numbers are Proclaim's: 101 = Genesis, so Matthew is 140.
+    $studies = [
+        ['title'         => 'Blessed Are the Poor in Spirit', 'teachers' => [$ruth],
+            'scriptures' => [[140, 5, 1, 5, 12]], 'series' => $mount],
+        ['title'         => 'Salt and Light', 'teachers' => [$ruth],
+            'scriptures' => [[140, 5, 13, 5, 16]], 'series' => $mount],
+        // Two teachers: the thing the flat column could never express.
+        ['title'         => 'On Prayer and Fasting', 'teachers' => [$ruth, $samuel],
+            'scriptures' => [[140, 6, 5, 6, 18]], 'series' => $mount],
+        // Three references: the thing the flat pair could never hold.
+        ['title'         => 'Do Not Worry', 'teachers' => [$samuel],
+            'scriptures' => [[140, 6, 25, 6, 34], [119, 37, 1, 37, 7], [150, 4, 6, 4, 7]], 'series' => $mount],
+        ['title'         => 'To the Church at Ephesus', 'teachers' => [$hana],
+            'scriptures' => [[149, 1, 1, 1, 14]], 'series' => $letters],
+        ['title'         => 'To the Church at Philippi', 'teachers' => [$hana, $ruth],
+            'scriptures' => [[150, 1, 1, 1, 11], [150, 4, 4, 4, 9]], 'series' => $letters],
+        ['title'         => 'To the Church at Colossae', 'teachers' => [$samuel],
+            'scriptures' => [[151, 3, 1, 3, 17]], 'series' => $letters],
+        ['title'         => 'The Good Shepherd', 'teachers' => [$ruth],
+            'scriptures' => [[143, 10, 1, 10, 18], [119, 23, 1, 23, 6]]],
+        ['title'         => 'A Living Hope', 'teachers' => [$hana],
+            'scriptures' => [[160, 1, 3, 1, 9]]],
+        ['title'         => 'Faith and Works', 'teachers' => [$samuel],
+            'scriptures' => [[159, 2, 14, 2, 26]]],
+        ['title'         => 'The Road to Emmaus', 'teachers' => [$ruth, $hana],
+            'scriptures' => [[142, 24, 13, 24, 35], [123, 53, 1, 53, 12], [119, 22, 1, 22, 18]]],
+        ['title'         => 'Come and See', 'teachers' => [$samuel],
+            'scriptures' => [[143, 1, 35, 1, 51]]],
+    ];
+
+    foreach ($studies as $i => $spec) {
+        seedStudy($db, $p, [
+            'title'      => $spec['title'],
+            'teachers'   => $spec['teachers'],
+            'scriptures' => $spec['scriptures'],
+            'topics'     => \array_slice($topics, 0, ($i % 3)),
+            'overrides'  => [
+                'series_id' => $spec['series'] ?? 0,
+                'studydate' => date('Y-m-d H:i:s', strtotime('2026-01-04 10:00:00 +' . $i . ' weeks')),
+            ],
+        ]);
+    }
+
+    return \count($studies);
+}
+
+/**
+ * The awkward cases. Useful to have, and they make a site look broken.
+ *
+ * @param   mysqli  $db  Connection
+ * @param   string  $p   Table prefix
+ *
+ * @return  int  Studies written
+ */
+function seedScenarios(mysqli $db, string $p): int
+{
+    $one   = seedTeacher($db, $p, 'Edge One', 'Pastor');
+    $two   = seedTeacher($db, $p, 'Edge Two', 'Elder');
+    $three = seedTeacher($db, $p, 'Edge Three', 'Deacon', false);
+
+    $cases = [
+        ['title'         => 'Scenario unpublished', 'teachers' => [$one],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['published' => 0]],
+        ['title'         => 'Scenario archived', 'teachers' => [$one],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['published' => 2]],
+        ['title'         => 'Scenario access Registered', 'teachers' => [$one],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['access' => 2]],
+        ['title'         => 'Scenario access Special', 'teachers' => [$one],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['access' => 3]],
+        ['title'         => 'Scenario no teacher', 'teachers' => [],
+            'scriptures' => [[143, 3, 16]]],
+        ['title' => 'Scenario no scripture', 'teachers' => [$one], 'scriptures' => []],
+        ['title'         => 'Scenario three teachers', 'teachers' => [$one, $two, $three],
+            'scriptures' => [[145, 8, 1, 8, 4]]],
+        ['title'         => 'Scenario four references', 'teachers' => [$two],
+            'scriptures' => [[101, 1, 1, 1, 5], [119, 1, 1, 1, 6], [143, 1, 1, 1, 14], [145, 8, 28, 8, 39]]],
+        ['title'         => 'Scenario other language', 'teachers' => [$two],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['language' => 'en-GB']],
+        ['title'         => 'Scenario no media', 'teachers' => [$two],
+            'scriptures' => [[143, 3, 16]], 'media' => false],
+        ['title'         => 'Scenario secondary reference text', 'teachers' => [$three],
+            'scriptures' => [[143, 3, 16]],
+            'overrides'  => ['secondary_reference' => 'See also the readings for Advent']],
+        [
+            'title' => 'Scenario a title that is quite a lot longer than anyone expected, with '
+                . '"quotes", <em>markup</em>, an ampersand & a dash — and an accent: Café',
+            'teachers'   => [$three],
+            'scriptures' => [[143, 3, 16]],
+        ],
+    ];
+
+    foreach ($cases as $i => $spec) {
+        seedStudy($db, $p, [
+            'title'      => $spec['title'],
+            'teachers'   => $spec['teachers'],
+            'scriptures' => $spec['scriptures'],
+            'media'      => $spec['media'] ?? true,
+            'overrides'  => array_merge(
+                ['studydate' => date('Y-m-d H:i:s', strtotime('2026-03-01 10:00:00 +' . $i . ' days'))],
+                $spec['overrides'] ?? []
+            ),
+        ]);
+    }
+
+    return \count($cases);
+}
+
+/**
+ * Remove everything this script wrote, and nothing else.
+ *
+ * @param   mysqli  $db  Connection
+ * @param   string  $p   Table prefix
+ *
+ * @return  array<string, int>  Table => rows removed
+ */
+function removeSeeded(mysqli $db, string $p): array
+{
+    $like    = SEED_PREFIX . '%';
+    $studies = array_column(
+        $db->query("SELECT id FROM {$p}bsms_studies WHERE alias LIKE '{$like}'")->fetch_all(MYSQLI_ASSOC),
+        'id'
+    );
+
+    $removed = [];
+
+    if ($studies !== []) {
+        $ids = implode(',', array_map('intval', $studies));
+
+        foreach (['bsms_study_scriptures', 'bsms_study_teachers', 'bsms_studytopics', 'bsms_mediafiles'] as $table) {
+            $db->query("DELETE FROM {$p}{$table} WHERE study_id IN ($ids)");
+            $removed[$table] = $db->affected_rows;
+        }
+
+        $db->query("DELETE FROM {$p}bsms_studies WHERE id IN ($ids)");
+        $removed['bsms_studies'] = $db->affected_rows;
+    }
+
+    foreach (['bsms_teachers', 'bsms_series'] as $table) {
+        $db->query("DELETE FROM {$p}{$table} WHERE alias LIKE '{$like}'");
+        $removed[$table] = $db->affected_rows;
+    }
+
+    return array_filter($removed);
+}
+
+// ---------------------------------------------------------------------------
+
+$options = getopt('', ['site:', 'demo', 'scenarios', 'remove', 'list']);
+
+if (!isset($options['site'])) {
+    fwrite(STDERR, "Usage: php build/seed-dev-data.php --site=<j5-dev|j6-dev|j62-dev|j70-dev> "
+        . "[--demo|--scenarios|--remove|--list]\n");
+    exit(1);
+}
+
+$site   = (string) $options['site'];
+$cfg    = siteConfig($site);
+$db     = connect($cfg);
+$prefix = $cfg['prefix'];
+
+if (isset($options['list'])) {
+    $rows = $db->query(
+        "SELECT id, studytitle, published, access, language FROM {$prefix}bsms_studies
+         WHERE alias LIKE '" . SEED_PREFIX . "%' ORDER BY id"
+    )->fetch_all(MYSQLI_ASSOC);
+
+    printf("%s: %d seeded studies\n", $site, \count($rows));
+
+    foreach ($rows as $row) {
+        printf(
+            "  %-5s pub=%-2s access=%-2s %-6s %s\n",
+            $row['id'],
+            $row['published'],
+            $row['access'],
+            $row['language'],
+            substr($row['studytitle'], 0, 60)
+        );
+    }
+
+    exit(0);
+}
+
+if (isset($options['remove'])) {
+    foreach (removeSeeded($db, $prefix) as $table => $count) {
+        printf("  removed %-24s %d\n", $table, $count);
+    }
+
+    exit(0);
+}
+
+// Re-running should replace, not pile up.
+removeSeeded($db, $prefix);
+
+$written = 0;
+
+if (isset($options['demo'])) {
+    $written += seedDemo($db, $prefix);
+}
+
+if (isset($options['scenarios'])) {
+    $written += seedScenarios($db, $prefix);
+}
+
+if ($written === 0) {
+    fwrite(STDERR, "Nothing to do: pass --demo, --scenarios, --remove or --list.\n");
+    exit(1);
+}
+
+printf("%s: seeded %d studies. Remove with --site=%s --remove\n", $site, $written, $site);

--- a/build/seed-dev-data.php
+++ b/build/seed-dev-data.php
@@ -164,6 +164,10 @@ function seedTeacher(mysqli $db, string $p, string $name, string $title, bool $i
 }
 
 /**
+ * ⚠️ `teacher` is deliberately not written. The column is `int NULL DEFAULT
+ * NULL`, so a series seeded here has no teacher -- which is valid, and which the
+ * listing used to fail on.
+ *
  * @param   mysqli  $db     Connection
  * @param   string  $p      Table prefix
  * @param   string  $title  Series title
@@ -344,6 +348,11 @@ function seedScenarios(mysqli $db, string $p): int
     $two   = seedTeacher($db, $p, 'Edge Two', 'Elder');
     $three = seedTeacher($db, $p, 'Edge Three', 'Deacon', false);
 
+    // ⚠️ teacher left NULL deliberately. The series form does not require one,
+    // and a NULL there used to throw a TypeError out of Cwmlisting::getLink()
+    // that took the entire series listing down -- every other series with it.
+    $orphan = seedSeries($db, $p, 'Scenario series with no teacher', 'Nobody was assigned to this one.');
+
     $cases = [
         ['title'         => 'Scenario unpublished', 'teachers' => [$one],
             'scriptures' => [[143, 3, 16]], 'overrides' => ['published' => 0]],
@@ -356,6 +365,9 @@ function seedScenarios(mysqli $db, string $p): int
         ['title'         => 'Scenario no teacher', 'teachers' => [],
             'scriptures' => [[143, 3, 16]]],
         ['title' => 'Scenario no scripture', 'teachers' => [$one], 'scriptures' => []],
+        // Gives the teacherless series something to list, so it reaches the page.
+        ['title'         => 'Scenario in a teacherless series', 'teachers' => [$one],
+            'scriptures' => [[143, 3, 16]], 'overrides' => ['series_id' => $orphan]],
         ['title'         => 'Scenario three teachers', 'teachers' => [$one, $two, $three],
             'scriptures' => [[145, 8, 1, 8, 4]]],
         ['title'         => 'Scenario four references', 'teachers' => [$two],

--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -614,7 +614,7 @@ final class Proclaim extends Adapter implements SubscriberInterface
                 . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('a.id')
                 . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
             ->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('a.teacher_id') . ')')
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
             ->join('LEFT', $db->quoteName('#__bsms_series', 's') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('a.series_id'))
             ->join('LEFT', $db->quoteName('#__bsms_locations', 'loc') . ' ON ' . $db->quoteName('loc.id') . ' = ' . $db->quoteName('a.location_id'));
 

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -556,7 +556,7 @@ class Cwmlisting
         );
         $query->leftJoin(
             $db->quoteName('#__bsms_teachers', 't') . ' ON ('
-            . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
+            . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id') . ')'
         );
 
         $ids = [];

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -1616,7 +1616,18 @@ class Cwmlisting
                     $item->teacher_id = $item->id;
                 }
 
-                $link = $this->getLink($row->linktype, $item->id, $item->teacher_id, $params, $item, $template, $type);
+                // ⚠️ getLink() types $tid as int. A series with no teacher has
+                // NULL there, and the TypeError takes down the whole listing
+                // rather than that one row.
+                $link = $this->getLink(
+                    $row->linktype,
+                    $item->id,
+                    (int) ($item->teacher_id ?? 0),
+                    $params,
+                    $item,
+                    $template,
+                    $type
+                );
             }
         }
 

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -1242,7 +1242,7 @@ class Cwmmedia
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't') . ' ON ('
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id') . ')'
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_series', 'se') . ' ON ('
@@ -1316,7 +1316,7 @@ class Cwmmedia
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't') . ' ON ('
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id') . ')'
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_series', 'se') . ' ON ('

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -420,7 +420,7 @@ class Cwmpagebuilder
         $query->join(
             'LEFT',
             $db->quoteName('#__bsms_teachers', 'teacher') . ' ON '
-            . $db->quoteName('teacher.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')'
+            . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('stj.teacher_id')
         );
 
         // Join over Series
@@ -498,17 +498,12 @@ class Cwmpagebuilder
 
         if ($wherefield && $whereitem) {
             if ($wherefield === 'teacher') {
-                // Junction table EXISTS subquery for multi-teacher support, with legacy
-                // study.teacher_id fallback to mirror CwmsermonsModel's COALESCE behavior
-                // and tolerate rows where the junction backfill has not run.
                 $tSubquery = $db->createQuery()
                     ->select('1')
                     ->from($db->quoteName('#__bsms_study_teachers', 'stf'))
                     ->where($db->quoteName('stf.study_id') . ' = ' . $db->quoteName('study.id'))
                     ->where($db->quoteName('stf.teacher_id') . ' = ' . (int) $whereitem);
-                $query->where(
-                    '(EXISTS (' . $tSubquery . ') OR ' . $db->quoteName('study.teacher_id') . ' = ' . (int) $whereitem . ')'
-                );
+                $query->where('EXISTS (' . $tSubquery . ')');
             } else {
                 $query->where($wherefield . ' = ' . $whereitem);
             }

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -1105,7 +1105,7 @@ class Cwmpodcast
                 . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                 . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
             ->leftJoin($db->quoteName('#__bsms_teachers', 't') . ' ON '
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')')
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
             ->leftJoin($db->quoteName('#__bsms_locations', 'loc') . ' ON ' . $db->quoteName('loc.id') . ' = ' . $db->quoteName('s.location_id'))
             ->leftJoin($db->quoteName('#__bsms_podcast', 'p') . ' ON FIND_IN_SET(' . $db->quoteName('p.id') . ', ' . $db->quoteName('mf.podcast_id') . ')')
             ->where('FIND_IN_SET(' . $id . ', ' . $db->quoteName('mf.podcast_id') . ')')

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -376,7 +376,7 @@ class Cwmrelatedstudies
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't')
-                . ' ON ' . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj2.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')'
+                . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj2.teacher_id')
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_series', 'ser')

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -220,7 +220,7 @@ class Cwmserieslist extends Cwmlisting
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_teachers', 't') . ' ON ('
-                . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('st.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . '))'
+                . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.teacher_id') . ')'
             )
             ->leftJoin(
                 $db->quoteName('#__bsms_message_type') . ' ON ('

--- a/site/src/Model/CwmlandingpageModel.php
+++ b/site/src/Model/CwmlandingpageModel.php
@@ -142,7 +142,7 @@ class CwmlandingpageModel extends ListModel
             . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
             . ' AND ' . $db->quoteName('stj.ordering') . ' = 0');
         $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-            . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')');
+            . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'));
         $query->select(
             $db->quoteName(
                 ['se.id', 'se.series_text', 'se.description', 'se.series_thumbnail'],

--- a/site/src/Model/CwmseriesdisplayModel.php
+++ b/site/src/Model/CwmseriesdisplayModel.php
@@ -166,7 +166,7 @@ class CwmseriesdisplayModel extends ItemModel
             $db->quoteName('teacher.teacher_thumbnail', 'thumb')
         );
         $query->join('LEFT', $db->quoteName('#__bsms_study_teachers', 'stj') . ' ON ' . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('study.id') . ' AND ' . $db->quoteName('stj.ordering') . ' = 0');
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')');
+        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('stj.teacher_id'));
 
         // Join over Series
         $query->select(

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -178,7 +178,7 @@ class CwmseriespodcastdisplayModel extends ItemModel
             $db->quoteName('teacher.teacher_thumbnail', 'thumb')
         );
         $query->join('LEFT', $db->quoteName('#__bsms_study_teachers', 'st') . ' ON ' . $db->quoteName('st.study_id') . ' = ' . $db->quoteName('study.id') . ' AND ' . $db->quoteName('st.ordering') . ' = 0');
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = COALESCE(' . $db->quoteName('st.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')');
+        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 'teacher') . ' ON ' . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('st.teacher_id'));
 
         // Join over Series
         $query->select(

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -119,7 +119,7 @@ class CwmsermonModel extends FormModel
                 $query->join(
                     'LEFT',
                     $db->quoteName('#__bsms_teachers', 't') . ' ON '
-                    . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('st.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')'
+                    . $db->quoteName('t.id') . ' = ' . $db->quoteName('st.teacher_id')
                 );
 
                 // Join over series

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -505,7 +505,7 @@ class CwmsermonsModel extends ListModel
         $query->join(
             'LEFT',
             $db->quoteName('#__bsms_teachers', 'teacher') . ' ON '
-            . $db->quoteName('teacher.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('study.teacher_id') . ')'
+            . $db->quoteName('teacher.id') . ' = ' . $db->quoteName('stj.teacher_id')
         );
 
         // Join over Series

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -244,7 +244,7 @@ class HtmlView extends BaseHtmlView
                             . ' ON ' . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
                             . ' AND ' . $db->quoteName('stj.ordering') . ' = 0')
                         ->join('LEFT', $db->quoteName('#__bsms_teachers', 't')
-                            . ' ON ' . $db->quoteName('t.id') . ' = COALESCE(' . $db->quoteName('stj.teacher_id') . ', ' . $db->quoteName('s.teacher_id') . ')')
+                            . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'))
                         ->where($db->quoteName('s.published') . ' = 1')
                         ->whereIn($db->quoteName('s.access'), $user->getAuthorisedViewLevels())
                         ->order($db->quoteName('s.studydate') . ' DESC')

--- a/tests/integration/Site/Helper/CwmlistingNullTeacherTest.php
+++ b/tests/integration/Site/Helper/CwmlistingNullTeacherTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * A series with no teacher must render, not take the page down with it.
+ *
+ * `Cwmlisting::getLink()` types its $tid parameter as int. The series listing
+ * copies `$item->teacher` into `$item->teacher_id` before calling it, and
+ * #__bsms_series.teacher is `int NULL DEFAULT NULL` -- so one teacherless series
+ * threw a TypeError that Joomla turned into an error page. Not the row: the
+ * whole cwmseriesdisplays listing, every other series with it.
+ *
+ * ⚠️ The teacher field is not required. serie.xml declares it with no
+ * `required`, offers "-1 = Select Teacher", and the listing LEFT JOINs teachers.
+ * A teacherless series is meant to be valid, so this is a null-handling gap
+ * rather than a case for tightening the form.
+ *
+ * Never seen because no series on any development site had a NULL teacher --
+ * 40 on one, 42 on another, all populated. The seeder was the first thing to
+ * make one.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\Cwmlisting;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmlisting::class)]
+class CwmlistingNullTeacherTest extends IntegrationTestCase
+{
+    /**
+     * A layout-editor element row, as getFluidRow() receives one.
+     *
+     * @return  \stdClass
+     * @since __DEPLOY_VERSION__
+     */
+    private function elementRow(): \stdClass
+    {
+        return (object) [
+            'linktype'    => 1,
+            'colspan'     => 0,
+            'element'     => 'series',
+            'name'        => 'sseries',
+            'custom'      => '',
+            'row'         => 1,
+            'col'         => 1,
+            'linktypeurl' => '',
+        ];
+    }
+
+    /**
+     * A series as the listing query returns one, with no teacher.
+     *
+     * @return  \stdClass
+     * @since __DEPLOY_VERSION__
+     */
+    private function teacherlessSeries(): \stdClass
+    {
+        return (object) [
+            'id'               => 1,
+            'sid'              => 1,
+            'series_text'      => 'A series nobody was assigned to',
+            'alias'            => 'a-series-nobody-was-assigned-to',
+            'description'      => '',
+            'series_thumbnail' => '',
+            'teacher'          => null,
+            'teachername'      => null,
+            'teachertitle'     => null,
+            'slug'             => '1:a-series-nobody-was-assigned-to',
+            'studydate'        => '2026-01-01 00:00:00',
+        ];
+    }
+
+    #[TestDox('a series with a null teacher renders instead of throwing')]
+    public function testNullTeacherDoesNotThrow(): void
+    {
+        $listing = new Cwmlisting();
+        $method  = new \ReflectionMethod($listing, 'getFluidData');
+
+        $rendered = $method->invoke(
+            $listing,
+            $this->teacherlessSeries(),
+            $this->elementRow(),
+            new Registry(['series_id' => 1]),
+            (object) ['id' => 1],
+            0,
+            'seriesdisplays'
+        );
+
+        $this->assertIsString(
+            $rendered,
+            'A null teacher raised instead of rendering. getLink() types $tid as int, and the TypeError '
+            . 'does not stop at this row -- it takes the whole listing with it.'
+        );
+    }
+
+    #[TestDox('a series with a teacher still renders')]
+    public function testATeacherStillRenders(): void
+    {
+        $listing = new Cwmlisting();
+        $method  = new \ReflectionMethod($listing, 'getFluidData');
+        $series  = $this->teacherlessSeries();
+
+        $series->teacher     = 2;
+        $series->teachername = 'A Teacher';
+
+        $this->assertIsString($method->invoke(
+            $listing,
+            $series,
+            $this->elementRow(),
+            new Registry(['series_id' => 1]),
+            (object) ['id' => 1],
+            0,
+            'seriesdisplays'
+        ));
+    }
+}

--- a/tests/integration/Site/Model/CwmsermonsMultiTeacherTest.php
+++ b/tests/integration/Site/Model/CwmsermonsMultiTeacherTest.php
@@ -1,0 +1,297 @@
+<?php
+
+/**
+ * A study with two teachers must appear once, not twice.
+ *
+ * The listings LEFT JOIN #__bsms_study_teachers to name a study's teacher. That
+ * join used to read `COALESCE(stj.teacher_id, study.teacher_id)`, and dropping
+ * the COALESCE (#1731) is only safe while the join is constrained to a single
+ * junction row. Without that constraint a second teacher multiplies the study
+ * through every list on the site -- silently, and only for the studies that have
+ * one, which is why no existing fixture would have shown it.
+ *
+ * No development site has a two-teacher study, so this builds one.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Model;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
+use CWM\Component\Proclaim\Site\Model\CwmsermonsModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\QueryInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Form\FormFactoryInterface;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmsermonsModel::class)]
+class CwmsermonsMultiTeacherTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseDriver|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var int
+     * @since __DEPLOY_VERSION__
+     */
+    private int $studyId = 0;
+
+    /**
+     * @var int[]
+     * @since __DEPLOY_VERSION__
+     */
+    private array $teacherIds = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        CwmstudyteacherHelper::resetCache();
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        CwmstudyteacherHelper::resetCache();
+
+        try {
+            $this->db?->transactionRollback(true);
+        } catch (\Throwable) {
+            // Connection lost; nothing to roll back.
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A published, publicly visible study taught by two people.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    private function studyWithTwoTeachers(): void
+    {
+        foreach (['cwm1731 primary', 'cwm1731 second'] as $ordering => $name) {
+            $alias = 'cwm1731-teacher-' . $ordering . '-' . uniqid('', false);
+            // #__bsms_teachers declares several NOT NULL columns with no
+            // default, so a minimal fixture will not insert.
+            $teacher = (object) [
+                'teachername' => $name,
+                'alias'       => $alias,
+                'published'   => 1,
+                'access'      => 1,
+                'language'    => '*',
+                'ordering'    => 0,
+                'address'     => '',
+                'phone'       => '',
+                'website'     => '',
+                'email'       => '',
+                'title'       => '',
+                'short'       => '',
+                'information' => '',
+                'params'      => '{}',
+            ];
+            $this->db->insertObject('#__bsms_teachers', $teacher, 'id');
+            $this->teacherIds[] = (int) $this->db->insertid();
+        }
+
+        $study = (object) [
+            'studytitle'  => 'cwm1731 two-teacher fixture',
+            'alias'       => 'cwm1731-two-teacher-' . uniqid('', false),
+            'studydate'   => '2026-01-15 10:00:00',
+            'series_id'   => 0,
+            'messagetype' => 1,
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+            'ordering'    => 0,
+            'params'      => '{}',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+
+        foreach ($this->teacherIds as $ordering => $teacherId) {
+            $link = (object) [
+                'study_id'   => $this->studyId,
+                'teacher_id' => $teacherId,
+                'ordering'   => $ordering,
+            ];
+            $this->db->insertObject('#__bsms_study_teachers', $link);
+        }
+    }
+
+    /**
+     * Build a real site sermons model through a component MVCFactory.
+     *
+     * @return  CwmsermonsModel
+     * @since __DEPLOY_VERSION__
+     */
+    private function createModel(): CwmsermonsModel
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+
+        // The harness container does not always carry a form factory, and the
+        // list query does not need one.
+        if ($container->has(FormFactoryInterface::class)) {
+            $factory->setFormFactory($container->get(FormFactoryInterface::class));
+        }
+
+        $model = $factory->createModel('Cwmsermons', 'Site', ['ignore_request' => true]);
+
+        // The list query reads template params off the state, which nothing
+        // populates outside a request. setModuleState() is the seam mod_proclaim
+        // uses and the one CwmsermonsModuleStateTest drives.
+        $this->silenced(static fn () => $model->setModuleState(new Registry(['moduleitems' => 100])));
+
+        return $model;
+    }
+
+    /**
+     * How many rows the real listing query returns for the fixture study.
+     *
+     * @return  int
+     * @since __DEPLOY_VERSION__
+     */
+    private function listingRowsForFixture(): int
+    {
+        $model = $this->createModel();
+        $ref   = new \ReflectionMethod($model, 'getListQuery');
+        $query = $this->silenced(static fn () => $ref->invoke($model));
+
+        $this->assertInstanceOf(QueryInterface::class, $query);
+
+        $query->where($this->db->quoteName('study.id') . ' = ' . $this->studyId);
+
+        return \count($this->silenced(fn () => $this->db->setQuery($query)->loadObjectList()) ?: []);
+    }
+
+    #[TestDox('a two-teacher study appears once in the listing, not once per teacher')]
+    public function testTwoTeachersDoNotDuplicateTheStudy(): void
+    {
+        $this->studyWithTwoTeachers();
+
+        $this->assertSame(
+            1,
+            $this->listingRowsForFixture(),
+            'A two-teacher study came back twice. Two things stop that here -- GROUP BY study.id and the '
+            . 'join being pinned to ordering 0 -- and this holds whichever of them changes.'
+        );
+    }
+
+    #[TestDox('the teacher join is pinned to a single junction row')]
+    public function testTheTeacherJoinIsPinnedToOneRow(): void
+    {
+        // ⚠️ Asserted on the SQL, deliberately. The row count above cannot see
+        // this: GROUP BY study.id collapses a duplicate on its own, so the
+        // listing looks right even with the join unpinned -- and every query
+        // that joins teachers without a GROUP BY then shows the study twice.
+        $model = $this->createModel();
+        $ref   = new \ReflectionMethod($model, 'getListQuery');
+        $sql   = (string) $this->silenced(static fn () => $ref->invoke($model));
+
+        $this->assertMatchesRegularExpression(
+            '/bsms_study_teachers.{0,200}?ordering.{0,10}=\s*0/s',
+            $sql,
+            'The teacher join is not constrained to one junction row. Dropping the COALESCE (#1731) is only '
+            . 'safe while it is.'
+        );
+    }
+
+    #[TestDox('both teachers are readable from the junction, in order')]
+    public function testBothTeachersAreReadable(): void
+    {
+        $this->studyWithTwoTeachers();
+
+        $teachers = CwmstudyteacherHelper::getTeachersForStudy($this->studyId);
+
+        $this->assertCount(2, $teachers, 'The junction holds both; a reader that finds one is reading the column.');
+        $this->assertSame(
+            $this->teacherIds,
+            array_map(static fn ($t) => (int) ($t->teacherId ?? $t->teacher_id ?? 0), $teachers),
+            'Order matters: ordering 0 is the primary, and that is the one single-teacher displays show.'
+        );
+    }
+
+    #[TestDox('the listing names the primary teacher, not the second')]
+    public function testTheListingNamesThePrimary(): void
+    {
+        $this->studyWithTwoTeachers();
+
+        $model = $this->createModel();
+        $ref   = new \ReflectionMethod($model, 'getListQuery');
+        $query = $this->silenced(static fn () => $ref->invoke($model));
+        $query->where($this->db->quoteName('study.id') . ' = ' . $this->studyId);
+
+        $row = $this->silenced(fn () => $this->db->setQuery($query)->loadObject());
+
+        $this->assertNotNull($row, 'The fixture study should be in the listing.');
+        $this->assertSame(
+            'cwm1731 primary',
+            $row->teachername ?? null,
+            'The join is pinned to ordering 0, so a second teacher must not become the one on show.'
+        );
+    }
+
+    /**
+     * Run something with Joomla's language warnings suppressed.
+     *
+     * ⚠️ The list query resolves language strings, and the harness has no active
+     * language, so Language.php emits a warning PHPUnit reports as risky output.
+     * Nothing to do with what is under test. Same helper as
+     * CwmsermonsModuleStateTest.
+     *
+     * @param   callable  $fn  Work to run
+     *
+     * @return  mixed
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function silenced(callable $fn): mixed
+    {
+        set_error_handler(
+            static fn (int $errno, string $errstr, string $errfile): bool
+                => str_contains($errfile, 'joomla/language/src/Language.php')
+        );
+
+        try {
+            return $fn();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
> Reader conversions for #1731, on top of commit 0 (#1746). See the [scope comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1731#issuecomment-5270134079).

Every teacher read now goes through `#__bsms_study_teachers`. Two shapes.

**19 `COALESCE` joins**, one uniform pattern across 16 files:

```sql
LEFT JOIN #__bsms_teachers t ON t.id = COALESCE(stj.teacher_id, s.teacher_id)
```

The `COALESCE` existed so a study whose junction row had never been written still found its teacher. **Commit 0 closed the last way that could happen**, so the fallback now only masks a missing row.

**Three filters** already junction-first with a bracketed flat fallback — `Cwmpagebuilder` and `CwmteacherModel` (twice). All three were the `(EXISTS (...) OR flat = X)` shape whose brackets #1735 was about; without the fallback there is no disjunction left to bracket.

## Verification

Eight views rendered before and after, with asset cache-busters and WebAuthn ids normalised so the harness is stable (**0 lines of noise** between two runs of the same code):

```
cwmsermons, cwmsermon&id=300, cwmseriesdisplay&id=35, cwmseriesdisplays,
cwmlandingpage, cwmseriespodcastdisplay&id=35, cwmteachers, cwmteacher&id=1

0 diff lines
```

Identical is the right answer here — no dev site has a study with two teachers, so the junction and the column still agree on every row.

## ⚠️ The risk worth testing, and tested

Removing a `COALESCE` from a join can **duplicate rows**: if the join is not constrained to a single junction row, a second teacher multiplies the study through every listing.

I checked this empirically rather than by reading the joins — a study visible on both the sermon listing and the landing page, given a second teacher, still appears **exactly once on each**:

```
one teacher    cwmsermons: 1    cwmlandingpage: 2
two teachers   cwmsermons: 1    cwmlandingpage: 2
```

(The landing page legitimately shows that title in two sections.)

```
composer test:unit          1741 tests, 3345 assertions — OK
composer test:integration    466 tests, 4035 assertions — OK
php-cs-fixer                 clean
```

## Not in this PR

The writes, and the column drop. The drop belongs in PHP rather than migration SQL for the reason #1744 established — and it has to settle what happens to `teacher_id` in `api/src/View/Series/JsonapiView.php`, which is a public REST field and probably an 11.0.0 change.

Refs #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)