### PR TITLE
fix: build the bundled scripture package from the pinned submodule, not the newest zip

### DIFF
--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -105,12 +105,14 @@
             { "from": "build/language/en-GB/en-GB.pkg_proclaim.sys.ini",
               "to":   "language/en-GB/en-GB.pkg_proclaim.sys.ini" }
         ],
-        "_includes_comment": "The scripture stack ships as pkg_cwmscripture but is deliberately NOT a child of pkg_proclaim — build/pkg_proclaim.xml does not list it. A package removes exactly what its <files> declares, by element+type lookup and without consulting package_id, so listing it would make uninstalling Proclaim remove a stack that ScriptureLinks or Living Word may still be using (#1675). It rides along in packages/ and script.install.php's preflight installs it. `includes` decides what goes INTO the zip; <files> decides what Joomla installs and removes — the two lists are independent, which is what makes this possible. Built fresh by build/build-subpackages.sh (run before cwm-package) and consumed here as a `prebuilt` artifact.",
+        "_includes_comment": "The scripture stack ships as pkg_cwmscripture but is deliberately NOT a child of pkg_proclaim — build/pkg_proclaim.xml does not list it. A package removes exactly what its <files> declares, by element+type lookup and without consulting package_id, so listing it would make uninstalling Proclaim remove a stack that ScriptureLinks or Living Word may still be using (#1675). It rides along in packages/ and script.install.php's preflight installs it. `includes` decides what goes INTO the zip; <files> decides what Joomla installs and removes — the two lists are independent, which is what makes this possible. Built via `subBuild`, which runs the ScriptureLinks package build itself. It used to be a `prebuilt` artifact relying on build/build-subpackages.sh having run first — but cwm-release invokes `build.command` (plain cwm-package), never that script, so releases bundled whatever pkg_cwmscripture zip was newest on disk rather than the pinned submodule (#1757).",
         "includes": [
             {
-                "type":       "prebuilt",
-                "distGlob":   "plugins/content/scripturelinks/build/dist/pkg_cwmscripture-*.zip",
-                "outputName": "pkg_cwmscripture.zip"
+                "type":        "subBuild",
+                "path":        "plugins/content/scripturelinks",
+                "buildScript": "vendor/cwm/build-tools/scripts/package.php",
+                "distGlob":    "build/dist/pkg_cwmscripture-*.zip",
+                "outputName":  "pkg_cwmscripture.zip"
             },
             {
                 "type":       "self",


### PR DESCRIPTION
Closes #1757. Same defect and same fix as CWMScriptureLinks#24, one level up.

## What was wrong

The `pkg_cwmscripture` include was `type: "prebuilt"`, which never builds anything — it
globs `build/dist` and breaks ties by **modification time**
(`cwm/build-tools`, `src/Build/Packager.php:263-264`). So what shipped inside
`pkg_proclaim` was whatever `pkg_cwmscripture` zip was last written to that directory,
with no relationship to the `plugins/content/scripturelinks` pin.

The old config comment claimed the artifact was "built fresh by
`build/build-subpackages.sh` (run before cwm-package)". That holds for
`build/build-package.sh:29`, which does call it — but **the release path does not**.
`cwm-release` invokes `build.command` (`release.sh:224`), and this project's
`build.command` is plain `cwm-package`. So releases have been relying on whatever
happened to be sitting in `build/dist` being fresh and correct.

That is not a theoretical concern: downstream, `pkg_cwmscripture-1.2.2.zip` bundled
library 1.1.10 for exactly this reason (CWMScriptureLinks#23).

## The change

```json
{
  "type":        "subBuild",
  "path":        "plugins/content/scripturelinks",
  "buildScript": "vendor/cwm/build-tools/scripts/package.php",
  "distGlob":    "build/dist/pkg_cwmscripture-*.zip",
  "outputName":  "pkg_cwmscripture.zip"
}
```

`subBuild` runs the ScriptureLinks package build itself, so the just-produced zip is
newest by construction. Note `distGlob` is relative to `path` under `subBuild`, unlike
`prebuilt`, so the `plugins/content/scripturelinks/` prefix is dropped.

This composes with CWMScriptureLinks#24: Proclaim sub-builds the ScriptureLinks package,
which in turn sub-builds the library — so the entire scripture stack derives from the
recorded pins instead of build leftovers.

## Verification

Touched `pkg_cwmscripture-1.2.0.zip` so it was the **newest file on disk** — the exact
condition that caused the downstream mistake — then rebuilt:

```
pkg_proclaim-10.5.8-dev.zip
└── packages/pkg_cwmscripture.zip     <version>1.2.2</version>   (freshly built, not the 1.2.0)
    └── lib_cwmscripture.zip
        ├── cwmscripture.xml          <version>1.1.11</version>
        └── src/LibraryVersion.php    public const VERSION = '1.1.11';
```

Both levels check out, and the library is verified in the manifest *and*
`LibraryVersion.php` — those two have drifted apart before (lib_cwmscripture#15).

## Notes for the reviewer

- **`subBuild` throws if the sub-project's build script is missing**
  (`Packager.php:191`). Nested submodule clones pick up stale vendor installs —
  the scripturelinks library clone was physically dated 2026-05-08 while its
  `composer.lock` pinned v1.15.1, and needed `composer install`. Worth knowing that
  `build-subpackages.sh` won't catch this: its guard tests for the
  `vendor/cwm/build-tools` **directory**, which exists even when the install inside it
  is stale.
- **`build/build-subpackages.sh` is left in place.** It still does useful work for
  `build/build-package.sh` and the e2e workflow; this change just stops the release
  path from silently depending on it having been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
