### PR TITLE
fix: default the download button to a variant the form can express

### DIFF
--- a/admin/forms/admin.xml
+++ b/admin/forms/admin.xml
@@ -96,7 +96,7 @@
                type="list"
                useglobal="true"
                validate="options"
-               default=""
+               default="btn-primary"
                label="JBS_ADDON_BUTTON_TYPE"
                description="JBS_ADDON_BUTTON_TYPE_DESC">
             <option value="btn-link">JBS_MED_NO_COLOR</option>

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -1126,7 +1126,18 @@ class Cwmmedia
     {
 
         $downloadImage = null;
-        $button        = $download->get('download_button_type', 'btn-outline-primary');
+        // btn-primary, not btn-outline-primary. Three things disagreed with that
+        // outline default: the settings form offers only solid variants, so it
+        // could not be chosen or restored; the setup wizard already writes
+        // btn-primary for new sites; and download_button_color emits an inline
+        // background-color, which fills in the very thing an outline button is.
+        //
+        // The combination was also unreadable. Registry::get() treats a stored
+        // empty string as unset, so every site that never picked a variant got
+        // the outline default -- and with the form's default colour saved, that
+        // rendered #0a58ca on black, 3.26:1. As a solid button the label is
+        // white on black instead (#1815).
+        $button        = $download->get('download_button_type', 'btn-primary');
         $buttonText    = $download->get('download_button_text', 'Audio');
         $textSize      = $download->get('download_icon_text_size', '24');
 


### PR DESCRIPTION
Closes #1815.

## The mismatch

`downloadButton()` defaulted to `btn-outline-primary`; the settings form offers only solid variants (`btn-link`, `btn-primary`, `btn-success`, `btn-info`, `btn-warning`, `btn-danger`). So the effective default could not be chosen, restored, or seen in the UI.

**It reached more sites than "fresh installs."** `Registry::get()` treats a stored empty string as unset, and the field stored `""` until someone picked a variant — verified against the vendored Registry:

```
stored empty string    -> 'btn-primary'   (the default)
absent                 -> 'btn-primary'
explicit choice        -> 'btn-success'   (respected)
```

j6-dev is exactly that case: `download_button_type = ''`, `download_button_color = 'black'`.

## Three things already disagreed with the outline default

- The form can't express it.
- **`CwmsetupwizardModel:190` already writes `btn-primary`** for new sites — so a wizard-configured site and an untouched one rendered different buttons.
- `download_button_color` emits an inline `background-color`, which fills in the very thing an outline button *is*.

## And it failed contrast

With the form's default colour saved, the button rendered `#0a58ca` on black:

| | ratio | |
|---|---|---|
| before | **3.26:1** | fails AA |
| after | **21:1** | white on black, from #1799 |

## ⚠️ Appearance-visible on upgrade

A site that never chose a variant will see the download button change from outline to solid. That is the intent — it becomes the button the form says it is — but it is a visible change and belongs in the release notes rather than passing quietly.

The field's own `default` moves to `btn-primary` as well, so the form shows what the code will actually do instead of a blank that means something else.

## Deliberately not done

Adding the outline variants to the form as choices. That would keep the incoherence available (an outline button the colour picker fills in) without fixing the contrast for anyone on the default. Worth revisiting if someone actually wants an outline download button, at which point the colour picker should probably not apply to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
