### PR TITLE
fix: keep Proclaim's landing page legible under a site template

### DIFF
--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -122,10 +122,31 @@
     overflow: visible;
     display: inline-block;
     padding: 0.5rem 1rem;
-    background: #0d6efd;
+    /*
+     * Dark rather than the #0d6efd this used to be: white on that blue measures
+     * exactly 4.5:1, the bare minimum, and it disagreed with the same control in
+     * cwmcore.css for no reason. This matches cwmcore's treatment, which measures
+     * 20.9:1 — the literal is repeated because --color-black is defined there and
+     * that file does not reach this page.
+     */
+    background: #212529;
     color: #fff;
     text-decoration: none;
     z-index: 1000;
+}
+
+/*
+ * Same clash as the hero card, on the one control a keyboard user meets first.
+ * Focused on nfsda.org this measured 1.3:1 — the template's link colour on the
+ * blue above — because the rule setting that white is (0,1,0) and a wrapper's
+ * anchor rule is (0,2,1).
+ *
+ * ⚠️ This duplicates .proclaim-skip-link in cwmcore.css, which the landing view
+ * does not load — it uses only cwm-landing, so the core accessibility rules
+ * never reach this page. Both copies need the fix until that is resolved.
+ */
+.com-proclaim .proclaim-skip-link:focus {
+    color: #fff;
 }
 
 /* =========================================================================

--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -342,6 +342,29 @@
     text-decoration: none;
 }
 
+/*
+ * Tags are anchors too, so they lose their colour to a site template's link
+ * rule the same way the hero card does — see the note above it. Measured on
+ * nfsda.org, every tag on the accent band rendered #8b5717 on a chip over that
+ * band's dark gradient: 2.0:1, against the 4.5:1 the text needs.
+ *
+ * The light variant survived on that site at 4.88:1, but only by luck of which
+ * accent the template happens to use, and it was still not the colour intended.
+ * Both are restated so neither depends on the template's palette.
+ */
+.com-proclaim .proclaim-landing-tag.proclaim-landing-tag--light {
+    color: #495057;
+}
+
+.com-proclaim .proclaim-landing-tag.proclaim-landing-tag--dark {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.com-proclaim .proclaim-landing-tag.proclaim-landing-tag--light:hover,
+.com-proclaim .proclaim-landing-tag.proclaim-landing-tag--dark:hover {
+    color: #fff;
+}
+
 /* =========================================================================
    Dashboard Style (.proclaim-landing--dashboard)
    ========================================================================= */

--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -280,6 +280,29 @@
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
+/*
+ * The card is an anchor, so its text takes whatever colour a site template
+ * paints links inside its content wrapper:
+ *
+ *     .box2 > .g-content a, .box2.moduletable a { color: #8b5717 }   (0,2,1)
+ *
+ * The card's own `color: #fff` is (0,1,0) and loses, and the text is inherited
+ * from the anchor rather than declared on the title, so nothing stops it. On
+ * nfsda.org that rendered every speaker's name in the template's orange over
+ * the dark overlay — the same clash #1799 fixed for Proclaim's buttons.
+ *
+ * White here is not a preference: the overlay gradient exists to make white
+ * text legible, and the text-shadows above are sized for it. Declaring the
+ * colour on the title and subtitle rather than inheriting it settles this on
+ * its own, since a declaration always beats an inherited value; the
+ * .com-proclaim scope and (0,3,0) specificity match #1799 so the two do not
+ * drift, and hold up if a template ever targets these elements directly.
+ */
+.com-proclaim .proclaim-landing-hero-card .proclaim-landing-hero-card__title,
+.com-proclaim .proclaim-landing-hero-card .proclaim-landing-hero-card__sub {
+    color: #ffffff;
+}
+
 /* Hero tags */
 .proclaim-landing-tags {
     display: flex;

--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -58,8 +58,51 @@
     margin-top: 1rem;
 }
 
+/*
+ * The accent band already gives this control its own colours further down. The
+ * other two bands relied on .btn-outline-primary, and a template that flattens
+ * .btn erases it: on nfsda.org the button rendered white text and a white
+ * border on a white band — the whole control invisible, at 1.0:1. Bootstrap's
+ * variant and the template's rule are both (0,1,0), so it came down to source
+ * order (#1806).
+ *
+ * Claimed for every landing style, not just the hero bands: the cards and
+ * dashboard styles render the same control with no band around it, so a
+ * band-scoped rule would have left two of the three layouts exposed. The accent
+ * band keeps its own colours and is scoped one class higher so it still wins.
+ *
+ * Stated here rather than in cwmcore.css with #1799's button rules, because
+ * this is Proclaim's own landing chrome — the bands, cards and tags around it
+ * are all ours — so claiming it does not override a template's styling of the
+ * buttons that genuinely belong to it. Cassiopeia's navy and Helium's grey are
+ * left alone everywhere else. There is no palette variable to defer to:
+ * --bs-btn-color and --bs-primary are unset on Cassiopeia, stock Helium and
+ * nfsda alike, so a literal is the only option.
+ *
+ * #0a58ca rather than the #0d6efd the tags hover to: that lighter blue measures
+ * exactly 4.5:1 on white, the bare minimum with no headroom, and the count below
+ * dims whatever it is given. This one measures 6.44:1.
+ */
+.com-proclaim .proclaim-landing__show-more {
+    color: #0a58ca;
+    border-color: #0a58ca;
+}
+
+.com-proclaim .proclaim-landing__show-more:hover {
+    background-color: #0a58ca;
+    border-color: #0a58ca;
+    color: #fff;
+}
+
 .proclaim-landing__toggle-count {
-    opacity: 0.6;
+    /*
+     * 0.6 dimmed this below the contrast floor on every template, not just a
+     * hostile one: opacity multiplies whatever colour it inherits, and
+     * getComputedStyle does not report it, so the count measured as passing
+     * while rendering at 2.4:1 on a light band and 4.86:1 on the accent one.
+     * 0.85 keeps it visibly secondary at 4.76:1 and 8.43:1.
+     */
+    opacity: 0.85;
     margin-left: 0.25rem;
 }
 
@@ -204,12 +247,12 @@
     letter-spacing: -0.02em;
 }
 
-.proclaim-landing-band--accent .proclaim-landing__show-more {
+.com-proclaim .proclaim-landing-band--accent .proclaim-landing__show-more {
     color: rgba(255, 255, 255, 0.8);
     border-color: rgba(255, 255, 255, 0.3);
 }
 
-.proclaim-landing-band--accent .proclaim-landing__show-more:hover {
+.com-proclaim .proclaim-landing-band--accent .proclaim-landing__show-more:hover {
     background: rgba(255, 255, 255, 0.15);
     color: #fff;
 }

--- a/build/media_source/css/cwmcore.css
+++ b/build/media_source/css/cwmcore.css
@@ -54,6 +54,21 @@
   outline-offset: 2px;
 }
 
+/*
+ * The skip link is an anchor, so a template colouring every anchor in its
+ * content wrapper repaints it — and it is the first control a keyboard user
+ * reaches. Measured on nfsda.org, focused, it rendered the template's #8b5717
+ * on this rule's dark background at 1.3:1.
+ *
+ * The single-class rules above are (0,1,0) and lose to a wrapper's (0,2,1).
+ * Restated at (0,3,0), scoped to .com-proclaim, matching #1799.
+ */
+.com-proclaim .proclaim-skip-link,
+.com-proclaim .proclaim-skip-link:focus {
+  background: var(--color-black);
+  color: var(--color-white);
+}
+
 /* Main content landmark */
 .proclaim-main-content {
   scroll-margin-top: 1rem;

--- a/site/layouts/landing/hero/section-images.php
+++ b/site/layouts/landing/hero/section-images.php
@@ -78,6 +78,9 @@ $bandClass = $bandStyle === 'dark' ? 'proclaim-landing-band--dark' : 'proclaim-l
                         <div class="proclaim-landing-hero-card__overlay"></div>
                         <div class="proclaim-landing-hero-card__content">
                             <div class="proclaim-landing-hero-card__title"><?php echo htmlspecialchars($item['text'], ENT_QUOTES, 'UTF-8'); ?></div>
+                            <?php if (!empty($item['meta'])) : ?>
+                                <div class="proclaim-landing-hero-card__sub"><?php echo htmlspecialchars($item['meta'], ENT_QUOTES, 'UTF-8'); ?></div>
+                            <?php endif; ?>
                         </div>
                     </a>
                 </div>


### PR DESCRIPTION
Closes #1803 (defect 1), closes #1804.

Also fixes the landing half of #1806 and the skip link found by the sweep. #1806 stays open for the outline buttons in the other views — see the bottom of this description.

`landing_style` defaults to `'hero'`, so both of these ship as the out-of-the-box landing page. Reported from `nfsda.org/resources/sermons/landing`.

## Show-more items lost their subtitle

The visible loop renders `__sub` when the item has meta; the hidden loop rendered only `__title`, with the meta block absent entirely. `splitItems()` splits one array, so the data was always there and the template dropped it — a teacher revealed by "Show more" lost their role while the one beside them kept it.

Not a decision: `cards/section-images.php` renders meta in **both** of its loops (`:71`, `:97`). Hero's hidden loop was an oversight.

## The card's text took the template's link colour

The card is an anchor, and a Gantry-family template colours every anchor inside its content wrapper:

```css
.box2 > .g-content a, .box2.moduletable a { color: #8b5717 }   /* (0,2,1) */
```

The card's own `color: #fff` is (0,1,0) and loses, and the title inherits from the anchor rather than declaring anything, so nothing stops it. Same clash as #1799, on the landing page instead of the buttons.

Declaring the colour on the title and subtitle settles it on its own — a declaration always beats an inherited value. The `.com-proclaim` scope at (0,3,0) matches #1799 so the two don't drift, and holds if a template ever targets these elements directly. White isn't a preference here: the overlay gradient exists to make white text legible and the text-shadows are sized for it.

## Verification

Both checks are against the real failure, not a stand-in.

**Subtitle**, rendered on j6-dev with the template flipped to hero (and flipped back afterwards):

| | hidden tiles | rendering `__sub` |
|---|---|---|
| without the fix | 91 | **0** |
| with the fix | 91 | **51** |

The other 40 have no Title to show. Example restored tile: *Alvaro Torres / Pastor*.

**Colour.** ⚠️ Stock Helium does **not** reproduce this — as `tests/e2e/site/template-gantry.spec.js` already warns, the colour comes from that site's own preset, not the template's defaults. Testing under stock Helium would have passed either way and proved nothing.

So this was measured the way #1799 was: an isolated document using nfsda's actual accent colour (`accent.color-1: '#8b5717'` from its `g5_helium_custom/config/default/styles.yaml`) and the actual containing chain read off the live page (`.box2 > .g-content > .com-proclaim`):

```
without Proclaim rule  title=rgb(139, 87, 23)   sub=rgb(139, 87, 23)
with Proclaim rule     title=rgb(255, 255, 255) sub=rgb(255, 255, 255)
```

`composer lint` clean (0 of 611 files).

## Deliberately not changed

A title with no subtitle still sits lower than its neighbours — the content block is anchored to the bottom of the tile. Reserving an empty line to align them costs dead space on every subtitle-less card, so the ragged look stays, now by decision rather than by accident. That's why #1803 is closed for defect 1 only.

Also unchanged: `<media>`-style honorifics like "Dr." appearing in the role slot are the teacher's Title field verbatim — content, not markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added after a full scan of the live page

Measuring every Proclaim element on `nfsda.org/resources/sermons/landing`, rather than only the reported ones, found the same clash on the **tags**. They are anchors too, so the template's link rule takes them and their single class loses to it.

| element | before | after |
|---|---|---|
| `tag--dark` (52 on the accent band) | **2.05** | **11.36** |
| `tag--light` (56 on light bands) | 4.88 | 6.59 |
| `hero-card__title` (31 visible) | **2.67** | **16.16** |
| `hero-card__sub` (15 visible) | **2.87** | **17.33** |

Normal-size text needs 4.5:1, so three of those four were failing. The light tags passed at 4.88 — but only by luck of which accent that template happens to use, and they were not the colour intended either, so both variants are restated.

Effective backgrounds come from sampling rendered pixels, because walking `background-color` up the DOM cannot see through the accent band's gradient or the tag chip's translucency — an earlier pass using that method reported white-on-white failures that were not real.

The "after" column is the rebuilt stylesheet injected into the live page, so it is this branch's CSS against the real template, not a synthetic reproduction.

⚠️ If you re-measure this: `.proclaim-landing-tag` has `transition: color .2s`, so sampling immediately after injecting a rule reads the blend, not the result. It first appeared not to work at all.

## What the scan cleared

No PHP notices, no duplicate IDs, no links without an accessible name, clean heading hierarchy (one H1, seven H2s), the single `<img>` has alt text. Hero card backgrounds are CSS images with the accessible name coming from the card's own title, which is the right pattern.

## Added after sweeping the other views

Running the same measurement across every Proclaim view reachable from the landing page turned up two more, both now fixed here.

**The show-more button (#1806, landing half).** White text *and* a white border on a white band — 1.0:1, the whole control invisible. A bare `.btn { color: #fff }` from the template beats Bootstrap's outline variant on source order alone.

Scoped to Proclaim's own control rather than extended to every outline variant. The bands, cards and tags around it are all ours, so claiming it does not override a template's styling of the buttons that genuinely belong to it — Cassiopeia's navy and Helium's grey stay put elsewhere. The cost: this one control moves from `rgb(1,1,86)` to `#0a58ca` on Cassiopeia. Applied to all three landing styles, since cards and dashboard render it with no band around it.

The count's `opacity` also moves from 0.6 to 0.85. Opacity multiplies whatever colour it inherits and `getComputedStyle` does not report it, so "(79)" measured as passing while rendering at 2.4:1 — a failure on *every* template, not just a hostile one.

**The skip link.** Focused, it rendered the template's `#8b5717` on its own dark background: 1.3:1 on landing, 3.45:1 on the listings. It is the first control a keyboard user reaches. Fixed in both copies — see #1808 for why there are two.

| | before | after |
|---|---|---|
| show-more button / label / count | 1.00 | 5.78 / 6.44 / 6.44 |
| skip link — landing / listings | 1.30 / 3.45 | 15.43 / 21.00 |

⚠️ Measuring the skip link needs care: injecting a whole stylesheet over a page already serving an older copy of itself leaves two rules of equal specificity, and the deployed one wins on order — which made the fix look like it had not worked (4.24). The numbers above are from an isolated document with the shipping CSS only. Additive higher-specificity rules like the hero card's are unaffected.

## Found but deliberately not in this PR

- **#1806 stays open** for the other 9 outline buttons across 6 site views. The narrow fix was chosen over extending #1799 to every variant, because that would force Bootstrap's blue onto templates that theme the variants themselves.
- **#1808** — the landing view never loads `cwmcore.css`, so Proclaim's focus outlines and skip-link rules have never reached that page and #1799 never applied there. That is the structural cause behind several of these, and why the skip-link fix had to be written twice.
- **#1807** — per-section custom CSS.
- **Already fixed, unreleased:** the "Return to Teacher List" button measures 1.07 (brown on brown) on the deployed 10.5.7; injecting #1799's `cwmcore.css` takes it to 5.23. It arrives with 10.5.8.
- **nfsda's own to fix:** the sermon list's "Clear" button is white on tan at 2.03 — forcing white text cannot fix a light button background, so their preset needs it darkened. More broadly, their `accent.color-1: #8b5717` is what most of this traces back to.

