### PR TITLE
fix: serve the landing page for a request with no view

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,10 @@ on:
       # two paths, so this roughly triples how often the job runs.
       - 'admin/src/Model/**'
       - 'admin/src/Table/**'
+      # The front-end check in this job renders the site views, so the site code
+      # it renders belongs here too. Without it a change to the public
+      # controllers, models and templates never reached the job that loads them.
+      - 'site/**'
       # ⚠️ The bundled scripture library and its plugin ship inside the package
       # this job installs and render the front end it checks. A pin move is a
       # one-line diff that replaces that shipped code wholesale, so these need

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -158,13 +158,18 @@ class CwmproclaimHelper
     /**
      * Update View and Controller to work with Namespace Case-Sensitive
      *
-     * @param   string  $defaultController  Default Controller
+     * @param   string   $defaultController  Default controller name
+     * @param   ?string  $defaultView        Default view, when it is not the
+     *                                       controller's own name. The site's
+     *                                       landing page is served by the
+     *                                       generic display controller, so the
+     *                                       two differ there.
      *
      * @return void
      * @throws \Exception
      * @since    10.0.0
      */
-    public static function applyViewAndController(string $defaultController): void
+    public static function applyViewAndController(string $defaultController, ?string $defaultView = null): void
     {
         $input      = Factory::getApplication()->getInput();
         $controller = $input->getCmd('controller');
@@ -178,7 +183,7 @@ class CwmproclaimHelper
 
         if (empty($controller) && empty($view)) {
             $controller = $defaultController;
-            $view       = $defaultController;
+            $view       = $defaultView ?? $defaultController;
         } elseif (!empty($controller) && empty($view)) {
             $view = $controller;
         }

--- a/site/src/Dispatcher/Dispatcher.php
+++ b/site/src/Dispatcher/Dispatcher.php
@@ -36,7 +36,18 @@ class Dispatcher extends ComponentDispatcher
      * @var string
      * @since 10.0.0
      */
-    protected string $defaultController = 'DisplayController';
+    protected string $defaultController = 'display';
+
+    /**
+     * The view shown when a request names neither a view nor a controller.
+     *
+     * Separate from the controller because no CwmlandingpageController exists —
+     * the generic display controller renders it.
+     *
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    protected string $defaultView = 'cwmlandingpage';
 
     /**
      * Dispatch a controller task. Redirecting the user if appropriate.
@@ -49,7 +60,7 @@ class Dispatcher extends ComponentDispatcher
     #[\Override]
     public function dispatch(): void
     {
-        CwmproclaimHelper::applyViewAndController($this->defaultController);
+        CwmproclaimHelper::applyViewAndController($this->defaultController, $this->defaultView);
 
         // Once per component request, ahead of the views, so a rule can reach
         // anything Proclaim renders.

--- a/tests/integration/Admin/Helper/CwmproclaimHelperDefaultViewTest.php
+++ b/tests/integration/Admin/Helper/CwmproclaimHelperDefaultViewTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Integration tests for the default view/controller a bare request resolves to.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmproclaimHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * `index.php?option=com_proclaim`, with no view, 404'd on the front end:
+ *
+ *     404 Invalid controller class: DisplayController
+ *
+ * The site dispatcher's default was the string 'DisplayController' — a class
+ * name where a controller *name* belongs. applyViewAndController() set both the
+ * controller and the view to it, so Joomla looked for a
+ * `DisplayControllerController` and found nothing.
+ *
+ * The two cannot be the same string on the site: the landing page has no
+ * controller of its own, it is rendered by the generic display controller. So
+ * the default view is now passed separately.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmproclaimHelper::class)]
+class CwmproclaimHelperDefaultViewTest extends IntegrationTestCase
+{
+    /**
+     * @var  array<string, mixed>
+     */
+    private array $saved = [];
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $input = Factory::getApplication()->getInput();
+
+        foreach (['view', 'controller', 'task'] as $key) {
+            $this->saved[$key] = $input->get($key);
+        }
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        $input = Factory::getApplication()->getInput();
+
+        foreach ($this->saved as $key => $value) {
+            $input->set($key, $value);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * The regression: a bare request must reach a controller that exists.
+     */
+    #[TestDox('a bare request resolves the landing view through the display controller')]
+    public function testBareRequestResolvesSeparateViewAndController(): void
+    {
+        $input = $this->clearRequest();
+
+        CwmproclaimHelper::applyViewAndController('display', 'cwmlandingpage');
+
+        self::assertSame('display', $input->getCmd('controller'), 'The controller must be one that exists.');
+        self::assertSame('cwmlandingpage', $input->getCmd('view'), 'The view must be the landing page.');
+    }
+
+    /**
+     * The admin side passes one argument and must keep behaving as it did.
+     */
+    #[TestDox('with no separate view the controller name is still used for both')]
+    public function testSingleArgumentKeepsTheOldBehaviour(): void
+    {
+        $input = $this->clearRequest();
+
+        CwmproclaimHelper::applyViewAndController('cwmcpanel');
+
+        self::assertSame('cwmcpanel', $input->getCmd('controller'));
+        self::assertSame('cwmcpanel', $input->getCmd('view'), 'Unchanged for callers that pass one name.');
+    }
+
+    /**
+     * An explicit controller still names the view, defaults untouched.
+     */
+    #[TestDox('an explicit controller with no view still supplies the view')]
+    public function testExplicitControllerSuppliesTheView(): void
+    {
+        $input = $this->clearRequest();
+        $input->set('controller', 'cwmsermon');
+
+        CwmproclaimHelper::applyViewAndController('display', 'cwmlandingpage');
+
+        self::assertSame('cwmsermon', $input->getCmd('controller'));
+        self::assertSame('cwmsermon', $input->getCmd('view'), 'The default view must not override an explicit controller.');
+    }
+
+    /**
+     * A controller.task command still splits, and the defaults stay out of it.
+     */
+    #[TestDox('a controller.task command is split and left alone')]
+    public function testControllerTaskCommandIsUnaffected(): void
+    {
+        $input = $this->clearRequest();
+        $input->set('task', 'cwmsermon.comment');
+
+        CwmproclaimHelper::applyViewAndController('display', 'cwmlandingpage');
+
+        self::assertSame('cwmsermon', $input->getCmd('controller'));
+        self::assertSame('comment', $input->getCmd('task'));
+    }
+
+    /**
+     * @return  \Joomla\Input\Input
+     */
+    private function clearRequest(): \Joomla\Input\Input
+    {
+        $input = Factory::getApplication()->getInput();
+
+        $input->set('view', null);
+        $input->set('controller', null);
+        $input->set('task', null);
+
+        return $input;
+    }
+}


### PR DESCRIPTION
Reported by Brent: `index.php/en/?option=com_proclaim` never rendered a default page.

It 404s:

```
404 Invalid controller class: DisplayController
```

## Cause

The site dispatcher's default was the **string** `'DisplayController'` — a class name where a controller *name* belongs:

```php
protected string $defaultController = 'DisplayController';
```

`applyViewAndController()` sets the controller **and** the view to that same value, so Joomla looked for a `DisplayControllerController` and found nothing. `DisplayController::display()` does default the view to `cwmlandingpage`, but the request never got that far — the controller could not be constructed.

The admin side works because its default, `cwmcpanel`, is a real controller name with a matching view.

## Fix

Controller and view cannot be one string here: the landing page has **no controller of its own**, it is rendered by the generic display controller. So `applyViewAndController()` takes an optional default view, and the site passes `'display'` + `'cwmlandingpage'`.

Callers passing a single name behave exactly as before — and the admin dispatcher does not call this helper at all, so that side is untouched.

## Verified

Reproduced on **both** J5 and J6 before the fix, including the language-prefixed form Brent reported:

| URL | before | after |
|---|---|---|
| `j6 /index.php?option=com_proclaim` | 404 | **200** |
| `j5 /index.php?option=com_proclaim` | 404 | **200** |
| `j5 /index.php/en/?option=com_proclaim` | 404 | **200** |

And it is genuinely the landing page, not just any 200 — 120,289 bytes against 121,090 for an explicit `view=cwmlandingpage`, with 756 landing-specific markup matches.

Four integration tests cover the resolution, including the single-argument path the admin side relies on. **Mutation-verified:** restoring `view = controller` fails the landing-page case.

## Also: a CI gap

`site/**` was not in the e2e path filter, so the job that renders the site views never ran on changes to the site code that produces them — the comment-submission fix (#1797) merged without it. Added.

That is the second hole in this filter today; `libraries/**` was the first (#1795), which meant scripture submodule pins could not trigger the clean-install job either.

`composer test` 2358 green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ