### PR TITLE
fix: give the series podcast view a not-found page, and deliver the 404

### DIFF
--- a/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
+++ b/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
@@ -116,6 +116,25 @@ class HtmlView extends BaseHtmlView
         $this->template = $this->state->get('template');
 
         if (!$item) {
+            // A bare return here rendered nothing at all: the template never
+            // ran, so the response was an empty 200 inside the site chrome —
+            // indexable, and with nothing for the visitor to act on. The
+            // router usually redirects to the list before this is reached,
+            // which is why it went unnoticed (#1813).
+            //
+            // Same shape as Cwmsermon: 404 for crawlers, a real page for
+            // people.
+            //
+            // ⚠️ Set through the application, not http_response_code(). Joomla
+            // builds the response from its own object and sends those headers
+            // at the end of the request, so a raw status set here is discarded
+            // — measured, Cwmsermon's not-found page still answers 200 despite
+            // asking for 404 that way.
+            $app->setHeader('status', 404, true);
+            $this->getDocument()->setTitle(Text::_('JBS_CMN_SERIES_NOT_FOUND'));
+            $this->setLayout('notfound');
+            parent::display($tpl);
+
             return;
         }
 

--- a/site/src/View/Cwmsermon/HtmlView.php
+++ b/site/src/View/Cwmsermon/HtmlView.php
@@ -219,8 +219,13 @@ class HtmlView extends BaseHtmlView
         if (!$item) {
             // Render within the site template so the user sees navigation,
             // footer, and suggested messages instead of a bare error page.
-            // Set 404 for SEO after rendering starts so Gantry/Joomla can't intercept.
-            http_response_code(404);
+            //
+            // ⚠️ Set through the application, not http_response_code(). Joomla
+            // builds the response from its own object and sends those headers
+            // at the end of the request, so a raw status set here is discarded:
+            // measured, this page answered 200 while asking for 404, which is
+            // the opposite of the SEO outcome the comment intended.
+            $app->setHeader('status', 404, true);
             $this->document->setTitle(Text::_('JBS_CMN_STUDY_NOT_FOUND'));
 
             // Load recent messages from cache (15 min TTL) to reduce server load

--- a/site/tmpl/cwmseriespodcastdisplay/notfound.php
+++ b/site/tmpl/cwmseriespodcastdisplay/notfound.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Not Found layout for the single series podcast view
+ *
+ * @package    Proclaim.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+/** @var CWM\Component\Proclaim\Site\View\Cwmseriespodcastdisplay\HtmlView $this */
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+$t = Factory::getApplication()->getInput()->getInt('t', 1);
+?>
+<div class="com-proclaim">
+    <div class="container-fluid proclaim-main-content" role="main">
+        <div class="proclaim-notfound text-center py-5">
+            <div class="mb-4">
+                <span class="fa fa-search fa-3x text-muted" aria-hidden="true"></span>
+            </div>
+            <h1 class="mb-4"><?php echo Text::_('JBS_CMN_SERIES_NOT_FOUND'); ?></h1>
+
+            <?php
+            // Only strings that already ship in every language are used here.
+            // There is no JBS_CMN_SERIES_NOT_FOUND_DESC, and adding one would
+            // render as the raw key on the twenty locales that would not have it.
+            ?>
+            <div class="mt-4">
+                <a href="<?php echo Route::_('index.php?option=com_proclaim&view=cwmseriespodcastlist&t=' . $t); ?>"
+                   class="btn btn-primary btn-lg">
+                    <span class="fa fa-list me-2" aria-hidden="true"></span><?php echo Text::_('JBS_CMN_SERIES_PODCASTS'); ?>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Closes #1813. Two defects — the second found while fixing the first.

## 1. The blank page

`Cwmseriespodcastdisplay\HtmlView` gave up with a bare `return`, so `parent::display()` was never reached, the template never ran, and the response was an **empty 200** inside the site chrome — indexable, with nothing for the visitor to act on.

The router usually redirects to the list first, which is why nobody saw it; the blank page appears once a parameter suppresses that redirect.

It now renders a not-found layout modelled on `Cwmsermon`'s: a heading and a route back to the podcast list.

**On the strings:** the layout uses only keys that already ship in every language. There is no `JBS_CMN_SERIES_NOT_FOUND_DESC`, and adding one would render as the raw key name on the twenty locales that wouldn't have it — so the page is deliberately a heading plus a way out rather than a translated explanation.

## 2. ⚠️ The 404 has never been delivered

`Cwmsermon`'s not-found page calls:

```php
// Set 404 for SEO after rendering starts so Gantry/Joomla can't intercept.
http_response_code(404);
```

It doesn't work. Joomla builds the response from its own object and sends those headers at the end of the request, discarding a raw status set mid-render. **Measured on j6-dev, that page answers 200** — the exact opposite of the SEO outcome the comment describes, and invisible in a browser because the page itself looks correct.

Both views now set it through the application (`$app->setHeader('status', 404, true)`).

## Verification

Mutation-checked rather than assumed — the sermon not-found page, same URL, change stashed and applied:

| | status | not-found layout rendered |
|---|---|---|
| without the fix | **200** | yes |
| with the fix | **404** | yes |

The rendered page is identical either way; only the status changes. The new podcast not-found page likewise goes from an empty 200 to a 404 with a real page, and a valid series still returns 200.

Reaching either branch needs the SEF redirect out of the way (appending `templateStyle` does it), which is also why both survived this long.

`composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
