### PR TITLE
fix(plugin): stop the DROP TABLE guard matching the phrase in a comment

### DIFF
--- a/plugins/system/proclaim/src/Extension/Proclaim.php
+++ b/plugins/system/proclaim/src/Extension/Proclaim.php
@@ -280,7 +280,20 @@ final class Proclaim extends CMSPlugin implements SubscriberInterface
 
         $buffer = @file_get_contents($sqlFile);
 
-        if ($buffer === false || stripos($buffer, 'DROP TABLE') === false) {
+        if ($buffer === false) {
+            return;
+        }
+
+        // Comments stripped before looking for the statement, so the phrase in
+        // prose does not count. The file this replaces documents itself with
+        // "Do not reintroduce DROP TABLE statements here", so matching the raw
+        // buffer made the one-shot repair above fire on every page load of
+        // com_installer, rewriting a file that was already harmless — and on a
+        // symlinked development checkout, rewriting it inside the library's own
+        // git working tree.
+        $statements = preg_replace(['~/\*.*?\*/~s', '~^\s*--.*$~m'], '', $buffer);
+
+        if ($statements === null || stripos($statements, 'DROP TABLE') === false) {
             return;
         }
 


### PR DESCRIPTION
`disarmLegacyScriptureUninstallSql()` rewrites lib_cwmscripture's uninstall SQL when it still holds `DROP TABLE` statements. Its own docblock describes the intent exactly:

> It is a one-shot repair: once the file holds no statements the DROP TABLE check below short-circuits.

**It never short-circuited.** The check reads the whole buffer, comments included:

```php
if ($buffer === false || stripos($buffer, 'DROP TABLE') === false) {
    return;
}
```

The file this method *writes* explains itself in prose containing those two words. So does the file lib_cwmscripture ships today — which ends, with some irony, on the line:

```sql
-- Do not reintroduce DROP TABLE statements here.
```

So the guard has been matching documentation, not SQL, and every page load of com_installer rewrote a file that was already harmless.

## How it surfaced

On a development machine `libraries/cwmscripture` is a **symlink to a git checkout** — that's what `composer link` sets up. So the plugin has been silently editing the library's own working tree: lib_cwmscripture showed a persistent uncommitted change to `sql/uninstall.mysql.utf8.sql` that came back after every `git checkout`, with content byte-identical to `Proclaim.php:288-296`.

## The fix

Strip comments before looking for the statement — `--` lines and `/* */` blocks. A trailing comment after a real statement leaves the statement intact, so it still fires where it must.

Verified against six inputs, including the two that matter most:

| input | before | after |
|---|---|---|
| the file as lib_cwmscripture ships it (prose only) | rewrite | **skip** |
| the stub this method writes | rewrite | **skip** |
| real legacy file, `DROP TABLE IF EXISTS …` | rewrite | **rewrite** |
| `DROP TABLE \`#__x\`; -- gone` | rewrite | **rewrite** |
| `/* DROP TABLE was here */` | rewrite | **skip** |
| empty | skip | skip |

The only behaviour that changes is on files whose sole mention is in a comment. **A file carrying a real statement still triggers the repair** — that's the half that must not regress, since the failure mode is a library update dropping `#__bsms_bible_verses` and every translation a site owner downloaded by hand.

## Same fault elsewhere

`plugins/content/scripturelinks/build/script.install.php:267` carries a byte-identical copy of this guard. That file belongs to the CWMScriptureLinks submodule, so it's fixed in its own repo: CWMScriptureLinks#31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
