### PR TITLE
fix: one missing table no longer stops the primary-key check

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -2561,7 +2561,6 @@ class com_proclaimInstallerScript extends InstallerScript
             // table_suffix => PK column
             $tables = [
                 'bsms_admin'              => 'id',
-                'bsms_books'              => 'id',
                 'bsms_comments'           => 'id',
                 'bsms_locations'          => 'id',
                 'bsms_mediafiles'         => 'id',
@@ -2586,10 +2585,19 @@ class com_proclaimInstallerScript extends InstallerScript
                 'bsms_timeset'            => 'timeset',
             ];
 
-            $added = 0;
+            $added    = 0;
+            $existing = $db->getTableList();
 
             foreach ($tables as $suffix => $pkColumn) {
                 $fullName = $prefix . $suffix;
+
+                // ⚠️ A table in this list may not exist — #__bsms_books was
+                // retired in #1687. Skipping is not just tidiness: the ALTER
+                // would throw, and the catch is outside this loop, so one
+                // missing table stopped every later table being checked.
+                if (!\in_array($fullName, $existing, true)) {
+                    continue;
+                }
 
                 // Check if a PK already exists
                 $query = $db->getQuery(true)


### PR DESCRIPTION
The release gate has been reporting this since #1687 retired the table:

```
[WARNING] Primary key check notice: Table 'j6test_bsms_books' doesn't exist
```

**It is not cosmetic.** `ensurePrimaryKeys()` iterates a hardcoded list of 24 tables, and its `try/catch` sits **outside** the loop. The `ALTER TABLE ... ADD PRIMARY KEY` against a table that no longer exists throws, and the loop stops there.

`bsms_books` was **second in the list**, so the remaining **22 were never checked** — including `bsms_studies`, `bsms_study_scriptures` and `bsms_study_teachers`.

The routine exists for sites upgraded from v7/v8/v9, whose tables can lack primary keys because the original install used `CREATE TABLE IF NOT EXISTS`. Those are precisely the sites that have since been silently keeping the missing keys.

## Changes

- `bsms_books` removed from the list
- every table checked against `getTableList()` first, so a future retirement cannot do this again

## Verification

```
composer test:install          exit 0
  Primary key check notice     0 occurrences (was 1)
  com_proclaim schema          ok=167  error=0
  Schema OK — Joomla reports no database errors
  CLEAN-INSTALL TEST PASSED for 10.5.8-dev
```

## ⚠️ The other gate warning is deliberate

`1 podcast link(s) could not be matched to a menu item` is the documented consequence of a test install having no site menu items (#1701), not a defect. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)