### PR TITLE
chore(deps): bump cwm/build-tools to 1.20.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.19.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "7f5f3c8a5566125ed06053df95587738a4bcca73"
+                "reference": "2b26988cd79916e6e158122056966282c6a242f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/7f5f3c8a5566125ed06053df95587738a4bcca73",
-                "reference": "7f5f3c8a5566125ed06053df95587738a4bcca73",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/2b26988cd79916e6e158122056966282c6a242f7",
+                "reference": "2b26988cd79916e6e158122056966282c6a242f7",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +658,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.19.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.20.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-13T18:11:03+00:00"
+            "time": "2026-08-14T12:54:55+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.20.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.20.0), which fixes the tool-side half of the problem behind #1801.

## Why it matters here

Proclaim declares the **flat** media layout — `proclaim.xml`: `<media destination="com_proclaim" folder="media">` — so repo `media/` maps to site `media/com_proclaim/`. Until 1.20.0 the tool inferred that layout from whether `media/com_proclaim/` happened to exist on disk rather than reading the manifest, so a stray empty directory made `composer verify` report a conflict on all four linked dev sites at once.

#1801 stopped the tests from creating that directory. This stops the directory from mattering. That second half is the one that counts: `cwm-link` shares the resolution, so relinking with a stray present would have repointed every dev site's `media/com_proclaim` symlink at the empty directory and taken Proclaim's assets offline.

## Verification

Stray `media/com_proclaim/` recreated deliberately, then `composer verify`:

| build-tools | result |
|---|---|
| v1.19.0 | `50 ok, 4 error(s)` |
| v1.20.0 | `54 ok, 0 error(s)` |

Lock-only change — the diff is the `cwm/build-tools` entry and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
