### PR TITLE
fix: let Batch → Teacher add rather than replace

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -1199,7 +1199,12 @@ JBS_BAT_LOCATION_NOCHANGE = "- Do Not Change Location -"
 JBS_BAT_SERIES_DESC = "Choose a new series"
 JBS_BAT_SERIES_NOCHANGE = "- Do Not Change Series -"
 JBS_BAT_TEACHER_DESC = "Choose a teacher for the batch process"
+JBS_BAT_TEACHER_MODE_ADD = "Add to existing teachers"
+JBS_BAT_TEACHER_MODE_QUESTION = "How should this teacher be applied?"
+JBS_BAT_TEACHER_MODE_REPLACE = "Replace all teachers"
 JBS_BAT_TEACHER_NOCHANGE = "- Do Not Change Teacher -"
+JBS_BAT_TEACHER_REPLACED_N_1 = "%d message credited other teachers. Replacing removed them."
+JBS_BAT_TEACHER_REPLACED_N_MORE = "%d messages credited other teachers. Replacing removed them."
 
 
 ;; BBK Book of the Bibles Translations

--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -217,6 +217,21 @@ class Cwmhtml
             '<option value="">' . Text::_('JBS_BAT_TEACHER_NOCHANGE') . '</option>',
             HTMLHelper::_('select.options', self::teacherList(), 'value', 'text'),
             '</select>',
+            '<fieldset id="batch-teacher-mode" class="mt-2">',
+            '<legend class="visually-hidden">' . Text::_('JBS_BAT_TEACHER_MODE_QUESTION') . '</legend>',
+            HTMLHelper::_(
+                'select.radiolist',
+                [
+                    HTMLHelper::_('select.option', 'a', Text::_('JBS_BAT_TEACHER_MODE_ADD')),
+                    HTMLHelper::_('select.option', 'r', Text::_('JBS_BAT_TEACHER_MODE_REPLACE')),
+                ],
+                'batch[teacher_mode]',
+                '',
+                'value',
+                'text',
+                'a'
+            ),
+            '</fieldset>',
         ];
 
         return implode("\n", $lines);

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -80,6 +80,56 @@ class CwmmessageModel extends AdminModel
     ];
 
     /**
+     * Whether a batched teacher is added to the message's existing teachers
+     * ('a') or replaces all of them ('r').
+     *
+     * @var string
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    protected string $batchTeacherMode = 'a';
+
+    /**
+     * Runs a batch operation, capturing the teacher mode on the way through.
+     *
+     * A message can credit several teachers, so the teacher command needs to say
+     * whether it adds or replaces. Batch methods are handed only their own value,
+     * so the mode is read here, the way core reads tag_addremove for batchTag.
+     *
+     * @param   array  $commands  The batch commands to perform
+     * @param   array  $pks       The rows to perform them on
+     * @param   array  $contexts  ACL contexts, keyed by row id
+     *
+     * @return  bool  True on success
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function batch($commands, $pks, $contexts): bool
+    {
+        $this->batchTeacherMode = self::resolveTeacherMode($commands);
+
+        return parent::batch($commands, $pks, $contexts);
+    }
+
+    /**
+     * Reads the teacher mode out of a set of batch commands.
+     *
+     * Anything other than an explicit 'r' means add, so a request that omits the
+     * command — an older form post, a script — cannot reach the branch that
+     * discards teachers.
+     *
+     * @param   array  $commands  The batch commands
+     *
+     * @return  string  'r' to replace, 'a' to add
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected static function resolveTeacherMode(array $commands): string
+    {
+        return ($commands['teacher_mode'] ?? 'a') === 'r' ? 'r' : 'a';
+    }
+
+    /**
      * Duplicate Check
      *
      * @param   int  $study_id  Study ID
@@ -885,6 +935,9 @@ class CwmmessageModel extends AdminModel
         /** @var CwmmessageTable $table */
         $table     = $this->getTable();
         $teacherId = (int) $value;
+        $replacing = $this->batchTeacherMode === 'r';
+        $existing  = CwmstudyteacherHelper::getTeachersForStudies($pks);
+        $displaced = 0;
 
         foreach ($pks as $pk) {
             if ($user->authorise('core.edit', $contexts[$pk])) {
@@ -895,13 +948,41 @@ class CwmmessageModel extends AdminModel
                     throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_SAVE_FAILED'));
                 }
 
-                $teachers = $teacherId > 0
-                    ? [['teacher_id' => $teacherId]]
-                    : [];
-                CwmstudyteacherHelper::saveTeachers((int) $pk, $teachers);
+                $current = array_map(
+                    static fn (object $t): int => (int) $t->teacher_id,
+                    $existing[(int) $pk] ?? []
+                );
+
+                if ($replacing) {
+                    // saveTeachers() rewrites the whole set, so anyone already
+                    // credited and not re-listed here loses the credit.
+                    $wanted = $teacherId > 0 ? [$teacherId] : [];
+
+                    if (array_diff($current, $wanted) !== []) {
+                        $displaced++;
+                    }
+                } else {
+                    $wanted = $current;
+
+                    if ($teacherId > 0 && !\in_array($teacherId, $wanted, true)) {
+                        $wanted[] = $teacherId;
+                    }
+                }
+
+                CwmstudyteacherHelper::saveTeachers(
+                    (int) $pk,
+                    array_map(static fn (int $id): array => ['teacher_id' => $id], $wanted)
+                );
             } else {
                 throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
             }
+        }
+
+        if ($displaced > 0) {
+            Factory::getApplication()->enqueueMessage(
+                Text::plural('JBS_BAT_TEACHER_REPLACED_N', $displaced),
+                'warning'
+            );
         }
 
         // Clean the cache

--- a/tests/integration/Admin/Model/CwmbatchTeacherTest.php
+++ b/tests/integration/Admin/Model/CwmbatchTeacherTest.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * Integration tests for the message teacher batch action.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmstudyteacherHelper;
+use CWM\Component\Proclaim\Administrator\Model\CwmmessageModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\CMS\User\User;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #1793.
+ *
+ * A message can credit several teachers, but the batch handed its single
+ * selection to saveTeachers(), which rewrites the whole junction. Setting a
+ * teacher on a message that already credited two silently dropped the other
+ * one, with the batch reporting success.
+ *
+ * The batch now carries a mode, the way core's batchTag carries tag_addremove,
+ * and defaults to adding so the destructive path has to be chosen.
+ *
+ * ⚠️ These tests cannot rely on transaction rollback. batchTeacher() calls
+ * CwmmessageTable::store(), and Table::store() commits, so every row is removed
+ * by hand in tearDown instead.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmmessageModel::class)]
+class CwmbatchTeacherTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * Study rows created by a test, removed in tearDown.
+     *
+     * @var  int[]
+     */
+    private array $studies = [];
+
+    /**
+     * Teacher rows created by a test, removed in tearDown.
+     *
+     * @var  int[]
+     */
+    private array $teachers = [];
+
+    /**
+     * @var  mixed
+     */
+    private mixed $savedIdentity = null;
+
+    /**
+     * @var  mixed
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+        $this->db            = Factory::getContainer()->get(DatabaseDriver::class);
+
+        // batchTeacher() checks core.edit per row, so borrow a real Super User
+        // rather than inventing an id with no groups.
+        $superUser = (int) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('user_id') . ' FROM ' . $this->db->quoteName('#__user_usergroup_map')
+            . ' WHERE ' . $this->db->quoteName('group_id') . ' = 8',
+            0,
+            1
+        )->loadResult();
+
+        if ($superUser === 0) {
+            $this->markTestSkipped('No Super User available to authorise the batch');
+        }
+
+        $app->loadIdentity(User::getInstance($superUser));
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            foreach ($this->studies as $id) {
+                $this->db->setQuery(
+                    'DELETE FROM ' . $this->db->quoteName('#__bsms_study_teachers')
+                    . ' WHERE ' . $this->db->quoteName('study_id') . ' = ' . $id
+                )->execute();
+                $this->db->setQuery(
+                    'DELETE FROM ' . $this->db->quoteName('#__bsms_studies')
+                    . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+                )->execute();
+            }
+
+            foreach ($this->teachers as $id) {
+                $this->db->setQuery(
+                    'DELETE FROM ' . $this->db->quoteName('#__bsms_teachers')
+                    . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+                )->execute();
+            }
+        }
+
+        CwmstudyteacherHelper::resetCache();
+
+        if ($this->savedIdentity !== null) {
+            Factory::getApplication()->loadIdentity($this->savedIdentity);
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    #[TestDox('adding leaves the teachers already credited in place')]
+    public function testAddKeepsExistingTeachers(): void
+    {
+        $first  = $this->createTeacher('Batch Test One');
+        $second = $this->createTeacher('Batch Test Two');
+        $third  = $this->createTeacher('Batch Test Three');
+        $study  = $this->createStudy([$first, $second]);
+
+        $this->runBatch($study, $third, 'a');
+
+        self::assertSame(
+            [$first, $second, $third],
+            $this->teacherIdsFor($study),
+            'Adding a teacher must not disturb the ones already credited.'
+        );
+    }
+
+    #[TestDox('adding a teacher the message already credits changes nothing')]
+    public function testAddIsIdempotent(): void
+    {
+        $first  = $this->createTeacher('Batch Test One');
+        $second = $this->createTeacher('Batch Test Two');
+        $study  = $this->createStudy([$first, $second]);
+
+        $this->runBatch($study, $second, 'a');
+
+        self::assertSame([$first, $second], $this->teacherIdsFor($study), 'No duplicate row, no reordering.');
+    }
+
+    #[TestDox('replacing sets the teacher list to exactly the chosen teacher')]
+    public function testReplaceOverwritesTheWholeList(): void
+    {
+        $first  = $this->createTeacher('Batch Test One');
+        $second = $this->createTeacher('Batch Test Two');
+        $third  = $this->createTeacher('Batch Test Three');
+        $study  = $this->createStudy([$first, $second]);
+
+        $this->runBatch($study, $third, 'r');
+
+        self::assertSame([$third], $this->teacherIdsFor($study), 'Replace is still available, and still replaces.');
+    }
+
+    /**
+     * The mode is a separate command, so a request that omits it must not get
+     * the destructive branch.
+     */
+    #[TestDox('only an explicit r replaces; every other command shape adds')]
+    public function testOnlyExplicitReplaceIsDestructive(): void
+    {
+        $resolve = new \ReflectionMethod(CwmmessageModel::class, 'resolveTeacherMode');
+
+        self::assertSame('r', $resolve->invoke(null, ['teacher_mode' => 'r']));
+        self::assertSame('a', $resolve->invoke(null, ['teacher_mode' => 'a']));
+        self::assertSame('a', $resolve->invoke(null, []), 'An absent mode must not reach the destructive branch.');
+        self::assertSame('a', $resolve->invoke(null, ['teacher_mode' => '']), 'Nor must an empty one.');
+        self::assertSame('a', $resolve->invoke(null, ['teacher_mode' => 'R']), 'Nor a near-miss.');
+    }
+
+    /**
+     * @param   int    $study    Study id to batch
+     * @param   int    $teacher  Teacher id to apply
+     * @param   string $mode     'a' to add, 'r' to replace
+     *
+     * @return  void
+     */
+    private function runBatch(int $study, int $teacher, string $mode): void
+    {
+        $model = $this->createModel();
+
+        // batchTeacher() directly, not batch(): the latter imports the content
+        // plugins and the console harness has no Finder to load. The mode is set
+        // the way batch() sets it, and resolveTeacherMode() is asserted on its own.
+        $property = new \ReflectionProperty(CwmmessageModel::class, 'batchTeacherMode');
+        $property->setValue($model, $mode);
+
+        $method = new \ReflectionMethod(CwmmessageModel::class, 'batchTeacher');
+        $method->invoke($model, $teacher, [$study], [$study => 'com_proclaim.cwmmessage']);
+    }
+
+    /**
+     * @param   int  $studyId  Study id
+     *
+     * @return  int[]  Teacher ids in stored order
+     */
+    private function teacherIdsFor(int $studyId): array
+    {
+        CwmstudyteacherHelper::resetCache($studyId);
+
+        return array_map(
+            static fn (int $id): int => $id,
+            array_map(
+                'intval',
+                $this->db->setQuery(
+                    'SELECT ' . $this->db->quoteName('teacher_id')
+                    . ' FROM ' . $this->db->quoteName('#__bsms_study_teachers')
+                    . ' WHERE ' . $this->db->quoteName('study_id') . ' = ' . $studyId
+                    . ' ORDER BY ' . $this->db->quoteName('ordering')
+                )->loadColumn() ?: []
+            )
+        );
+    }
+
+    /**
+     * @param   string  $name  Teacher name
+     *
+     * @return  int  New teacher id
+     */
+    private function createTeacher(string $name): int
+    {
+        $this->db->setQuery(
+            'INSERT INTO ' . $this->db->quoteName('#__bsms_teachers')
+            . ' (' . $this->db->quoteName('teachername') . ', ' . $this->db->quoteName('alias') . ', '
+            . $this->db->quoteName('published') . ', ' . $this->db->quoteName('language') . ', '
+            . $this->db->quoteName('address') . ')'
+            . ' VALUES (' . $this->db->quote($name) . ', '
+            . $this->db->quote('batch-teacher-' . uniqid('', true)) . ', 1, '
+            . $this->db->quote('*') . ', ' . $this->db->quote('') . ')'
+        )->execute();
+
+        $id = (int) $this->db->insertid();
+
+        $this->teachers[] = $id;
+
+        return $id;
+    }
+
+    /**
+     * @param   int[]  $teacherIds  Teachers to credit, in order
+     *
+     * @return  int  New study id
+     */
+    private function createStudy(array $teacherIds): int
+    {
+        $this->db->setQuery(
+            'INSERT INTO ' . $this->db->quoteName('#__bsms_studies')
+            . ' (' . $this->db->quoteName('studytitle') . ', ' . $this->db->quoteName('alias') . ', '
+            . $this->db->quoteName('published') . ', ' . $this->db->quoteName('access') . ', '
+            . $this->db->quoteName('language') . ')'
+            . ' VALUES (' . $this->db->quote('Batch Teacher Test') . ', '
+            . $this->db->quote('batch-teacher-test-' . uniqid()) . ', 1, 1, ' . $this->db->quote('*') . ')'
+        )->execute();
+
+        $id = (int) $this->db->insertid();
+
+        $this->studies[] = $id;
+
+        foreach (array_values($teacherIds) as $ordering => $teacherId) {
+            $this->db->setQuery(
+                'INSERT INTO ' . $this->db->quoteName('#__bsms_study_teachers')
+                . ' (' . $this->db->quoteName('study_id') . ', ' . $this->db->quoteName('teacher_id') . ', '
+                . $this->db->quoteName('ordering') . ')'
+                . ' VALUES (' . $id . ', ' . (int) $teacherId . ', ' . $ordering . ')'
+            )->execute();
+        }
+
+        CwmstudyteacherHelper::resetCache($id);
+
+        return $id;
+    }
+
+    /**
+     * @return  CwmmessageModel
+     */
+    private function createModel(): CwmmessageModel
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+        $factory->setFormFactory($container->get(FormFactoryInterface::class));
+
+        /** @var CwmmessageModel $model */
+        $model = $factory->createModel('Cwmmessage', 'Administrator', ['ignore_request' => true]);
+
+        $this->assertInstanceOf(CwmmessageModel::class, $model);
+
+        return $model;
+    }
+}


### PR DESCRIPTION
Closes #1793.

A message can credit several teachers, but the batch handed its single selection straight to `saveTeachers()`, which rewrites the whole junction. Setting a teacher on a message that already credited two silently dropped the other, and the batch reported "Batch process completed".

## What changed

The batch now carries a mode, read from the commands the way core's `batchTag` reads `tag_addremove`, and **defaults to adding**:

```
Teacher
┌────────────────────────────────────┐
│ - Do Not Change Teacher -       ▾  │
└────────────────────────────────────┘
  (•) Add to existing teachers
  ( ) Replace all teachers
```

- **Add** (default) — merges into the existing credits, and is idempotent if the teacher is already there.
- **Replace** — the old behaviour, still available, but now chosen rather than assumed.

`resolveTeacherMode()` treats anything other than a literal `'r'` as add, so a form post or script that omits the command cannot reach the destructive branch.

## Replace now says what it destroyed

Per Brent's note on the issue — when Replace actually discards someone, the batch warns instead of reporting a clean success:

> ⚠️ *3 messages credited other teachers. Replacing removed them.*

The count comes from `getTeachersForStudies()`, which is a single query for the whole selection, so this costs nothing per row.

## Why a mode and not multi-select

All three options on the issue were buildable — `batch[]` is read as an array, so a `multiple` select would have worked. The mode was chosen because it is the only one where the **default is non-destructive**: with multi-select the semantics are still replace, just more visible. Add-by-default means the accident is no longer reachable without a deliberate click.

## Tests

`CwmbatchTeacherTest` runs against the real junction: add keeps existing credits, add is idempotent, replace still replaces, and only a literal `'r'` selects it.

**Both halves mutation-verified** — pinning `$replacing = true` (the old behaviour) fails the two add tests; defaulting the mode to `'r'` fails the resolver test.

⚠️ The tests delete their rows by hand rather than rolling back: `batchTeacher()` calls `Table::store()`, and `Table::store()` commits the transaction.

`composer test` — 2349 green; lint clean.

## Not covered here

Batch still cannot **clear** a message's teachers — an empty command is skipped by `AdminModel::batch()` before any of this runs, exactly as before. Same for Location, which papers over it with a `- Clear Location -` option. Out of scope; say the word and it is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ
