### PR TITLE
fix(api): apply the five list filters that were accepted and discarded (#1753)

### DIFF
--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -143,6 +143,7 @@ class CwmcommentsModel extends ListModel
         $id .= ':' . $this->getState('filter.published');
         $id .= ':' . $this->getState('filter.language');
         $id .= ':' . $this->getState('filter.location');
+        $id .= ':' . $this->getState('filter.study_id');
 
         return parent::getStoreId($id);
     }
@@ -277,6 +278,16 @@ class CwmcommentsModel extends ListModel
             $locationVal = (int) $location;
             $query->where($db->quoteName('study.location_id') . ' = :locationId')
                 ->bind(':locationId', $locationVal, \Joomla\Database\ParameterType::INTEGER);
+        }
+
+        // Filter by parent study. Set only by the API (?filter[study_id]=);
+        // the admin screen has no field for it, so getState returns null there.
+        $studyId = $this->getState('filter.study_id');
+
+        if (is_numeric($studyId)) {
+            $studyIdVal = (int) $studyId;
+            $query->where($db->quoteName('comment.study_id') . ' = :studyId')
+                ->bind(':studyId', $studyIdVal, \Joomla\Database\ParameterType::INTEGER);
         }
 
         // Join over the users for the checked out user.

--- a/admin/src/Model/CwmplaylistsModel.php
+++ b/admin/src/Model/CwmplaylistsModel.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 /**
  * Playlists model class
@@ -79,6 +80,7 @@ class CwmplaylistsModel extends ListModel
         $id .= ':' . $this->getState('filter.access');
         $id .= ':' . $this->getState('filter.search');
         $id .= ':' . $this->getState('filter.server_id');
+        $id .= ':' . $this->getState('filter.series_id');
 
         return parent::getStoreId($id);
     }
@@ -193,6 +195,19 @@ class CwmplaylistsModel extends ListModel
         // Filter by server.
         if ($serverId = $this->getState('filter.server_id')) {
             $query->where($db->quoteName('playlist.server_id') . ' = ' . (int) $serverId);
+        }
+
+        // Filter by series. Set only by the API (?filter[series_id]=); the
+        // admin screen has no field for it, so getState returns null there.
+        //
+        // is_numeric, not truthiness: series_id is nullable, so a truthy test
+        // would make filter[series_id]=0 indistinguishable from "not set".
+        $seriesId = $this->getState('filter.series_id');
+
+        if (is_numeric($seriesId)) {
+            $seriesIdVal = (int) $seriesId;
+            $query->where($db->quoteName('playlist.series_id') . ' = :seriesId')
+                ->bind(':seriesId', $seriesIdVal, ParameterType::INTEGER);
         }
 
         // Filter by search in title.

--- a/admin/src/Model/CwmserversModel.php
+++ b/admin/src/Model/CwmserversModel.php
@@ -219,6 +219,28 @@ class CwmserversModel extends ListModel
     }
 
     /**
+     * Build a store id that distinguishes one filter combination from another.
+     *
+     * ⚠️ Without this the parent keys the result cache on pagination alone, so
+     * two different filter values in one request return the same rows.
+     *
+     * @param   string  $id  A prefix for the store id.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getStoreId($id = ''): string
+    {
+        $id .= ':' . $this->getState('filter.published');
+        $id .= ':' . $this->getState('filter.location');
+        $id .= ':' . $this->getState('filter.search');
+        $id .= ':' . $this->getState('filter.type');
+
+        return parent::getStoreId($id);
+    }
+
+    /**
      * Method to get a JDatabaseQuery object for retrieving the data set from a database.
      *
      * @return  QueryInterface|string   A JDatabaseQuery object to retrieve the data set.
@@ -289,6 +311,31 @@ class CwmserversModel extends ListModel
             $locationVal = (int) $location;
             $query->where($db->quoteName('server.location_id') . ' = :locationId')
                 ->bind(':locationId', $locationVal, \Joomla\Database\ParameterType::INTEGER);
+        }
+
+        // Search and type are set only by the API (?filter[search]=,
+        // ?filter[type]=); the admin screen has no field for either, so
+        // getState returns null there and both stay inert.
+        $search = $this->getState('filter.search');
+
+        if (!empty($search)) {
+            if (stripos($search, 'id:') === 0) {
+                $query->where($db->quoteName('server.id') . ' = ' . (int) substr($search, 3));
+            } else {
+                $like = '%' . str_replace(['%', '_'], ['\%', '\_'], $search) . '%';
+                $query->where($db->quoteName('server.server_name') . ' LIKE :search')
+                    ->bind(':search', $like, \Joomla\Database\ParameterType::STRING);
+            }
+        }
+
+        // ⚠️ server.type is CHAR(255), not an id. Bound as a string — casting
+        // it to int, as every other filter in this file does, would match
+        // every row whose type does not begin with a digit against 0.
+        $type = $this->getState('filter.type');
+
+        if (\is_string($type) && $type !== '') {
+            $query->where($db->quoteName('server.type') . ' = :type')
+                ->bind(':type', $type, \Joomla\Database\ParameterType::STRING);
         }
 
         // Add the list ordering clause with whitelist validation

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -118,6 +118,7 @@ class CwmtopicsModel extends ListModel
         // Compile the store id.
         $id .= ':' . $this->getState('filter.search');
         $id .= ':' . $this->getState('filter.published');
+        $id .= ':' . $this->getState('filter.language');
 
         return parent::getStoreId($id);
     }
@@ -165,6 +166,13 @@ class CwmtopicsModel extends ListModel
             $query->where($db->quoteName('topic.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
             $query->where('(' . $db->quoteName('topic.published') . ' = 0 OR ' . $db->quoteName('topic.published') . ' = 1)');
+        }
+
+        // Filter on the language. Set only by the API (?filter[language]=);
+        // the admin screen has no field for it, so getState returns null there.
+        if ($language = $this->getState('filter.language')) {
+            $query->where($db->quoteName('topic.language') . ' = :language')
+                ->bind(':language', $language);
         }
 
         // Restrict non-admin users to their authorised view levels

--- a/tests/integration/Admin/Model/ApiFilterQueryTest.php
+++ b/tests/integration/Admin/Model/ApiFilterQueryTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Integration tests: API list filters reach the SQL.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\QueryInterface;
+use Joomla\Event\DispatcherInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The five filters #1753 fixed, asserted on the query the model builds.
+ *
+ * ApiFilterContractTest is the cheap half: it proves each controller's
+ * `filter.*` key is mentioned somewhere in its model. That catches "never
+ * wired up" and nothing more -- a model could read the state and forget to
+ * apply it, and the contract test would still pass.
+ *
+ * This is the other half. Each case builds the real list query twice, with the
+ * filter set and without, and requires the predicate to appear only in the
+ * first. ⚠️ The negative half is the point: asserting only that the column name
+ * appears would pass on every one of these models, because all five columns are
+ * already in the SELECT list or a JOIN condition.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ApiFilterQueryTest extends IntegrationTestCase
+{
+    /**
+     * @return  void
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+    }
+
+    /**
+     * model, filter key, filter value, and a pattern the WHERE must gain.
+     *
+     * @return array<string, array{0: string, 1: string, 2: mixed, 3: string}>
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function filterProvider(): array
+    {
+        return [
+            'comments by study'   => ['Cwmcomments', 'filter.study_id', 7, '/comment`?\.`?study_id`?\s*=\s*:/i'],
+            'playlists by series' => ['Cwmplaylists', 'filter.series_id', 4, '/playlist`?\.`?series_id`?\s*=\s*:/i'],
+            'servers by type'     => ['Cwmservers', 'filter.type', 'legacy', '/server`?\.`?type`?\s*=\s*:/i'],
+            'servers by search'   => ['Cwmservers', 'filter.search', 'sermon', '/server`?\.`?server_name`?\s+LIKE\s+:/i'],
+            'topics by language'  => ['Cwmtopics', 'filter.language', 'en-GB', '/topic`?\.`?language`?\s*=\s*:/i'],
+        ];
+    }
+
+    /**
+     * Build a model's list query as SQL, with the given state applied.
+     *
+     * @param   string  $name   Model name without the Model suffix
+     * @param   array   $state  State keys to set before building
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function listSql(string $name, array $state): string
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+
+        if ($container->has(FormFactoryInterface::class)) {
+            $factory->setFormFactory($container->get(FormFactoryInterface::class));
+        }
+
+        // ignore_request mirrors how ApiController builds these models: it sets
+        // __state_set, so populateState() never runs and the state below is the
+        // only state there is. Without it the admin session's filters leak in.
+        $model = $factory->createModel($name, 'Administrator', ['ignore_request' => true]);
+
+        foreach ($state as $key => $value) {
+            $model->setState($key, $value);
+        }
+
+        $ref = new \ReflectionMethod($model, 'getListQuery');
+
+        $query = $this->silenced(static fn () => $ref->invoke($model));
+        $this->assertInstanceOf(QueryInterface::class, $query);
+
+        return (string) $query;
+    }
+
+    #[DataProvider('filterProvider')]
+    #[TestDox('$model applies $filter to the query')]
+    public function testTheFilterReachesTheQuery(string $model, string $filter, mixed $value, string $pattern): void
+    {
+        $withFilter = $this->listSql($model, [$filter => $value]);
+
+        $this->assertMatchesRegularExpression(
+            $pattern,
+            $withFilter,
+            \sprintf(
+                '%sModel was given %s and built a query with no predicate for it. The API accepts that filter, '
+                . 'so the caller would get the whole unfiltered set back with nothing to say so (#1753).',
+                $model,
+                $filter
+            )
+        );
+    }
+
+    #[DataProvider('filterProvider')]
+    #[TestDox('$model omits the $filter predicate when the filter is unset')]
+    public function testThePredicateIsAbsentWithoutTheFilter(string $model, string $filter, mixed $value, string $pattern): void
+    {
+        $withoutFilter = $this->listSql($model, []);
+
+        $this->assertDoesNotMatchRegularExpression(
+            $pattern,
+            $withoutFilter,
+            \sprintf(
+                '%sModel emitted the %s predicate with no filter set, so the test above proves nothing -- it '
+                . 'would pass whether or not the filter is wired up.',
+                $model,
+                $filter
+            )
+        );
+    }
+
+    /**
+     * Run something with Joomla's language warnings suppressed.
+     *
+     * ⚠️ List queries resolve language strings and the harness has no active
+     * language, so Language.php emits a warning PHPUnit reports as risky
+     * output. Same helper as CwmsermonsMultiTeacherTest.
+     *
+     * @param   callable  $fn  Work to run
+     *
+     * @return  mixed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function silenced(callable $fn): mixed
+    {
+        set_error_handler(
+            static fn (int $errno, string $errstr, string $errfile): bool
+                => str_contains($errfile, 'joomla/language/src/Language.php')
+        );
+
+        try {
+            return $fn();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/tests/unit/Admin/Api/Controller/ApiFilterContractTest.php
+++ b/tests/unit/Admin/Api/Controller/ApiFilterContractTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * Contract test: every API list filter reaches a model that reads it.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Api\Controller;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * ⚠️ An API controller sanitises `?filter[x]=` and writes it to `modelState` as
+ * `filter.x`. If the list model never reads that state key, the filter does
+ * nothing — no error, no 400, no hint. The caller gets **the whole unfiltered
+ * set back**, correctly shaped, and cannot tell the scoping was discarded.
+ *
+ * That is worse than a missing response field: a dropped attribute is visibly
+ * absent, wrong rows are not. Five such filters shipped from 10.3.0 (#1753).
+ *
+ * Sibling of JsonapiViewFieldsTest, which guards the same "declared but never
+ * delivered" shape one layer down, in the response fields.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ApiFilterContractTest extends ProclaimTestCase
+{
+    /**
+     * API controller => the list model it dispatches to.
+     *
+     * Resolved through each controller's own getModel() map, not by convention:
+     * SermonsController maps 'sermons' to Cwmmessages, SeriesController maps
+     * 'series' to Cwmseries or Cwmserie depending on route.
+     *
+     * @var array<string, string>
+     * @since __DEPLOY_VERSION__
+     */
+    private const CONTROLLER_MODELS = [
+        'Comments'     => 'CwmcommentsModel',
+        'Locations'    => 'CwmlocationsModel',
+        'Media'        => 'CwmmediafilesModel',
+        'Messagetypes' => 'CwmmessagetypesModel',
+        'Playlists'    => 'CwmplaylistsModel',
+        'Podcasts'     => 'CwmpodcastsModel',
+        'Series'       => 'CwmseriesModel',
+        'Sermons'      => 'CwmmessagesModel',
+        'Servers'      => 'CwmserversModel',
+        'Teachers'     => 'CwmteachersModel',
+        'Templates'    => 'CwmtemplatesModel',
+        'Topics'       => 'CwmtopicsModel',
+
+        // Info is a synthetic singleton with no list route and no filters.
+        'Info' => '',
+    ];
+
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 5);
+    }
+
+    /**
+     * Every API controller on disk, by name.
+     *
+     * @return  array<string, array{0: string}>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function controllerProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(self::repoRoot() . '/api/src/Controller/*Controller.php') as $file) {
+            $name = basename($file, 'Controller.php');
+
+            // The two abstract bases dispatch nothing and set no filters.
+            if (str_starts_with($name, 'Abstract')) {
+                continue;
+            }
+
+            $cases[$name] = [$name];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * The `filter.*` keys a controller writes into modelState.
+     *
+     * @param   string  $controller  Controller name without the suffix
+     *
+     * @return  string[]
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function filtersSetBy(string $controller): array
+    {
+        $src = file_get_contents(self::repoRoot() . '/api/src/Controller/' . $controller . 'Controller.php');
+
+        preg_match_all("/modelState->set\('filter\.([a-z_]+)'/", $src, $matches);
+
+        return array_values(array_unique($matches[1]));
+    }
+
+    /**
+     * Whether a model reads a given filter key.
+     *
+     * ⚠️ Deliberately permissive: any mention of the key in the model source
+     * counts, whether through getState() or getUserStateFromRequest(). It can
+     * therefore pass a filter that is read and then not applied to the query.
+     * It cannot pass one the model never mentions, which is the failure this
+     * test exists for.
+     *
+     * @param   string  $model   Model class name
+     * @param   string  $filter  Filter key without the `filter.` prefix
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function modelReads(string $model, string $filter): bool
+    {
+        $src = file_get_contents(self::repoRoot() . '/admin/src/Model/' . $model . '.php');
+
+        return (bool) preg_match("/'filter\.{$filter}'|\.filter\.{$filter}'/", $src);
+    }
+
+    #[DataProvider('controllerProvider')]
+    #[TestDox('every filter $controller accepts reaches a model that reads it')]
+    public function testEveryFilterReachesAModelThatReadsIt(string $controller): void
+    {
+        $this->assertArrayHasKey(
+            $controller,
+            self::CONTROLLER_MODELS,
+            "The $controller API controller has no entry in CONTROLLER_MODELS, so none of its filters are checked."
+        );
+
+        $model   = self::CONTROLLER_MODELS[$controller];
+        $filters = self::filtersSetBy($controller);
+
+        if ($model === '') {
+            $this->assertSame([], $filters, "$controller reads no table but sets filters.");
+
+            return;
+        }
+
+        $this->assertFileExists(self::repoRoot() . '/admin/src/Model/' . $model . '.php');
+
+        $ignored = array_values(array_filter(
+            $filters,
+            static fn (string $f) => !self::modelReads($model, $f)
+        ));
+
+        $this->assertSame(
+            [],
+            $ignored,
+            \sprintf(
+                '%sController accepts %s, but %s never reads that state key. The request succeeds and the '
+                . 'filter is discarded, so the caller gets the whole unfiltered set back with nothing to say '
+                . 'so. Either apply it in the model or stop accepting it in the controller.',
+                $controller,
+                implode(', ', array_map(static fn ($f) => "filter[$f]", $ignored)),
+                $model
+            )
+        );
+    }
+
+    #[TestDox('the filter scan is finding filters, so the checks above are not vacuous')]
+    public function testTheFilterScanIsNotVacuous(): void
+    {
+        $found = [];
+
+        foreach (array_keys(self::controllerProvider()) as $controller) {
+            foreach (self::filtersSetBy($controller) as $filter) {
+                $found[] = $controller . '.' . $filter;
+            }
+        }
+
+        // Every controller that has a list route sets at least filter.published
+        // and filter.search. A scan returning far fewer pairs than that has
+        // stopped matching and is asserting nothing.
+        $this->assertGreaterThan(
+            24,
+            \count($found),
+            'The filter scan found almost nothing. If the regex or the glob has drifted, every case above '
+            . 'passes for free.'
+        );
+
+        // Spot-check the pairs #1753 turned on, so a rename cannot quietly
+        // remove them from the scan.
+        foreach (['Comments.study_id', 'Playlists.series_id', 'Servers.type', 'Topics.language'] as $pair) {
+            $this->assertContains($pair, $found, "The scan no longer sees $pair.");
+        }
+    }
+
+    #[TestDox('every API controller on disk is covered by these checks')]
+    public function testEveryControllerIsCovered(): void
+    {
+        $found = array_keys(self::controllerProvider());
+
+        $this->assertNotEmpty($found, 'No API controllers were found — the glob is wrong and nothing is checked.');
+        $this->assertSame([], array_values(array_diff($found, array_keys(self::CONTROLLER_MODELS))));
+    }
+}


### PR DESCRIPTION
Closes #1753.

## The bug

Each API controller sanitises an incoming `?filter[x]=` and writes it to `modelState` as `filter.x`. Where the list model never reads that key, the filter does nothing — no error, no 400, no hint. **The caller gets the whole unfiltered set back, correctly shaped, and cannot tell the scoping was discarded.**

That is worse than #1749's missing response fields: a dropped attribute is visibly absent, wrong rows are not.

| Resource | Filter | Now applied as |
|---|---|---|
| Comments | `study_id` | `comment.study_id = :studyId` |
| Playlists | `series_id` | `playlist.series_id = :seriesId` |
| Servers | `search` | `server.server_name LIKE :search` (with `id:` prefix support) |
| Servers | `type` | `server.type = :type` |
| Topics | `language` | `topic.language = :language` |

All five are documented in their own controller docblocks, so this was a stated contract. Broken since 10.3.0 / 10.3.4.

## Where the fix goes, and where it deliberately doesn't

Applied in `getListQuery()` only. **`populateState()` is untouched on purpose:** `ApiController` builds these models with `ignore_request`, which sets `__state_set`, so `populateState()` never runs on the API path. Adding `getUserStateFromRequest` lines would instead give the *admin screens* filters they have no UI for and persist them in session state — a behaviour change to screens this issue isn't about. `getState()` returns null there, so every new predicate stays inert for the admin list.

Each new key is added to `getStoreId()`. Without that the result cache is keyed on pagination alone, and two different filter values inside one request return the same rows — the filter would look wired up and still be defeated. **`CwmserversModel` had no `getStoreId()` at all** and gains one covering `published`, `location`, `search` and `type`.

Two type details that the surrounding code would have got wrong:
- `server.type` is `CHAR(255)`, not an id. Bound as a string — the `(int)` cast every other filter in that file uses would match every non-numeric type against `0`.
- `playlist.series_id` is nullable, so it gates on `is_numeric()` rather than truthiness, which would make `filter[series_id]=0` indistinguishable from "not set".

## Tests — two, because either alone is insufficient

**`ApiFilterContractTest`** (unit, no DB) pairs every controller's `filter.*` with its model and fails when the model never mentions the key. This is what found the five. It is *deliberately permissive* about how the key is read, documented at the call site: it cannot distinguish read-but-not-applied.

**`ApiFilterQueryTest`** (integration) closes exactly that gap. It builds each list query twice — with the filter and without — and requires the predicate to appear only in the first. ⚠️ The negative half is the point: asserting only that the column name appears would pass on all five, because every one of those columns is already in a SELECT list or a JOIN condition.

Both carry not-vacuous guards (a minimum pair count, and spot-checks of the four names this issue turned on), following the lesson from #1752 where a coverage check silently early-returned on every case.

Mutation-tested:
- remove the `filter.series_id` read from `CwmplaylistsModel` → contract test fails
- remove the comments `study_id` predicate → query test fails
- disable the servers `type` predicate → query test fails

## Verification

- `composer test:unit` — 1803 tests, green (was 1788)
- `composer test:integration` — 482 tests, green
- `composer lint:fix` — clean
- Wiki `REST-API.md` gains Filtering blocks for Comments, Playlists, Servers and Topics, **which it had never documented** — these four resources' filters are usable for the first time.

## Still open from #1753

The nine JsonapiViews whose controllers set no `LIST_SELECT` remain unguarded against the list half of the #1749 defect class. That is test coverage for code that is currently correct, so it is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)