### PR TITLE
fix: stop the upgrade harness removing the scripture stack it depends on

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -127,6 +127,21 @@ fi
 OTHER_CONSUMERS="$(php build/verify-scripture-uninstall.php other-consumer-ids | grep -E '^[0-9]+$' || true)"
 
 if [ -n "$OTHER_CONSUMERS" ]; then
+    # Before removing anything: hand the shared scripture stack back to
+    # pkg_cwmscripture. The library and plg_content_scripturelinks are package
+    # children, and package_id points at whichever package installed them last
+    # -- on a site carrying LivingWord that can be pkg_livingword, so removing
+    # it below took the library and the content plugin with it. Every phase
+    # after this then failed on a missing library, and because these removals
+    # persist, so did the next run (#1820).
+    echo "   protecting the scripture stack from the removals below:"
+
+    if ! php build/verify-scripture-uninstall.php protect-scripture-ownership; then
+        echo "ERROR: could not protect the scripture stack; refusing to remove consumers." >&2
+        echo "       Removing them now could take lib_cwmscripture with them." >&2
+        exit 1
+    fi
+
     echo "   clearing other scripture consumers before the uninstall phases:"
 
     for CID in $OTHER_CONSUMERS; do

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -62,6 +62,7 @@ $modes = [
     'assert-tables-gone',
     'assert-no-other-consumer',
     'other-consumer-ids',
+    'protect-scripture-ownership',
     'assert-sql-armed',
     'assert-sql-disarmed',
     'arm',
@@ -160,11 +161,91 @@ $connect = static function (object $install): array {
 };
 
 // --- value-printing modes: first test install only, for the shell to consume --
-if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids'], true)) {
+if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids', 'protect-scripture-ownership'], true)) {
     $install = $installs[0];
 
     if ($mode === 'site-path') {
         echo $install->path . "\n";
+
+        exit(0);
+    }
+
+    if ($mode === 'protect-scripture-ownership') {
+        // Hand the shared scripture stack back to the package that ships it,
+        // before any consumer is removed.
+        //
+        // The library and plg_content_scripturelinks are Joomla package
+        // children, and package_id points at whichever package installed them
+        // LAST. On a site carrying LivingWord that can be pkg_livingword — so
+        // `extension:remove` on it takes the library and the content plugin
+        // down as its children, and every phase after step 9 then fails for a
+        // reason unrelated to the code under test. Worse, the removals persist:
+        // the site is left with com_proclaim installed against a library that
+        // no longer exists, and the next run starts from that wreckage (#1820).
+        //
+        // Reassigning is not a workaround for the test's benefit. pkg_cwmscripture
+        // is the package that ships these, so this restores the ownership that
+        // install order happened to overwrite.
+        [$db, $prefix] = $connect($install);
+
+        if ($db === null) {
+            fwrite(STDERR, "Could not connect to the test database.\n");
+
+            exit(1);
+        }
+
+        $owner = mysqli_fetch_row(mysqli_query(
+            $db,
+            "SELECT `extension_id` FROM `{$prefix}extensions`
+             WHERE `type` = 'package' AND `element` = 'pkg_cwmscripture' LIMIT 1"
+        ) ?: null);
+
+        if ($owner === null || $owner === false) {
+            // Nothing to hand ownership to. Say so rather than silently leaving
+            // the stack adoptable by whatever gets removed next.
+            fwrite(STDERR, "pkg_cwmscripture is not installed; cannot protect the scripture stack.\n");
+
+            exit(1);
+        }
+
+        $ownerId = (int) $owner[0];
+
+        // The shared pieces a consumer package can end up owning. The task and
+        // system plugins ship in pkg_cwmscripture too, so they are listed for
+        // completeness -- reassigning an already-correct row is a no-op.
+        $parts = [
+            ['library', 'cwmscripture', null],
+            ['plugin', 'scripturelinks', 'content'],
+            ['plugin', 'cwmscripture', 'task'],
+            ['plugin', 'cwmscripture', 'system'],
+        ];
+
+        $moved = 0;
+
+        foreach ($parts as [$type, $element, $folder]) {
+            $folderSql = $folder === null
+                ? "AND (`folder` = '' OR `folder` IS NULL)"
+                : "AND `folder` = '" . mysqli_real_escape_string($db, $folder) . "'";
+
+            $sql = "UPDATE `{$prefix}extensions`
+                    SET `package_id` = {$ownerId}
+                    WHERE `type` = '" . mysqli_real_escape_string($db, $type) . "'
+                      AND `element` = '" . mysqli_real_escape_string($db, $element) . "'
+                      {$folderSql}
+                      AND `package_id` <> {$ownerId}";
+
+            if (mysqli_query($db, $sql) && mysqli_affected_rows($db) > 0) {
+                $label = $folder === null ? "{$type} {$element}" : "{$type} {$element} ({$folder})";
+                echo "  reassigned {$label} to pkg_cwmscripture\n";
+                $moved++;
+            }
+        }
+
+        echo $moved === 0
+            ? "  scripture stack already owned by pkg_cwmscripture\n"
+            : "  {$moved} extension(s) reassigned — removing a consumer can no longer take them\n";
+
+        mysqli_close($db);
 
         exit(0);
     }


### PR DESCRIPTION
Closes #1820.

## What was happening

`test-upgrade.sh` step 9 clears "other scripture consumers" so the uninstall phases assert against their own fixtures. On a site carrying LivingWord, that removal **took the shared scripture stack with it**:

- the run failed at step 10 on a missing library
- j6-test was left serving **HTTP 500** — `com_proclaim` installed against a library that no longer existed
- and because `reset-testsite.php` only removes the Proclaim family, every *later* run started from that wreckage

`lib_cwmscripture` and `plg_content_scripturelinks` are Joomla package children, and `package_id` points at whichever package installed them **last**. When that's `pkg_livingword`, `extension:remove` on it takes them down as its children. The survivor set proved the mechanism: the task plugin, owned by `pkg_cwmscripture`, lived.

## The fix

A `protect-scripture-ownership` mode, called immediately before the removal loop, hands the shared pieces back to `pkg_cwmscripture`.

That's **restoring the correct owner**, not a convenience for the test — `pkg_cwmscripture` is the package that ships them, and install order overwriting `package_id` is what put them under LivingWord.

If `pkg_cwmscripture` isn't installed there's nothing to hand ownership to, so the mode exits non-zero and the harness refuses to remove anything rather than proceeding and orphaning the stack.

## ⚠️ What is and isn't proven

`composer test:upgrade` passes (10.5.8 → 10.5.9-dev), so **the harness isn't broken** — but the new path **did not execute**. j6-test carries no other consumers, so `other-consumer-ids` came back empty and the whole block was skipped.

The fix itself was verified directly instead:

```
# no-op path
  scripture stack already owned by pkg_cwmscripture

# after setting library + content plugin package_id to a foreign package
  reassigned library cwmscripture to pkg_cwmscripture
  reassigned plugin scripturelinks (content) to pkg_cwmscripture
  2 extension(s) reassigned — removing a consumer can no longer take them
```

Reproducing the original failure end to end would mean installing LivingWord on j6-test, which is more setup than this fix warrants.

## Correction to the issue

The report said the code hardcodes LivingWord where its comment claims to read the registry. That's only half right — there's a **second block** that joins `bsms_scripture_consumers` to `#__extensions` for any non-first-party consumer, so the hardcoded pair supplements it. The cascade, not the hardcoding, is what broke the run. Noted on the issue too.

## Still open, separately

Whether a **real** site running Proclaim and LivingWord loses the library when LivingWord is uninstalled. The harness no longer demonstrates it, but the underlying `package_id` ownership is Joomla's and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
