### PR TITLE
fix(forms): point the popup-image picker at a directory that exists

### DIFF
--- a/admin/forms/template.xml
+++ b/admin/forms/template.xml
@@ -223,7 +223,7 @@
                    label="JBS_MED_MEDIA_POPUPMARGIN" description="JBS_TPL_MEDIA_POPUPMARGIN_DESC"/>
             <field name="popupbackground" type="ColorPicker" default="black"
                    label="JBS_TPL_MEDIA_POPUPBACKGROUND" description="JBS_TPL_MEDIA_POPUPBACKGROUND_DESC"/>
-            <field name="popupimage" type="media" size="75" directory="com_proclaim/images"
+            <field name="popupimage" type="media" size="75" directory="biblestudy"
                    default="media/com_proclaim/images/speaker24.png" label="JBS_TPL_MEDIA_POPUPIMAGE"
                    description="JBS_TPL_MEDIA_POPUPIMAGE_DESC"/>
             <field name="media_popout_yes" type="radio" default="1"


### PR DESCRIPTION
`popupimage` was the only one of Proclaim's **45** `type="media"` fields not rooted under `biblestudy`:

```diff
-<field name="popupimage" type="media" size="75" directory="com_proclaim/images"
+<field name="popupimage" type="media" size="75" directory="biblestudy"
                 default="media/com_proclaim/images/speaker24.png" ...
```

A media field's `directory` resolves against com_media's `file_path` — `images/` by default — so this opened **`images/com_proclaim/images`**, which no install has (checked on j6-dev: `images/com_proclaim` does not exist). Every other field opens `images/biblestudy`.

## Why it was written that way

Almost certainly to start the picker where the shipped icon lives, since the field defaults to `media/com_proclaim/images/speaker24.png`. **That cannot be expressed with `directory`** — those icons are under `media/`, outside the media manager's root, and no `directory` value reaches them.

## The default is deliberately unchanged

It is correct. The repo's `media/` installs to `media/com_proclaim/`, so `media/com_proclaim/images/speaker24.png` resolves on a real site — verified present on j6-dev. A stored value outside the picker's starting folder still renders; only where the picker *opens* changes.

No stored data is affected: `directory` sets the starting folder, not a constraint on the value.

## After this

```
43  directory="biblestudy"
 1  directory="biblestudy/media"
 1  directory="biblestudy/studies"
 1  directory="biblestudy/teachers"
```

Every media field now points inside the documented `images/biblestudy/` tree.

Found while researching #1656 (closed as decided — media stays global). Not required by that decision; worth fixing on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ