### PR TITLE
fix: load Proclaim's core stylesheet on every site view

### DIFF
--- a/site/src/Dispatcher/Dispatcher.php
+++ b/site/src/Dispatcher/Dispatcher.php
@@ -62,6 +62,17 @@ class Dispatcher extends ComponentDispatcher
     {
         CwmproclaimHelper::applyViewAndController($this->defaultController, $this->defaultView);
 
+        // Proclaim's core stylesheet, for the same reason and in the same place:
+        // every front-end view needs it, and registering here puts it ahead of
+        // any sheet a view adds, so a view can still override it.
+        //
+        // It used to arrive only through Cwmlisting::getFluidListing(), so the
+        // views that do not call that helper rendered without it. That was not
+        // only a missing focus ring: cwmseriespodcastlist styles its thumbnail
+        // grid from this sheet, and without it the grid collapsed into a stack
+        // five times taller than intended (#1808).
+        $this->app->getDocument()->getWebAssetManager()->useStyle('com_proclaim.cwmcore');
+
         // Once per component request, ahead of the views, so a rule can reach
         // anything Proclaim renders.
         CwmcustomcssHelper::apply();


### PR DESCRIPTION
Follow-up to #1809, from sweeping the views it flagged. The gap turned out to be wider and considerably worse than a missing focus ring.

## The mechanism

`cwmcore.css` reached the front end through exactly one path — `Cwmlisting::getFluidListing()` — plus the popup template. Any view not calling that helper rendered without Proclaim's core stylesheet. #1809 repaired the landing page by declaring a dependency on its asset, which fixed one view and left the mechanism in place.

## What the sweep found

| view | verdict |
|---|---|
| `cwmseriespodcastlist` | **rendering broken** — see below |
| `cwmterms` | real gap, 2 cwmcore rules apply, benign |
| `cwmlatest` | **not a gap** — `display()` redirects and never renders |
| `cwmseriespodcastdisplay` | redirects to the list without an item id |

⚠️ **Correction to #1809:** I listed all four as gaps in that commit and PR. `cwmlatest` renders nothing by design — its empty template is correct, not a symptom.

## The one that mattered

`cwmseriespodcastlist` styles its thumbnail grid from `cwmcore`. Without it the grid never became flex and collapsed into a single column:

| | without cwmcore | with |
|---|---|---|
| `.effects` | 1126×**3380**, `block` | 1126×**642**, `flex` |
| `.jbsmimg` | 1126×169, `block` | 200×145, `flex` |

All 60 sampled elements differed. That is a visibly broken page in a released view, not a subtle regression.

## The fix

Registered in the dispatcher rather than as a fifth `useStyle()` call site — four call sites are how this drifted in the first place, and the same method already loads the custom-CSS layer there for the same stated reason: *once per component request, ahead of the views*.

**Ahead** matters: a view's own sheet still overrides the core one. Confirmed by the emitted order — `general → cwmcore → cwm-landing`.

## Verification

**Every site view now loads it, in that order.**

**No regression where it already loaded.** `cwmsermons`, `cwmteachers` and `cwmseriesdisplays` diffed with the change stashed and unstashed — 120 elements each, **0 differences**. Registering earlier does not flip anything against `podcast.css` or `sermon-filters.css`, which was the risk worth checking.

**`cwmseriespodcastlist` measured back to** 1126×642 flex, page height 1312px.

`composer lint` clean.

## Notes

- The asset dependency added in #1809 is now redundant but kept — it still holds if `com_proclaim.cwm-landing` is ever used outside this dispatcher.
- Two things spotted while sweeping, neither addressed here: `cwmseriespodcastdisplay` renders a completely blank page when reached without `t`, rather than redirecting as it does with it; and its "Listen" control is an `<a href="javascript:loadVideo(...)">`, which is neither keyboard-friendly nor CSP-friendly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
