### PR TITLE
chore: remove issue citations from comments in site and media_source

### DIFF
--- a/build/media_source/css/cwm-landing.css
+++ b/build/media_source/css/cwm-landing.css
@@ -59,29 +59,10 @@
 }
 
 /*
- * The accent band already gives this control its own colours further down. The
- * other two bands relied on .btn-outline-primary, and a template that flattens
- * .btn erases it: on nfsda.org the button rendered white text and a white
- * border on a white band — the whole control invisible, at 1.0:1. Bootstrap's
- * variant and the template's rule are both (0,1,0), so it came down to source
- * order (#1806).
- *
- * Claimed for every landing style, not just the hero bands: the cards and
- * dashboard styles render the same control with no band around it, so a
- * band-scoped rule would have left two of the three layouts exposed. The accent
- * band keeps its own colours and is scoped one class higher so it still wins.
- *
- * Stated here rather than in cwmcore.css with #1799's button rules, because
- * this is Proclaim's own landing chrome — the bands, cards and tags around it
- * are all ours — so claiming it does not override a template's styling of the
- * buttons that genuinely belong to it. Cassiopeia's navy and Helium's grey are
- * left alone everywhere else. There is no palette variable to defer to:
- * --bs-btn-color and --bs-primary are unset on Cassiopeia, stock Helium and
- * nfsda alike, so a literal is the only option.
- *
- * #0a58ca rather than the #0d6efd the tags hover to: that lighter blue measures
- * exactly 4.5:1 on white, the bare minimum with no headroom, and the count below
- * dims whatever it is given. This one measures 6.44:1.
+ * ⚠️ Stated rather than inherited. A template that flattens .btn erases
+ * .btn-outline-primary and this control disappears — Bootstrap's variant and a
+ * template's own .btn rule are both (0,1,0), so source order decides it. The
+ * accent band overrides these below at one class higher.
  */
 .com-proclaim .proclaim-landing__show-more {
     color: #0a58ca;
@@ -302,22 +283,10 @@
 }
 
 /*
- * The card is an anchor, so its text takes whatever colour a site template
- * paints links inside its content wrapper:
- *
- *     .box2 > .g-content a, .box2.moduletable a { color: #8b5717 }   (0,2,1)
- *
- * The card's own `color: #fff` is (0,1,0) and loses, and the text is inherited
- * from the anchor rather than declared on the title, so nothing stops it. On
- * nfsda.org that rendered every speaker's name in the template's orange over
- * the dark overlay — the same clash #1799 fixed for Proclaim's buttons.
- *
- * White here is not a preference: the overlay gradient exists to make white
- * text legible, and the text-shadows above are sized for it. Declaring the
- * colour on the title and subtitle rather than inheriting it settles this on
- * its own, since a declaration always beats an inherited value; the
- * .com-proclaim scope and (0,3,0) specificity match #1799 so the two do not
- * drift, and hold up if a template ever targets these elements directly.
+ * ⚠️ Declared here, not inherited from the card. A template colouring anchors
+ * inside its content wrapper (0,2,1) beats the card's own colour (0,1,0), and
+ * an inherited value loses to any declaration. White is required: the overlay
+ * gradient and the text-shadows above exist to make white legible.
  */
 .com-proclaim .proclaim-landing-hero-card .proclaim-landing-hero-card__title,
 .com-proclaim .proclaim-landing-hero-card .proclaim-landing-hero-card__sub {

--- a/build/media_source/css/cwmcore.css
+++ b/build/media_source/css/cwmcore.css
@@ -55,13 +55,9 @@
 }
 
 /*
- * The skip link is an anchor, so a template colouring every anchor in its
- * content wrapper repaints it — and it is the first control a keyboard user
- * reaches. Measured on nfsda.org, focused, it rendered the template's #8b5717
- * on this rule's dark background at 1.3:1.
- *
- * The single-class rules above are (0,1,0) and lose to a wrapper's (0,2,1).
- * Restated at (0,3,0), scoped to .com-proclaim, matching #1799.
+ * ⚠️ Restated at (0,3,0). The single-class rules above are (0,1,0) and lose to a
+ * template colouring anchors inside its content wrapper, which leaves the first
+ * control a keyboard user reaches unreadable.
  */
 .com-proclaim .proclaim-skip-link,
 .com-proclaim .proclaim-skip-link:focus {
@@ -1132,7 +1128,7 @@ p.expand {
  * explicit colour on several button variants, so the button ends up wearing the
  * alert's text colour over its own background. Inside .alert-warning that gives
  * #996901 on #ffb514 — 2.71:1 — which is how the control panel's schema-fix
- * button failed WCAG AA (#1375), and #996901 on the secondary blue is worse
+ * button failed WCAG AA, and #996901 on the secondary blue is worse
  * still at 1.32:1.
  *
  * The colours below are the ones each variant already computes when rendered
@@ -1191,7 +1187,7 @@ p.expand {
 
 /*
  * The outline variants, which the block above did not cover and which fail
- * worse (#1806). A solid button keeps its background, so a template repainting
+ * worse. A solid button keeps its background, so a template repainting
  * the label only lowers contrast. An outline button has no background and takes
  * the same colour on its border, so it disappears entirely: on nfsda.org the
  * landing "Show All Speakers" control measured white on white, 1.0:1, border

--- a/build/media_source/js/delete-confirm.es6.js
+++ b/build/media_source/js/delete-confirm.es6.js
@@ -87,7 +87,7 @@
         // addScriptOptions('com_proclaim.deleteConfirm', ...)) rather than
         // guessed by scanning the DOM. Joomla renders more than one hidden
         // input with value="1" on this form (e.g. delete_physical_files),
-        // so a `value="1"` selector can't reliably tell them apart — see #1501.
+        // so a `value="1"` selector can't reliably tell them apart.
         const { csrfToken } = Joomla.getOptions('com_proclaim.deleteConfirm') || {};
         const tokenParam = csrfToken ? `&${encodeURIComponent(csrfToken)}=1` : '';
 

--- a/build/media_source/js/mediafile-edit.es6.js
+++ b/build/media_source/js/mediafile-edit.es6.js
@@ -262,7 +262,7 @@
                         }
 
                         // The playlist picker sits outside both swapped containers, so
-                        // follow the new server's capability explicitly (#1392).
+                        // follow the new server's capability explicitly.
                         const playlistContainer = document.getElementById('playlist-field-container');
                         if (playlistContainer) {
                             playlistContainer.classList.toggle('d-none', !data.supportsPlaylists);

--- a/build/media_source/js/message-ai-assist.es6.js
+++ b/build/media_source/js/message-ai-assist.es6.js
@@ -180,7 +180,7 @@
             // appends to a multi-select; setValue([{…}]) REPLACES the whole
             // selection list, so the loop in btn-add-matched would only
             // ever leave the last topic selected. Confirmed in the current
-            // Choices.js bundled with Joomla — see issue history (PR #1237).
+            // Choices.js bundled with Joomla.
             choices.setChoiceByValue(resolvedValue);
         } else {
             // New topic — add as text value (backend will create it)

--- a/build/media_source/js/playlist-picker.es6.js
+++ b/build/media_source/js/playlist-picker.es6.js
@@ -1,5 +1,5 @@
 /**
- * Playlist picker (#1273 phase 4)
+ * Playlist picker (phase 4)
  *
  * Opens a modal listing the selected server's live channel playlists and, on
  * pick, writes the remote playlist ID into the read-only remote_playlist_id

--- a/build/media_source/js/podcast-audio.es6.js
+++ b/build/media_source/js/podcast-audio.es6.js
@@ -66,7 +66,7 @@ window.loadVideo = function loadVideo(path) {
  * Content-Security-Policy allows and which is announced as a link to a
  * destination that does not exist. They are now buttons carrying the path in a
  * data attribute, bound here — in the file that already owns loadVideo and is
- * already loaded on this view (#1814).
+ * already loaded on this view.
  *
  * Delegated, so it does not care whether the rows were present at parse time.
  *
@@ -79,11 +79,8 @@ document.addEventListener('click', (event) => {
         return;
     }
 
-    // The value is read out of the DOM and ends up on audio.src, so only ever
-    // pass a media URL through. Without this the listener would accept any
-    // scheme written into the attribute — reintroducing at the point of use
-    // exactly what #1814 removed from the markup. Relative paths resolve
-    // against the page first, so ordinary media URLs still pass.
+    // ⚠️ The value comes from the DOM and ends up on audio.src, so only a media
+    // URL may pass. Relative paths resolve against the page first.
     const raw = trigger.getAttribute('data-proclaim-audio') || '';
     let path = null;
 

--- a/build/media_source/js/proclaim-media-popup.es6.js
+++ b/build/media_source/js/proclaim-media-popup.es6.js
@@ -7,7 +7,7 @@
  * CSP-hardened site unable to play anything, and an anchor whose href goes
  * nowhere cannot be middle-clicked, copied, or opened in a new tab, and is
  * announced to assistive technology as a link to a destination that does not
- * exist (#1814).
+ * exist.
  *
  * They now carry the real URL in href and the window size in data attributes.
  * Without this script the link still works — it opens in the same tab — so the
@@ -32,10 +32,8 @@
     /**
      * Only ever hand http(s) to window.open.
      *
-     * The value is read out of the DOM, and window.open('javascript:…') runs in
-     * the opener's context — so this script would otherwise reintroduce, at the
-     * point of use, exactly the execute-a-URL problem #1814 removed from the
-     * markup. Relative values are resolved against the page first, so an
+     * ⚠️ The value comes from the DOM, and window.open('javascript:…') runs in the
+     * opener's context. Relative values resolve against the page first, so an
      * ordinary index.php?… link still passes.
      *
      * @param   {string}  value  The href as written in the document.

--- a/build/media_source/js/sermon-filters.es6.js
+++ b/build/media_source/js/sermon-filters.es6.js
@@ -738,7 +738,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * every select.  It is there for the simple/expert/custom sermon templates,
      * which never load this script and still need an immediate submit.  Here it
      * would fire alongside the change listeners below, costing a second AJAX
-     * request that the first one immediately aborts.  See #1389.
+     * request that the first one immediately aborts.
      */
     form.querySelectorAll('select[name^="filter_"], select[name^="filter["], select[name^="list_"], select[name^="list["]').forEach((select) => {
         select.removeAttribute('onchange');

--- a/build/media_source/js/subform-tooltip-a11y.es6.js
+++ b/build/media_source/js/subform-tooltip-a11y.es6.js
@@ -25,7 +25,7 @@
  * Confirmed present in Joomla 5.4.7, 6.1.2, 6.2.0 and 7.0.0, and only in the
  * repeatable-table layout. Reported upstream as joomla/joomla-cms#48151
  * (https://github.com/joomla/joomla-cms/issues/48151); this runs until that
- * lands and the oldest supported Joomla carries it. Tracked in #1341.
+ * lands and the oldest supported Joomla carries it.
  *
  * Chosen over overriding the layout in admin/layouts/. The override would mean
  * carrying a 125-line copy of a core file across four Joomla versions, going

--- a/site/src/Controller/CwmpodcastController.php
+++ b/site/src/Controller/CwmpodcastController.php
@@ -93,7 +93,7 @@ class CwmpodcastController extends BaseController
     }
 
     /**
-     * Download tracking endpoint (#1281, byte-range support #1424).
+     * Download tracking endpoint, with byte-range support.
      *
      * The podcast feed points <enclosure> URLs here (when the podcast has
      * track_downloads enabled) instead of at the live media. This counts the
@@ -186,7 +186,7 @@ class CwmpodcastController extends BaseController
         // involved. Comparing against it made isLocalHost() misroute local
         // media to the remote-proxy path on any such mismatch. Uri::root()
         // reflects Joomla's own site configuration (the "Live Site URL"
-        // when set) instead. See #1552.
+        // when set) instead.
         $host            = (string) (parse_url(Uri::root(), PHP_URL_HOST) ?: '');
         $range           = (string) $this->input->server->getString('HTTP_RANGE', '');
         $ifModifiedSince = (string) $this->input->server->getString('HTTP_IF_MODIFIED_SINCE', '');

--- a/site/src/Controller/CwmseriesdisplaysController.php
+++ b/site/src/Controller/CwmseriesdisplaysController.php
@@ -38,8 +38,7 @@ class CwmseriesdisplaysController extends BaseController
      * ListModel — ignore_request => true here would set __state_set in
      * BaseModel::__construct(), permanently skipping populateState() and
      * leaving list/filter/template state empty for any caller (like
-     * paginateAjax()) that fetches the model with fewer than 3 args. See
-     * #1502.
+     * paginateAjax()) that fetches the model with fewer than 3 args.
      *
      * @param   string  $name    The name of the model
      * @param   string  $prefix  The prefix for the PHP class name
@@ -109,7 +108,7 @@ class CwmseriesdisplaysController extends BaseController
         } catch (\Throwable $e) {
             // \Throwable (not \Exception): a graceful {success:false} beats an
             // unhandled fatal HTML page for an endpoint whose only consumer is
-            // fetch()-based JS expecting JSON. See #1502.
+            // fetch()-based JS expecting JSON.
             echo json_encode([
                 'success' => false,
                 'message' => 'Failed to load results',

--- a/site/src/Controller/CwmsermonController.php
+++ b/site/src/Controller/CwmsermonController.php
@@ -315,7 +315,7 @@ class CwmsermonController extends FormController
      *
      * Private: only meant to be called internally from comment(). Public
      * visibility made `task=cwmsermon.commentsEmail` a directly dispatchable
-     * Joomla task with no CSRF token check of its own — see #1441.
+     * Joomla task with no CSRF token check of its own.
      *
      * @param   Registry  $params  Params to parse
      *

--- a/site/src/Dispatcher/Dispatcher.php
+++ b/site/src/Dispatcher/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher extends ComponentDispatcher
         // views that do not call that helper rendered without it. That was not
         // only a missing focus ring: cwmseriespodcastlist styles its thumbnail
         // grid from this sheet, and without it the grid collapsed into a stack
-        // five times taller than intended (#1808).
+        // five times taller than intended.
         $this->app->getDocument()->getWebAssetManager()->useStyle('com_proclaim.cwmcore');
 
         // Once per component request, ahead of the views, so a rule can reach

--- a/site/src/Helper/CwmcustomcssHelper.php
+++ b/site/src/Helper/CwmcustomcssHelper.php
@@ -29,7 +29,7 @@ use Joomla\Registry\Registry;
  * rather than replacing it. Both live in params (`#__bsms_admin` and
  * `#__bsms_templates`) so they are covered by Proclaim's backup and survive an
  * update untouched — a file under `media/com_proclaim/` would be neither, since
- * the installer prunes that directory. See discussion #1719.
+ * the installer prunes that directory.
  *
  * @since  10.5.8
  */
@@ -106,7 +106,7 @@ class CwmcustomcssHelper
      * The two sheets apply() emits are page-wide by nature. A landing page is a
      * stack of independently configured sections, and until now styling one of
      * them meant writing a selector against the markup by hand and hoping it
-     * did not change (#1807).
+     * did not change.
      *
      * Each section's CSS is wrapped in `[data-section="<id>"] { … }` and relies
      * on native CSS nesting, so an author writes plain rules as though the

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -115,7 +115,7 @@ class Cwmdownload
         //
         // ⚠️ This gates Proclaim's download route only. A file stored under the
         // web root is still served directly by the web server, which never
-        // enters PHP — see #1774.
+        // enters PHP.
         $user = $app->getIdentity();
 
         if (!self::isAccessible($media, $user->getAuthorisedViewLevels())) {
@@ -146,14 +146,14 @@ class Cwmdownload
         // Streaming is CwmmediaStreamer's job — it resolves the target to local
         // disk or proxies it, and it is the same implementation the podcast
         // redirect uses, so there is one Range/HEAD/If-Modified-Since handler
-        // rather than two (#1774).
+        // rather than two.
         //
         // What this replaces was weaker in two ways: it sent Content-Length and
         // readfile() with no Range support, so a browser could not seek in
         // gated audio or video; and its remote branch fopen()ed an
         // admin-configured URL and relayed the response to the caller with no
         // SSRF guard — the shape that was patched for the podcast endpoint in
-        // 10.5.5 (#1426) but never here.
+        // 10.5.5 but never here.
         //
         // Access was already checked above. The streamer answers how to send a
         // file, never whether to.
@@ -178,7 +178,7 @@ class Cwmdownload
 
         // Uri::root(), not the incoming Host header: that is client-supplied
         // and proxy-rewritable, so comparing against it misroutes local media
-        // down the remote path (#1552).
+        // down the remote path.
         CwmmediaStreamer::serve(
             $download_file,
             'application/octet-stream',
@@ -220,7 +220,7 @@ class Cwmdownload
      *
      * ⚠️ This governs Proclaim's download route only. A file stored under the
      * web root is served by the web server without ever entering PHP, so no
-     * check here can protect it — see #1774.
+     * check here can protect it.
      *
      * @param   object        $media   Media row, joined to its study and series levels.
      * @param   array<int>    $levels  The user's authorised view levels.

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -582,10 +582,10 @@ class Cwmlanding
                 // the same five columns, and a book's name is no longer
                 // available to SQL: #__bsms_books held language keys the
                 // scripture library already carries, so the join it needed
-                // earned nothing (#1687).
+                // earned nothing.
                 //
                 // Books come from the junction, so a study with more than two
-                // references contributes all of them (#1623).
+                // references contributes all of them.
                 $query->select(
                     'DISTINCT ' . $this->db->quoteName('sr.booknumber', 'id') . ', '
                     . $null . ' AS ' . $this->db->quoteName('text') . ', '
@@ -1134,9 +1134,9 @@ class Cwmlanding
 
             // Books come from the junction, so a study with more than two
             // references contributes all of them rather than the two the flat
-            // columns could hold (#1623). The name is attached afterwards from
+            // columns could hold. The name is attached afterwards from
             // the scripture library, which holds the language keys
-            // #__bsms_books used to store (#1687).
+            // #__bsms_books used to store.
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
             // b.access.
@@ -1193,7 +1193,7 @@ class Cwmlanding
      * Those queries used to join #__bsms_books for a `bookname` column holding a
      * JBS_BBK_* language key, which the callers then passed to Text::_(). The
      * scripture library holds the same keys against the same numbers, so the
-     * join earned nothing (#1687).
+     * join earned nothing.
      *
      * Rows whose number the library cannot name are dropped. The join could not
      * produce one — the row existed or it did not — and an entry with no label
@@ -1728,9 +1728,9 @@ class Cwmlanding
 
             // Books come from the junction, so a study with more than two
             // references contributes all of them rather than the two the flat
-            // columns could hold (#1623). The name is attached afterwards from
+            // columns could hold. The name is attached afterwards from
             // the scripture library, which holds the language keys
-            // #__bsms_books used to store (#1687).
+            // #__bsms_books used to store.
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
             // b.access.

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -2182,7 +2182,7 @@ class Cwmlisting
      * queried the database to fetch a key it then handed to Text::_() — and the
      * library holds the same 73 keys against the same 101-173 numbers, in code.
      * Verified identical: same count, same numbers, no key differing either way
-     * (#1687).
+     * .
      *
      * The method name and the local cache stay: getBookName() resolves through
      * array_search over BOOK_KEYS, so caching still earns its place on a listing

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -893,7 +893,7 @@ class Cwmmedia
 
         // href is the media itself, not a javascript: placeholder: Fancybox reads
         // data-src and intercepts the click, and without JS the file is still
-        // reachable rather than the control being inert (#1814).
+        // reachable rather than the control being inert.
         return '<a href="' . $path . '" data-src="' . $path . '" data-id="' . $media->id . '" id="' . $media->id .
             '" class="fancybox_player hitplay" potext="' . $popout . '" ptype="' . $player->player .
             '" pwidth="' . $player->playerwidth . '" pheight="' .
@@ -1136,7 +1136,7 @@ class Cwmmedia
         // empty string as unset, so every site that never picked a variant got
         // the outline default -- and with the form's default colour saved, that
         // rendered #0a58ca on black, 3.26:1. As a solid button the label is
-        // white on black instead (#1815).
+        // white on black instead.
         $button        = $download->get('download_button_type', 'btn-primary');
         $buttonText    = $download->get('download_button_text', 'Audio');
         $textSize      = $download->get('download_icon_text_size', '24');
@@ -1415,7 +1415,7 @@ class Cwmmedia
             // Audio formats
             // Registered types, matching Cwmmime::MAP. 'audio/mp3' was offered here
             // for years and is not IANA-registered — it is how feeds came to declare
-            // it on every episode. M4A is MPEG-4 audio, not MPEG audio (#1397).
+            // it on every episode. M4A is MPEG-4 audio, not MPEG audio.
             'm4a|m4b'  => 'audio/mp4',
             'mp3'      => 'audio/mpeg',
             'ra|ram'   => 'audio/x-realaudio',

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -407,7 +407,7 @@ class Cwmpodcast
      *
      * The line was hardcoded as "© (2026) All rights reserved." — stray
      * parentheses, and naming nobody, which is the one thing a copyright notice
-     * exists to say (#1412). The holder now comes from the podcast, falling back
+     * exists to say. The holder now comes from the podcast, falling back
      * to the site name so existing feeds gain a real one without anyone having
      * to edit a record.
      *
@@ -869,13 +869,13 @@ class Cwmpodcast
             $type         = $this->resolveEnclosureType($path, $mimeType);
             $enclosureUrl = $url;
 
-            // Opt-in: route the enclosure through the tracking redirect (#1281).
+            // Opt-in: route the enclosure through the tracking redirect.
             // The <guid> above is deliberately left as the direct URL so toggling
             // this on/off never changes item identity.
             if ($trackDownloads && $website !== '') {
                 $tracked = $this->buildTrackedEnclosureUrl($website, $protocol, $episode, $path);
 
-                // #1424: a bare "?...&task=cwmpodcast.track&media_id=N" URL has
+                // A bare "?...&task=cwmpodcast.track&media_id=N" URL has
                 // no file extension anywhere in it, and Apple's own RSS guide
                 // says that determines whether an episode is even ingested —
                 // this isn't validator pickiness. buildTrackedEnclosureUrl()
@@ -897,8 +897,8 @@ class Cwmpodcast
         );
 
         // isPermaLink defaults to true in RSS 2.0, which would invite readers to
-        // fetch the guid as the episode's web page. Since #1299 froze guids and
-        // decoupled them from the enclosure URL, it is an identity token only.
+        // fetch the guid as the episode's web page. Guids are frozen and
+        // decoupled from the enclosure URL, so it is an identity token only.
         return '
 		<enclosure url="' . $enclosureUrl . '" length="' . $size . '" type="' . $this->escapeHTML($type) . '" />
 		<guid isPermaLink="false">' . $guid . '</guid>';
@@ -906,7 +906,7 @@ class Cwmpodcast
 
     /**
      * Build the download-tracking enclosure URL as a real, extension-bearing
-     * path instead of a bare task query string (#1424).
+     * path instead of a bare task query string.
      *
      * Apple's Podcaster's Guide to RSS is explicit that the enclosure's file
      * extension "determines whether or not content appears in the podcast
@@ -947,7 +947,7 @@ class Cwmpodcast
         // only strips a query or fragment when the value really is a URL --
         // parse_url() alone would turn "Sermon #12.mp4" into "Sermon " and lose
         // the extension, and an enclosure URL without one is what Apple refuses
-        // to ingest (#1424).
+        // to ingest.
         $extension = Cwmmime::extensionOf($path);
 
         if ($extension === '') {
@@ -965,8 +965,8 @@ class Cwmpodcast
      * Resolve the MIME type to declare for a media enclosure.
      *
      * Derived from the file extension first: the stored mime_type is admin-entered
-     * and free to contradict the file it describes (the audit behind #1391 found
-     * .m4a files declared as audio/mp3, itself not a registered type). The stored
+     * and free to contradict the file it describes (.m4a files declared as
+     * audio/mp3, itself not a registered type). The stored
      * value is honoured only where the extension yields nothing.
      *
      * @param   string   $path       Media path or URL the enclosure points at.
@@ -1040,7 +1040,7 @@ class Cwmpodcast
                 continue;
             }
 
-            // Same derive-from-extension rule as the primary enclosure (#1391).
+            // Same derive-from-extension rule as the primary enclosure.
             $mimeType = $this->resolveEnclosureType($filename, $altParams->get('mime_type'));
 
             $url = $protocol . Cwmhelper::mediaBuildUrl(
@@ -1122,7 +1122,7 @@ class Cwmpodcast
         // whoever reads it, and podcast apps read it with no session. An item
         // the fetching user cannot see must therefore not appear at all —
         // listing it would publish the URL of a file they were refused, which
-        // is worse than the restriction simply not applying (#1774).
+        // is worse than the restriction simply not applying.
         //
         // Same chain as the download route (Cwmdownload::isAccessible) and the
         // sermon listings: media file, its message, and its series. The series
@@ -1569,10 +1569,10 @@ class Cwmpodcast
                 $warnings[] = Text::sprintf('JBS_PDC_VALIDATE_MEDIA_NO_MIME', $media->studytitle ?: 'ID: ' . $media->id);
             } elseif (!$isYouTube && !empty($filename)) {
                 // A stored type that contradicts the file. The feed no longer trusts
-                // it — the enclosure type is derived from the extension (#1391) — but
+                // it — the enclosure type is derived from the extension — but
                 // the stored value is still wrong, and is a sign the record was
                 // created or imported incorrectly. YouTube URLs have no meaningful
-                // extension, so they are skipped rather than warned about (#1396).
+                // extension, so they are skipped rather than warned about.
                 $derived = Cwmmime::fromExtension($filename);
 
                 if ($derived !== null && $derived !== $mimeType) {
@@ -1587,7 +1587,7 @@ class Cwmpodcast
 
             // Check for missing duration. Compare numerically: a value stored as
             // '0' rather than '00' is still no duration, but slips past a strict
-            // string comparison and goes unreported (#1391).
+            // string comparison and goes unreported.
             $hours   = (int) $params->get('media_hours', '00');
             $minutes = (int) $params->get('media_minutes', '00');
             $seconds = (int) $params->get('media_seconds', '00');
@@ -1802,7 +1802,7 @@ class Cwmpodcast
             // Check if duration is already set. Numeric comparison: a record
             // holding '0' rather than '00' has no duration, and a string
             // comparison here made the repair tool skip the very records it
-            // exists to fix (#1391).
+            // exists to fix.
             $hours   = (int) $params->get('media_hours', '00');
             $minutes = (int) $params->get('media_minutes', '00');
             $seconds = (int) $params->get('media_seconds', '00');
@@ -2377,7 +2377,7 @@ class Cwmpodcast
             }
 
             // Check for missing MIME type, or one that contradicts the file — both
-            // are fixed by re-detection, so both belong in the queue (#1396).
+            // are fixed by re-detection, so both belong in the queue.
             $mimeType = $params->get('mime_type');
             if (empty($mimeType) || $this->mimeTypeContradictsFile($params)) {
                 $missing[] = 'mime_type';
@@ -2385,7 +2385,7 @@ class Cwmpodcast
 
             // Check for missing duration. Compare numerically: a value stored as
             // '0' rather than '00' is still no duration, but slips past a strict
-            // string comparison and goes unreported (#1391).
+            // string comparison and goes unreported.
             $hours   = (int) $params->get('media_hours', '00');
             $minutes = (int) $params->get('media_minutes', '00');
             $seconds = (int) $params->get('media_seconds', '00');
@@ -2412,7 +2412,7 @@ class Cwmpodcast
      * Whether a stored mime_type disagrees with what the filename implies.
      *
      * Detection is the authority — the feed derives the enclosure type from the
-     * extension since #1391 — so a disagreement means the stored value is wrong
+     * extension — so a disagreement means the stored value is wrong
      * and worth replacing. YouTube URLs carry no meaningful extension and are
      * never a mismatch.
      *

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -83,7 +83,7 @@ class Cwmrelatedstudies
         // Dimension 2: Same teacher (2 points).
         //
         // From the junction: a study can have several teachers, and the column
-        // this used to read is gone (#1731).
+        // this used to read is gone.
         foreach (CwmstudyteacherHelper::getTeachersForStudy($studyId) as $teacher) {
             $teacherId = (int) ($teacher->teacherId ?? $teacher->teacher_id ?? 0);
 

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -283,7 +283,7 @@ class Cwmserieslist extends Cwmlisting
      * ⚠️ series_detail_sort is a saved template param that goes straight into
      * ORDER BY. quoteName() makes it safe, not valid: any column that no longer
      * exists takes the page down with it, which is how a retired column reaches
-     * a live site (#1623).
+     * a live site.
      *
      * @param   mixed  $column  The saved param value
      *

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -61,7 +61,7 @@ class Cwmshowscripture
 
         // The row already knows its book number; formReference() renders it to a
         // localised name that the provider then has to match back. Keep both, and
-        // let fetchPassage() prefer the structured one where it can (#1688).
+        // let fetchPassage() prefer the structured one where it can.
         $ref = ScriptureReference::fromRow($row);
         CwmDebug::startTimer('buildPassage');
 
@@ -647,7 +647,7 @@ class Cwmshowscripture
         // ScriptureHelper::getBookName() loads lib_cwmscripture's own language
         // file first; a bare Text::_() only resolves if something else happened
         // to load a file carrying JBS_BBK_*, which used to be com_proclaim's own
-        // duplicate copy of those keys (#1761).
+        // duplicate copy of those keys.
         $name = !empty($row->booknumber)
             ? CwmscriptureHelper::getBookName((int) $row->booknumber)
             : '';

--- a/site/src/Model/CwmseriesdisplaysModel.php
+++ b/site/src/Model/CwmseriesdisplaysModel.php
@@ -117,7 +117,7 @@ class CwmseriesdisplaysModel extends ListModel
         // Re-persist after the merge — 'params' must hold the template-merged
         // Registry (with the per-field row/column layout settings the
         // listing helper needs), not the raw application params captured
-        // above. Matches the equivalent line in CwmsermonsModel. See #1502.
+        // above. Matches the equivalent line in CwmsermonsModel.
         $this->setState('params', $params);
 
         $t = (int)$params->get('seriesid');

--- a/site/src/Model/CwmseriespodcastdisplayModel.php
+++ b/site/src/Model/CwmseriespodcastdisplayModel.php
@@ -320,7 +320,7 @@ class CwmseriespodcastdisplayModel extends ItemModel
 
         // Junction is the real model; the flat columns hold at most two
         // references. Cwmlisting::getAllScriptures() prefers ->scriptures when it
-        // is populated and falls back to the flat columns otherwise (#1623).
+        // is populated and falls back to the flat columns otherwise.
         $scriptureMap = CwmscriptureHelper::getScripturesForStudies(array_column($studies, 'id'));
 
         foreach ($studies as $study) {

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -984,7 +984,7 @@ class CwmsermonsModel extends ListModel
      * A correlated EXISTS over a study's scripture references.
      *
      * Self-contained, so it can be ANDed with anything without the bracketing
-     * hazard a bare disjunction carries (#1735).
+     * hazard a bare disjunction carries.
      *
      * @param   object    $db            Database driver
      * @param   int[]     $books         Book numbers, any of which may match

--- a/site/src/Service/Router.php
+++ b/site/src/Service/Router.php
@@ -138,7 +138,7 @@ class Router extends RouterView
     }
 
     /**
-     * Recognizes the cosmetic podcast download-tracking path (#1424) and maps
+     * Recognizes the cosmetic podcast download-tracking path and maps
      * it back to the track task from the media id alone. The trailing
      * filename segment is decorative only — it exists so the enclosure URL
      * carries a real file extension for Apple's ingestion crawler — and is

--- a/site/src/View/Cwmlandingpage/HtmlView.php
+++ b/site/src/View/Cwmlandingpage/HtmlView.php
@@ -128,7 +128,7 @@ class HtmlView extends BaseHtmlView
         $this->landingData = $this->landing->getLandingData($this->params);
 
         // Per-section sheets, after the component and template ones the
-        // dispatcher already emitted, so a section can override them (#1807).
+        // dispatcher already emitted, so a section can override them.
         CwmcustomcssHelper::applySections($this->params, $this->landing->getSectionOrder($this->params));
 
         // Load landing page assets

--- a/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
+++ b/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
@@ -120,7 +120,7 @@ class HtmlView extends BaseHtmlView
             // ran, so the response was an empty 200 inside the site chrome —
             // indexable, and with nothing for the visitor to act on. The
             // router usually redirects to the list before this is reached,
-            // which is why it went unnoticed (#1813).
+            // which is why it went unnoticed.
             //
             // Same shape as Cwmsermon: 404 for crawlers, a real page for
             // people.

--- a/site/src/View/Cwmsermons/HtmlView.php
+++ b/site/src/View/Cwmsermons/HtmlView.php
@@ -293,7 +293,7 @@ class HtmlView extends BaseHtmlView
             // Joomla's searchtools stays loaded on purpose: it owns the Filter Options
             // toggle, the Clear button and the sortable column headers, all of which
             // sermon-filters hooks into. Its submit paths run through form.submit(),
-            // which sermon-filters overrides to fetch over AJAX instead. See #1389.
+            // which sermon-filters overrides to fetch over AJAX instead.
             $wa->useScript('com_proclaim.sermon-filters');
             $wa->useStyle('com_proclaim.sermon-filters-css');
         }

--- a/site/tmpl/cwmseriespodcastdisplay/default.php
+++ b/site/tmpl/cwmseriespodcastdisplay/default.php
@@ -101,7 +101,7 @@ $CWMedia = new Cwmmedia();
                                     // no href that would mean anything. It used to be
                                     // href="javascript:loadVideo(…)", which no Content-Security-Policy
                                     // allows and which assistive technology announces as a link to a
-                                    // destination that does not exist (#1814).
+                                    // destination that does not exist.
                                     //
                                     // The thumbnail used to be passed as a second argument;
                                     // window.loadVideo() takes only the path and always ignored it.


### PR DESCRIPTION
First batch of #1826. **69 of the 218 citations** removed, across `site/` and `build/media_source/`.

A citation in a comment points at the investigation, which `git log` and `git blame` already provide. What stays is the mechanism it was attached to.

## How they broke down

| shape | count | treatment |
|---|---|---|
| trailing pointers — `(#1723)`, `. See #1569.`, `— see #1774` | 53 | lifted out cleanly |
| woven into a sentence | 16 | rewritten in the present tense |
| oversized blocks around a citation | 5 | cut to the line a maintainer needs |

Rewrites keep the fact and drop the pointer — *"Since #1299 froze guids"* becomes *"Guids are frozen"*; *"the audit behind #1391 found .m4a declared as audio/mp3"* keeps the finding and loses the audit.

The largest block ran **twenty lines** — a customer's site, a measured contrast ratio, source order, and the reasoning behind a scope choice — above four lines of CSS. It is now five lines saying the colours are stated rather than inherited because a template that flattens `.btn` erases the variant, with the trap marked ⚠️.

## ⚠️ Two things the next batch should know

**Five apparent citations were false positives.** `#996901` and `#ffb514` are hex colours in a contrast note, and `0x287585 -> #287585` documents a format conversion. A `#\d{3,4}` pattern **matches inside a six-digit hex value**, so a mechanical strip edits colour values. This is the "overstates by roughly half" trap from #1617, in a new form.

**Two upstream references are deliberately kept.** `joomla/joomla-cms#48151` and `#48152` point at Joomla's tracker, which blame cannot lead anyone to, and both carry the URL alongside. Worth confirming that reading before the `admin/` batch, where more may appear.

A first pass also silently ate leading indentation — collapsing runs of spaces inside comment text also collapsed the indent. Caught in review and redone against the text after the comment marker only.

## Verification

- **Comments-only:** the diff contains no non-comment, non-blank changed line
- `composer lint` clean · `npm run lint:js` clean · assets rebuild
- Site suites: **247 tests, 480 assertions**
- Zero citations remain in this batch's scope

**Remaining: 149 in `admin/` and 2 in `plugins/`**, to be done by subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
