### PR TITLE
feat(media): verify a directory is actually refused, rather than assuming

### DIFF
--- a/admin/src/Helper/CwmmediaProtectionHelper.php
+++ b/admin/src/Helper/CwmmediaProtectionHelper.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Uri\Uri;
+use Joomla\Http\HttpFactory;
 
 /**
  * Answers whether a media file is restricted in Proclaim while still being
@@ -113,5 +114,191 @@ class CwmmediaProtectionHelper
     {
         return self::isRestrictedFromGuests($media, $guestLevels)
             && self::isServedByWebServer($resolvedUrl);
+    }
+
+    /**
+     * The directory is genuinely refused by the web server.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public const PROTECTED = 'protected';
+
+    /**
+     * The web server handed the file back. Whatever is in here is public.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public const EXPOSED = 'exposed';
+
+    /**
+     * We could not find out. ⚠️ Never treat this as protected: an unanswered
+     * probe is exactly what a broken deny rule looks like from here.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public const UNVERIFIED = 'unverified';
+
+    /**
+     * Seconds to wait for the probe. The request is to this same site, so a
+     * slow answer means something is wrong rather than far away.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const PROBE_TIMEOUT = 10;
+
+    /**
+     * Decide what a probe response means.
+     *
+     * Split from the request itself so the reasoning is testable without a web
+     * server. The rule that matters is the last one: anything we cannot
+     * positively read as a refusal is UNVERIFIED, never PROTECTED. A deny rule
+     * that silently does nothing and a network hiccup look identical from
+     * here, and only one of them is safe to assume.
+     *
+     * @param   int|null  $status  HTTP status, or null if the request itself failed.
+     * @param   string    $body    Response body, empty when there was none.
+     * @param   string    $token   The canary's contents.
+     *
+     * @return  string  One of the class constants.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function interpretProbe(?int $status, string $body, string $token): string
+    {
+        if ($status === null) {
+            return self::UNVERIFIED;
+        }
+
+        // A 200 that returns the canary is unambiguous: the file is public.
+        if ($status >= 200 && $status < 300) {
+            return str_contains($body, $token)
+                ? self::EXPOSED
+                // Success, but not our file — a login page, an error document,
+                // a CDN interstitial. Not served, but not a refusal either.
+                : self::UNVERIFIED;
+        }
+
+        // Only a client error is the web server actually declining. 403 is the
+        // usual answer and 404 is what some configurations return instead of
+        // admitting the file exists; both are refusals.
+        if ($status >= 400 && $status < 500) {
+            return self::PROTECTED;
+        }
+
+        // 3xx and 5xx say nothing useful. A redirect might be a login wall or
+        // might be a canonical-host hop that would have served the file; a 500
+        // means something broke, which is not the same as being refused.
+        // Neither is evidence of protection.
+        return self::UNVERIFIED;
+    }
+
+    /**
+     * Ask the web server whether it will serve a file from this directory.
+     *
+     * Writes a file with known contents, requests it over HTTP the way any
+     * visitor would, and removes it again. This tests the *outcome* rather
+     * than the mechanism, so it is equally valid behind Apache, nginx, IIS or
+     * anything else — which matters because `.htaccess` is silently inert on
+     * nginx, and on Apache with AllowOverride off.
+     *
+     * The canary is removed in a finally block: leaving a readable file behind
+     * in a directory that just proved itself readable would be its own small
+     * hole.
+     *
+     * @param   string  $absoluteDir  Directory to test, absolute filesystem path.
+     * @param   string  $dirUrl       The URL that directory is served from, trailing slash optional.
+     *
+     * @return  string  One of the class constants.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function probeDirectory(string $absoluteDir, string $dirUrl): string
+    {
+        if (!is_dir($absoluteDir) || !is_writable($absoluteDir)) {
+            return self::UNVERIFIED;
+        }
+
+        $token = 'proclaim-canary-' . bin2hex(random_bytes(16));
+        $name  = 'proclaim-canary-' . bin2hex(random_bytes(8)) . '.txt';
+        $path  = rtrim($absoluteDir, '/\\') . '/' . $name;
+
+        if (@file_put_contents($path, $token) === false) {
+            return self::UNVERIFIED;
+        }
+
+        try {
+            $url = rtrim($dirUrl, '/') . '/' . $name;
+
+            try {
+                $response = (new HttpFactory())->getHttp()->get($url, [], self::PROBE_TIMEOUT);
+            } catch (\Throwable) {
+                // No answer at all — could not verify, must not assume safe.
+                return self::UNVERIFIED;
+            }
+
+            return self::interpretProbe(
+                $response->getStatusCode(),
+                (string) $response->getBody(),
+                $token
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * Write deny-all guards into a directory.
+     *
+     * Apache 2.2 and 2.4 both, plus IIS via request filtering — the same pair
+     * Proclaim already ships statically for `media/backup/` and writes at
+     * runtime for the YouTube cache. Shared here so there is one copy rather
+     * than a third.
+     *
+     * ⚠️ Writing these proves nothing. `.htaccess` is inert on nginx and on
+     * Apache with AllowOverride off, and this method cannot tell. Follow it
+     * with probeDirectory() before describing anything as protected.
+     *
+     * @param   string  $dir  Directory to guard, absolute filesystem path.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function writeDenyFiles(string $dir): void
+    {
+        $htaccess = $dir . '/.htaccess';
+
+        if (!file_exists($htaccess)) {
+            @file_put_contents(
+                $htaccess,
+                "<IfModule !mod_authz_core.c>\n"
+                . "Order deny,allow\n"
+                . "Deny from all\n"
+                . "</IfModule>\n"
+                . "<IfModule mod_authz_core.c>\n"
+                . "  <RequireAll>\n"
+                . "    Require all denied\n"
+                . "  </RequireAll>\n"
+                . "</IfModule>\n"
+            );
+        }
+
+        $webConfig = $dir . '/web.config';
+
+        if (!file_exists($webConfig)) {
+            @file_put_contents(
+                $webConfig,
+                "<?xml version=\"1.0\"?>\n"
+                . "<configuration>\n"
+                . "    <system.webServer>\n"
+                . "        <security>\n"
+                . "            <requestFiltering>\n"
+                . "                <fileExtensions allowUnlisted=\"false\" />\n"
+                . "            </requestFiltering>\n"
+                . "        </security>\n"
+                . "    </system.webServer>\n"
+                . "</configuration>\n"
+            );
+        }
     }
 }

--- a/admin/src/Helper/CwmyoutubeFileCache.php
+++ b/admin/src/Helper/CwmyoutubeFileCache.php
@@ -654,6 +654,7 @@ class CwmyoutubeFileCache
         }
     }
 
+
     /**
      * Write deny-all .htaccess/web.config into a newly created cache
      * directory.
@@ -664,48 +665,19 @@ class CwmyoutubeFileCache
      * cached video metadata, scheduled-stream times -- are web-servable with
      * no auth check.
      *
-     * @param   string  $dir  The cache directory that was just created
+     * The writing itself now lives in CwmmediaProtectionHelper, which needed
+     * the same guards for protected media and is where the check that they
+     * actually work also lives (#1774). One copy, two callers.
+     *
+     * @param   string  $dir  Directory to guard
      *
      * @return  void
      *
-     * @since   10.5.6
+     * @since   10.5.0
      */
     private static function writeAccessDenyFiles(string $dir): void
     {
-        $htaccess = $dir . '/.htaccess';
-
-        if (!file_exists($htaccess)) {
-            @file_put_contents(
-                $htaccess,
-                "<IfModule !mod_authz_core.c>\n"
-                . "Order deny,allow\n"
-                . "Deny from all\n"
-                . "</IfModule>\n"
-                . "<IfModule mod_authz_core.c>\n"
-                . "  <RequireAll>\n"
-                . "    Require all denied\n"
-                . "  </RequireAll>\n"
-                . "</IfModule>\n"
-            );
-        }
-
-        $webConfig = $dir . '/web.config';
-
-        if (!file_exists($webConfig)) {
-            @file_put_contents(
-                $webConfig,
-                "<?xml version=\"1.0\"?>\n"
-                . "<configuration>\n"
-                . "    <system.webServer>\n"
-                . "        <security>\n"
-                . "            <requestFiltering>\n"
-                . "                <fileExtensions allowUnlisted=\"false\" />\n"
-                . "            </requestFiltering>\n"
-                . "        </security>\n"
-                . "    </system.webServer>\n"
-                . "</configuration>\n"
-            );
-        }
+        CwmmediaProtectionHelper::writeDenyFiles($dir);
     }
 
     /**

--- a/tests/unit/Admin/Helper/CwmmediaProtectionHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmmediaProtectionHelperTest.php
@@ -134,4 +134,121 @@ class CwmmediaProtectionHelperTest extends ProclaimTestCase
             'public and on our web server — working as intended'
         );
     }
+
+    // -----------------------------------------------------------------
+    // the canary: does the web server actually refuse this directory?
+    // -----------------------------------------------------------------
+
+    /** A 200 handing back the canary is the whole point: the file is public. */
+    public function testTheCanaryComingBackMeansExposed(): void
+    {
+        self::assertSame(
+            CwmmediaProtectionHelper::EXPOSED,
+            CwmmediaProtectionHelper::interpretProbe(200, 'tok-123', 'tok-123')
+        );
+    }
+
+    /** A client error is the web server declining. 404 counts as much as 403. */
+    public function testAClientErrorMeansProtected(): void
+    {
+        foreach ([401, 403, 404, 410] as $status) {
+            self::assertSame(
+                CwmmediaProtectionHelper::PROTECTED,
+                CwmmediaProtectionHelper::interpretProbe($status, '', 'tok-123'),
+                "HTTP {$status} is a refusal."
+            );
+        }
+    }
+
+    /**
+     * The rule that matters most. A deny rule that silently does nothing and a
+     * network failure look identical from here, so anything we cannot read as
+     * a refusal must not be reported as protection.
+     */
+    public function testAnythingInconclusiveIsNeverReportedAsProtected(): void
+    {
+        $cases = [
+            'no response at all'            => [null, ''],
+            'a redirect'                    => [302, ''],
+            'a server error'                => [500, ''],
+            'a bad gateway'                 => [502, ''],
+            '200 with someone else\'s body' => [200, '<html>Please log in</html>'],
+        ];
+
+        foreach ($cases as $what => [$status, $body]) {
+            self::assertSame(
+                CwmmediaProtectionHelper::UNVERIFIED,
+                CwmmediaProtectionHelper::interpretProbe($status, $body, 'tok-123'),
+                ucfirst($what) . ' must be UNVERIFIED, never PROTECTED.'
+            );
+        }
+    }
+
+    /**
+     * A 500 is not a refusal. Treating every non-2xx as protection would call
+     * a broken server a secure one, which is the failure this check exists to
+     * prevent.
+     */
+    public function testAServerErrorIsNotMistakenForARefusal(): void
+    {
+        self::assertNotSame(
+            CwmmediaProtectionHelper::PROTECTED,
+            CwmmediaProtectionHelper::interpretProbe(500, '', 'tok-123')
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // the deny files
+    // -----------------------------------------------------------------
+
+    /** Apache 2.2 and 2.4 both, plus IIS — the pair Proclaim already ships. */
+    public function testItWritesGuardsForApacheAndIis(): void
+    {
+        $dir = sys_get_temp_dir() . '/cwm-deny-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o777, true);
+
+        try {
+            CwmmediaProtectionHelper::writeDenyFiles($dir);
+
+            $htaccess = (string) file_get_contents($dir . '/.htaccess');
+            self::assertStringContainsString('Deny from all', $htaccess, 'Apache 2.2');
+            self::assertStringContainsString('Require all denied', $htaccess, 'Apache 2.4');
+            self::assertStringContainsString(
+                'allowUnlisted="false"',
+                (string) file_get_contents($dir . '/web.config'),
+                'IIS'
+            );
+        } finally {
+            @unlink($dir . '/.htaccess');
+            @unlink($dir . '/web.config');
+            @rmdir($dir);
+        }
+    }
+
+    /** Never clobber a guard an administrator has customised. */
+    public function testItLeavesAnExistingGuardAlone(): void
+    {
+        $dir = sys_get_temp_dir() . '/cwm-deny-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o777, true);
+        file_put_contents($dir . '/.htaccess', '# hand-written');
+
+        try {
+            CwmmediaProtectionHelper::writeDenyFiles($dir);
+
+            self::assertSame('# hand-written', file_get_contents($dir . '/.htaccess'));
+        } finally {
+            @unlink($dir . '/.htaccess');
+            @unlink($dir . '/web.config');
+            @rmdir($dir);
+        }
+    }
+
+    /** An unwritable or missing directory cannot be verified, so it is not. */
+    public function testAnUnusableDirectoryIsUnverifiedRatherThanProtected(): void
+    {
+        self::assertSame(
+            CwmmediaProtectionHelper::UNVERIFIED,
+            CwmmediaProtectionHelper::probeDirectory('/no/such/directory/here', 'https://example.org/x')
+        );
+    }
 }


### PR DESCRIPTION
The load-bearing piece of the re-scoped step 3 (#1774). Nothing is wired up yet — this is the check everything else will rest on.

## Why this and not the deny rule

The deny rule is the easy part, and **Proclaim already has it**: `media/backup/` ships `.htaccess` + `web.config`, and `CwmyoutubeFileCache` writes the same pair at runtime for its cache directory.

What was missing is that **nobody checks it works**. `.htaccess` is silently inert on **nginx**, and on Apache with `AllowOverride` off. Proclaim would write the file, believe the directory protected, and show an administrator a green light over an open door.

Since most supported hosts cannot write above the web root, that verification is the difference between a real boundary and a comforting fiction.

## How it verifies

`probeDirectory()` writes a file with known contents, requests it **over HTTP** the way a visitor would, and removes it again in a `finally` — leaving a readable canary in a directory that just proved itself readable would be its own small hole.

It tests the **outcome**, not the mechanism, so it is equally valid behind Apache, nginx, IIS or anything else.

## The rule, and why it is deliberately asymmetric

`interpretProbe()` is split out so the reasoning is testable without a web server:

| Response | Verdict | Why |
|---|---|---|
| 2xx returning the canary | `EXPOSED` | unambiguous — the file is public |
| **4xx** | `PROTECTED` | the server declined; 404 counts as much as 403 |
| 2xx returning something else | `UNVERIFIED` | a login page or CDN interstitial — not served, but not a refusal |
| **3xx** | `UNVERIFIED` | might be a login wall, might be a canonical-host hop that would have served it |
| **5xx** | `UNVERIFIED` | something broke, which is not the same as being declined |
| no response | `UNVERIFIED` | tells us nothing |

**Only a 4xx is read as a refusal.** A deny rule that does nothing and a network hiccup look identical from here, and only one of them is safe to assume — so nothing is ever reported as protected without positive evidence.

That asymmetry *is* the class. Both mutations of it fail the tests: making every non-2xx mean `PROTECTED` breaks 2, and treating a failed request as `PROTECTED` breaks 1.

## Also: one copy of the guards

`writeDenyFiles()` is shared rather than copied a third time. `CwmyoutubeFileCache::writeAccessDenyFiles()` now delegates to it, leaving a single definition of those Apache/IIS guards in the codebase — and its docblock says outright that writing them proves nothing, pointing at the probe.

## Tests

15 tests / 29 assertions: every verdict above, the deny files covering Apache 2.2, 2.4 and IIS, that an administrator's hand-written `.htaccess` is never clobbered, and that an unusable directory is `UNVERIFIED` rather than optimistically protected.

`composer lint` 0 of 603.

## Not in this PR

The protected directory itself, the storage plumbing, and the UI that surfaces the verdict. Those follow — this is the piece they depend on, built and provable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
