### PR TITLE
fix: stop reading and writing the retired teacher_id column

### DIFF
--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -188,16 +188,10 @@ class CwmcsvimportHelper
         $columns = [
             'studytitle', 'alias', 'studydate', 'published', 'access', 'language',
             'hits', 'studyintro', 'studytext', 'studynumber',
-            'series_id', 'location_id', 'messagetype', 'teacher_id',
+            'series_id', 'location_id', 'messagetype',
             'thumbnailm', 'created_by_alias',
             'created_by', 'ordering',
         ];
-
-        $primaryTeacherId = 0;
-
-        if (!empty($teacherIds)) {
-            $primaryTeacherId = $teacherIds[0];
-        }
 
         $values = [
             $db->quote($title),
@@ -213,7 +207,6 @@ class CwmcsvimportHelper
             (int) $seriesId ?: 'NULL',
             (int) $locationId ?: 'NULL',
             (int) $messageTypeId ?: 'NULL',
-            (int) $primaryTeacherId ?: 'NULL',
             $db->quote($rowData['thumbnailm'] ?? ''),
             $db->quote($rowData['created_by_alias'] ?? ''),
             (int) ($user ? $user->id : 0),

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -888,15 +888,13 @@ class CwmmessageModel extends AdminModel
 
         foreach ($pks as $pk) {
             if ($user->authorise('core.edit', $contexts[$pk])) {
+                // Confirm the study exists before writing junction rows for it.
                 $table->reset();
-                $table->load($pk);
-                $table->teacher_id = $teacherId;
 
-                if (!$table->store()) {
+                if (!$table->load($pk)) {
                     throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
 
-                // Update junction table to match
                 $teachers = $teacherId > 0
                     ? [['teacher_id' => $teacherId]]
                     : [];

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -888,10 +888,10 @@ class CwmmessageModel extends AdminModel
 
         foreach ($pks as $pk) {
             if ($user->authorise('core.edit', $contexts[$pk])) {
-                // Confirm the study exists before writing junction rows for it.
                 $table->reset();
 
-                if (!$table->load($pk)) {
+                // Storing a table that failed to load would insert a new row.
+                if (!$table->load($pk) || !$table->store()) {
                     throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
 

--- a/admin/tmpl/cwmmessage/edit.php
+++ b/admin/tmpl/cwmmessage/edit.php
@@ -43,7 +43,7 @@ $options = base64_encode('study_id=' . $this->item->id . '&createdate=' . $this-
 
 // Set up defaults
 if ($input->getInt('id')) {
-    $teacher_id   = $this->item->teacher_id;
+    $teacher_id   = (int) ($this->item->teachers[0]['teacher_id'] ?? 0);
     $location_id  = $this->item->location_id;
     $series_id    = $this->item->series_id;
     $messagetype  = $this->item->messagetype;

--- a/tests/unit/Sql/StudyColumnContractTest.php
+++ b/tests/unit/Sql/StudyColumnContractTest.php
@@ -111,6 +111,50 @@ class StudyColumnContractTest extends ProclaimTestCase
         );
     }
 
+    /**
+     * The CSV importer builds its INSERT from two parallel literals, so it has
+     * both failure modes at once: a name no longer in the table is a fatal
+     * "Unknown column", and a count that drifts apart writes every value after
+     * the gap into the wrong column.
+     */
+    #[TestDox('the CSV importer inserts real study columns, one value each')]
+    public function testCsvImportColumnsExist(): void
+    {
+        $source = (string) file_get_contents(JPATH_ROOT . '/admin/src/Helper/CwmcsvimportHelper.php');
+
+        if (!preg_match('/\$columns\s*=\s*\[(.*?)\];/s', $source, $columnBlock)) {
+            self::fail('Could not find the $columns literal in CwmcsvimportHelper.');
+        }
+
+        if (!preg_match('/\$values\s*=\s*\[(.*?)\n\s*\];/s', $source, $valueBlock)) {
+            self::fail('Could not find the $values literal in CwmcsvimportHelper.');
+        }
+
+        preg_match_all("/'([a-z0-9_]+)'/i", $columnBlock[1], $names);
+
+        self::assertNotEmpty($names[1], 'No column names were parsed, so this test checks nothing.');
+
+        foreach ($names[1] as $column) {
+            self::assertContains(
+                $column,
+                self::studyColumns(),
+                'CwmcsvimportHelper inserts into #__bsms_studies.' . $column . ', which the table does not have. '
+                . 'Unlike a stale read this is fatal: the whole import fails with "Unknown column".'
+            );
+        }
+
+        $values = array_filter(
+            array_map('trim', explode("\n", $valueBlock[1])),
+            static fn (string $line): bool => $line !== ''
+        );
+
+        self::assertCount(
+            \count($names[1]),
+            $values,
+            'The $columns and $values literals have drifted apart, so imported rows land in the wrong columns.'
+        );
+    }
+
     #[DataProvider('itemPropertyProvider')]
     #[TestDox('$file reads $property, which the item carries')]
     public function testItemReadsNameSomethingTheItemCarries(string $file, string $property): void

--- a/tests/unit/Sql/StudyColumnContractTest.php
+++ b/tests/unit/Sql/StudyColumnContractTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Contract tests binding message template reads to the shipped study schema
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Unit\Sql;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Every `$this->item->x` in the message templates must name something the item
+ * actually carries: a column of #__bsms_studies, or a property the model adds.
+ *
+ * The item is a plain stdClass built by `SELECT *`, so a property that no longer
+ * exists reads as null and raises a PHP warning rather than failing. A template
+ * therefore keeps rendering after the column behind it is retired — the field it
+ * feeds simply goes empty, which looks like missing data rather than a defect.
+ *
+ * Retiring a column is a schema change with no compiler and no failing test to
+ * connect it to the templates that read it, which is what this asserts instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[Group('sql')]
+class StudyColumnContractTest extends ProclaimTestCase
+{
+    /**
+     * The shipped schema, which is authoritative for what a study row holds.
+     */
+    private const INSTALL_SQL = JPATH_ROOT . '/admin/sql/install.mysql.utf8.sql';
+
+    /**
+     * Templates whose `$this->item` is a study row.
+     */
+    private const TEMPLATE_DIR = JPATH_ROOT . '/admin/tmpl/cwmmessage';
+
+    /**
+     * Properties CwmmessageModel::getItem() attaches to the row after loading it.
+     *
+     * These are subform payloads assembled from junction tables, so they are
+     * legitimately absent from #__bsms_studies. Anything else must be a column.
+     */
+    private const MODEL_ADDED = [
+        'scriptures',
+        'teachers',
+    ];
+
+    /**
+     * One case per distinct property read across the message templates.
+     *
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function itemPropertyProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(self::TEMPLATE_DIR . '/*.php') ?: [] as $file) {
+            $source = (string) file_get_contents($file);
+
+            preg_match_all('/\$this->item->([a-zA-Z_][a-zA-Z0-9_]*)/', $source, $matches);
+
+            foreach (array_unique($matches[1]) as $property) {
+                $cases[basename($file) . ': ' . $property] = [basename($file), $property];
+            }
+        }
+
+        return $cases;
+    }
+
+    /**
+     * Column names declared for #__bsms_studies by the install schema.
+     *
+     * @return  string[]
+     */
+    private static function studyColumns(): array
+    {
+        $sql = (string) file_get_contents(self::INSTALL_SQL);
+
+        if (!preg_match('/CREATE TABLE[^`]*`#__bsms_studies`\s*\((.*?)\n\)\s*ENGINE/s', $sql, $table)) {
+            self::fail('Could not find the CREATE TABLE block for #__bsms_studies in ' . self::INSTALL_SQL);
+        }
+
+        // Column definitions open with a backticked name; KEY and CONSTRAINT lines do not.
+        preg_match_all('/^\s*`([a-z0-9_]+)`\s+/mi', $table[1], $columns);
+
+        return $columns[1];
+    }
+
+    /**
+     * A parser that silently matched nothing would pass every other case here.
+     */
+    #[TestDox('the schema and the templates both actually parse')]
+    public function testTheInputsAreNotEmpty(): void
+    {
+        self::assertNotEmpty(
+            self::studyColumns(),
+            'No columns were parsed out of the install schema, so the contract below checks nothing.'
+        );
+        self::assertNotEmpty(
+            self::itemPropertyProvider(),
+            'No item reads were found in ' . self::TEMPLATE_DIR . ', so the contract below checks nothing.'
+        );
+    }
+
+    #[DataProvider('itemPropertyProvider')]
+    #[TestDox('$file reads $property, which the item carries')]
+    public function testItemReadsNameSomethingTheItemCarries(string $file, string $property): void
+    {
+        if (\in_array($property, self::MODEL_ADDED, true)) {
+            self::assertTrue(true, $property . ' is attached by the model rather than selected.');
+
+            return;
+        }
+
+        self::assertContains(
+            $property,
+            self::studyColumns(),
+            $file . ' reads $this->item->' . $property . ', which is neither a column of #__bsms_studies nor '
+            . 'listed in MODEL_ADDED. On a live site that reads as null and warns, and the field it fills '
+            . 'renders empty. Either the column was retired and this read needs a new source, or the model '
+            . 'now attaches the property and it belongs in MODEL_ADDED.'
+        );
+    }
+}


### PR DESCRIPTION
Started as the `Undefined property: stdClass::$teacher_id` warning on the message edit screen. The sweep behind it found a **fatal** one too.

#1731 retired `bsms_studies.teacher_id` in favour of `#__bsms_study_teachers`. Three places never got the message.

## 1. Message edit screen — warning, and AI Assist silently degraded

`admin/tmpl/cwmmessage/edit.php` seeded its hidden `teacher_id` field from `$this->item->teacher_id`, so every edit of an existing message warned and the field fell back to `null`.

That field is not decorative — `message-ai-assist.js` posts it so `CwmmessageController` can look up the teacher name for **AI voice context**. AI Assist has been generating without the teacher since the column went, with nothing to show for it. `getItem()` already attaches the junction rows as `$this->item->teachers`, so the template takes the first of those.

## 2. CSV import — fatal, whole batch

`CwmcsvimportHelper` had `teacher_id` in the column list of its `INSERT INTO #__bsms_studies`. Not a silent null — **every CSV message import died** with `Unknown column 'teacher_id' in 'field list'`. The junction save directly below it already stored every teacher on the row, so the column and its value come out.

Proven against the live schema:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'teacher_id' in 'field list'
```

## 3. `batchTeacher()` — dead write, and a near-miss

`$table->teacher_id = $teacherId` was silently discarded (`DatabaseDriver::updateObject()` skips properties with no matching column), so the batch was **not** broken — only the assignment was dead.

Worth recording: I first removed the `store()` call along with it, which was wrong. `CwmmessageTable` overrides `store()` to unset the generated `studynumber_uk` column, turn a duplicate-episode race into a message rather than a fatal, and strip the empty asset row a failed save leaves behind (#1723). Only the assignment goes. The `load` is now checked, since storing a table that failed to load would insert a new row.

## Sweep

Since #1623/#1731 retired 14 columns, I swept for readers of all of them rather than fixing only the reported line — **both** as `->property` and as a quoted string, because those fail differently (silent null vs. hard SQL error):

| Columns | Result |
|---|---|
| the 7 dropped by `10.5.8-20260811` (`prod_cd`, `prod_dvd`, `server_cd`, `server_dvd`, `image_cd`, `image_dvd`, `studytext2`) | no readers anywhere |
| scripture columns (`booknumber`, `chapter_begin`, …) | all read off `#__bsms_scriptures` rows, not study rows — correct |
| `teacher_id` | the three above. Everything else reads the junction, a teacher row, a module param, or the migration's own guarded DDL. |

`CwmsermonsModel:370` maps a *module param* named `teacher_id`, not a column — checked, fine.

## Guard

`StudyColumnContractTest` (`tests/unit/Sql/`, already covered by the existing suite) asserts:

- every `$this->item->x` in the message templates names either a column of `#__bsms_studies` or a property the model attaches
- the CSV importer's `$columns` names only real columns, **and** that `$columns`/`$values` have not drifted apart — a count mismatch would write every value after the gap into the wrong column

Both mutation-verified: restoring each original line fails the test with the message a maintainer needs.

**Scope caveat so nobody reads this as full coverage:** it scans the message templates and that one importer literal. It would not have caught the `batchTeacher()` write, a list template using `$item->x`, or a retired column in an arbitrary query.

## Verification — real dispatch on j6-dev, not inspection

- message **with** a teacher → `jform_teacher_id` renders `"2"`, matching its subform row. This is the assertion that matters: `?? 0` would also silence the warning while staying wrong
- message with **no** teacher → `"0"`; neither warns
- real CSV import through `cwmadmin.csvImportBatchXHR` → `{"imported":1,"errors":[]}`, study created, named teacher resolved into the junction
- real **batch** teacher assignment through the admin UI, on a message with both a series and an episode number (the row shape `store()` protects) → "Batch process completed", `studynumber_uk` intact, junction written
- all test rows restored afterwards
- `composer test` — **2345 green** (2330 + 15 new); lint clean

## Note

No `10.5.8` milestone exists, so this PR has none — the open ones are `v11.0.0`, `Backlog`, `10.5.6` while `active_development` is `10.5.8-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ