### PR TITLE
feat(podcast): the feed no longer lists items the reader cannot see

### DIFF
--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -35,6 +35,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Proclaim Podcast Class
@@ -1116,6 +1117,33 @@ class Cwmpodcast
                 . $db->quoteName('s.series_id') . ' <= 0)'
             )
             ->order($db->quoteName('createdate') . ' DESC');
+
+        // A feed is a published artifact: it hands out the enclosure URL to
+        // whoever reads it, and podcast apps read it with no session. An item
+        // the fetching user cannot see must therefore not appear at all —
+        // listing it would publish the URL of a file they were refused, which
+        // is worse than the restriction simply not applying (#1774).
+        //
+        // Same chain as the download route (Cwmdownload::isAccessible) and the
+        // sermon listings: media file, its message, and its series. The series
+        // clause mirrors the published one above, allowing a study that is in
+        // no series at all.
+        //
+        // Bracketed deliberately — a top-level OR here would escape every
+        // preceding condition, published ones included (see
+        // tests/unit/Query/WhereClauseContractTest.php).
+        $levels = ArrayHelper::toInteger(
+            Factory::getApplication()->getIdentity()->getAuthorisedViewLevels()
+        );
+        $levels = $levels ?: [0];
+
+        $query->whereIn($db->quoteName('mf.access'), $levels)
+            ->whereIn($db->quoteName('s.access'), $levels)
+            ->where(
+                '(' . $db->quoteName('se.access') . ' IN (' . implode(',', $levels) . ') OR '
+                . $db->quoteName('s.series_id') . ' IS NULL OR '
+                . $db->quoteName('s.series_id') . ' <= 0)'
+            );
 
         $db->setQuery($query, 0, $set_limit);
         $episodes = $db->loadObjectList() ?: [];

--- a/tests/unit/Site/Helper/CwmpodcastFeedAccessTest.php
+++ b/tests/unit/Site/Helper/CwmpodcastFeedAccessTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Contract test: the podcast feed must not list items the reader cannot see
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A feed hands out the enclosure URL to whoever reads it, and podcast apps read
+ * it with no session. Listing an item the reader was refused publishes the URL
+ * of a file they cannot legitimately fetch — worse than the restriction simply
+ * not applying (#1774).
+ *
+ * Asserted at source level rather than by running the query: getEpisodes()
+ * needs a database and an application, and what matters is that the three
+ * filters are present in the SQL the method builds.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmpodcastFeedAccessTest extends TestCase
+{
+    /**
+     * The source of Cwmpodcast::getEpisodes().
+     *
+     * @return string
+     */
+    private static function episodeQuerySource(): string
+    {
+        $method = new \ReflectionMethod(Cwmpodcast::class, 'getEpisodes');
+        $lines  = file($method->getFileName());
+
+        return implode('', \array_slice(
+            $lines,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+    }
+
+    /**
+     * Every link in the chain must be filtered, matching
+     * Cwmdownload::isAccessible() and the sermon listings. Filtering only the
+     * media file would still publish an episode whose message is restricted.
+     */
+    public function testTheFeedQueryFiltersOnTheWholeAccessChain(): void
+    {
+        $source = self::episodeQuerySource();
+
+        foreach (['mf.access' => 'the media file', 's.access' => 'its message', 'se.access' => 'its series'] as $column => $what) {
+            $this->assertStringContainsString(
+                $column,
+                $source,
+                "getEpisodes() must filter on {$column} — otherwise the feed publishes the enclosure URL of an "
+                . "episode whose access is restricted by {$what}."
+            );
+        }
+    }
+
+    /** The levels must come from the reader, not be hardcoded to Public. */
+    public function testItFiltersAgainstTheReadersOwnViewLevels(): void
+    {
+        $this->assertStringContainsString(
+            'getAuthorisedViewLevels',
+            self::episodeQuerySource(),
+            'The feed must filter against the fetching user\'s view levels rather than assuming a fixed level, '
+            . 'so a site whose guests hold more than Public still gets a correct feed.'
+        );
+    }
+
+    /**
+     * Guards the two assertions above. A scan that finds nothing proves nothing
+     * unless it is known to find something, and the same applies to a scan that
+     * finds everything: this fails if episodeQuerySource() ever returns empty
+     * or stops resolving the method.
+     */
+    public function testTheSourceScannerActuallyReadsTheMethod(): void
+    {
+        $source = self::episodeQuerySource();
+
+        $this->assertNotSame('', trim($source), 'The scanner read nothing.');
+        $this->assertStringContainsString(
+            'FIND_IN_SET',
+            $source,
+            'The scanner is not reading getEpisodes() — its podcast_id membership test is missing.'
+        );
+        $this->assertStringNotContainsString(
+            'function getEpisodes',
+            substr($source, 20),
+            'The scanner is reading past the end of the method.'
+        );
+    }
+}


### PR DESCRIPTION
Step 4 of the #1774 design, and the last one before protected storage.

## The gap

`getEpisodes()` — the one query that builds a feed — filtered on `published` for the media file, its message **and** its series, but never on `access`.

So a restricted episode was listed with its enclosure URL. Podcast apps fetch feeds **with no session**, so that URL went to anyone who subscribed.

That is worse than the restriction merely not applying: the download route would refuse the same user (#1777), while the feed handed them the address of the file — which, for web-root media, is all they need (#1774).

## What changed

Filters the same chain the download route and the sermon listings use: **media file, message, series** — with the series clause mirroring the `published` one directly above it, so a study in no series is still allowed.

Levels come from the **fetching user**, not a hardcoded Public, so a site granting its logged-out visitors more than Public still gets a correct feed rather than an over-filtered one.

The clause is bracketed. A top-level `OR` here would escape every preceding condition *including the published ones*, which is exactly what `WhereClauseContractTest` exists to catch — and it passes.

## Only one query changed, deliberately

Seven other queries join mediafiles to studies. All seven are **admin maintenance** — `validatePodcastMedia`, `fixMediaDurations`, `getMediaFilesNeedingDuration`, `fixSingleMediaDuration`, `getMediaFilesNeedingMetadata`, `fixSingleMediaMetadata` — and they must keep seeing restricted rows, since an administrator repairing metadata has to repair those too. Filtering them would have been a bug dressed as consistency.

`getEpisodes()` has exactly one caller: the feed builder.

## Measured impact

On j6-dev: **115 episodes in feeds, 115 still visible to a guest, 0 newly excluded.** Preventive rather than corrective, like #1777 — the restricted rows there are trashed or archived, and the feed already required `published = 1`.

## Tests

`CwmpodcastFeedAccessTest` — source-level, because `getEpisodes()` needs a database and an application while what matters is the SQL it builds:

- all three links of the chain are filtered (filtering only the media file would still publish an episode whose message is restricted)
- levels come from the reader rather than being hardcoded
- **a self-check that the scanner actually reads the method** — a scan that finds everything proves nothing if it is reading the wrong thing

Mutation-checked: removing the filter fails the suite.

`composer lint` 0 of 603; 21 tests green across this, the bracket contract, download-access and protection-helper suites.

## After this

Only **step 3** remains — protected storage outside the web root, the one step that actually stops a direct fetch. Everything shipped so far makes Proclaim consistent about *who may have a file*; step 3 is what makes the file agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
