### PR TITLE
test: remove the media dirs the YouTube cache tests create

### DIFF
--- a/tests/unit/Admin/Helper/CwmyoutubeFileCacheTest.php
+++ b/tests/unit/Admin/Helper/CwmyoutubeFileCacheTest.php
@@ -78,6 +78,13 @@ class CwmyoutubeFileCacheTest extends ProclaimTestCase
         }
 
         @rmdir($this->cacheDir);
+
+        // Also drop the now-empty parents. A leftover media/com_proclaim/ makes
+        // cwm-verify read this flat-layout component as namespaced, so every dev
+        // site's media symlink is reported as a conflict. @rmdir is a no-op on a
+        // directory that still has contents.
+        @rmdir(\dirname($this->cacheDir));
+        @rmdir(\dirname($this->cacheDir, 2));
     }
 
     public function testStoreAndRetrieveLastKnownVideo(): void

--- a/tests/unit/Admin/Helper/CwmyoutubeQuotaTest.php
+++ b/tests/unit/Admin/Helper/CwmyoutubeQuotaTest.php
@@ -65,6 +65,15 @@ class CwmyoutubeQuotaTest extends ProclaimTestCase
 
         CwmyoutubeQuota::resetQuota(self::TEST_SERVER_ID);
 
+        // Drop the directories setUp() created. A leftover media/com_proclaim/
+        // makes cwm-verify read this flat-layout component as namespaced, so
+        // every dev site's media symlink is reported as a conflict. @rmdir is a
+        // no-op on a directory that still has contents.
+        $dir = \dirname($this->quotaFile);
+        @rmdir($dir);
+        @rmdir(\dirname($dir));
+        @rmdir(\dirname($dir, 2));
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
## Problem

Running the unit suite left an empty `media/com_proclaim/` in the repo, which made `composer verify` report a symlink conflict on **all four** dev sites at once:

```
! conflict  .../Sites/j6-dev/media/com_proclaim
            expected: .../Proclaim/media/com_proclaim
            found:    .../Proclaim/media
```

The symlinks were correct. Proclaim uses the flat media layout — `pkg_proclaim.xml:58` declares `<media destination="com_proclaim" folder="media">`, so repo `media/` maps to site `media/com_proclaim/`. But cwm-build-tools infers that layout rather than reading the manifest: `LinkResolver::componentMediaSource()` returns the namespaced source whenever `media/<name>/` happens to be a directory. The stray directory flipped the guess, so the expectation was wrong, not the sites.

## Cause

- `CwmyoutubeQuotaTest::setUp()` `mkdir`'d `media/com_proclaim/youtube_cache/<siteId>` recursively and removed nothing.
- `CwmyoutubeFileCacheTest` removed only the leaf `<siteId>` directory.

Both left the two parents behind. The directories are empty and untracked, so `git status` stays clean while `composer verify` fails — nothing in the working copy points at the cause.

## Fix

Walk up from `<siteId>` and drop the empty parents in both teardowns. `@rmdir` is a no-op on a directory that still has contents, so this cannot touch a real `media/com_proclaim/` in a non-symlinked checkout.

## Verification

- Both tests: **OK (14 tests, 26 assertions)**; no `media/com_proclaim` left afterwards.
- `composer verify` after the run: **54 ok, 0 errors** (12 × 4 dev sites + 6 for j6-test).
- `composer lint`: 0 of 611 files need fixing.
- Confirmed load-bearing rather than coincidentally clean — stashing the change and re-running the same two tests recreates the directory.

## Follow-up

The tool-side weakness is filed as Joomla-Bible-Study/cwm-build-tools#95: the layout should come from the manifest already being parsed, with `is_dir()` kept only as a fallback. That matters beyond verify — the same resolution feeds the linker at three call sites, so relinking while a stray directory exists would repoint every dev site's `media/com_proclaim` symlink at the empty directory and take all component assets offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
