### PR TITLE
fix: derive comment moderation state server-side

### DIFF
--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -17,6 +17,7 @@ use CWM\Component\Proclaim\Site\Model\CwmsermonModel;
 use Joomla\CMS\Captcha\Captcha;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
@@ -174,12 +175,11 @@ class CwmsermonController extends FormController
         $model = $this->getModel();
         $t     = $input->getInt('t', 1);
 
-        // Get template params
-        $params = new Registry();
-
-        if (!empty($model->_template[0]->params)) {
-            $params->loadString($model->_template[0]->params);
-        }
+        // ⚠️ This read $model->_template[0]->params, a property nothing ever
+        // sets. Behind !empty() that is silent, so $params was always empty and
+        // every setting below took its default: the captcha was never checked
+        // however the template was configured, and no notification was sent.
+        $params = $model->getCommentParams();
 
         // Check captcha if enabled (Joomla 5/6 compatible Captcha API)
         if ($params->get('use_captcha') > 0) {
@@ -207,7 +207,9 @@ class CwmsermonController extends FormController
 
         // Store the comment
         if ($model->storecomment()) {
-            $published = $input->getInt('published', 1);
+            // The state the comment was actually stored with, not the one the
+            // request asked for.
+            $published = $model->getCommentPublishState();
 
             // Show appropriate message based on whether the comment is auto-approved or held
             if ($published === 0) {
@@ -216,12 +218,14 @@ class CwmsermonController extends FormController
                 // Send moderation notification email if configured
                 $notifyEmail = $params->get('comment_notify_email', '');
                 if (!empty($notifyEmail) || $app->get('mailfrom')) {
-                    CwmnotificationHelper::notifyCommentPending(
-                        $input->getInt('study_id', 0),
-                        $input->getString('full_name', 'Anonymous'),
-                        $input->get('comment_text', '', 'raw'),
-                        $params
-                    );
+                    $this->notifyQuietly(static function () use ($input, $params) {
+                        CwmnotificationHelper::notifyCommentPending(
+                            $input->getInt('study_id', 0),
+                            $input->getString('full_name', 'Anonymous'),
+                            $input->get('comment_text', '', 'raw'),
+                            $params
+                        );
+                    });
                 }
             } else {
                 $app->enqueueMessage(Text::_('JBS_STY_COMMENT_SUBMITTED'), 'success');
@@ -229,7 +233,7 @@ class CwmsermonController extends FormController
 
             // Send general email notification if enabled
             if ($params->get('email_comments') > 0) {
-                $this->commentsEmail($params);
+                $this->notifyQuietly(fn () => $this->commentsEmail($params));
             }
         } else {
             $app->enqueueMessage(Text::_('JBS_STY_ERROR_SUBMITTING_COMMENT'), 'error');
@@ -280,6 +284,33 @@ class CwmsermonController extends FormController
     }
 
     /**
+     * Run a notification, letting it fail without taking the submission with it.
+     *
+     * The comment is already stored by the time these run. A mail transport that
+     * is misconfigured, or simply absent on the machine, threw straight out of
+     * the controller — so the visitor saw a 500 for a comment that had in fact
+     * been saved, and resubmitted it.
+     *
+     * @param   callable  $send  The notification to attempt
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function notifyQuietly(callable $send): void
+    {
+        try {
+            $send();
+        } catch (\Throwable $e) {
+            Log::add(
+                'Comment notification failed: ' . $e->getMessage(),
+                Log::WARNING,
+                'com_proclaim'
+            );
+        }
+    }
+
+    /**
      * Email comment out.
      *
      * Private: only meant to be called internally from comment(). Public
@@ -299,7 +330,9 @@ class CwmsermonController extends FormController
 
         $comment_author    = $input->get('full_name', 'Anonymous', 'string');
         $comment_study_id  = $input->get('study_detail_id', 0, 'int');
-        $comment_published = $input->get('published', 0, 'int');
+        /** @var CwmsermonModel $model */
+        $model             = $this->getModel();
+        $comment_published = $model->getCommentPublishState();
         $comment_date      = date('Y-m-d H:i:s');
         $config            = Factory::getApplication();
         $comment_mailfrom  = $config->get('mailfrom');

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -339,6 +339,47 @@ class CwmsermonModel extends FormModel
     }
 
     /**
+     * The state a newly submitted comment is stored with.
+     *
+     * Read from the template's comment_publish setting, never from the request.
+     * Defaults to 0 — hold for approval — matching the field's own default in
+     * template.xml, so an unset or unreadable setting holds the comment rather
+     * than publishing it.
+     *
+     * @return  int  1 to publish immediately, 0 to hold for approval
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getCommentPublishState(): int
+    {
+        return (int) $this->getCommentParams()->get('comment_publish', 0) === 1 ? 1 : 0;
+    }
+
+    /**
+     * The template parameters governing comment submission.
+     *
+     * @return  Registry
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getCommentParams(): Registry
+    {
+        $template = Cwmparams::getTemplateparams();
+
+        if (!empty($template->params) && $template->params instanceof Registry) {
+            return $template->params;
+        }
+
+        $params = new Registry();
+
+        if (!empty($template->params)) {
+            $params->loadString((string) $template->params);
+        }
+
+        return $params;
+    }
+
+    /**
      * Method to store a record
      *
      * @return    bool    True on success
@@ -351,14 +392,19 @@ class CwmsermonModel extends FormModel
         $row   = $this->getTable('Cwmcomment');
         $input = Factory::getApplication()->getInput();
 
-        // Build data array from input (not raw $_POST)
+        // Build data array from input (not raw $_POST).
+        //
+        // ⚠️ published and comment_date are NOT read from the request. The form
+        // posts both, but a visitor decides what a visitor posts: `published`
+        // set the moderation state directly, so anyone could approve their own
+        // comment on a site configured to hold them.
         $data = [
             'study_id'     => $input->getInt('study_id', 0),
             'full_name'    => $input->getString('full_name', ''),
             'user_email'   => $input->getString('user_email', ''),
             'comment_text' => $input->get('comment_text', '', 'raw'),
-            'comment_date' => $input->getString('comment_date', (new Date())->toSql()),
-            'published'    => $input->getInt('published', 1),
+            'comment_date' => (new Date())->toSql(),
+            'published'    => $this->getCommentPublishState(),
             'language'     => $input->getString('language', '*'),
         ];
 

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -489,6 +489,13 @@ class HtmlView extends BaseHtmlView
         $wa = $this->getDocument()->getWebAssetManager();
         $wa->useStyle('com_proclaim.print');
 
+        // The comments block renders inside a Bootstrap collapse whose toggle is
+        // the Show/Hide Comments button. Without this the button does nothing and
+        // the comments cannot be opened at all, since the section starts hidden.
+        if (empty($this->print)) {
+            $wa->useScript('bootstrap.collapse');
+        }
+
         // Load player chapters script for chapter lists and timestamp seeking
         if (empty($this->print)) {
             $wa->useScript('com_proclaim.cwm-player-chapters');

--- a/site/tmpl/cwmsermon/default_commentsform.php
+++ b/site/tmpl/cwmsermon/default_commentsform.php
@@ -171,8 +171,7 @@ if (!$this->item->id) {
                         <input type="hidden" name="study_id" value="<?php echo $this->item->id; ?>">
                         <input type="hidden" name="study_detail_id" value="<?php echo $this->item->id; ?>">
                         <input type="hidden" name="t" value="<?php echo $input->getInt('t', 0); ?>">
-                        <input type="hidden" name="published" value="<?php echo (int) $this->item->params->get('comment_publish', 1); ?>">
-                        <input type="hidden" name="comment_date" value="<?php echo (new Date())->toSql(); ?>">
+                        <?php // published and comment_date are set server-side; posting them here only invited them to be forged. ?>
                         <?php echo HTMLHelper::_('form.token'); ?>
                     </form>
                 </div>

--- a/tests/integration/Site/Model/CwmsermonCommentSubmissionTest.php
+++ b/tests/integration/Site/Model/CwmsermonCommentSubmissionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * Integration tests for public comment submission.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Model;
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
+use CWM\Component\Proclaim\Site\Model\CwmsermonModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The comment form is the one place a stranger writes to the database, and
+ * storecomment() took the moderation state straight from the request:
+ *
+ *     'published' => $input->getInt('published', 1)
+ *
+ * The template posted it as a hidden field, but a visitor decides what a visitor
+ * posts. Anyone could approve their own comment on a site configured to hold
+ * them — and the default was 1, so omitting the field published too. Verified
+ * against a live site before the fix: a POST carrying published=1 stored a
+ * visible comment while the template said comment_publish=0.
+ *
+ * The state now comes from the template and defaults to 0, matching the field's
+ * own default in template.xml, so an unreadable setting holds rather than
+ * publishes.
+ *
+ * ⚠️ These tests delete their rows by hand rather than rolling back:
+ * Table::store() commits.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmsermonModel::class)]
+class CwmsermonCommentSubmissionTest extends IntegrationTestCase
+{
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * Comment rows created by a test.
+     *
+     * @var  int[]
+     */
+    private array $comments = [];
+
+    /**
+     * @var  object|null
+     */
+    private ?object $savedTemplate = null;
+
+    /**
+     * @var  bool
+     */
+    private bool $hadTemplate = false;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        // Cwmparams caches the template in a public static, so a test can seed it
+        // and must put it back.
+        $this->hadTemplate = isset(Cwmparams::$templateTable);
+
+        if ($this->hadTemplate) {
+            $this->savedTemplate = Cwmparams::$templateTable;
+        }
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null && $this->comments !== []) {
+            foreach ($this->comments as $id) {
+                $this->db->setQuery(
+                    'DELETE FROM ' . $this->db->quoteName('#__bsms_comments')
+                    . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $id
+                )->execute();
+            }
+        }
+
+        if ($this->hadTemplate && $this->savedTemplate !== null) {
+            Cwmparams::$templateTable = $this->savedTemplate;
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * The exploit, as a test: the request asks to be published, the template
+     * says hold, and the template wins.
+     */
+    #[TestDox('a comment claiming published=1 is still held when the template holds comments')]
+    public function testRequestCannotSelfApprove(): void
+    {
+        $this->seedTemplate(0);
+        $this->postComment(['published' => 1]);
+
+        self::assertSame(0, $this->storedState(), 'A visitor must not be able to approve their own comment.');
+    }
+
+    #[TestDox('omitting published does not publish')]
+    public function testOmittingPublishedDoesNotPublish(): void
+    {
+        $this->seedTemplate(0);
+        $this->postComment([]);
+
+        self::assertSame(0, $this->storedState(), 'The old default of 1 published whenever the field was absent.');
+    }
+
+    #[TestDox('a template that auto-approves still auto-approves')]
+    public function testAutoApproveIsPreserved(): void
+    {
+        $this->seedTemplate(1);
+        $this->postComment(['published' => 0]);
+
+        self::assertSame(1, $this->storedState(), 'comment_publish=1 means publish, whatever the request says.');
+    }
+
+    /**
+     * Fail closed: an unreadable or unset setting must hold, not publish.
+     */
+    #[TestDox('an unset comment_publish holds the comment')]
+    public function testUnsetSettingHolds(): void
+    {
+        $this->seedTemplate(null);
+        $this->postComment(['published' => 1]);
+
+        self::assertSame(0, $this->storedState(), 'An absent setting must hold rather than publish.');
+    }
+
+    /**
+     * The date is recorded by the server, not asked for.
+     */
+    #[TestDox('comment_date is set server-side, not taken from the request')]
+    public function testCommentDateIsNotTakenFromTheRequest(): void
+    {
+        $this->seedTemplate(0);
+        $this->postComment(['comment_date' => '1999-01-01 00:00:00']);
+
+        $stored = (string) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('comment_date')
+            . ' FROM ' . $this->db->quoteName('#__bsms_comments')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . end($this->comments)
+        )->loadResult();
+
+        self::assertStringStartsNotWith('1999', $stored, 'A forged date must not be stored.');
+    }
+
+    /**
+     * @param   int|null  $publish  comment_publish value, or null to leave it unset
+     *
+     * @return  void
+     */
+    private function seedTemplate(?int $publish): void
+    {
+        $params = new Registry();
+
+        if ($publish !== null) {
+            $params->set('comment_publish', (string) $publish);
+        }
+
+        $template         = new \stdClass();
+        $template->id     = 1;
+        $template->params = $params;
+
+        Cwmparams::$templateTable = $template;
+        Cwmparams::$templateId    = 1;
+
+        // getTemplateparams() resolves the id from input when it has no pk.
+        Factory::getApplication()->getInput()->set('t', 1);
+    }
+
+    /**
+     * @param   array  $extra  Request values a visitor could control
+     *
+     * @return  void
+     */
+    private function postComment(array $extra): void
+    {
+        $input = Factory::getApplication()->getInput();
+
+        $input->set('study_id', 1);
+        $input->set('full_name', 'Integration Probe');
+        $input->set('user_email', 'probe@example.test');
+        $input->set('comment_text', 'submitted by a test');
+        $input->set('published', null);
+        $input->set('comment_date', null);
+
+        foreach ($extra as $key => $value) {
+            $input->set($key, $value);
+        }
+
+        self::assertTrue($this->createModel()->storecomment(), 'The comment should store.');
+
+        $this->comments[] = (int) $this->db->setQuery(
+            'SELECT MAX(' . $this->db->quoteName('id') . ') FROM ' . $this->db->quoteName('#__bsms_comments')
+        )->loadResult();
+    }
+
+    /**
+     * @return  int  The published state of the comment this test just stored
+     */
+    private function storedState(): int
+    {
+        return (int) $this->db->setQuery(
+            'SELECT ' . $this->db->quoteName('published')
+            . ' FROM ' . $this->db->quoteName('#__bsms_comments')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . end($this->comments)
+        )->loadResult();
+    }
+
+    /**
+     * @return  CwmsermonModel
+     */
+    private function createModel(): CwmsermonModel
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+        $factory->setFormFactory($container->get(FormFactoryInterface::class));
+
+        /** @var CwmsermonModel $model */
+        $model = $factory->createModel('Cwmsermon', 'Site', ['ignore_request' => true]);
+
+        $this->assertInstanceOf(CwmsermonModel::class, $model);
+
+        return $model;
+    }
+}


### PR DESCRIPTION
Closes #1796.

A visitor could approve their own comment. `storecomment()` read the moderation state from the request, defaulting to **published**, and nothing re-derived it server-side.

**Verified before the fix**, on a site set to hold comments — a POST carrying `published=1` stored a visible comment. The same request now stores it held.

## What changed

| | |
|---|---|
| `published` | from the template's `comment_publish`, default **0** (matching `template.xml`) |
| `comment_date` | server-side |
| template params | loaded via `Cwmparams::getTemplateparams()` |
| notifications | can no longer fail a stored comment |
| hidden `published`/`comment_date` fields | removed |

## The captcha never ran

`comment()` read `$model->_template[0]->params` — a property **nothing in the codebase ever assigns**, appearing only on those two lines. Behind `!empty()` that is silent, so `$params` was always empty and every setting took its default: no captcha check however the template was configured, and no notification email ever sent.

Fixing that made the notification path run for the first time, which exposed the third defect — a throwing mail transport took the whole request with it *after* the comment was stored, so the visitor saw an error for a comment that had saved, and resubmitted. I generated four duplicate rows that way while testing.

## Tests

The Comments system had **3 test methods** before this, none covering public submission. Five integration tests now exercise it against the real table, including the exploit itself, plus fail-closed on an unset setting and the forged-date case.

**Mutation-verified:** restoring the request read fails four of the five.

`composer test` 2354 green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ