### PR TITLE
chore(config): declare the protected-media state so Options does not drop it

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -165,6 +165,33 @@
                 default="0"
                 filter="int"
         />
+        <!--
+            Protected-media state, written by CwmprotectedStorage rather than
+            by anyone editing this form. Declared only so that saving Options
+            does not drop it: the component save binds the submitted fields
+            over the whole params blob, so an undeclared value disappears the
+            first time an administrator presses Save.
+
+            Losing it is not harmful - the next check re-probes and rewrites
+            both - but it would mean a needless HTTP round trip after every
+            Options save, and a value that appears to reset for no reason.
+
+            Not authoritative. The status is re-taken weekly regardless of what
+            is stored here, so an edited value corrects itself rather than
+            silently suppressing a warning for good.
+        -->
+        <field
+                name="protected_media_status"
+                type="hidden"
+                default=""
+                filter="string"
+        />
+        <field
+                name="protected_media_checked"
+                type="hidden"
+                default="0"
+                filter="int"
+        />
     </fieldset>
     <fieldset name="permissions" label="JCONFIG_PERMISSIONS_LABEL"
               description="JCONFIG_PERMISSIONS_DESC">


### PR DESCRIPTION
`CwmprotectedStorage` writes `protected_media_status` and `protected_media_checked`, but neither was declared in `config.xml`.

com_config's save binds the submitted fields over the **whole** params blob — `ComponentModel::save()` → `$table->bind($data)` — so an undeclared value disappears the first time an administrator presses Save in Options.

## Why it mattered, and why it did not

Losing it was never harmful: the next check re-probes and rewrites both, so the state is self-healing. What it cost was a needless HTTP round trip after every Options save, and a stored value that appeared to reset for no reason — the kind of thing someone later spends an afternoon explaining.

## How

Declared `type="hidden"`, matching `location_system_dismissed` directly above it — the existing precedent for internal state kept in params rather than edited on the form. Filters match how the values are written and read: `string` for the verdict, `int` for the timestamp.

## One thing said out loud in the comment

Declaring a field does put it in the form's DOM, so the comment states that **these are not authoritative**. The status is re-taken weekly regardless of what is stored, so an edited value corrects itself rather than suppressing a warning permanently.

## Verified

`config.xml` parses; 20 declared fields, up from 18. No test asserts on the form's shape — the one test referencing `config.xml` does so in a docblock about a *missing* key and still passes. Protection suites green (35 tests), `composer lint` 0 of 605.

No migration: absent params still mean "never checked", which is exactly the state that triggers the first probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ