### PR TITLE
ci: make the JS Lint job actually lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,8 +423,39 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      # ESLint, not Jest, is what needs PHP here: eslint.config.mjs extends
+      # libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs, and
+      # Composer is what puts that file on disk. Without this the lint step dies
+      # with ERR_MODULE_NOT_FOUND before reading a single source file — which is
+      # exactly how it failed in CWMLivingWord and lib_cwmscripture when the
+      # shared pipeline first tried to lint JS in a job with no PHP setup
+      # (cwm-build-tools v1.16.1).
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, json, xml
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --dev --no-interaction --prefer-dist
+
       - name: Install npm dependencies
         run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint:js
 
       - name: Run Jest tests
         run: npm test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,11 +4,21 @@ export default [
     ...baseConfig,
     {
         // Skip minified files (lint sources, not build output) and vendored
-        // submodules (lib_cwmscripture is maintained in its own repo).
+        // submodules — lib_cwmscripture and CWMScriptureLinks are maintained in
+        // their own repositories and linted by their own CI.
+        //
+        // The whole scripturelinks submodule, not just its libraries/: it
+        // carries an eslint.config.mjs of its own, and ESLint 10 looks up the
+        // nearest config per file rather than using only the root one. That
+        // config extends a base out of the submodule's own vendor/, which
+        // Composer would have to install separately — so CI, which checks the
+        // submodule out but never installs it, died with ERR_MODULE_NOT_FOUND.
+        // Paired with --no-config-lookup in the lint:js script, which is what
+        // makes these ignores authoritative rather than advisory.
         ignores: [
             '**/*.min.js',
             '**/lib_cwmscripture/**',
-            'plugins/content/scripturelinks/libraries/**',
+            'plugins/content/scripturelinks/**',
         ],
     },
     {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report build/reports/e2e",
-    "lint:js": "eslint --max-warnings=0 ."
+    "lint:js": "eslint --no-config-lookup -c eslint.config.mjs --max-warnings=0 ."
   },
   "dependencies": {
     "@fancyapps/ui": "^6.1.11",


### PR DESCRIPTION
The `js-checks` job has been called **"JS Lint & Tests"** while running only Jest. Nothing ran ESLint — here, or anywhere else in the org.

That gap is how CWMLivingWord accumulated **394 lint errors** across three source files without CI noticing; it surfaced only when someone ran the script by hand. Proclaim's own sources are clean — `npm run lint:js` passes over 114 files today — so this gates what is already true rather than fixing anything.

## ESLint is why the job now needs PHP

Not Jest. `eslint.config.mjs` extends `libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs`, and **Composer** is what puts that file on disk. Linting in a job without `composer install` dies before reading a source file:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs'
```

That is exactly how the shared pipeline failed when it first tried a standalone JS lint job — fixed in [cwm-build-tools v1.16.1](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.16.1), where the lint step moved onto the job that runs `composer install`. Here the same constraint means adding PHP setup, the Composer cache and `composer install --dev` to `js-checks`, matching the pattern the other jobs in this file already use.

The reasoning is a comment in the workflow, so the job isn't later "simplified" back into a broken state by removing the PHP steps from a job that looks like it shouldn't need them.

## A second bug, found by turning it on

The first commit passed locally and failed in CI — on a file that isn't this project's:

```
Cannot find module
plugins/content/scripturelinks/vendor/cwm/build-tools/templates/eslint.config.base.mjs
imported from plugins/content/scripturelinks/eslint.config.mjs
```

**ESLint 10 looks up the nearest `eslint.config.*` per file** rather than using only the root one. So linting `.` walks into the CWMScriptureLinks submodule and loads *that repository's* config, which extends a base out of *its own* `vendor/`. Locally that directory exists from an earlier composer install inside the submodule — which is exactly why this passed here and failed there. CI checks the submodule out and never installs it.

Second commit fixes it, and both halves are needed:

- **`--no-config-lookup -c eslint.config.mjs`** in `lint:js`, so only this project's config is ever loaded. Without it the root `ignores` are advisory rather than authoritative: the submodule's lib_cwmscripture build sources were being linted *through the nested config* despite matching two separate ignore patterns already in this repo's config.
- **The ignore widened** from the submodule's `libraries/` to the whole submodule. None of it is this repository's code, and CWMScriptureLinks lints it in its own CI.

Linted file count goes **113 → 105**: eight submodule files out, and they were only ever in because of the nested-config lookup this disables. Zero messages either way.

Worth knowing for the other repos: CWMLivingWord and lib_cwmscripture aren't exposed to this, since neither has a submodule carrying its own ESLint config. Proclaim is the only one.

## Cost

About 15–20s on the `js-checks` job, which runs in parallel with the PHP jobs — the overall run's wall clock is unchanged. `npm ci` was already there for Jest.

## Related

- cwm-build-tools#84, #87 — the `run-lint-js` input and the same lesson
- CWMLivingWord#121 — the 394 errors
- CWMLivingWord#124, lib_cwmscripture#56 — JS lint gated in the two repos on the shared pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
