### PR TITLE
feat(media): a media file inherits the access of its message and series

### DIFF
--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -68,15 +68,27 @@ class Cwmdownload
         $registry->loadString($template->params);
         $params = $registry;
 
+        // The study and series levels come along because a media file is only
+        // as reachable as the message it belongs to — see the access check below.
         $query = $db->createQuery();
         $query->select(
             $db->quoteName('#__bsms_mediafiles') . '.*,'
             . $db->quoteName('#__bsms_servers.id', 'ssid') . ', ' . $db->quoteName('#__bsms_servers.params', 'sparams')
+            . ', ' . $db->quoteName('study.access', 'study_access')
+            . ', ' . $db->quoteName('series.access', 'series_access')
         )
             ->from($db->quoteName('#__bsms_mediafiles'))
             ->leftJoin(
                 $db->quoteName('#__bsms_servers') . ' ON ('
                 . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_studies', 'study') . ' ON ('
+                . $db->quoteName('study.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_series', 'series') . ' ON ('
+                . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id') . ')'
             )
             ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid)
             ->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
@@ -88,11 +100,24 @@ class Cwmdownload
             $this->sendError($app, 404, 'Media not found');
         }
 
-        // Verify the current user has the required access level
-        $user         = $app->getIdentity();
-        $accessLevels = $user->getAuthorisedViewLevels();
+        // A media file is only as reachable as the message it belongs to, and
+        // the series that message is in. Checking the file's own level alone
+        // let a Public file hang off a Registered message and be downloaded by
+        // anyone — j6-dev had seven of those.
+        //
+        // Every level in the chain must be satisfied, rather than picking the
+        // "most restrictive" one: Joomla view levels are arbitrary sets of user
+        // groups with no ordering between them, so there is no such thing as
+        // the strictest of Registered, Special and Guest. Requiring all of them
+        // is the same rule the listing queries already apply to study + series
+        // (CwmsermonsModel::getListQuery()).
+        //
+        // ⚠️ This gates Proclaim's download route only. A file stored under the
+        // web root is still served directly by the web server, which never
+        // enters PHP — see #1774.
+        $user = $app->getIdentity();
 
-        if (isset($media->access) && !\in_array((int) $media->access, $accessLevels, true)) {
+        if (!self::isAccessible($media, $user->getAuthorisedViewLevels())) {
             $this->sendError($app, 403, 'Access denied');
         }
 
@@ -213,6 +238,51 @@ class Cwmdownload
      *
      * @since   10.0.0
      */
+    /**
+     * Whether a user holding these view levels may reach this media file.
+     *
+     * A media file is only as reachable as the message it belongs to, and the
+     * series that message is in. Checking the file's own level alone let a
+     * Public file hang off a Registered message and be downloaded by anyone.
+     *
+     * Every level in the chain has to be satisfied, rather than reducing them
+     * to whichever is "most restrictive": Joomla view levels are arbitrary sets
+     * of user groups with no ordering between them, so there is no strictest of
+     * Registered, Special and Guest to pick. Requiring all of them is the rule
+     * the listing queries already apply to study + series — see
+     * `CwmsermonsModel::getListQuery()`.
+     *
+     * A null level means that link in the chain is absent (a media file with no
+     * study, or a study in no series) and constrains nothing.
+     *
+     * ⚠️ This governs Proclaim's download route only. A file stored under the
+     * web root is served by the web server without ever entering PHP, so no
+     * check here can protect it — see #1774.
+     *
+     * @param   object        $media   Media row, joined to its study and series levels.
+     * @param   array<int>    $levels  The user's authorised view levels.
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function isAccessible(object $media, array $levels): bool
+    {
+        $required = [
+            $media->access ?? null,
+            $media->study_access ?? null,
+            $media->series_access ?? null,
+        ];
+
+        foreach ($required as $level) {
+            if ($level !== null && !\in_array((int) $level, $levels, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     protected function sendError(CMSApplication $app, int $code, string $message): never
     {
         $statusText = match ($code) {

--- a/tests/unit/Site/Helper/CwmdownloadAccessTest.php
+++ b/tests/unit/Site/Helper/CwmdownloadAccessTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Unit tests for the media access chain in Cwmdownload
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\Cwmdownload;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * A media file is only as reachable as the message it belongs to, and the
+ * series that message is in.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmdownloadAccessTest extends ProclaimTestCase
+{
+    /** An anonymous visitor: Public and Guest. */
+    private const ANON = [1, 5];
+
+    /** A logged-in member: Public and Registered. */
+    private const MEMBER = [1, 2];
+
+    /**
+     * Build a media row as the download query returns it.
+     *
+     * @param   int|null  $file    The media file's own access level.
+     * @param   int|null  $study   The message's level, or null when there is no message.
+     * @param   int|null  $series  The series' level, or null when the message is in no series.
+     *
+     * @return object
+     */
+    private function media(?int $file, ?int $study = null, ?int $series = null): object
+    {
+        return (object) ['access' => $file, 'study_access' => $study, 'series_access' => $series];
+    }
+
+    // -----------------------------------------------------------------
+    // the bug this closes
+    // -----------------------------------------------------------------
+
+    /**
+     * The whole point. Before this, only the file's own level was checked, so a
+     * Public file hanging off a Registered message was downloadable by anyone —
+     * j6-dev carried seven such rows.
+     */
+    public function testAPublicFileUnderARestrictedMessageIsRefused(): void
+    {
+        $media = $this->media(file: 1, study: 2);
+
+        $this->assertFalse(
+            Cwmdownload::isAccessible($media, self::ANON),
+            'A Public file on a Registered message must not be downloadable anonymously.'
+        );
+        $this->assertTrue(
+            Cwmdownload::isAccessible($media, self::MEMBER),
+            'A member who holds Registered may still download it.'
+        );
+    }
+
+    /** The series restricts too, even when the message itself is Public. */
+    public function testAPublicFileUnderARestrictedSeriesIsRefused(): void
+    {
+        $media = $this->media(file: 1, study: 1, series: 2);
+
+        $this->assertFalse(Cwmdownload::isAccessible($media, self::ANON));
+        $this->assertTrue(Cwmdownload::isAccessible($media, self::MEMBER));
+    }
+
+    /** Nothing restricted anywhere in the chain: still downloadable. */
+    public function testAFullyPublicChainIsAllowed(): void
+    {
+        $this->assertTrue(
+            Cwmdownload::isAccessible($this->media(file: 1, study: 1, series: 1), self::ANON)
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // the file's own level still counts
+    // -----------------------------------------------------------------
+
+    /**
+     * The per-file level is not ignored — it can tighten beyond the message.
+     * Today every media file is Public, so this never fires in practice, but
+     * the field keeps its meaning rather than becoming decorative.
+     */
+    public function testTheFilesOwnLevelCanRestrictBeyondItsMessage(): void
+    {
+        $this->assertFalse(
+            Cwmdownload::isAccessible($this->media(file: 2, study: 1), self::ANON)
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // why every level is required, rather than "the most restrictive"
+    // -----------------------------------------------------------------
+
+    /**
+     * Joomla view levels are arbitrary sets of user groups with no ordering, so
+     * there is no "strictest" of Special and Guest to reduce the chain to. A
+     * user holding one but not the other must be refused, which only works if
+     * every level is required independently.
+     */
+    public function testEveryLevelIsRequiredBecauseLevelsHaveNoOrdering(): void
+    {
+        // Holds Special (3) but not Guest (5).
+        $holdsSpecial = [1, 3];
+
+        $this->assertFalse(
+            Cwmdownload::isAccessible($this->media(file: 5, study: 3), $holdsSpecial),
+            'Holding the message level is not enough when the file requires another.'
+        );
+        $this->assertTrue(
+            Cwmdownload::isAccessible($this->media(file: 5, study: 3), [1, 3, 5])
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // absent links in the chain
+    // -----------------------------------------------------------------
+
+    /**
+     * The joins are LEFT joins: a media file with no message, or a message in no
+     * series, yields null. A missing link constrains nothing — it must not be
+     * treated as level 0 and deny everyone.
+     */
+    public function testAbsentChainLinksDoNotRestrict(): void
+    {
+        $this->assertTrue(
+            Cwmdownload::isAccessible($this->media(file: 1, study: null, series: null), self::ANON),
+            'Media with no message must not be denied by the missing link.'
+        );
+        $this->assertTrue(
+            Cwmdownload::isAccessible($this->media(file: 1, study: 1, series: null), self::ANON),
+            'A message in no series must not be denied by the missing series.'
+        );
+        $this->assertFalse(
+            Cwmdownload::isAccessible($this->media(file: 1, study: 2, series: null), self::ANON),
+            'A missing series must not rescue a restricted message either.'
+        );
+    }
+
+    /** A user with no levels at all gets nothing, not everything. */
+    public function testAUserWithNoLevelsIsRefused(): void
+    {
+        $this->assertFalse(
+            Cwmdownload::isAccessible($this->media(file: 1, study: 1), [])
+        );
+    }
+}


### PR DESCRIPTION
Step 1 of the design agreed on #1774: **a media file is only as reachable as the message it belongs to, and the series that message is in.**

## The gap

`Cwmdownload` checked only the media file's own access level. Proclaim's listing queries already require **both** `study.access` and `series.access` (`CwmsermonsModel::getListQuery()`) — the download route was the one place that did not. So a Public file hanging off a Registered message was downloadable by anyone with the id.

The query now left-joins the study and its series, and the check requires every level in the chain.

## Why every level, rather than "the most restrictive"

Joomla view levels are **arbitrary sets of user groups with no ordering between them**. There is no strictest of Registered, Special and Guest to reduce a chain to — a user holding one but not the other must still be refused. Requiring each level independently is the only correct rule, and it is the one the listing queries already use.

A consequence worth stating: the **per-file level still counts and can tighten** beyond the message. It cannot loosen. Since every media file on the sites we can see is Public, this reads in practice as exactly what was asked for — *the file follows its message, and its series* — while leaving room for the per-file override that was raised as a maybe-later.

## Measured impact: nothing changes live, and that is the point

On j6-dev:

```
published media files under a non-Public message:  0
same rule ignoring published state:                7 would be refused
```

Seven such rows exist but are **trashed or archived**, and the route already excludes those by published state. So this is preventive — it closes the hole before the first subscriber-only series is built, which is what prompted the issue.

I want to correct something I said earlier on #1774: I described those seven as currently exposed through the download route. They are not — the `published = 1` filter already excludes them. They remain fetchable by **direct URL**, but that is the separate problem below.

## Scope — what this does not do

⚠️ **This gates Proclaim's download route only.** A file stored under the web root is served by the web server, which never enters PHP, so no check here can protect it. That is #1774's core finding and it needs gated media stored outside the web root — not another check. The docblock says so at the point someone would otherwise assume they are protected.

## Tests

`Cwmdownload::isAccessible()` is extracted so the rule can be tested without standing up an application. 7 tests / 12 assertions covering: the Public-file-under-Registered-message case, restriction via the series, a fully public chain, the per-file level tightening, the no-ordering case, absent chain links (LEFT joins yield null — a missing link must constrain nothing rather than deny everyone), and a user with no levels.

Mutation-checked: removing the chain from the check fails 3 of them.

`composer lint` 0 of 599. Note the wider "Site Helper Tests" suite reports pre-existing `Failed to start application` errors in my sandbox (no configured Joomla app); none mention `Cwmdownload`, and CI is the arbiter there.

## Still to come from the #1774 design

2. HTTP Range support in `Cwmdownload` — it has none today, so gated audio/video cannot be seeked
3. storage for gated media outside the web root ← the one that actually enforces
4. podcast exclusion for non-Public items
5. UI warning until 3 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
