### PR TITLE
chore(deps): bump cwm/build-tools to 1.21.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.20.0",
+            "version": "v1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "2b26988cd79916e6e158122056966282c6a242f7"
+                "reference": "fab4ebda22d0b88572f45c19216f34b2e9ab7fcb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/2b26988cd79916e6e158122056966282c6a242f7",
-                "reference": "2b26988cd79916e6e158122056966282c6a242f7",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/fab4ebda22d0b88572f45c19216f34b2e9ab7fcb",
+                "reference": "fab4ebda22d0b88572f45c19216f34b2e9ab7fcb",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +658,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.20.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.21.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-14T12:54:55+00:00"
+            "time": "2026-08-14T14:28:03+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.21.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.21.0), completing the thread #95 opened and 1.20.0 started.

## What's in it

- **The `joomlaLinks` `manifest` key is no longer dropped during validation** (cwm-build-tools#97). `LinkResolver` had read it since packages were first supported and the docblock advertised it, but the tuple validator's key whitelist discarded it, so the fallback always won — silently. Fixing it also gave `derivePackageComponent()` a declared signal in place of the `is_dir()` probe that caused #95.
- **An explicit `dev.links[]` entry now overrides the auto-derived pair for the same target** (cwm-build-tools#98). Derived pairs were emitted first and deduplication kept the *first* writer, so an explicit correction was discarded without a word.

## Effect on Proclaim: none today

No package Proclaim installs declares a `manifest` key, and Proclaim does not override an auto-derived dev link — it does not need to, now that its own media layout is read from `proclaim.xml` rather than guessed (1.20.0, #1802).

The value is the escape hatch. Before 1.21.0, correcting a single wrong auto-derived link meant `dev.deriveLinks: false` — hand-writing *every* link for the project. That is precisely what made #95 unworkaroundable while it was live.

## Verification

- `composer verify` → **54 ok, 0 errors**
- YouTube helper tests green (14 tests, 26 assertions)
- Lock-only change; the diff is the `cwm/build-tools` entry and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
