### PR TITLE
fix: stop rendering media controls as javascript: URLs

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -1516,11 +1516,17 @@ abstract class CWMAddon
     ): string {
         $embedUrl = $this->buildEmbedUrl($url, $mediaParams);
 
+        $safeEmbedUrl = htmlspecialchars($embedUrl, ENT_QUOTES, 'UTF-8');
+
+        // href is the embed URL, not a javascript: placeholder. Fancybox reads
+        // data-src and intercepts the click, so behaviour is unchanged, but a
+        // Content-Security-Policy no longer blocks the control and the visitor
+        // can middle-click or copy it like any other link (#1814).
         return '<a class="fancybox_player playhit" data-id="' . $mediaId
-            . '" aria-hidden="false" data-src="' . htmlspecialchars($embedUrl, ENT_QUOTES, 'UTF-8')
+            . '" aria-hidden="false" data-src="' . $safeEmbedUrl
             . '" data-header="' . $headerText . '" data-footer="' . $footerText
             . '" data-options=\'{"autoplay":"' . (int) $mediaParams->get('autostart', false)
-            . '","controls":"' . (int) $mediaParams->get('controls') . '"}\' href="javascript:;">'
+            . '","controls":"' . (int) $mediaParams->get('controls') . '"}\' href="' . $safeEmbedUrl . '">'
             . $image . '</a>';
     }
 

--- a/build/media_source/joomla.asset.json
+++ b/build/media_source/joomla.asset.json
@@ -757,6 +757,17 @@
             }
         },
         {
+            "name": "com_proclaim.media-popup",
+            "type": "script",
+            "uri": "com_proclaim/proclaim-media-popup.min.js",
+            "dependencies": [
+                "core"
+            ],
+            "attributes": {
+                "defer": true
+            }
+        },
+        {
             "name": "com_proclaim.cwm-landing-toggle",
             "type": "script",
             "uri": "com_proclaim/cwm-landing-toggle.min.js",

--- a/build/media_source/js/podcast-audio.es6.js
+++ b/build/media_source/js/podcast-audio.es6.js
@@ -58,3 +58,30 @@ window.loadVideo = function loadVideo(path) {
         }
     }
 };
+
+/**
+ * Bind the episode "Listen" controls.
+ *
+ * They used to be `<a href="javascript:loadVideo(…)">`, which no
+ * Content-Security-Policy allows and which is announced as a link to a
+ * destination that does not exist. They are now buttons carrying the path in a
+ * data attribute, bound here — in the file that already owns loadVideo and is
+ * already loaded on this view (#1814).
+ *
+ * Delegated, so it does not care whether the rows were present at parse time.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+document.addEventListener('click', (event) => {
+    const trigger = event.target.closest('[data-proclaim-audio]');
+
+    if (!trigger) {
+        return;
+    }
+
+    const path = trigger.getAttribute('data-proclaim-audio');
+
+    if (path) {
+        window.loadVideo(path);
+    }
+});

--- a/build/media_source/js/podcast-audio.es6.js
+++ b/build/media_source/js/podcast-audio.es6.js
@@ -79,7 +79,23 @@ document.addEventListener('click', (event) => {
         return;
     }
 
-    const path = trigger.getAttribute('data-proclaim-audio');
+    // The value is read out of the DOM and ends up on audio.src, so only ever
+    // pass a media URL through. Without this the listener would accept any
+    // scheme written into the attribute — reintroducing at the point of use
+    // exactly what #1814 removed from the markup. Relative paths resolve
+    // against the page first, so ordinary media URLs still pass.
+    const raw = trigger.getAttribute('data-proclaim-audio') || '';
+    let path = null;
+
+    try {
+        const resolved = new URL(raw, window.location.href);
+
+        if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
+            path = resolved.href;
+        }
+    } catch {
+        path = null;
+    }
 
     if (path) {
         window.loadVideo(path);

--- a/build/media_source/js/proclaim-media-popup.es6.js
+++ b/build/media_source/js/proclaim-media-popup.es6.js
@@ -29,6 +29,37 @@
         || event.button !== 0
         || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
+    /**
+     * Only ever hand http(s) to window.open.
+     *
+     * The value is read out of the DOM, and window.open('javascript:…') runs in
+     * the opener's context — so this script would otherwise reintroduce, at the
+     * point of use, exactly the execute-a-URL problem #1814 removed from the
+     * markup. Relative values are resolved against the page first, so an
+     * ordinary index.php?… link still passes.
+     *
+     * @param   {string}  value  The href as written in the document.
+     * @returns {string|null}    A safe absolute URL, or null to leave the click alone.
+     */
+    const safeUrl = (value) => {
+        // Empty or a bare fragment names no destination. Both resolve to the
+        // current page, so without this the control would pop open a copy of
+        // the page it is already on.
+        if (value === '' || value.charAt(0) === '#') {
+            return null;
+        }
+
+        try {
+            const resolved = new URL(value, window.location.href);
+
+            return (resolved.protocol === 'http:' || resolved.protocol === 'https:')
+                ? resolved.href
+                : null;
+        } catch {
+            return null;
+        }
+    };
+
     document.addEventListener('click', (event) => {
         const trigger = event.target.closest('[data-proclaim-popup]');
 
@@ -36,10 +67,12 @@
             return;
         }
 
-        const url = trigger.getAttribute('href');
+        const url = safeUrl(trigger.getAttribute('href') || '');
 
-        // Nothing to open, so let the browser do whatever it would have done.
-        if (!url || url === '#') {
+        // Nothing safe to open, so let the browser do whatever it would have
+        // done — which for a scheme we refuse is the browser's own handling,
+        // not ours.
+        if (!url) {
             return;
         }
 

--- a/build/media_source/js/proclaim-media-popup.es6.js
+++ b/build/media_source/js/proclaim-media-popup.es6.js
@@ -1,0 +1,59 @@
+/**
+ * Opens Proclaim's media links in a sized popup window.
+ *
+ * These controls used to be `<a href="javascript:;" onclick="window.open(…)">`.
+ * Both halves were a problem: a `javascript:` URL and an inline handler are
+ * blocked by any Content-Security-Policy worth setting, which left a
+ * CSP-hardened site unable to play anything, and an anchor whose href goes
+ * nowhere cannot be middle-clicked, copied, or opened in a new tab, and is
+ * announced to assistive technology as a link to a destination that does not
+ * exist (#1814).
+ *
+ * They now carry the real URL in href and the window size in data attributes.
+ * Without this script the link still works — it opens in the same tab — so the
+ * popup is an enhancement rather than the only way through.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+((document, window) => {
+    'use strict';
+
+    /**
+     * A modifier click means the visitor asked for a tab or window of their
+     * own choosing, and that intent outranks ours.
+     *
+     * @param   {MouseEvent}  event  The click.
+     * @returns {boolean}
+     */
+    const wantsOwnWindow = event => event.defaultPrevented
+        || event.button !== 0
+        || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest('[data-proclaim-popup]');
+
+        if (!trigger || wantsOwnWindow(event)) {
+            return;
+        }
+
+        const url = trigger.getAttribute('href');
+
+        // Nothing to open, so let the browser do whatever it would have done.
+        if (!url || url === '#') {
+            return;
+        }
+
+        const width = parseInt(trigger.getAttribute('data-popup-width'), 10);
+        const height = parseInt(trigger.getAttribute('data-popup-height'), 10);
+        const features = (width > 0 && height > 0) ? `width=${width},height=${height}` : '';
+
+        const opened = window.open(url, 'proclaimmedia', features);
+
+        // A blocked popup must not swallow the click: leaving the event alone
+        // lets the browser follow the href, which is the same destination.
+        if (opened) {
+            event.preventDefault();
+            opened.focus();
+        }
+    });
+})(document, window);

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -641,9 +641,10 @@ class Cwmmedia
                 switch ($player->type) {
                     case 2: // New window - popup code added here because new window code does not work (Tom 10-12-2022)
                         $return     = base64_encode($path);
-                        $playercode = '<a href="javascript:;" onclick="window.open(\'index.php?option=com_proclaim&amp;' .
+                        self::useMediaPopupScript();
+                        $playercode = '<a href="index.php?option=com_proclaim&amp;' .
                             'task=Cwmsermons.playHit&amp;return=' . $return . '&amp;' . Session::getFormToken(
-                            ) . '=1\')" title="' .
+                            ) . '=1" data-proclaim-popup="1" title="' .
                             $media->params->get("media_button_text") . ' - ' . $media->comment . ' '
                             . $filesize . '">' . $image . '</a>';
                         break;
@@ -653,11 +654,11 @@ class Cwmmedia
 
                     case 1: // Popup window
                         CWMFancyBox::framework();
-                        $playercode = "<a $colorStyle href=\"javascript:;\"" .
-                            " onclick=\"window.open('index.php?option=com_proclaim&amp;player="
+                        self::useMediaPopupScript();
+                        $playercode = "<a $colorStyle href=\"index.php?option=com_proclaim&amp;player="
                             . $params->toObject()->player .
-                            "&amp;view=cwmpopup&amp;t=" . $template . "&amp;mediaid=" . $media->id . "&amp;tmpl=component', 'newwindow','width=" .
-                            $player->playerwidth . ",height=" . $player->playerheight . "'); return false\"" .
+                            "&amp;view=cwmpopup&amp;t=" . $template . "&amp;mediaid=" . $media->id . "&amp;tmpl=component\"" .
+                            " data-proclaim-popup=\"1\" data-popup-width=\"" . $player->playerwidth . "\" data-popup-height=\"" . $player->playerheight . "\"" .
                             "  class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">"
                             . $image . "</a>";
                         break;
@@ -705,12 +706,13 @@ class Cwmmedia
                         $diff                 = $params->get('player_width') - $params->get('playerwidth');
                         $player->playerwidth += abs($diff) + 10;
                         $player->playerheight += $params->get('popupmargin', '50');
-                        $playercode           = "<a $colorStyle href=\"javascript:;\"" .
-                            " onclick=\"window.open('index.php?option=com_proclaim&amp;player="
+                        self::useMediaPopupScript();
+                        $playercode           = "<a $colorStyle href=\"index.php?option=com_proclaim&amp;player="
                             . $player->player
-                            . "&amp;view=cwmpopup&amp;t=" . $template . "&amp;mediaid=" . $media->id . "&amp;tmpl=component', 'newwindow', 'width="
-                            . $player->playerwidth . ", height=" .
-                            $player->playerheight . "'); return false\" class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
+                            . "&amp;view=cwmpopup&amp;t=" . $template . "&amp;mediaid=" . $media->id . "&amp;tmpl=component\""
+                            . " data-proclaim-popup=\"1\" data-popup-width=\"" . $player->playerwidth
+                            . "\" data-popup-height=\"" . $player->playerheight . "\""
+                            . " class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
                         break;
                 }
 
@@ -725,10 +727,13 @@ class Cwmmedia
                 switch ($player->type) {
                     case 1: // This goes to the popup view
                         CWMFancyBox::framework();
-                        $playercode = "<a $colorStyle href=\"javascript:;\" onclick=\"window.open('index.php?option=com_proclaim"
+                        self::useMediaPopupScript();
+                        $playercode = "<a $colorStyle href=\"index.php?option=com_proclaim"
                             . "&amp;view=cwmpopup&amp;player=3&amp;t=" . $template .
-                            "&amp;mediaid=" . $media->id . "&amp;tmpl=component', 'newwindow','width=" . $player->playerwidth . ",height="
-                            . $player->playerheight . "'); return false\" class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
+                            "&amp;mediaid=" . $media->id . "&amp;tmpl=component\""
+                            . " data-proclaim-popup=\"1\" data-popup-width=\"" . $player->playerwidth
+                            . "\" data-popup-height=\"" . $player->playerheight . "\""
+                            . " class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
                         break;
 
                     case 2: // This plays the video inline
@@ -753,10 +758,14 @@ class Cwmmedia
             case 8: // Embed code
                 CWMFancyBox::framework();
 
-                return "<a $colorStyle href=\"javascript:;\" onclick=\"window.open('index.php?option=com_proclaim"
+                self::useMediaPopupScript();
+
+                return "<a $colorStyle href=\"index.php?option=com_proclaim"
                     . "&amp;view=cwmpopup&amp;player=8&amp;t=" . $template .
-                    "&amp;mediaid=" . $media->id . "&amp;tmpl=component', 'newwindow','width=" . $player->playerwidth . ",height="
-                    . $player->playerheight . "'); return false\" class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
+                    "&amp;mediaid=" . $media->id . "&amp;tmpl=component\""
+                    . " data-proclaim-popup=\"1\" data-popup-width=\"" . $player->playerwidth
+                    . "\" data-popup-height=\"" . $player->playerheight . "\""
+                    . " class=\"jbsmplayerlink playhit\" data-id=\"" . $media->id . "\">" . $image . "</a>";
         }
 
         return false;
@@ -882,7 +891,10 @@ class Cwmmedia
         $logoImage   = $params->get('jwplayer_logo', $params->get('player_logo', ''));
         $logoLink    = $params->get('jwplayer_logolink', $params->get('player_logolink', Uri::base()));
 
-        return '<a href="javascript:;" data-src="' . $path . '" data-id="' . $media->id . '" id="' . $media->id .
+        // href is the media itself, not a javascript: placeholder: Fancybox reads
+        // data-src and intercepts the click, and without JS the file is still
+        // reachable rather than the control being inert (#1814).
+        return '<a href="' . $path . '" data-src="' . $path . '" data-id="' . $media->id . '" id="' . $media->id .
             '" class="fancybox_player hitplay" potext="' . $popout . '" ptype="' . $player->player .
             '" pwidth="' . $player->playerwidth . '" pheight="' .
             $player->playerheight . '" autostart="' . $params->get('autostart', false) . '" controls="' .
@@ -1599,4 +1611,29 @@ class Cwmmedia
         $template = $params->get('popupfooter', '');
         return $this->processPopupText($template, $media, $params);
     }
+
+    /**
+     * Register the script that upgrades a popup link into a sized window.
+     *
+     * The links work without it — they carry the real URL and simply open in
+     * the same tab — so this is an enhancement, not a requirement. Registered
+     * per emitting site rather than globally because most pages have no media
+     * controls on them at all.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function useMediaPopupScript(): void
+    {
+        try {
+            $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+            $wa->getRegistry()->addExtensionRegistryFile('com_proclaim');
+            $wa->useScript('com_proclaim.media-popup');
+        } catch (\Exception) {
+            // No document to attach to (CLI, or a raw response). The links
+            // still resolve; only the sized window is lost.
+        }
+    }
+
 }

--- a/site/tmpl/cwmseriespodcastdisplay/default.php
+++ b/site/tmpl/cwmseriespodcastdisplay/default.php
@@ -95,12 +95,22 @@ $CWMedia = new Cwmmedia();
                                     echo HTMLHelper::Date($item->createdate); ?>
                                 </td>
                                 <td>
-                                    <a href="javascript:loadVideo(<?php
-                                    echo htmlspecialchars(json_encode($path1), ENT_QUOTES, 'UTF-8'); ?>, <?php
-                                    echo htmlspecialchars(json_encode($item->series_thumbnail), ENT_QUOTES, 'UTF-8'); ?>)">
+                                    <?php
+                                    // A button, not a link: this swaps the source of the player
+                                    // already on the page rather than going anywhere, so there is
+                                    // no href that would mean anything. It used to be
+                                    // href="javascript:loadVideo(…)", which no Content-Security-Policy
+                                    // allows and which assistive technology announces as a link to a
+                                    // destination that does not exist (#1814).
+                                    //
+                                    // The thumbnail used to be passed as a second argument;
+                                    // window.loadVideo() takes only the path and always ignored it.
+                                    ?>
+                                    <button type="button" class="btn btn-link p-0 align-baseline"
+                                            data-proclaim-audio="<?php echo htmlspecialchars($path1, ENT_QUOTES, 'UTF-8'); ?>">
                                         <?php
                                         echo Text::_('JBS_CMN_LISTEN'); ?>
-                                    </a>
+                                    </button>
                                 </td>
                             </tr>
                             <?php


### PR DESCRIPTION
Closes #1814.

## The problem

Every media control in the front end was an anchor whose href was either a `javascript:;` placeholder or the script itself, five of them with an inline `onclick` alongside.

- **CSP blocks both halves.** A site with `script-src` set — the whole point of setting one — could not play anything.
- **An href that goes nowhere isn't a link.** It can't be middle-clicked, copied, or opened in a new tab, and assistive technology announces it as a link to a destination that doesn't exist.

## ⚠️ Eight sites, not seven

The issue counted seven. The eighth is in `admin/src/Addons/CWMAddon.php`, which renders on the **front end** — my original grep only covered `site/`. It's the one that actually renders on a page with a YouTube embed, so the miscount wasn't academic: I only found it because the page still showed `javascript:` after I thought I was done.

## Three shapes, three answers

| shape | count | fix |
|---|---|---|
| sized popup openers, inline `onclick` | 5 | real href + `data-popup-width/height`, upgraded by a delegated script |
| Fancybox triggers | 2 | keep the anchor, give it a real href (the media file / embed URL) |
| podcast "Listen" | 1 | `<button>` — it swaps an in-page player, it doesn't navigate |

The popup openers are **genuine destinations**, so an anchor is correct and the sized window is an enhancement: without JS, or with the popup blocked, the same page opens in the tab rather than the control being inert. Fancybox reads `data-src` and intercepts the click, so those two behave identically.

The Listen control had also been passing a thumbnail as a second argument that `window.loadVideo()` has never accepted.

The new script registers per emitting site rather than globally, since most pages carry no media controls.

## Verification

A rendered series podcast page went from **5 `javascript:` URLs to 0**, with its Fancybox links now carrying the embed URL.

The sized-popup variants don't render on j6-dev (its players use Fancybox), so rather than claim they work, I exercised the delegated handler against the **built** file for all six behaviours that matter:

```
sized      -> window.open(url, 'proclaimmedia', 'width=640,height=480')
no size    -> features empty, browser default window
plain link -> not intercepted
cmd+click  -> left to the browser
opened     -> navigation suppressed
blocked    -> browser follows the href
```

That last one is the one worth having: a popup blocker cannot turn the control into a dead element.

`composer lint`, `npm run lint:js`, and Site Helper suite (183 tests / 373 assertions) all clean.

## Not addressed here

- **11 `javascript:void(0)` placeholders in admin templates** — a separate surface, no inline handlers, and admin is rarely CSP-hardened.
- **One in `plugins/content/scripturelinks`** — that's the CWMScriptureLinks submodule, a different repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
