### PR TITLE
fix: keep Proclaim's buttons readable under a site template's link colour

### DIFF
--- a/build/media_source/css/cwmcore.css
+++ b/build/media_source/css/cwmcore.css
@@ -1142,3 +1142,34 @@ p.expand {
 .alert .btn.btn-dark {
   color: #ffffff;
 }
+
+/*
+ * The same clash, on the front end, from the site template rather than Atum.
+ *
+ * Templates routinely colour every anchor inside their content wrapper:
+ *
+ *     .box2 > .g-content a, .box2.moduletable a { color: #8b5717 }   (0,2,1)
+ *
+ * Proclaim's buttons are anchors, so they are caught by it, and Bootstrap's own
+ * `.btn-primary { color: #fff }` is only (0,1,0) and loses. On nfsda.org that
+ * painted the teacher page's navigation buttons #8b5717 on a #8b5717 background
+ * — the text was still there, at a contrast ratio of 1:1.
+ *
+ * Scoped to .com-proclaim so this only claims Proclaim's own buttons, at (0,3,0)
+ * to clear a wrapper rule's (0,2,1). --bs-btn-color is preferred where the
+ * template defines it (Bootstrap 5.3 does), so a deliberate choice still wins
+ * and the fallback only applies to templates that set none.
+ */
+.com-proclaim .btn.btn-warning,
+.com-proclaim .btn.btn-light {
+  color: var(--bs-btn-color, #000000);
+}
+
+.com-proclaim .btn.btn-primary,
+.com-proclaim .btn.btn-secondary,
+.com-proclaim .btn.btn-success,
+.com-proclaim .btn.btn-danger,
+.com-proclaim .btn.btn-info,
+.com-proclaim .btn.btn-dark {
+  color: var(--bs-btn-color, #ffffff);
+}


### PR DESCRIPTION
Reported by Brent with a screenshot from nfsda.org: the teacher page's navigation buttons render as solid brown blocks with no visible label.

The labels are not missing. They are painted the same colour as the button.

```
color: rgb(139, 87, 23)
bg:    rgb(139, 87, 23)
```

## Cause — measured on the live page, not guessed

The winning `color` declaration is the **template's**:

```css
.box2 > .g-content a, .box2.moduletable a, .box2.widget a { color: #8b5717 }   /* (0,2,1) */
```

Gantry-family templates colour every anchor inside their content wrapper. Proclaim renders its buttons as anchors, so they are caught by it — and Bootstrap's own `.btn-primary { color: #fff }` is only `(0,1,0)` and loses. Contrast ratio **1:1**, with the text still selectable.

Our stylesheet *is* loaded there (20 `.com-proclaim` rules present — the site combines CSS into hashed bundles, which is why a filename check misses it). This is purely a cascade fight.

## Fix

`cwmcore.css` already documents this exact clash for Atum colouring links inside an alert. Same remedy: scoped to `.com-proclaim`, at `(0,3,0)` to clear a wrapper rule's `(0,2,1)`.

`--bs-btn-color` is preferred where the template defines it, so a Bootstrap 5.3 template's deliberate choice still wins and the fallback only reaches templates that set none.

## Verification

Cassiopeia already defends its buttons by other means, so the failure **cannot be staged on j6-dev** — I tried, and said so rather than claiming a reproduction I did not have. Proved it in an isolated document instead:

| | rendered colour |
|---|---|
| template rule alone | `rgb(139, 87, 23)` — the live failure |
| plus this rule | `rgb(255, 255, 255)` |

No regression on Cassiopeia — buttons measure white on dark blue before and after — and `composer test:a11y` is green at **53**.

Only the source file changes; `media/css/` is generated and gitignored.

## Follow-up worth considering

We have no dev site running a Gantry template, which is why this shipped. Brent raised installing **Helium** — that would turn the isolated proof above into a real reproduction and give ongoing coverage for template-cascade bugs, which are invisible on Cassiopeia by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ