### PR TITLE
feat(media): move a self-hosted file into protected storage

### DIFF
--- a/admin/src/Helper/CwmprotectedStorage.php
+++ b/admin/src/Helper/CwmprotectedStorage.php
@@ -236,4 +236,129 @@ class CwmprotectedStorage
     {
         return CwmmediaProtectionHelper::isServedByWebServer($resolvedUrl);
     }
+
+    /**
+     * Is this absolute path inside this root?
+     *
+     * Pure, and separated because getting it wrong is how a path check becomes
+     * decorative. The trailing separator matters: without it `/var/www-evil`
+     * passes a prefix test against `/var/www`.
+     *
+     * Both sides are expected to be already resolved — symlinks and `..`
+     * removed — because this cannot do that for a path that does not exist.
+     *
+     * @param   string  $absolute  Resolved absolute path to test.
+     * @param   string  $root      Resolved absolute root it must be under.
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function isInside(string $absolute, string $root): bool
+    {
+        if ($absolute === '' || $root === '') {
+            return false;
+        }
+
+        $root = rtrim($root, '/\\');
+
+        return $absolute === $root || str_starts_with($absolute, $root . '/');
+    }
+
+    /**
+     * A filename that will not overwrite something already in the directory.
+     *
+     * Collisions are likely rather than exotic: two services in one week both
+     * uploading `sermon.mp3` is the normal case, and silently replacing the
+     * first would destroy a file this class exists to look after.
+     *
+     * @param   string  $dir       Directory the file will land in.
+     * @param   string  $basename  Desired filename.
+     *
+     * @return  string  A name not currently taken in that directory.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function uniqueName(string $dir, string $basename): string
+    {
+        $dir = rtrim($dir, '/\\');
+
+        if (!file_exists($dir . '/' . $basename)) {
+            return $basename;
+        }
+
+        $extension = pathinfo($basename, PATHINFO_EXTENSION);
+        $stem      = pathinfo($basename, PATHINFO_FILENAME);
+        $suffix    = $extension === '' ? '' : '.' . $extension;
+
+        for ($i = 1; $i < 1000; $i++) {
+            $candidate = $stem . '-' . $i . $suffix;
+
+            if (!file_exists($dir . '/' . $candidate)) {
+                return $candidate;
+            }
+        }
+
+        // A thousand collisions on one name is not a case worth an algorithm.
+        return $stem . '-' . bin2hex(random_bytes(6)) . $suffix;
+    }
+
+    /**
+     * Move a self-hosted media file into protected storage.
+     *
+     * ⚠️ Only restricted media belongs here. Everything public should stay
+     * where it is and keep being served by the web server directly — moving it
+     * would put every download through PHP for no benefit, and the proxy cost
+     * should scale with the restricted material rather than the whole library.
+     *
+     * Refuses anything that does not resolve to a real file inside the site
+     * root. The stored filename comes from the database, which an administrator
+     * can edit, so it is treated as untrusted: resolved first, checked second,
+     * moved only if both hold.
+     *
+     * @param   string  $relativePath  Current path of the file, relative to the site root.
+     *
+     * @return  string|null  The new site-relative path, or null if it could not be moved.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function moveInto(string $relativePath): ?string
+    {
+        $relativePath = ltrim(trim($relativePath), '/');
+
+        if ($relativePath === '') {
+            return null;
+        }
+
+        $root   = realpath(JPATH_ROOT);
+        $source = realpath(rtrim(JPATH_ROOT, '/\\') . '/' . $relativePath);
+
+        // Missing, or resolving outside the site — either way, not ours to move.
+        if ($root === false || $source === false || !is_file($source)) {
+            return null;
+        }
+
+        if (!self::isInside($source, $root)) {
+            return null;
+        }
+
+        // Already where it should be. Idempotent so a repeated call — a retried
+        // request, a re-run migration — is harmless rather than a second move.
+        if (self::isInside($source, realpath(self::path()) ?: self::path())) {
+            return $relativePath;
+        }
+
+        if (!self::ensure()) {
+            return null;
+        }
+
+        $name        = self::uniqueName(self::path(), basename($source));
+        $destination = self::path() . '/' . $name;
+
+        if (!@rename($source, $destination)) {
+            return null;
+        }
+
+        return self::RELATIVE_PATH . '/' . $name;
+    }
 }

--- a/tests/unit/Admin/Helper/CwmprotectedStorageTest.php
+++ b/tests/unit/Admin/Helper/CwmprotectedStorageTest.php
@@ -115,4 +115,128 @@ class CwmprotectedStorageTest extends ProclaimTestCase
             'A remote object is not ours to relocate — which is not the same as it being unprotectable.'
         );
     }
+
+    // -----------------------------------------------------------------
+    // path containment — the check that must not be decorative
+    // -----------------------------------------------------------------
+
+    /**
+     * The sibling-prefix case. Without the trailing separator, /var/www-evil
+     * passes a prefix test against /var/www and the guard means nothing.
+     */
+    public function testASiblingDirectoryIsNotInside(): void
+    {
+        self::assertFalse(CwmprotectedStorage::isInside('/var/www-evil/x.mp3', '/var/www'));
+        self::assertFalse(CwmprotectedStorage::isInside('/var/wwwsomething', '/var/www'));
+    }
+
+    public function testRealChildrenAreInside(): void
+    {
+        self::assertTrue(CwmprotectedStorage::isInside('/var/www/x.mp3', '/var/www'));
+        self::assertTrue(CwmprotectedStorage::isInside('/var/www/deep/er/x.mp3', '/var/www'));
+        self::assertTrue(
+            CwmprotectedStorage::isInside('/var/www', '/var/www'),
+            'The root itself is inside itself.'
+        );
+    }
+
+    public function testATrailingSlashOnTheRootDoesNotBreakIt(): void
+    {
+        self::assertTrue(CwmprotectedStorage::isInside('/var/www/x.mp3', '/var/www/'));
+    }
+
+    public function testEmptyPathsAreNeverInside(): void
+    {
+        self::assertFalse(CwmprotectedStorage::isInside('', '/var/www'));
+        self::assertFalse(CwmprotectedStorage::isInside('/var/www/x', ''));
+    }
+
+    // -----------------------------------------------------------------
+    // collisions — two services, one sermon.mp3
+    // -----------------------------------------------------------------
+
+    public function testAFreeNameIsUsedAsIs(): void
+    {
+        $dir = $this->tempDir();
+
+        try {
+            self::assertSame('sermon.mp3', CwmprotectedStorage::uniqueName($dir, 'sermon.mp3'));
+        } finally {
+            $this->cleanup($dir);
+        }
+    }
+
+    /** Overwriting would destroy a file this class exists to look after. */
+    public function testATakenNameIsNotOverwritten(): void
+    {
+        $dir = $this->tempDir();
+        file_put_contents($dir . '/sermon.mp3', 'first');
+
+        try {
+            $name = CwmprotectedStorage::uniqueName($dir, 'sermon.mp3');
+
+            self::assertNotSame('sermon.mp3', $name);
+            self::assertStringEndsWith('.mp3', $name, 'The extension has to survive.');
+            self::assertFileDoesNotExist($dir . '/' . $name);
+        } finally {
+            $this->cleanup($dir);
+        }
+    }
+
+    public function testAnExtensionlessNameStillGetsUniquified(): void
+    {
+        $dir = $this->tempDir();
+        file_put_contents($dir . '/README', 'first');
+
+        try {
+            self::assertNotSame('README', CwmprotectedStorage::uniqueName($dir, 'README'));
+        } finally {
+            $this->cleanup($dir);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // moving in
+    // -----------------------------------------------------------------
+
+    /** The stored filename is administrator-editable, so it is untrusted. */
+    public function testItRefusesPathsThatEscapeTheSiteRoot(): void
+    {
+        foreach (['../../../etc/passwd', '/etc/passwd', ''] as $path) {
+            self::assertNull(
+                CwmprotectedStorage::moveInto($path),
+                \sprintf('%s must not be movable.', $path === '' ? '(empty)' : $path)
+            );
+        }
+    }
+
+    public function testItRefusesAFileThatDoesNotExist(): void
+    {
+        self::assertNull(CwmprotectedStorage::moveInto('images/biblestudy/nope-' . bin2hex(random_bytes(4)) . '.mp3'));
+    }
+
+    /**
+     * @return string
+     */
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/cwm-ps-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o777, true);
+
+        return $dir;
+    }
+
+    /**
+     * @param   string  $dir  Directory to remove.
+     *
+     * @return void
+     */
+    private function cleanup(string $dir): void
+    {
+        foreach (glob($dir . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+
+        @rmdir($dir);
+    }
 }


### PR DESCRIPTION
## Two of the three items turned out to be already done

Keeping the directory **inside** the web root — forced by the hosting constraint — removed most of this:

- **Uploads already work.** `Cwmuploadscript.php:96` builds `JPATH_ROOT / folder / name`, and the protected directory is under `JPATH_ROOT`.
- **Deletes already work.** `CWMAddonLocal.php:170` confines itself to `realpath(JPATH_SITE)`, and the directory is inside that too.

Neither guard needed relaxing. That was the point of choosing an in-web-root location, and it is worth noting the outside-the-web-root design would have required loosening both — the two most safety-relevant checks in the media path.

## What was left: moving a file in

The stored filename comes from the database and an administrator can edit it, so `moveInto()` treats it as untrusted — resolved first, checked against the site root second, moved only if both hold.

**`isInside()` is separate and pure**, because getting it wrong is how a path check becomes decorative:

```
isInside('/var/www-evil/x.mp3', '/var/www')   →  false
```

Without the trailing separator that passes a naive prefix test. Removing the separator fails the test written for it.

**`uniqueName()` refuses to overwrite.** Two services in one week both uploading `sermon.mp3` is the normal case, not an exotic one, and silently replacing the first would destroy a file this class exists to look after. Making it overwrite fails 2 tests.

**`moveInto()` is idempotent** — a file already in the directory is reported as moved rather than moved again, so a retried request or a re-run migration is harmless.

## On server load

⚠️ **Only restricted media belongs in here.** Public media should stay where it is and keep being served directly by the web server; moving it would put every download through PHP for no benefit.

That is the answer to the cost question this design raises: proxy load scales with the *restricted* material, not the whole library. A site with one subscriber series and four hundred public sermons proxies one series. The docblock says so at the point someone would otherwise be tempted to move everything.

Worth knowing for later, not now: the streamer chunks at 8KB and honours Range, so memory is flat regardless of file size — the cost is PHP process time held open for the duration of a download, which is a concurrency question rather than a memory one.

## Tests

17 tests / 29 assertions. The containment cases (sibling prefix, real children, the root itself, trailing slash, empty), collision handling (free name, taken name keeps its extension, extensionless name), and refusal of `../../../etc/passwd`, an absolute path, an empty string and a non-existent file.

Both safety rules mutation-checked. `composer lint` 0 of 605; 39 tests green across the protection suites.

## Remaining for step 3

The UI that surfaces the verdict and offers the move. The mechanics are now all present and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
