### PR TITLE
feat(media): serve downloads through the shared streamer

### DIFF
--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -18,6 +18,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediaStreamer;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
@@ -142,50 +143,32 @@ class Cwmdownload
             'download'
         );
 
-        // Optimization: Check if a file is local to avoid HTTP loopback and get an accurate size
-        if ($download_file) {
-            $root = Uri::root();
-            if (str_starts_with($download_file, $root)) {
-                $relativePath = substr($download_file, \strlen($root));
-                $localPath    = JPATH_ROOT . '/' . $relativePath;
-                // Clean up path
-                $localPath = str_replace('//', '/', $localPath);
+        // Streaming is CwmmediaStreamer's job — it resolves the target to local
+        // disk or proxies it, and it is the same implementation the podcast
+        // redirect uses, so there is one Range/HEAD/If-Modified-Since handler
+        // rather than two (#1774).
+        //
+        // What this replaces was weaker in two ways: it sent Content-Length and
+        // readfile() with no Range support, so a browser could not seek in
+        // gated audio or video; and its remote branch fopen()ed an
+        // admin-configured URL and relayed the response to the caller with no
+        // SSRF guard — the shape that was patched for the podcast endpoint in
+        // 10.5.5 (#1426) but never here.
+        //
+        // Access was already checked above. The streamer answers how to send a
+        // file, never whether to.
 
-                if (file_exists($localPath)) {
-                    $download_file = $localPath;
-                    $isLocal       = true;
-                }
-            }
-        }
-
-        if ((int) $params->get('size', 0) === 0) {
-            if ($isLocal) {
-                $getSize = filesize($download_file);
-            } else {
-                $getSize = Cwmhelper::getRemoteFileSize($download_file);
-            }
-        } else {
-            $getSize = $params->get('size', 0);
-        }
-
-        // Disable the time limit and close the session to prevent locking
-        @set_time_limit(0);
-        ignore_user_abort(false);
+        // Long downloads should not hold the session lock.
         if (session_id()) {
             session_write_close();
         }
 
-        ini_set('output_buffering', 0);
-        ini_set('zlib.output_compression', 0);
-
-        // Clean the output buffer, Added to fix ZIP file corruption
-        while (ob_get_level()) {
-            @ob_end_clean();
-        }
-
+        // Headers the streamer does not set. It owns Content-Type,
+        // Content-Length, Accept-Ranges, Content-Range and Last-Modified —
+        // Content-Length especially, which has to reflect the range served
+        // rather than the whole file.
+        $safeFilename = preg_replace('/[^\w.\-]/', '_', basename((string) $params->get('filename')));
         header('Content-Description: File Transfer');
-        header('Content-Type: application/octet-stream');
-        $safeFilename = preg_replace('/[^\w.\-]/', '_', basename($params->get('filename')));
         header('Content-Disposition: attachment; filename="' . $safeFilename . '"');
         header('Expires: 0');
         header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
@@ -193,38 +176,18 @@ class Cwmdownload
         header('Pragma: public');
         header('Content-Transfer-Encoding: binary');
 
-        if ($getSize > 0) {
-            header('Content-Length: ' . $getSize);
-        }
-
-        // Flush headers before streaming
-        flush();
-
-        if ($isLocal) {
-            readfile($download_file);
-        } else {
-            // Bytes per chunk (8 KB) - Reduced from 10MB to save memory
-            $chunk = 8 * 1024;
-
-            $fh = @fopen($download_file, 'rb');
-
-            if (!$fh) {
-                CwmDebug::log('download fopen failed path=' . $download_file, 'download');
-
-                // We cannot send a 500 error cleanly if headers are already sent, but we can try
-                exit;
-            }
-
-            // Repeat reading until EOF
-            while (!feof($fh)) {
-                echo fread($fh, $chunk);
-                flush();
-            }
-
-            fclose($fh);
-        }
-
-        $app->close();
+        // Uri::root(), not the incoming Host header: that is client-supplied
+        // and proxy-rewritable, so comparing against it misroutes local media
+        // down the remote path (#1552).
+        CwmmediaStreamer::serve(
+            $download_file,
+            'application/octet-stream',
+            (string) (parse_url(Uri::root(), PHP_URL_HOST) ?: ''),
+            (string) $input->server->getString('HTTP_RANGE', ''),
+            (string) $input->server->getString('HTTP_IF_MODIFIED_SINCE', ''),
+            (string) $input->server->getString('HTTP_IF_NONE_MATCH', ''),
+            strtoupper((string) $input->getMethod()) === 'HEAD'
+        );
     }
 
     /**


### PR DESCRIPTION
Completes the reuse @bcordis asked about: **both front ends now run the same streaming code, with no duplicate.**

## What `Cwmdownload` was doing

`Content-Length` + `readfile()` for a local file, or `fopen()`/`fread` for a remote one. Two problems beyond the duplication:

**No Range support.** A browser could not seek in audio or video served through this route. That mattered little while every file was also fetchable straight from the web server — it matters entirely once gated media has to go through PHP (#1774).

⚠️ **No SSRF guard.** The remote branch `fopen()`ed a URL built from admin-configured server params and relayed the response to the caller. That is the same shape patched for the podcast endpoint in **10.5.5 (#1426)** — the fix never reached this helper. `CwmmediaStreamer` refuses loopback, RFC1918 and link-local (cloud metadata) targets, so this change closes that gap as a side effect.

## What changes

**Gained:** `Range` → `206`/`416`, `Accept-Ranges`, `Last-Modified`/`304`, `HEAD`, and the SSRF guard.

**Kept:** `Content-Disposition: attachment` with the sanitised filename, `application/octet-stream`, and the existing cache headers — set before the call, since the streamer owns only `Content-Type`, `Content-Length`, `Accept-Ranges`, `Content-Range` and `Last-Modified`.

## Two deliberate behaviour changes

1. **Local/remote detection moved to the streamer**, which does it more carefully: `realpath()` plus a web-root containment check, rather than a string-prefix comparison against `Uri::root()`.
2. **The `params.size` override no longer feeds `Content-Length`.** Range arithmetic needs the real size — a configured value that disagreed with the file would now produce a genuinely broken response rather than a cosmetically wrong header. Real size is used instead.

## Access is untouched

The `isAccessible()` chain from #1777 still runs **first** — call at line 121, streaming at line 182 — and nothing writes a header before it. Verified rather than assumed. The streamer answers *how* to send a file, never *whether* to.

## Verification

`Cwmdownload` is 33 insertions / 70 deletions — it got smaller. 66 tests pass (the podcast helper, controller and download-access suites), `composer lint` 0 of 600, no orphaned imports.

The Range behaviour itself is not newly written: it is the implementation already serving podcast audio to Apple's crawler in production, now shared rather than reimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
