### PR TITLE
test: run the site views under a Gantry template

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -87,7 +87,7 @@ module.exports = defineConfig({
         {
             name: 'site-j5',
             testMatch: '**/site/**/*.spec.js',
-            testIgnore: '**/a11y.spec.js',
+            testIgnore: ['**/a11y.spec.js', '**/template-gantry.spec.js'],
             use: {
                 ...devices['Desktop Chrome'],
                 baseURL: j5Url,
@@ -105,6 +105,28 @@ module.exports = defineConfig({
         {
             name: 'site-j6',
             testMatch: '**/site/**/*.spec.js',
+            testIgnore: '**/template-gantry.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: j6Url,
+            },
+        },
+
+        // Proclaim rendered by a Gantry template rather than Cassiopeia.
+        //
+        // Every other site project runs Cassiopeia, so nothing exercised the
+        // markup under a template that styles it differently — which is how
+        // buttons whose label matched their own background reached production
+        // (#1799). Its own project rather than a second run of the whole site
+        // suite: this is about the template, and the a11y scan is expensive.
+        //
+        // The spec pins a template style by id, configurable because Helium
+        // installs with a different one per site. It asserts Gantry markup is
+        // actually present, so a stale id fails rather than quietly re-testing
+        // Cassiopeia.
+        {
+            name: 'site-helium',
+            testMatch: '**/site/template-gantry.spec.js',
             use: {
                 ...devices['Desktop Chrome'],
                 baseURL: j6Url,

--- a/tests/e2e/site/template-gantry.spec.js
+++ b/tests/e2e/site/template-gantry.spec.js
@@ -1,0 +1,132 @@
+/**
+ * E2E — Proclaim under a Gantry template
+ *
+ * Every dev site ran Cassiopeia, so nothing exercised Proclaim's markup under a
+ * template that styles it differently. That blind spot is how the teacher page's
+ * navigation buttons reached production painted #8b5717 on a #8b5717 background:
+ * a Gantry section preset colours every anchor inside its wrapper, Proclaim
+ * renders its buttons as anchors, and Bootstrap's own `.btn-primary` colour is
+ * less specific and loses (#1799).
+ *
+ * ⚠️ Stock Helium does not reproduce that particular failure — the colour came
+ * from that site's own preset, not from the template's defaults. So this file is
+ * not a regression test for #1799. It is coverage for the thing that was missing
+ * underneath it: that Proclaim renders, and stays legible, in a Gantry document
+ * at all.
+ *
+ * Runs only in the `site-helium` project, which pins a Gantry template style.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const PROCLAIM_CONTENT = '.com-proclaim';
+
+/**
+ * The template style id to render under. Helium installs as a style whose id
+ * varies per site, so it is configurable; 13 is j6-dev's.
+ */
+const STYLE = process.env.PROCLAIM_GANTRY_STYLE || '13';
+
+/**
+ * Views worth rendering under a second template. Detail views are reached by id
+ * rather than click-through: this file is about the template, and the listings
+ * already prove the links work in the site suite.
+ */
+const VIEWS = [
+    ['landing page', 'cwmlandingpage'],
+    ['sermon listing', 'cwmsermons'],
+    ['teacher listing', 'cwmteachers'],
+    ['series listing', 'cwmseriesdisplays'],
+    ['series podcast listing', 'cwmseriespodcastlist'],
+];
+
+/**
+ * PHP notices leak into the body and would otherwise read as ordinary content.
+ */
+const PHP_ERRORS = /(Fatal error|Parse error|Warning:|Notice:|Deprecated:)/;
+
+/**
+ * @param {string} view Proclaim site view name
+ * @returns {string} URL pinned to the Gantry template style
+ */
+function url(view) {
+    return `/index.php?option=com_proclaim&view=${view}&templateStyle=${STYLE}`;
+}
+
+test.describe('Proclaim under a Gantry template @gantry', () => {
+    for (const [label, view] of VIEWS) {
+        test(`${label} renders under Gantry`, async ({ page }) => {
+            const response = await page.goto(url(view), { waitUntil: 'networkidle' });
+
+            expect(response.status()).toBeLessThan(400);
+
+            // ⚠️ Assert, do not skip. A style id that no longer resolves renders
+            // the site's default template instead, and every assertion below
+            // would pass while testing Cassiopeia again — the blind spot this
+            // file exists to close.
+            await expect(
+                page.locator('.g-content, [class*="g-container"], body[class*="g-"]').first(),
+                `Template style ${STYLE} did not render Gantry markup. Set PROCLAIM_GANTRY_STYLE to the Helium style id.`
+            ).toBeAttached({ timeout: 15000 });
+
+            await expect(page.locator(PROCLAIM_CONTENT).first()).toBeAttached({ timeout: 15000 });
+            await expect(page.locator('body')).not.toContainText(PHP_ERRORS);
+        });
+    }
+
+    /**
+     * The shape of #1799, generalised: a template rule that wins over Bootstrap's
+     * button colour leaves the label the same colour as the button behind it.
+     * Text that is present but invisible reads as an empty button, and no
+     * rendering check catches it.
+     */
+    test('button labels are not the same colour as their button', async ({ page }) => {
+        // The navigation buttons live on a teacher's detail page, not the
+        // listing. Collect the href before navigating — the listing locator goes
+        // stale the moment we leave it.
+        await page.goto(url('cwmteachers'), { waitUntil: 'networkidle' });
+
+        const links = page.locator('.proclaim-grid-card a[href], .proclaim-item a[href]');
+        const total = await links.count();
+        let target = null;
+
+        for (let i = 0; i < total && target === null; i++) {
+            const href = await links.nth(i).getAttribute('href');
+
+            if (href && href.startsWith('/')) {
+                target = href;
+            }
+        }
+
+        expect(target, 'No teacher detail link to open, so this checks nothing').not.toBeNull();
+
+        await page.goto(
+            `${target}${target.includes('?') ? '&' : '?'}templateStyle=${STYLE}`,
+            { waitUntil: 'networkidle' }
+        );
+
+        const buttons = page.locator(`${PROCLAIM_CONTENT} .btn`);
+        const buttonCount = await buttons.count();
+
+        expect(buttonCount, 'No Proclaim buttons rendered, so this checks nothing').toBeGreaterThan(0);
+
+        for (let i = 0; i < buttonCount; i++) {
+            const button = buttons.nth(i);
+
+            const [colour, background, label] = await button.evaluate((el) => {
+                const style = getComputedStyle(el);
+
+                return [style.color, style.backgroundColor, el.textContent.trim()];
+            });
+
+            // A transparent button takes its contrast from whatever is behind it,
+            // which axe judges properly in the a11y suite; here only the
+            // same-colour case is decidable.
+            if (background === 'rgba(0, 0, 0, 0)' || label === '') {
+                continue;
+            }
+
+            expect(colour, `"${label}" is the same colour as its button`).not.toBe(background);
+        }
+    });
+});


### PR DESCRIPTION
Every dev site ran Cassiopeia, so nothing exercised Proclaim's markup under a template that styles it differently. That is the blind spot behind #1799 — a Gantry section preset painted the teacher page's buttons the same colour as their own background, and it reached production.

Brent installed Gantry + Helium on j6-dev, so there is now somewhere to run this.

## What it does

A `site-helium` project renders the site views under a pinned Gantry template style and asserts:

- each view returns < 400, renders `.com-proclaim`, and leaks no PHP notice into the body
- **no button label is the same colour as the button behind it** — the generalised shape of #1799, which no rendering check catches because the text is present and merely invisible

## What it is not

⚠️ **Stock Helium does not reproduce #1799.** I checked before writing this: the buttons render white on teal with and without the fix. That colour came from nfsda's own section preset, not Helium's defaults.

So this is **not** a regression test for #1799, and the file says so in its header rather than leaving someone to infer it. It is the coverage that was missing underneath — that Proclaim renders, and stays legible, in a Gantry document at all.

## Not passing vacuously

Three specs in this suite were green for months by never running, so the anti-vacuous guards are deliberate:

- the style id is **configurable** (`PROCLAIM_GANTRY_STYLE`, default 13) because Helium installs with a different id per site
- the spec **asserts Gantry markup is present** rather than skipping. A stale id renders the site default, and every other assertion would pass while quietly re-testing Cassiopeia
- the button test **fails if it finds no buttons** — which it did on first run, because the buttons live on teacher detail, not the listing

**Mutation-verified:** `PROCLAIM_GANTRY_STYLE=999` fails with *"Template style 999 did not render Gantry markup"* rather than passing.

## Scope

Its own project rather than a second pass of the whole site suite — this is about the template, and the a11y scan is expensive. Excluded from `site-j5`/`site-j6`, which would fail its Gantry assertion.

`site-j6` + `site-helium` together: **20 passed**. eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gmbekFfrJBK9fiyZ3MSQ