### PR TITLE
feat: look scripture up from the book number, with a fallback

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1564,6 +1564,57 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
+     * Warn when the installed scripture library is older than this release expects.
+     *
+     * The component degrades rather than breaks — Cwmshowscripture checks for
+     * `getPassageFor()` before using it — so this reports rather than blocks.
+     * Blocking would strand a site on the old version with no path forward, and
+     * the usual cause is transient: pkg_proclaim installs the library in the
+     * same package, so by postflight it is normally already current.
+     *
+     * Everything here is guarded by class_exists()/method_exists() because the
+     * whole point is that the library on disk may be older than the one this
+     * code was written against — including too old to have LibraryVersion.
+     *
+     * @return  void
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private function checkScriptureLibraryVersion(): void
+    {
+        $minimum = '1.1.13';
+        $class   = 'CWM\\Library\\Scripture\\LibraryVersion';
+
+        // Too old to report its own version. The presence check in preflight has
+        // already run, so the library exists; it simply predates LibraryVersion.
+        $satisfied = class_exists($class)
+            && method_exists($class, 'satisfies')
+            && $class::satisfies($minimum);
+
+        if ($satisfied) {
+            return;
+        }
+
+        $installed = class_exists($class) && \defined($class . '::VERSION')
+            ? $class::VERSION
+            : 'unknown';
+
+        $msg = sprintf(
+            'Proclaim: the installed scripture library is %s, older than the %s this release expects. '
+            . 'Scripture still displays, using the previous lookup path. Update pkg_cwmscripture '
+            . 'to get the faster and more reliable one.',
+            $installed,
+            $minimum
+        );
+
+        try {
+            Factory::getApplication()->enqueueMessage($msg, 'warning');
+        } catch (\Throwable) {
+            // CLI install: no application to enqueue against.
+        }
+    }
+
+    /**
      * Post Flight
      *
      * @param   string            $type    The type of change (install, update, or discover_install, not uninstall)
@@ -1598,6 +1649,8 @@ class com_proclaimInstallerScript extends InstallerScript
 
             return;
         }
+
+        $this->checkScriptureLibraryVersion();
 
         // Rename old folders before deletion (must happen before removeFiles is called)
         if ($type === 'update') {

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -58,6 +58,11 @@ class Cwmshowscripture
         }
 
         $reference = $this->formReference($row);
+
+        // The row already knows its book number; formReference() renders it to a
+        // localised name that the provider then has to match back. Keep both, and
+        // let fetchPassage() prefer the structured one where it can (#1688).
+        $ref = ScriptureReference::fromRow($row);
         CwmDebug::startTimer('buildPassage');
 
         $choice    = (int) $params->get('show_passage_view', 3);
@@ -92,7 +97,7 @@ class Cwmshowscripture
                 $provider->setCacheTtl($cacheDays * 86400);
             }
 
-            $result = $provider->getPassage($reference, $version);
+            $result = $this->fetchPassage($provider, $ref, $reference, $version);
         } catch (\Exception $e) {
             Log::add('Provider error for "' . $reference . '" (' . $version . '): ' . $e->getMessage(), Log::ERROR, 'com_proclaim.bible');
         }
@@ -101,7 +106,7 @@ class Cwmshowscripture
         if (($result === null || !$result->hasText()) && ($provider === null || $provider->getName() !== 'local')) {
             try {
                 $localProvider = BibleProviderFactory::getProvider('local');
-                $localResult   = $localProvider->getPassage($reference, $version);
+                $localResult   = $this->fetchPassage($localProvider, $ref, $reference, $version);
 
                 if ($localResult->hasText()) {
                     Log::add('Fallback to local provider for "' . $reference . '" (' . $version . ')', Log::INFO, 'com_proclaim.bible');
@@ -123,7 +128,7 @@ class Cwmshowscripture
             if ($defaultVersion !== $version) {
                 try {
                     $localProvider = BibleProviderFactory::getProvider('local');
-                    $defaultResult = $localProvider->getPassage($reference, $defaultVersion);
+                    $defaultResult = $this->fetchPassage($localProvider, $ref, $reference, $defaultVersion);
 
                     if ($defaultResult->hasText()) {
                         Log::add(
@@ -147,7 +152,7 @@ class Cwmshowscripture
             if ($coreDefault !== $version) {
                 try {
                     $localProvider = BibleProviderFactory::getProvider('local');
-                    $kjvResult     = $localProvider->getPassage($reference, $coreDefault);
+                    $kjvResult     = $this->fetchPassage($localProvider, $ref, $reference, $coreDefault);
 
                     if ($kjvResult->hasText()) {
                         Log::add(
@@ -599,6 +604,43 @@ class Cwmshowscripture
      *
      * @since    7.1
      */
+    /**
+     * Fetch a passage, preferring the structured entry point where it exists.
+     *
+     * Falls back to the string API on two independent conditions, so this is
+     * safe to ship ahead of a library release and on a site whose library has
+     * not caught up:
+     *
+     * - the installed library predates `getPassageFor()`
+     * - the row carries no book number, so there is nothing structured to send
+     *
+     * Capability is detected rather than version: `LibraryVersion::VERSION` is a
+     * hardcoded constant that has drifted from the manifest before
+     * (lib_cwmscripture#15), whereas the method either exists or it does not.
+     * `setCacheTtl()` above is checked the same way.
+     *
+     * @param   object              $provider   Bible provider
+     * @param   ScriptureReference  $ref        Structured reference built from the row
+     * @param   string              $reference  Rendered reference, the legacy argument
+     * @param   string              $version    Translation abbreviation
+     *
+     * @return  BiblePassageResult
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private function fetchPassage(
+        object $provider,
+        ScriptureReference $ref,
+        string $reference,
+        string $version
+    ): BiblePassageResult {
+        if ($ref->booknumber > 0 && method_exists($provider, 'getPassageFor')) {
+            return $provider->getPassageFor($ref, $version);
+        }
+
+        return $provider->getPassage($reference, $version);
+    }
+
     public function formReference($row): string
     {
         $book      = str_replace(' ', '+', Text::_($row->bookname));


### PR DESCRIPTION
The component-side half of #1688 item 3.

`buildPassage()` already knows the book number — `buildPassages()` holds `ScriptureReference` objects and destructures them into a virtual row purely so `formReference()` can render a localised name the provider then has to match back. All four fallback legs now route through `fetchPassage()`, which prefers the structured entry point.

## ✅ Safe to merge before the library release

`fetchPassage()` degrades on **two independent conditions**:

- the installed library predates `getPassageFor()` (the released 1.1.12 does)
- the row carries no book number, so there is nothing structured to send

So this ships now and sites pick up the improvement as their library catches up, over as many versions as that takes.

**Capability is detected, not version.** `LibraryVersion::VERSION` is a hardcoded constant that has drifted from the manifest before (lib_cwmscripture#15) — a version check would trust a number that has been wrong. `setCacheTtl()` is already checked the same way a few lines above.

## ⚠️ CwmscriptureLookupHelper is deliberately not migrated

Structurally it is the same four-leg chain, which is why an earlier note of mine called it "the same change twice" — that was wrong. `lookupPassage(string $reference, ...)` takes a reference **typed by a user**, so it is the same category as `ScriptureLinks.php:1089`: no book number available, and it relies on `resolveBookCode()`'s single-match prefix pass to answer `Joh` → `JHN`. Migrating it would silently drop typed abbreviations.

## Installer warning

`postflight()` warns when the installed library is older than this release expects — the first real caller of `LibraryVersion::satisfies()`, which has had none.

It **reports rather than blocks**: the component degrades, so a blocked upgrade would strand a site with no path forward in exchange for avoiding a slower lookup, and `pkg_proclaim` installs the library in the same package so a mismatch is normally transient ordering. Guarded by `class_exists()`/`method_exists()` throughout, since the premise is that the library on disk may predate the code inspecting it.

## Testing

2285 tests, 7606 assertions. PSR-12 clean across 646 files.

The fallback path is what CI exercises today — Proclaim's pinned library is 1.1.12, which has no `getPassageFor()`. The structured branch gets its coverage when the pin moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
