### PR TITLE
fix(api): do not touch the document when there is no document

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -11,6 +11,7 @@
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Factory;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -81,26 +82,41 @@ if (is_dir($modProclaimPath)) {
 
 // Register web asset registries so assets are available when views/modules request them.
 // Actual useStyle/useScript calls are made by individual views and module dispatchers.
-$wa = $app->getDocument()->getWebAssetManager();
-$wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
+//
+// Guarded because this file does NOT only run in web applications, despite what
+// the comment below used to claim. plg_task_proclaim requires it from its
+// constructor, and com_scheduler imports every task plugin just to list the
+// routines they offer — so `php cli/joomla.php scheduler:run` reached this line
+// with a ConsoleApplication, which has no getDocument(), and died before any
+// task ran. Every scheduled task on the site was affected, including other
+// extensions' and Joomla's own (#1787).
+//
+// Asset registries mean nothing without a document, so skipping them off the
+// web costs nothing. CMSWebApplicationInterface is what declares getDocument();
+// ConsoleApplication implements CMSApplicationInterface but not that.
+if ($app instanceof CMSWebApplicationInterface) {
+    $wa = $app->getDocument()->getWebAssetManager();
+    $wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
 
-// Admin pages load core assets globally; front-end views load them on demand
-// to avoid render-blocking CSS/JS on pages that don't need them.
-if ($app->isClient('administrator')) {
-    $wa->useStyle('com_proclaim.cwmcore')
-        ->useScript('com_proclaim.cwmcorejs')
-        ->useScript('com_proclaim.cwmcorejs-admin');
+    // Admin pages load core assets globally; front-end views load them on demand
+    // to avoid render-blocking CSS/JS on pages that don't need them.
+    if ($app->isClient('administrator')) {
+        $wa->useStyle('com_proclaim.cwmcore')
+            ->useScript('com_proclaim.cwmcorejs')
+            ->useScript('com_proclaim.cwmcorejs-admin');
+    }
+
+    // Register lib_cwmscripture web assets (libraries aren't auto-discovered by Joomla)
+    $wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
 }
-
-// Register lib_cwmscripture web assets (libraries aren't auto-discovered by Joomla)
-$wa->getRegistry()->addExtensionRegistryFile('lib_cwmscripture');
 
 // Log categories are registered by CwmlogHelper, not here.
 //
-// This file only runs in the administrator and site applications — it needs a
-// document for the web asset manager, which the API application does not have.
-// Registering loggers here therefore left API code with no logger at all, and
-// silently discarded everything it logged.
+// This file was written on the assumption that it only runs in the
+// administrator and site applications, because it needs a document for the web
+// asset manager. That assumption was wrong twice over: registering loggers here
+// left API code with no logger at all and silently discarded everything it
+// logged, and the console reaches this file too, via plg_task_proclaim (#1787).
 //
 // Registration now lives in CwmlogHelper (called from ProclaimComponent::boot(),
 // so every application is covered). The call below is for the paths that reach

--- a/tests/unit/Admin/Helper/ApiBootstrapConsoleSafetyTest.php
+++ b/tests/unit/Admin/Helper/ApiBootstrapConsoleSafetyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Contract test: admin/api.php must survive being required off the web
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `admin/api.php` is required from plugin constructors — plg_task_proclaim and
+ * plg_finder_proclaim both do it — and plugins are imported in every
+ * application, including the console.
+ *
+ * com_scheduler imports every task plugin merely to list the routines it
+ * offers, so `php cli/joomla.php scheduler:run` executed this file with a
+ * ConsoleApplication. It called `getDocument()`, which ConsoleApplication does
+ * not have, and the process died before any task ran — Joomla's own tasks
+ * included, on any site with Proclaim installed (#1787).
+ *
+ * Asserted at source level because the failure needs a console application to
+ * reproduce, which a unit test has no way to stand up.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ApiBootstrapConsoleSafetyTest extends TestCase
+{
+    /**
+     * Does this line call getDocument() unconditionally?
+     *
+     * api.php is a procedural bootstrap, so column zero means "runs in every
+     * application". Comments are excluded — the explanation of this very rule
+     * names the method, and flagging prose would make the test unmaintainable.
+     *
+     * @param   string  $line  A line of source.
+     *
+     * @return  bool
+     */
+    private static function isUnguardedCall(string $line): bool
+    {
+        $trimmed = ltrim($line);
+
+        if ($trimmed === '' || str_starts_with($trimmed, '//') || str_starts_with($trimmed, '*')) {
+            return false;
+        }
+
+        return str_contains($line, 'getDocument()') && !str_starts_with($line, ' ');
+    }
+
+    /**
+     * @return string
+     */
+    private static function source(): string
+    {
+        return (string) file_get_contents(\dirname(__DIR__, 4) . '/admin/api.php');
+    }
+
+    /**
+     * Every web-only call has to sit inside a guard.
+     *
+     * Checked by indentation: this file is a procedural bootstrap, so anything
+     * at column zero runs unconditionally. A `getDocument()` there is the bug.
+     */
+    public function testNoUnconditionalDocumentAccess(): void
+    {
+        $offenders = [];
+
+        foreach (explode("\n", self::source()) as $number => $line) {
+            if (self::isUnguardedCall($line)) {
+                $offenders[] = \sprintf('api.php:%d  %s', $number + 1, trim($line));
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "getDocument() at the top level of api.php runs in every application. ConsoleApplication does not "
+            . 'have it, and this file is reached from plugin constructors, so an unguarded call breaks '
+            . '`joomla.php scheduler:run` for every task on the site.'
+        );
+    }
+
+    /** And the guard has to be the one that actually implies a document. */
+    public function testTheGuardIsTheInterfaceThatDeclaresGetDocument(): void
+    {
+        $this->assertStringContainsString(
+            'instanceof CMSWebApplicationInterface',
+            self::source(),
+            'CMSWebApplicationInterface is what declares getDocument(). ConsoleApplication implements '
+            . 'CMSApplicationInterface but not that one, so checking the wrong interface would still break.'
+        );
+    }
+
+    /**
+     * Guards the scan above. A test that finds nothing proves nothing unless it
+     * is known to find something.
+     */
+    public function testTheDetectorWorks(): void
+    {
+        $this->assertTrue(
+            self::isUnguardedCall('$wa = $app->getDocument()->getWebAssetManager();'),
+            'The detector no longer recognises the unguarded call it was written for.'
+        );
+        $this->assertFalse(
+            self::isUnguardedCall('    $wa = $app->getDocument()->getWebAssetManager();'),
+            'The detector reports a guarded call as an offender.'
+        );
+        $this->assertFalse(
+            self::isUnguardedCall('// ... is what declares getDocument();'),
+            'The detector must not flag prose. The explanation of this very rule mentions the call.'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1787.

## Reproduced exactly as reported

On j6-dev, against Joomla's **own** Rotate Logs task — nothing to do with Proclaim:

```
$ php cli/joomla.php scheduler:run --id=1

In api.php line 84:
  Call to undefined method Joomla\CMS\Application\ConsoleApplication::getDocument()
```

## The chain, confirmed

`admin/api.php` registered web asset registries unconditionally. `plg_task_proclaim` requires that file **from its constructor**, and com_scheduler imports every task plugin just to list the routines each offers — so the console reached a line that assumes a web application and died before any task ran.

`plg_finder_proclaim` requires the same file, so the finder CLI indexer was on the same path.

**The blast radius is the point.** CLI cron is the recommended way to run the scheduler in production, so on a Proclaim site *no* scheduled task could run that way — other extensions' included. It surfaced through CWMLivingWord's daily reading email, which would simply never send, with nothing in any log a site administrator would look at. The lazy web scheduler kept working, which is why this went unnoticed.

## The fix

Guarded on `CMSWebApplicationInterface` — the interface that **declares** `getDocument()`. `ConsoleApplication` implements `CMSApplicationInterface` but not that one, so checking the wrong interface would have left the bug in place. Asset registries are meaningless without a document, so skipping them off the web costs nothing.

## I checked the rest of the file, as the issue asked

Only `getDocument()` needed guarding. `getIdentity()`, `getInput()`, `isClient()` and `getLanguage()` all exist on `ConsoleApplication` — the first via the `IdentityAware` trait, the rest via `CMSApplicationInterface`. The remainder of the file is safe as written.

## A stale comment, corrected

The file claimed it *"only runs in the administrator and site applications"*. That assumption was **already known to be wrong once** — the logger note directly beneath it records the API application breaking the same way and having its logging silently discarded. It is wrong again here. Corrected rather than left to mislead whoever reads it next.

## Verified

| | |
|---|---|
| before | fatal on `--id=1` |
| after | `Task#01 'Rotate Logs' processed in 0.06 seconds.` |

Tested by pointing the dev site's component symlink at this branch, running the real CLI scheduler, and restoring it — Joomla 6, PHP 8.5.

`ApiBootstrapConsoleSafetyTest` guards it at source level, since reproducing needs a console application a unit test cannot stand up. It scans for `getDocument()` at column zero — this file is a procedural bootstrap, so column zero means "runs in every application" — and asserts the guard is the right interface. Mutation-checked: un-indenting the call fails it.

The detector ignores comments, which it learned the hard way: the explanation of this very rule names the method, and the first version flagged its own prose.

`composer lint` 0 of 606. The 36 errors in the wider Admin Helper suite are `Access denied for user 'root'` in my sandbox and are **identical on the base commit** (743 tests there, 746 here — the 3 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
