### PR TITLE
fix: empty phone links, and a11y detail tests that were not running

### DIFF
--- a/admin/sql/updates/mysql/10.1.0-20260207.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260207.sql
@@ -21,7 +21,16 @@ INSERT IGNORE INTO `#__action_logs_extensions` (`extension`) VALUES ('com_procla
 ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_access_series` (`published`, `access`, `series_id`, `studydate`);
 
 -- Studies: Teacher filter pattern
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_teacher_published` (`teacher_id`, `published`, `studydate`);
+-- The statement that created idx_teacher_published is deliberately gone. #1731
+-- retired the teacher_id column it covers, and the retirement drops whatever
+-- MySQL leaves of the index, so on every site that has taken that update it no
+-- longer exists.
+--
+-- Joomla's schema check reads every historical file in this folder and tests it
+-- against the CURRENT schema, with no notion of a change being superseded. Left
+-- in place, this line reports a permanent error in System → Maintenance →
+-- Database for an index the component removed on purpose — the same defect as
+-- #1706, and the same fix already applied to idx_booknumber_published.
 
 -- Studies: Location filter pattern
 ALTER TABLE `#__bsms_studies` ADD KEY `idx_location_published` (`location_id`, `published`);

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -1159,8 +1159,14 @@ class Cwmlisting
             case $extra . 'teacherphone':
                 if ($header === 1) {
                     $data = Text::_('JBS_TCH_PHONE');
-                } else {
-                    (isset($item->phone) ? $data = '<a href="tel:' . preg_replace('/[^0-9]/', '', $item->phone) . '" target="_blank">' . $item->phone . '</a>' : $data);
+                } elseif (trim((string) ($item->phone ?? '')) !== '') {
+                    // ⚠️ Truthiness, not isset(). An empty phone is stored as ''
+                    // rather than NULL, so isset() rendered `<a href="tel:"></a>`
+                    // -- a link with no discernible text, which is a WCAG 2.2 AA
+                    // failure (link-name) on every teacher without a number.
+                    // Every neighbouring field here already guards this way.
+                    $data = '<a href="tel:' . preg_replace('/[^0-9]/', '', $item->phone) . '" target="_blank">'
+                        . $item->phone . '</a>';
                 }
                 break;
 

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -649,7 +649,10 @@ class Cwmshowscripture
         $html .= '<div class="scripture-text">';
         $html .= '<div class="scripture-body">';
         $html .= '<p class="text-muted"><em>' . Text::_('JBS_CMN_SCRIPTURE_UNAVAILABLE') . '</em></p>';
-        $html .= '<button type="button" class="btn btn-sm btn-outline-secondary scripture-retry-btn" '
+        // ⚠️ btn-outline-dark, not btn-outline-secondary. Bootstrap's secondary
+        // renders #6d757e, which against this template's #fafaf8 is 4.46:1 --
+        // just under the 4.5:1 WCAG AA needs at this size.
+        $html .= '<button type="button" class="btn btn-sm btn-outline-dark scripture-retry-btn" '
             . 'id="' . $uid . '">'
             . '<i class="fa-solid fa-arrow-rotate-right" aria-hidden="true"></i> '
             . Text::_('JBS_CMN_SCRIPTURE_RETRY') . '</button>';

--- a/tests/e2e/site/a11y.spec.js
+++ b/tests/e2e/site/a11y.spec.js
@@ -43,11 +43,23 @@ const LISTINGS = [
  * Detail views, each reached from its listing so the test never has to guess
  * a record id. [label, listing view, selector for the first item link]
  */
+/**
+ * How many records to open per detail view. Each is a full page load and an axe
+ * scan, so this trades runtime for the chance of catching a record whose data
+ * shape differs from the first one's.
+ */
+const DETAIL_SAMPLE = 5;
+
+// ⚠️ .proclaim-grid-card is in every one of these. The selectors here used to
+// name .proclaim-item and .effects, which the sermons and series-podcast
+// listings do not render at all — so those two tests skipped on every run
+// rather than testing anything, and reported themselves as skipped rather than
+// failed.
 const DETAILS = [
-    ['sermon detail', 'cwmsermons', '.proclaim-item a[href]'],
-    ['teacher detail', 'cwmteachers', '.proclaim-item a[href], .teacher-card a[href]'],
-    ['series detail', 'cwmseriesdisplays', '.proclaim-item a[href], .series-card a[href]'],
-    ['series podcast detail', 'cwmseriespodcastlist', '.effects a[href]'],
+    ['sermon detail', 'cwmsermons', '.proclaim-grid-card a[href], .proclaim-item a[href]'],
+    ['teacher detail', 'cwmteachers', '.proclaim-grid-card a[href], .proclaim-item a[href]'],
+    ['series detail', 'cwmseriesdisplays', '.proclaim-grid-card a[href], .proclaim-item a[href]'],
+    ['series podcast detail', 'cwmseriespodcastlist', '.proclaim-grid-card a[href], .effects a[href]'],
 ];
 
 test.describe('Site accessibility (WCAG 2.2 AA) @a11y', () => {
@@ -76,19 +88,46 @@ test.describe('Site accessibility (WCAG 2.2 AA) @a11y', () => {
                 waitUntil: 'networkidle',
             });
 
-            const firstLink = page.locator(itemSelector).first();
+            const links = page.locator(itemSelector);
+            const total = await links.count();
 
             // Nothing to open on an empty database — skip rather than fail,
             // the same way the rest of the site suite handles missing data.
-            if (!(await firstLink.count())) {
+            if (!total) {
                 test.skip(true, `No records on the ${listing} listing to open`);
             }
 
-            await firstLink.click();
-            await page.waitForLoadState('networkidle');
-            await expect(page.locator(PROCLAIM_CONTENT).first()).toBeVisible({ timeout: 15000 });
+            // ⚠️ Sample several records, not just the first. Detail pages differ
+            // by what the record actually has: a teacher with no phone rendered
+            // `<a href="tel:"></a>`, a link with no accessible name, on most of
+            // the teachers on the site — and this suite passed for months
+            // because whichever record happened to sort first had a phone.
+            // Whatever sorts first is data, not a decision.
+            const hrefs = [];
 
-            await expectNoViolations(page, expect, { include: PROCLAIM_CONTENT });
+            for (let i = 0; i < total && hrefs.length < DETAIL_SAMPLE; i++) {
+                const href = await links.nth(i).getAttribute('href');
+
+                // ⚠️ The item selectors match every link inside a card, and a
+                // card carries mailto: and tel: links too. Navigating to one
+                // aborts the request and fails the test for the wrong reason.
+                if (!href || !href.startsWith('/') || hrefs.includes(href)) {
+                    continue;
+                }
+
+                hrefs.push(href);
+            }
+
+            if (!hrefs.length) {
+                test.skip(true, `No navigable ${listing} detail links found`);
+            }
+
+            for (const href of hrefs) {
+                await page.goto(href, { waitUntil: 'networkidle' });
+                await expect(page.locator(PROCLAIM_CONTENT).first()).toBeVisible({ timeout: 15000 });
+
+                await expectNoViolations(page, expect, { include: PROCLAIM_CONTENT });
+            }
         });
     }
 


### PR DESCRIPTION
`composer test:release` failed on the merged tree. **Three separate problems, each uncovered by fixing the one before it.**

## 1. The superseded index statement

```
ERROR in 10.1.0-20260207.sql
  ALTER TABLE `#__bsms_studies` ADD KEY `idx_teacher_published` (`teacher_id`, ...)
```

#1731 retires that column and its index, and ChangeSet replays every historical file against the *current* schema with no notion of supersession — a permanent error on System → Maintenance → Database.

Removed, exactly as #1743 did for `idx_booknumber_published`. ⚠️ I knew that pattern and did not check for the teacher equivalent.

## 2. `<a href="tel:"></a>` on most teacher pages

```
[serious] link-name — Links must have discernible text (wcag2a, wcag244, wcag412)
```

`teacherphone` guarded with `isset($item->phone)`. An empty phone is stored as `''`, not NULL, so it rendered a link with no text. Every neighbouring field — `teacheremail`, `teacherweb`, `teacherlink3` — already guards on truthiness. This one was the odd case out.

⚠️ **Not seeded data.** 119 of 131 real published teachers on j6-dev have no phone. Confirmed on David Denton (id=3), untouched imported content.

## 3. Two a11y tests that had never run, and one that passed by luck

`.proclaim-item` and `.effects` are **not in the rendered markup at all**, so **sermon detail and series podcast detail skipped on every run** — and reported themselves skipped rather than failed. Every listing renders `.proclaim-grid-card`.

The detail tests also opened only the *first* record, so which page got scanned was decided by sort order. They now sample up to five — which is what surfaced the phone bug, since the previous first teacher happened to have a number.

⚠️ Sampling needed a filter: the item selectors match every link in a card, including `mailto:` and `tel:`, and navigating to one aborts the request.

## 4. What the newly-running test then found

```
[serious] color-contrast — 4.46 against the 4.5 required
  #6d757e on #fafaf8, 14px
```

Bootstrap's `btn-outline-secondary` on the scripture retry button. Now `btn-outline-dark`.

## Verification

```
composer test:release        exit 0
  CLEAN-INSTALL TEST PASSED
  UPGRADE TEST PASSED 10.5.7 -> 10.5.8-dev
  2 scripture reference(s) moved out of the legacy columns
  All migration assertions passed
  Schema OK — error=0
  73 passed, 3 skipped        (was 71 passed with 2 permanently skipped)

composer test:unit           1739 tests, 3343 assertions — OK
composer test:integration     472 tests, 4058 assertions — OK
```

Refs #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)