### PR TITLE
chore: refresh cwm/build-tools to 1.18.0 for the artifact token gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,177 +1,239 @@
 {
-  "name": "joomla-bible-study/proclaim",
-  "type": "project",
-  "description": "CWM Proclaim",
-  "keywords": [
-    "bible",
-    "joomla",
-    "comments",
-    "Proclaim"
-  ],
-  "homepage": "https://github.com/Joomla-Bible-Study/Proclaim",
-  "license": "GPL-2.0-or-later",
-  "authors": [
-    {
-      "name": "Tom Fuller",
-      "email": "info@christianwebministries.org",
-      "homepage": "https://www.christianwebministries.org",
-      "role": "Tech Writer & Developer"
-    },
-    {
-      "name": "Brent Cordis",
-      "email": "info@christianwebministries.org",
-      "homepage": "https://www.christianwebministries.org",
-      "role": "Lead Developer"
-    }
-  ],
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools"
-    }
-  ],
-  "config": {
-    "optimize-autoloader": true,
-    "platform": {
-      "php": "8.3.0"
-    },
-    "vendor-dir": "libraries/vendor",
-    "github-protocols": [
-      "https"
+    "name": "joomla-bible-study/proclaim",
+    "type": "project",
+    "description": "CWM Proclaim",
+    "keywords": [
+        "bible",
+        "joomla",
+        "comments",
+        "Proclaim"
     ],
-    "allow-plugins": {}
-  },
-  "support": {
-    "issues": "https://www.christianwebministries.org/issues",
-    "forum": "https://www.christianwebministries.org/forum",
-    "docs": "https://www.christianwebministries.org/docs"
-  },
-  "autoload": {
-    "psr-4": {
-      "CWM\\Component\\Proclaim\\Administrator\\": "admin/src/",
-      "CWM\\Component\\Proclaim\\Api\\": "api/src/",
-      "CWM\\Component\\Proclaim\\Site\\": "site/src/",
-      "CWM\\Library\\Scripture\\": "libraries/lib_cwmscripture/src/"
-    },
-    "exclude-from-classmap": [
-      "/admin/src/Addons/Servers/Youtube/vendor/"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "CWM\\Component\\Proclaim\\Tests\\": "tests/unit/"
-    }
-  },
-  "require": {
-    "php": "^8.3.0",
-    "ext-mbstring": "*",
-    "ext-json": "*",
-    "ext-simplexml": "*",
-    "ext-gd": "*",
-    "simplepie/simplepie": "^1.8",
-    "google/recaptcha": "^1.3",
-    "psr/log": "^3.0",
-    "composer/ca-bundle": "^1.3",
-    "ext-zip": "*",
-    "ext-libxml": "*",
-    "ext-fileinfo": "*"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^12.5",
-    "friendsofphp/php-cs-fixer": "^3.0",
-    "phan/phan": "^6.0",
-    "roave/security-advisories": "dev-latest",
-    "pdepend/pdepend": "^2.16",
-    "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.12.0",
-    "joomla/database": "^4.0",
-    "joomla/registry": "^4.0",
-    "joomla/di": "^4.0",
-    "joomla/event": "^4.0",
-    "joomla/input": "^4.0",
-    "joomla/filter": "^4.0",
-    "joomla/filesystem": "^4.0",
-    "joomla/uri": "^4.0",
-    "joomla/application": "^4.0",
-    "joomla/string": "^4.0"
-  },
-  "replace": {
-    "paragonie/random_compat": "9.99.99",
-    "symfony/polyfill-php80": "*",
-    "symfony/polyfill-php81": "*"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "2.x-dev"
-    },
-    "cwm-build-tools": {
-      "joomlaLinks": [
-        { "type": "component", "name": "com_proclaim" },
-        { "type": "module",    "name": "mod_proclaim",         "client": "site" },
-        { "type": "module",    "name": "mod_proclaim_podcast", "client": "site" },
-        { "type": "module",    "name": "mod_proclaim_youtube", "client": "site" },
-        { "type": "module",    "name": "mod_proclaimicon",     "client": "administrator" },
-        { "type": "plugin",    "group": "finder",      "element": "proclaim" },
-        { "type": "plugin",    "group": "schemaorg",   "element": "proclaim" },
-        { "type": "plugin",    "group": "system",      "element": "proclaim" },
-        { "type": "plugin",    "group": "task",        "element": "proclaim" },
-        { "type": "plugin",    "group": "webservices", "element": "proclaim" }
-      ]
-    }
-  },
-  "scripts": {
-    "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
-    "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
-    "test:js": "npm test",
-    "test:e2e": "npm run test:e2e",
-    "test:a11y": "npx playwright test --grep @a11y --project=admin-j6 --project=site-j6",
-    "test:api": ["@test:install", "npx playwright test --project=api-test"],
-    "test:all": ["@test", "@test:js"],
-    "test:reset-testsite": "@php build/reset-testsite.php",
-    "test:migrations": "@php build/verify-migrations.php",
-    "verify:update-stream": "@php build/verify-update-stream.php",
-    "test:install": "bash build/test-install.sh",
-    "test:upgrade": "bash build/test-upgrade.sh",
-    "test:release": ["@test:install", "@test:upgrade", "@test:e2e"],
-    "lint:syntax": "find admin/src api/src site/src modules plugins -type f -name '*.php' -print0 | xargs -0 -n 1 -P 8 php -l > /dev/null",
-    "lint:queries": "sh build/lint-queries.sh",
-    "lint": "php-cs-fixer fix --dry-run --diff",
-    "lint:fix": "php-cs-fixer fix",
-    "check": ["@lint:syntax", "@lint:queries", "@lint", "@test"],
-    "check:all": ["@lint:syntax", "@lint:queries", "@lint", "@test:all"],
-    "build:assets": "npm ci && npm run build",
-    "build:bridge": "cd build/migration-bridge && zip -r ../packages/proclaim_bridge_v1.0.0.zip proclaim_bridge.xml script.php index.html",
-    "build:full": ["@check:all", "@build"],
-    "setup": "cwm-setup",
-    "joomla-install": "cwm-joomla-install",
-    "joomla-latest": "cwm-joomla-latest",
-    "symlink": "cwm-link",
-    "symlink:check": "cwm-link-check",
-    "verify": "cwm-verify",
-    "clean": "cwm-clean",
-    "build": "cwm-build",
-    "package": "cwm-package",
-    "version": "cwm-bump",
-    "sync-languages": "cwm-sync-languages",
-    "sync-languages-force": "cwm-sync-languages --force",
-    "sync-languages-setup": "cwm-sync-languages setup",
-    "sync-configs": "cwm-sync-configs",
-    "vendor:check": "node libraries/vendor/cwm/build-tools/templates/vendor-check.js",
-    "vendor:update": "node libraries/vendor/cwm/build-tools/templates/vendor-update.js",
-    "post-install-cmd": [
-      "@php -r \"if (!file_exists('build.properties')) { copy('build.dist.properties', 'build.properties'); echo 'Created build.properties from template. Run composer setup to configure.\\n'; }\"",
-      "@joomla-cms-deps"
+    "homepage": "https://github.com/Joomla-Bible-Study/Proclaim",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Tom Fuller",
+            "email": "info@christianwebministries.org",
+            "homepage": "https://www.christianwebministries.org",
+            "role": "Tech Writer & Developer"
+        },
+        {
+            "name": "Brent Cordis",
+            "email": "info@christianwebministries.org",
+            "homepage": "https://www.christianwebministries.org",
+            "role": "Lead Developer"
+        }
     ],
-    "joomla-cms-deps": "cwm-joomla-cms-deps",
-    "changelog": "cwm-changelog",
-    "ars-publish": "cwm-ars-publish",
-    "ars-list": "cwm-ars-list",
-    "cwm-article": "cwm-article",
-    "release": "cwm-release",
-    "jed-prep": "bash build/jed-prep.sh",
-    "release:wiki": "bash build/sync-wiki-version.sh"
-  }
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools"
+        }
+    ],
+    "config": {
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "8.3.0"
+        },
+        "vendor-dir": "libraries/vendor",
+        "github-protocols": [
+            "https"
+        ],
+        "allow-plugins": {}
+    },
+    "support": {
+        "issues": "https://www.christianwebministries.org/issues",
+        "forum": "https://www.christianwebministries.org/forum",
+        "docs": "https://www.christianwebministries.org/docs"
+    },
+    "autoload": {
+        "psr-4": {
+            "CWM\\Component\\Proclaim\\Administrator\\": "admin/src/",
+            "CWM\\Component\\Proclaim\\Api\\": "api/src/",
+            "CWM\\Component\\Proclaim\\Site\\": "site/src/",
+            "CWM\\Library\\Scripture\\": "libraries/lib_cwmscripture/src/"
+        },
+        "exclude-from-classmap": [
+            "/admin/src/Addons/Servers/Youtube/vendor/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "CWM\\Component\\Proclaim\\Tests\\": "tests/unit/"
+        }
+    },
+    "require": {
+        "php": "^8.3.0",
+        "ext-mbstring": "*",
+        "ext-json": "*",
+        "ext-simplexml": "*",
+        "ext-gd": "*",
+        "simplepie/simplepie": "^1.8",
+        "google/recaptcha": "^1.3",
+        "psr/log": "^3.0",
+        "composer/ca-bundle": "^1.3",
+        "ext-zip": "*",
+        "ext-libxml": "*",
+        "ext-fileinfo": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.5",
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phan/phan": "^6.0",
+        "roave/security-advisories": "dev-latest",
+        "pdepend/pdepend": "^2.16",
+        "phpmd/phpmd": "^2.15",
+        "cwm/build-tools": "^1.17.0",
+        "joomla/database": "^4.0",
+        "joomla/registry": "^4.0",
+        "joomla/di": "^4.0",
+        "joomla/event": "^4.0",
+        "joomla/input": "^4.0",
+        "joomla/filter": "^4.0",
+        "joomla/filesystem": "^4.0",
+        "joomla/uri": "^4.0",
+        "joomla/application": "^4.0",
+        "joomla/string": "^4.0"
+    },
+    "replace": {
+        "paragonie/random_compat": "9.99.99",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        },
+        "cwm-build-tools": {
+            "joomlaLinks": [
+                {
+                    "type": "component",
+                    "name": "com_proclaim"
+                },
+                {
+                    "type": "module",
+                    "name": "mod_proclaim",
+                    "client": "site"
+                },
+                {
+                    "type": "module",
+                    "name": "mod_proclaim_podcast",
+                    "client": "site"
+                },
+                {
+                    "type": "module",
+                    "name": "mod_proclaim_youtube",
+                    "client": "site"
+                },
+                {
+                    "type": "module",
+                    "name": "mod_proclaimicon",
+                    "client": "administrator"
+                },
+                {
+                    "type": "plugin",
+                    "group": "finder",
+                    "element": "proclaim"
+                },
+                {
+                    "type": "plugin",
+                    "group": "schemaorg",
+                    "element": "proclaim"
+                },
+                {
+                    "type": "plugin",
+                    "group": "system",
+                    "element": "proclaim"
+                },
+                {
+                    "type": "plugin",
+                    "group": "task",
+                    "element": "proclaim"
+                },
+                {
+                    "type": "plugin",
+                    "group": "webservices",
+                    "element": "proclaim"
+                }
+            ]
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+        "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
+        "test:js": "npm test",
+        "test:e2e": "npm run test:e2e",
+        "test:a11y": "npx playwright test --grep @a11y --project=admin-j6 --project=site-j6",
+        "test:api": [
+            "@test:install",
+            "npx playwright test --project=api-test"
+        ],
+        "test:all": [
+            "@test",
+            "@test:js"
+        ],
+        "test:reset-testsite": "@php build/reset-testsite.php",
+        "test:migrations": "@php build/verify-migrations.php",
+        "verify:update-stream": "@php build/verify-update-stream.php",
+        "test:install": "bash build/test-install.sh",
+        "test:upgrade": "bash build/test-upgrade.sh",
+        "test:release": [
+            "@test:install",
+            "@test:upgrade",
+            "@test:e2e"
+        ],
+        "lint:syntax": "find admin/src api/src site/src modules plugins -type f -name '*.php' -print0 | xargs -0 -n 1 -P 8 php -l > /dev/null",
+        "lint:queries": "sh build/lint-queries.sh",
+        "lint": "php-cs-fixer fix --dry-run --diff",
+        "lint:fix": "php-cs-fixer fix",
+        "check": [
+            "@lint:syntax",
+            "@lint:queries",
+            "@lint",
+            "@test"
+        ],
+        "check:all": [
+            "@lint:syntax",
+            "@lint:queries",
+            "@lint",
+            "@test:all"
+        ],
+        "build:assets": "npm ci && npm run build",
+        "build:bridge": "cd build/migration-bridge && zip -r ../packages/proclaim_bridge_v1.0.0.zip proclaim_bridge.xml script.php index.html",
+        "build:full": [
+            "@check:all",
+            "@build"
+        ],
+        "setup": "cwm-setup",
+        "joomla-install": "cwm-joomla-install",
+        "joomla-latest": "cwm-joomla-latest",
+        "symlink": "cwm-link",
+        "symlink:check": "cwm-link-check",
+        "verify": "cwm-verify",
+        "clean": "cwm-clean",
+        "build": "cwm-build",
+        "package": "cwm-package",
+        "version": "cwm-bump",
+        "sync-languages": "cwm-sync-languages",
+        "sync-languages-force": "cwm-sync-languages --force",
+        "sync-languages-setup": "cwm-sync-languages setup",
+        "sync-configs": "cwm-sync-configs",
+        "vendor:check": "node libraries/vendor/cwm/build-tools/templates/vendor-check.js",
+        "vendor:update": "node libraries/vendor/cwm/build-tools/templates/vendor-update.js",
+        "post-install-cmd": [
+            "@php -r \"if (!file_exists('build.properties')) { copy('build.dist.properties', 'build.properties'); echo 'Created build.properties from template. Run composer setup to configure.\\n'; }\"",
+            "@joomla-cms-deps"
+        ],
+        "joomla-cms-deps": "cwm-joomla-cms-deps",
+        "changelog": "cwm-changelog",
+        "ars-publish": "cwm-ars-publish",
+        "ars-list": "cwm-ars-list",
+        "cwm-article": "cwm-article",
+        "release": "cwm-release",
+        "jed-prep": "bash build/jed-prep.sh",
+        "release:wiki": "bash build/sync-wiki-version.sh"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "roave/security-advisories": "dev-latest",
         "pdepend/pdepend": "^2.16",
         "phpmd/phpmd": "^2.15",
-        "cwm/build-tools": "^1.17.0",
+        "cwm/build-tools": "^1.18.0",
         "joomla/database": "^4.0",
         "joomla/registry": "^4.0",
         "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8dceded82880cabf2c7229cb5d0fc041",
+    "content-hash": "0cfb57d7195c510b79da653bea8aaa81",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.15.1",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "5aacbd42a6f102bb59b7780e06d3b0d528e9ed79"
+                "reference": "494086fabd0178c5370a227f1f64dfed062624b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/5aacbd42a6f102bb59b7780e06d3b0d528e9ed79",
-                "reference": "5aacbd42a6f102bb59b7780e06d3b0d528e9ed79",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/494086fabd0178c5370a227f1f64dfed062624b0",
+                "reference": "494086fabd0178c5370a227f1f64dfed062624b0",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +658,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.15.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.17.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-10T23:05:01+00:00"
+            "time": "2026-08-13T17:09:19+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cfb57d7195c510b79da653bea8aaa81",
+    "content-hash": "e1b0f467625f6f7a5fe2e2a70be03b1d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "494086fabd0178c5370a227f1f64dfed062624b0"
+                "reference": "8b1af0150815b74cf2ca8784b3bca40c04b33052"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/494086fabd0178c5370a227f1f64dfed062624b0",
-                "reference": "494086fabd0178c5370a227f1f64dfed062624b0",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/8b1af0150815b74cf2ca8784b3bca40c04b33052",
+                "reference": "8b1af0150815b74cf2ca8784b3bca40c04b33052",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +658,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.17.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.18.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-13T17:09:19+00:00"
+            "time": "2026-08-13T17:34:29+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up `cwm/build-tools` **1.17.0** (cwm-build-tools#85 — the release gate that unzips the artifact before pushing and refuses to publish if `__DEPLOY_VERSION__` survived, recursing into nested zips). The lock was pinned at **1.15.1** under a `^1.12.0` floor; both move to `^1.17.0`.

## ⚠️ Do not merge before cwm-build-tools#89

Proclaim bundles `pkg_cwmscripture` as a **`subBuild` of a git submodule**, and `subBuild` packages the child from its working tree *without substituting* — substitution is a release step in the child's own repo, which a `subBuild` never runs. The outer release must not substitute into a submodule either (it would stamp another repo's source with Proclaim's version, and since 1.16.0 the substituter refuses).

So the bundled child contributes occurrences that **no Proclaim-side change can remove**. From a locally built `pkg_proclaim-10.5.8-dev.zip`:

```
10  ...!packages/pkg_cwmscripture.zip!script.install.php
 5  ...!packages/pkg_cwmscripture.zip!plg_system_cwmscripture.zip!src/Extension/Cwmscripture.php
 1  ...!packages/pkg_cwmscripture.zip!plg_content_scripturelinks.zip!script.php
```

Merging this arms the gate and **stops Proclaim's next release** with no remedy available in this repo. That is why it is held.

To be clear, the gate is not wrong: the shipped `pkg_proclaim-10.5.7.zip` really does carry **23** literal tags, 16 of them from that path. The problem is that Proclaim currently has no way to fix them.

## Verified

- Resolves to v1.17.0; the tree lands in `libraries/vendor/` (this repo sets `vendor-dir`) and carries the scanner, the CLI and the `release.sh` wiring.
- Ran the shipped gate against real artifacts: `pkg_proclaim-10.5.7.zip` → 23 findings across three nesting levels; `pkg_proclaim-10.5.8-dev.zip` → the 16 above plus `com_proclaim`'s own placeholders, which a real release substitutes (`admin/`, `site/`, `api/` are all in `paths`) and which are expected in a dev build.

## Recommended order

1. cwm-build-tools#89 — substitute a `subBuild` child using the child's own version before packaging
2. release that as 1.18.0
3. re-point this PR at it, then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
