### PR TITLE
fix: guard the composer install on the entry point, not its directory

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,9 +90,16 @@ jobs:
           submodules: recursive
 
       - name: Setup PHP
+        # 8.4, not Proclaim's 8.3 floor: this job builds the package, and that
+        # means composer-installing plugins/content/scripturelinks, whose
+        # composer.json requires php >=8.4. On 8.3 the install fails with "your
+        # lock file does not contain a compatible set of packages".
+        #
+        # This is a build-time requirement only — the shipped extensions still
+        # target 8.3, and ci.yml continues to lint and test on 8.3 and 8.5.
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, json, xml, mysqli, zip, gd, intl, curl
           coverage: none
 

--- a/build/build-subpackages.sh
+++ b/build/build-subpackages.sh
@@ -31,6 +31,34 @@ if [ ! -f "${LIB_DIR}/cwm-build.config.json" ] || [ ! -f "${PLG_DIR}/cwm-build.c
     exit 1
 fi
 
+# Install a sub-project's composer dependencies when the build script the
+# packager will invoke is missing.
+#
+# Guarded on that entry point rather than on the vendor directory: a
+# vendor/cwm/build-tools that exists but predates the script passes a directory
+# test, the install is skipped, and the build then runs against stale tooling
+# (#1760). That is how the nested lib_cwmscripture clone sat on a 2026-05-08
+# install while its composer.lock pinned v1.15.1.
+#
+# Called for every sub-project the packager enters, not only those with npm
+# assets. pkg_proclaim subBuilds into content/scripturelinks, which has no
+# package.json — so while this lived inside build_npm_assets() that submodule's
+# vendor was never installed, and a clean-install build died on
+# "buildScript not found: .../scripts/package.php" (#1758).
+ensure_vendor() {
+    local dir="$1"
+    local needs="$2"
+
+    if [ ! -f "${dir}/composer.json" ]; then
+        return 0
+    fi
+
+    if [ ! -f "${dir}/vendor/cwm/build-tools/${needs}" ]; then
+        echo "   composer install (${dir#"${ROOT}"/})"
+        ( cd "${dir}" && composer install --no-interaction --prefer-dist --quiet )
+    fi
+}
+
 # Build a submodule's npm assets when it has them. The min files are
 # gitignored, so a fresh clone (CI, a new contributor) has none, and each
 # submodule's ensure-minified gate rightly refuses to package without them.
@@ -47,17 +75,6 @@ build_npm_assets() {
         return 0
     fi
 
-    # Guard on the entry point the build actually needs, not on the directory
-    # containing it. A vendor/cwm/build-tools that exists but predates
-    # scripts/build.php passes a directory test and the install is skipped, so
-    # the build then runs against stale tooling (#1760). That is how the nested
-    # lib_cwmscripture clone sat on a 2026-05-08 install while its composer.lock
-    # pinned v1.15.1.
-    if [ -f "${dir}/composer.json" ] && [ ! -f "${dir}/vendor/cwm/build-tools/scripts/build.php" ]; then
-        echo "   composer install (${dir#"${ROOT}"/})"
-        ( cd "${dir}" && composer install --no-interaction --prefer-dist --quiet )
-    fi
-
     if [ ! -d "${dir}/node_modules" ]; then
         echo "   npm ci (${dir#"${ROOT}"/})"
         ( cd "${dir}" && npm ci --no-audit --no-fund --silent )
@@ -67,6 +84,7 @@ build_npm_assets() {
 }
 
 echo "-- building lib_cwmscripture (npm + cwm-build)"
+ensure_vendor "${LIB_DIR}" "scripts/build.php"
 build_npm_assets "${LIB_DIR}"
 ( cd "${LIB_DIR}" && "${BIN}/cwm-build" )
 
@@ -75,10 +93,12 @@ build_npm_assets "${LIB_DIR}"
 # clean clone dies with "no zip matched" (or worse, silently bundles a
 # stale zip a local tree happened to retain).
 echo "-- building scripturelinks' nested lib_cwmscripture (npm + cwm-build)"
+ensure_vendor "${NESTED_LIB_DIR}" "scripts/build.php"
 build_npm_assets "${NESTED_LIB_DIR}"
 ( cd "${NESTED_LIB_DIR}" && "${BIN}/cwm-build" )
 
 echo "-- building content/scripturelinks (cwm-package)"
+ensure_vendor "${PLG_DIR}" "scripts/package.php"
 ( cd "${PLG_DIR}" && "${BIN}/cwm-package" )
 
 echo "Sub-packages built."

--- a/build/build-subpackages.sh
+++ b/build/build-subpackages.sh
@@ -47,7 +47,13 @@ build_npm_assets() {
         return 0
     fi
 
-    if [ -f "${dir}/composer.json" ] && [ ! -d "${dir}/vendor/cwm/build-tools" ]; then
+    # Guard on the entry point the build actually needs, not on the directory
+    # containing it. A vendor/cwm/build-tools that exists but predates
+    # scripts/build.php passes a directory test and the install is skipped, so
+    # the build then runs against stale tooling (#1760). That is how the nested
+    # lib_cwmscripture clone sat on a 2026-05-08 install while its composer.lock
+    # pinned v1.15.1.
+    if [ -f "${dir}/composer.json" ] && [ ! -f "${dir}/vendor/cwm/build-tools/scripts/build.php" ]; then
         echo "   composer install (${dir#"${ROOT}"/})"
         ( cd "${dir}" && composer install --no-interaction --prefer-dist --quiet )
     fi

--- a/composer.lock
+++ b/composer.lock
@@ -1752,20 +1752,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -1800,15 +1800,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -3773,12 +3773,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "f4f38b8750fb0db0242fb03d4727517e3611da8b"
+                "reference": "001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f4f38b8750fb0db0242fb03d4727517e3611da8b",
-                "reference": "f4f38b8750fb0db0242fb03d4727517e3611da8b",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb",
+                "reference": "001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb",
                 "shasum": ""
             },
             "conflict": {
@@ -3877,7 +3877,7 @@
                 "brotkrueml/codehighlight": "<2.7",
                 "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
                 "brotkrueml/typo3-matomo-integration": "<1.3.2",
-                "buddypress/buddypress": "<7.2.1",
+                "buddypress/buddypress": "<14.5",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
                 "bvbmedia/multishop": "<2.0.39",
                 "bytefury/crater": "<6.0.2",
@@ -4016,7 +4016,7 @@
                 "drupal/umami_analytics": "<1.0.1",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
-                "easycorp/easyadmin-bundle": ">=4,<4.29.10|>=5,<5.0.13",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.16|>=5,<5.5.1",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
@@ -4248,7 +4248,7 @@
                 "leantime/leantime": "<3.3",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "libreform/libreform": ">=2,<=2.0.8",
-                "librenms/librenms": "<26.3",
+                "librenms/librenms": "<=26.4",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<=7.0.0.0-beta1",
@@ -4417,6 +4417,7 @@
                 "php-standard-library/h2": ">=6.1,<6.1.2|>=6.2,<6.2.1",
                 "php-standard-library/php-standard-library": ">=6.1,<6.1.2|>=6.2,<6.2.1",
                 "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
+                "phpcsstandards/phpcsutils": ">=1.0.0.0-alpha1,<1.2.3",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
@@ -4444,7 +4445,7 @@
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=12.3.8|>=2026.1,<2026.1.3",
+                "pimcore/pimcore": "<12.3.9|>=2026.1,<=2026.1.4",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
@@ -4678,7 +4679,7 @@
                 "thelia/thelia": ">=2.0.0.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.1.4",
+                "thorsten/phpmyfaq": "<4.2.0.0-alpha",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
@@ -4705,7 +4706,7 @@
                 "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
-                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.34|>=14,<14.3.6",
                 "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
@@ -4775,8 +4776,8 @@
                 "wikibase/wikibase": "<=1.39.3",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
-                "winter/wn-backend-module": "<1.2.12",
-                "winter/wn-cms-module": "<=1.2.9",
+                "winter/wn-backend-module": "<1.2.13",
+                "winter/wn-cms-module": "<=1.2.12",
                 "winter/wn-dusk-plugin": "<2.1",
                 "winter/wn-system-module": "<1.2.4",
                 "wintercms/winter": "<=1.2.3",
@@ -4891,7 +4892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-07T18:55:46+00:00"
+            "time": "2026-08-13T14:57:02+00:00"
         },
         {
             "name": "sabre/event",
@@ -5926,16 +5927,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b18e33881ef402ad940f36e85935420624009bf4"
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b18e33881ef402ad940f36e85935420624009bf4",
-                "reference": "b18e33881ef402ad940f36e85935420624009bf4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e896f5e874e6983d0a098f554ca82a08a924c298",
+                "reference": "e896f5e874e6983d0a098f554ca82a08a924c298",
                 "shasum": ""
             },
             "require": {
@@ -5981,7 +5982,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.15"
+                "source": "https://github.com/symfony/config/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6001,20 +6002,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T12:54:40+00:00"
+            "time": "2026-07-30T15:04:16+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
@@ -6079,7 +6080,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6099,20 +6100,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:51:00+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b7825671c553af46a98c744e23f37f972aee6427"
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b7825671c553af46a98c744e23f37f972aee6427",
-                "reference": "b7825671c553af46a98c744e23f37f972aee6427",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
+                "reference": "7f59a843c1fbcceafecdf6863d3e38ea6ecd5061",
                 "shasum": ""
             },
             "require": {
@@ -6163,7 +6164,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.15"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6183,7 +6184,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T08:40:50+00:00"
+            "time": "2026-08-06T09:45:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7356,16 +7357,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.14",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "0118811b1d59f323bf131250b3fb919febfece28"
+                "reference": "ca31404415670aa3834809005b529df1b84f0790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0118811b1d59f323bf131250b3fb919febfece28",
-                "reference": "0118811b1d59f323bf131250b3fb919febfece28",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/ca31404415670aa3834809005b529df1b84f0790",
+                "reference": "ca31404415670aa3834809005b529df1b84f0790",
                 "shasum": ""
             },
             "require": {
@@ -7413,7 +7414,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.14"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -7433,7 +7434,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T08:41:53+00:00"
+            "time": "2026-07-30T12:37:26+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Closes #1760.

## The bug

`build-subpackages.sh` decided whether to run `composer install` in a submodule by testing for the **presence of a directory**:

```bash
if [ -f "${dir}/composer.json" ] && [ ! -d "${dir}/vendor/cwm/build-tools" ]; then
```

A `vendor/cwm/build-tools` that exists but holds an **outdated** install passes that test, so the install is skipped and the build runs against stale tooling.

Not hypothetical: the nested `lib_cwmscripture` clone carried a vendor tree physically dated 2026-05-08 while its `composer.lock` pinned v1.15.1, and the directory test waved it through. It stayed invisible until #1758 switched `pkg_proclaim` to `subBuild`, which throws when the sub-project's build script is missing — before that, a stale install just meant nothing rebuilt, which is the same silent class of failure #1757 was about.

## The fix

Test for `scripts/build.php` — the entry point the build actually needs.

## Verified both directions

Against a fixture, since the real clone is currently healthy and would not show the divergence:

```
stale install (dir exists, build.php missing)
  old guard -> SKIPS composer install   (bug)
  new guard -> RUNS  composer install   (fixed)

current install (build.php present)
  new guard -> skips                    (correct, no needless install)
```

## Why it still matters

`cwm-release` no longer depends on this script — that was the point of #1758. But it is still reachable from `build/build-package.sh:29` and `.github/workflows/e2e.yml`, so it can still hand someone a build assembled from stale tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
