### PR TITLE
chore(deps): bump cwm/build-tools to 1.22.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.21.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "fab4ebda22d0b88572f45c19216f34b2e9ab7fcb"
+                "reference": "35c0c3138fb86bc3ef374407a785ebe5b6c79d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/fab4ebda22d0b88572f45c19216f34b2e9ab7fcb",
-                "reference": "fab4ebda22d0b88572f45c19216f34b2e9ab7fcb",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/35c0c3138fb86bc3ef374407a785ebe5b6c79d44",
+                "reference": "35c0c3138fb86bc3ef374407a785ebe5b6c79d44",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +658,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.21.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.22.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-14T14:28:03+00:00"
+            "time": "2026-08-14T15:36:50+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [cwm-build-tools v1.22.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.22.0).

## What's in it

`sync-configs` now warns when a consumer's `lint:js` does not pin its ESLint config (cwm-build-tools#90). ESLint 10 resolves the nearest `eslint.config.*` per file, so a plain `eslint .` walks into any directory carrying its own config — a submodule, or `vendor/` — and the shared base's `ignores` never reach those files.

## Effect on Proclaim: none, by construction

Proclaim is the repo that **found** this bug and already carries the fix. Its `lint:js` uses `--no-config-lookup`, added in #1768/#1769 after ESLint 10 walked into the scripturelinks submodule and died on a base config whose vendor tree wasn't installed there.

So the new warning is silent here. This bump is about staying current, not repairing anything — and confirms the check doesn't false-positive on the repo it was designed around.

## Verification

- `composer verify` → **54 ok, 0 errors**
- Lock-only change; the diff is the `cwm/build-tools` entry and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
