### PR TITLE
fix: load cwmcore on the landing page and drop its duplicate skip link

### DIFF
--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -106,49 +106,6 @@
     margin-left: 0.25rem;
 }
 
-.proclaim-skip-link {
-    position: absolute;
-    left: -9999px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-}
-
-.proclaim-skip-link:focus {
-    position: static;
-    width: auto;
-    height: auto;
-    overflow: visible;
-    display: inline-block;
-    padding: 0.5rem 1rem;
-    /*
-     * Dark rather than the #0d6efd this used to be: white on that blue measures
-     * exactly 4.5:1, the bare minimum, and it disagreed with the same control in
-     * cwmcore.css for no reason. This matches cwmcore's treatment, which measures
-     * 20.9:1 — the literal is repeated because --color-black is defined there and
-     * that file does not reach this page.
-     */
-    background: #212529;
-    color: #fff;
-    text-decoration: none;
-    z-index: 1000;
-}
-
-/*
- * Same clash as the hero card, on the one control a keyboard user meets first.
- * Focused on nfsda.org this measured 1.3:1 — the template's link colour on the
- * blue above — because the rule setting that white is (0,1,0) and a wrapper's
- * anchor rule is (0,2,1).
- *
- * ⚠️ This duplicates .proclaim-skip-link in cwmcore.css, which the landing view
- * does not load — it uses only cwm-landing, so the core accessibility rules
- * never reach this page. Both copies need the fix until that is resolved.
- */
-.com-proclaim .proclaim-skip-link:focus {
-    color: #fff;
-}
-
 /* =========================================================================
    Card Grid Style (.proclaim-landing--cards)
    ========================================================================= */

--- a/build/media_source/joomla.asset.json
+++ b/build/media_source/joomla.asset.json
@@ -544,6 +544,7 @@
             "type": "style",
             "uri": "com_proclaim/cwm-landing.min.css",
             "dependencies": [
+                "com_proclaim.cwmcore",
                 "com_proclaim.general",
                 "fontawesome"
             ]


### PR DESCRIPTION
Closes #1808.

## The gap

`cwmcore.css` reaches the front end through exactly one path — `Cwmlisting::getFluidListing()` (`Cwmlisting.php:73`) — plus the popup view. The landing page calls neither, so **Proclaim's core stylesheet has never loaded there.**

Confirmed against the live site: `--focus-outline-color`, defined at the top of `cwmcore.css`, appears in none of the stylesheets served on `nfsda.org/resources/sermons/landing`.

Three consequences, all closed here:

- **The accessibility block did not apply** — skip-link rules, the `.proclaim-main-content` landmark, and the focus-visible outlines for every interactive element.
- **#1799 did not apply**, which is why the show-more button needed its own repair in `cwm-landing.css` (#1806) rather than inheriting one.
- **The skip link was defined twice and had diverged.** `cwmcore.css:37` uses a dark background and hides it with `top: -40px`; `cwm-landing.css` used `#0d6efd` and `left: -9999px`. Two implementations of one component — presumably copied rather than loaded, when whoever built the page found the core rules missing.

## The change

Two lines net: `com_proclaim.cwmcore` added as a dependency of `com_proclaim.cwm-landing`, and the 43-line duplicated skip-link block deleted.

Declared as a **dependency** rather than a `useStyle()` call in the view, so it holds for any consumer of the asset and the dependency loads first — the landing sheet can still override it.

## Verification

**Blast radius measured before changing anything**, by testing every `cwmcore` selector against the landing DOM. Nine match:

| matches | selector | effect |
|---|---|---|
| 1 | `:root` | custom properties — additive |
| 2 | `.proclaim-skip-link`, `.com-proclaim .proclaim-skip-link` | the point of the change |
| 1 | `.proclaim-main-content` | `scroll-margin-top` |
| 1050 | `.com-proclaim *` | inside `prefers-reduced-motion` only |
| 5 | `.bsms_media_container` | geometry unchanged in practice |
| 5 | `.proclaim-listing a` | drops an underline |
| 1 | `.com-proclaim .btn.btn-primary` | #1799 finally reaching the page |

**Rendered under both templates** — cwmcore now loads ahead of `cwm-landing`, the custom properties resolve, and the focused skip link measures **21.00:1** with the 3px focus ring, up from 4.24 on the duplicate it replaces.

**Diffed geometry and key styles with the sheet toggled off and on:**

| | elements | differing |
|---|---|---|
| hero, under Gantry/Helium | 198 | **0** |
| dashboard, under Cassiopeia | 11 | 5 |

Those five are media play links losing their underline — same size, same colour, no layout shift. That is `.proclaim-listing a` doing on this page what it already does on every other Proclaim view, so it makes landing consistent rather than introducing something new.

## Still open

Four more views never load `cwmcore.css`: `cwmlatest`, `cwmseriespodcastdisplay`, `cwmseriespodcastlist`, `cwmterms`. None renders a skip link, so the gap there is focus styling rather than a broken control — but it is the same gap, and worth a sweep once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
