### PR TITLE
chore: remove issue citations from comments in admin and plugins

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -36,7 +36,7 @@ try {
 // Checked on both clients rather than restricted to the administrator client:
 // Cwmdownload logs through CwmDebug on the front end, so an admin debugging a
 // site-side download still needs ?jbsmdbg=1 to work there. Anything that fails
-// to resolve an identity falls through to "not allowed". See #1569.
+// to resolve an identity falls through to "not allowed".
 $jbsmDebugRequested = $app->getInput()->getInt('jbsmdbg', 0) === 1;
 $jbsmDebugAllowed   = false;
 
@@ -89,7 +89,7 @@ if (is_dir($modProclaimPath)) {
 // routines they offer — so `php cli/joomla.php scheduler:run` reached this line
 // with a ConsoleApplication, which has no getDocument(), and died before any
 // task ran. Every scheduled task on the site was affected, including other
-// extensions' and Joomla's own (#1787).
+// extensions' and Joomla's own.
 //
 // Asset registries mean nothing without a document, so skipping them off the
 // web costs nothing. CMSWebApplicationInterface is what declares getDocument();
@@ -116,7 +116,7 @@ if ($app instanceof CMSWebApplicationInterface) {
 // administrator and site applications, because it needs a document for the web
 // asset manager. That assumption was wrong twice over: registering loggers here
 // left API code with no logger at all and silently discarded everything it
-// logged, and the console reaches this file too, via plg_task_proclaim (#1787).
+// logged, and the console reaches this file too, via plg_task_proclaim.
 //
 // Registration now lives in CwmlogHelper (called from ProclaimComponent::boot(),
 // so every application is covered). The call below is for the paths that reach

--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -898,7 +898,7 @@ abstract class CWMAddon
     }
 
     /**
-     * Whether this addon can create live broadcasts on its platform (#1298).
+     * Whether this addon can create live broadcasts on its platform.
      *
      * A capable platform is only the first of three gates — a broadcast is
      * created solely when the server is in Direct stream mode AND the
@@ -915,7 +915,7 @@ abstract class CWMAddon
     }
 
     /**
-     * Create a scheduled live broadcast on the platform (#1298 phase 1).
+     * Create a scheduled live broadcast on the platform (phase 1).
      *
      * Called from the media-file save path when all three gates pass
      * (capability, server Direct mode, per-record opt-in). Override in a
@@ -945,7 +945,7 @@ abstract class CWMAddon
 
     /**
      * Cancel a platform live broadcast that has not yet gone live
-     * (#1298 phase 3).
+     * (phase 3).
      *
      * Called from the media-file delete path when the record carries a
      * broadcast the platform still lists as upcoming. Override in a capable
@@ -1101,7 +1101,7 @@ abstract class CWMAddon
     {
         // Numeric comparison: a duration stored as '0' rather than '00' is still
         // no duration, but a string comparison read it as set and skipped
-        // detection for exactly those records (#1391).
+        // detection for exactly those records.
         $hours   = (int) $params->get('media_hours', '00');
         $minutes = (int) $params->get('media_minutes', '00');
         $seconds = (int) $params->get('media_seconds', '00');
@@ -1521,7 +1521,7 @@ abstract class CWMAddon
         // href is the embed URL, not a javascript: placeholder. Fancybox reads
         // data-src and intercepts the click, so behaviour is unchanged, but a
         // Content-Security-Policy no longer blocks the control and the visitor
-        // can middle-click or copy it like any other link (#1814).
+        // can middle-click or copy it like any other link.
         return '<a class="fancybox_player playhit" data-id="' . $mediaId
             . '" aria-hidden="false" data-src="' . $safeEmbedUrl
             . '" data-header="' . $headerText . '" data-footer="' . $footerText

--- a/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
+++ b/admin/src/Addons/Servers/Direct/CWMAddonDirect.php
@@ -51,7 +51,7 @@ class CWMAddonDirect extends CWMAddon
     /**
      * {@inheritdoc}
      *
-     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     * Called through cwmmediafile.xhr by the media-file upload path (, which made this reachable again).
      *
      * @since   10.5.6
      */

--- a/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
+++ b/admin/src/Addons/Servers/Legacy/CWMAddonLegacy.php
@@ -55,7 +55,7 @@ class CWMAddonLegacy extends CWMAddon
     /**
      * {@inheritdoc}
      *
-     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     * Called through cwmmediafile.xhr by the media-file upload path (, which made this reachable again).
      *
      * @since   10.5.6
      */

--- a/admin/src/Addons/Servers/Local/CWMAddonLocal.php
+++ b/admin/src/Addons/Servers/Local/CWMAddonLocal.php
@@ -57,7 +57,7 @@ class CWMAddonLocal extends CWMAddon
     /**
      * {@inheritdoc}
      *
-     * Called through cwmmediafile.xhr by the media-file upload path (see #1564, which made this reachable again).
+     * Called through cwmmediafile.xhr by the media-file upload path (, which made this reachable again).
      *
      * @since   10.5.6
      */

--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -178,7 +178,7 @@ class CWMAddonYoutube extends CWMAddon
             $html .= $field->renderField();
         }
 
-        // Live broadcast panel (#1298): only on NEW media, and only when
+        // Live broadcast panel: only on NEW media, and only when
         // this server streams Direct — an External/restreamer setup never
         // sees it, because the restreamer owns the broadcast there. The
         // scheduled start is the record's Media Date; say so where the
@@ -2016,7 +2016,7 @@ class CWMAddonYoutube extends CWMAddon
     }
 
     /**
-     * Cancel an upcoming YouTube broadcast (#1298 phase 3).
+     * Cancel an upcoming YouTube broadcast (phase 3).
      *
      * Status is checked FIRST, and only 'created' or 'ready' broadcasts are
      * deleted. Anything else — testing, live, complete — is someone's
@@ -2095,7 +2095,7 @@ class CWMAddonYoutube extends CWMAddon
 
     /**
      * The server's persistent ingestion stream — created once, reused for
-     * every broadcast (#1298 phase 2).
+     * every broadcast (phase 2).
      *
      * One stream per server means one RTMP URL + stream key the church
      * configures into their encoder once and never touches again — the way
@@ -2431,7 +2431,7 @@ class CWMAddonYoutube extends CWMAddon
     }
 
     /**
-     * YouTube can create live broadcasts (#1298). Capability only — the
+     * YouTube can create live broadcasts. Capability only — the
      * server's Direct stream mode and the per-record opt-in are separate
      * gates enforced by the caller and re-checked in createLiveEvent().
      *
@@ -2447,7 +2447,7 @@ class CWMAddonYoutube extends CWMAddon
 
     /**
      * Create a scheduled YouTube live broadcast via liveBroadcasts.insert
-     * (#1298 phase 1 — broadcast only; the ingestion stream and bind are
+     * (Phase 1 — broadcast only; the ingestion stream and bind are
      * phase 2).
      *
      * Requires OAuth — youtube.force-ssl already covers liveBroadcasts.*,
@@ -2514,7 +2514,7 @@ class CWMAddonYoutube extends CWMAddon
             $status->setSelfDeclaredMadeForKids(false);
 
             $contentDetails = new LiveBroadcastContentDetails();
-            // Auto-start is a per-server opt-in (#1298 phase 3): with it on,
+            // Auto-start is a per-server opt-in (phase 3): with it on,
             // the broadcast goes live the moment the encoder starts sending —
             // no Studio visit, which is the whole point for a volunteer AV
             // team. Off by default, because an encoder started early for a

--- a/admin/src/Addons/Servers/Youtube/Field/YoutubeStreamKeyField.php
+++ b/admin/src/Addons/Servers/Youtube/Field/YoutubeStreamKeyField.php
@@ -23,7 +23,7 @@ use Joomla\Registry\Registry;
 
 /**
  * YouTube Stream Key Field — read-only display of the server's persistent
- * ingestion details (#1298 phase 2): the RTMP URL and the stream key the
+ * ingestion details (phase 2): the RTMP URL and the stream key the
  * encoder points at.
  *
  * The key is a secret — anyone holding it can stream to the channel — so

--- a/admin/src/Controller/CwmadminController.php
+++ b/admin/src/Controller/CwmadminController.php
@@ -2161,12 +2161,12 @@ class CwmadminController extends FormController
 
         // Not validated against Cwmmedia::getMimetypes()'s current value list --
         // that list dropped the legacy 'audio/mp3' string in favor of the
-        // IANA-registered 'audio/mpeg' (#1397), but existing rows can still
+        // IANA-registered 'audio/mpeg', but existing rows can still
         // have 'audio/mp3' stored, and MimeTypeField deliberately keeps a
         // stored-but-no-longer-offered value selectable in the mtFrom dropdown
         // (see MimeTypeField::getOptions()). Rejecting it here would silently
-        // break matching for exactly the records #1397 was written to keep
-        // working. An unrecognized value just matches zero rows below.
+        // break matching for exactly the records that dropdown keeps
+        // selectable. An unrecognized value just matches zero rows below.
         if ($mediaType === 'x' || $mediaType === '' || $player === 'x') {
             echo json_encode([
                 'success' => false,

--- a/admin/src/Controller/CwmcpanelController.php
+++ b/admin/src/Controller/CwmcpanelController.php
@@ -24,7 +24,7 @@ use Joomla\CMS\MVC\Controller\BaseController;
  * Pure display controller -- CwmcpanelModel extends BaseModel, not
  * FormModel, and no task=cwmcpanel.* routing exists (only view=cwmcpanel
  * display links). Matches DisplayController's pattern for display-only
- * controllers. See #1449.
+ * controllers.
  *
  * @package  Proclaim.Admin
  * @since    7.0.0

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -185,7 +185,7 @@ class CwmmediafileController extends FormController
         // callable by request-supplied name -- including createLiveEvent()
         // and cancelLiveEvent(), which act on the connected platform account.
         // Those are invoked server-side (CwmmediafileModel/CwmmediafileTable)
-        // and deliberately stay off the allow-list. See #1599.
+        // and deliberately stay off the allow-list.
         if (!\in_array($handler, $addon->getXhrHandlers(), true) || !method_exists($addon, $handler)) {
             throw new \RuntimeException(
                 Text::sprintf('Handler: "%s" does not exist!', htmlspecialchars($handler, ENT_QUOTES, 'UTF-8')),
@@ -413,7 +413,7 @@ class CwmmediafileController extends FormController
                 'serverType'  => $serverType,
                 // The playlist picker lives outside the swapped containers, so the
                 // capability has to travel with the response for the client to
-                // show or hide it on a server change. See #1392.
+                // show or hide it on a server change.
                 'supportsPlaylists' => $addon->supportsPlaylists(),
             ]);
         } catch (\Exception $e) {

--- a/admin/src/Controller/CwmplaylistController.php
+++ b/admin/src/Controller/CwmplaylistController.php
@@ -63,7 +63,7 @@ class CwmplaylistController extends FormController
      * Without this, a non-admin editor in a multi-campus install could edit
      * any playlist regardless of its access level — every other ACL-scoped
      * singular controller (Location, Serie, Topic) already uses this trait.
-     * See #1438.
+     *
      *
      * @param   array   $data  An array of input data.
      * @param   string  $key   The name of the key for the primary key.

--- a/admin/src/Field/BookListField.php
+++ b/admin/src/Field/BookListField.php
@@ -69,7 +69,7 @@ class BookListField extends ListField
 
         // Books come from the junction, so a study with more than two references
         // offers all of them rather than the two the flat columns could hold
-        // (#1623). The studies keep the alias `s`: applyCrossFilters() below
+        // . The studies keep the alias `s`: applyCrossFilters() below
         // writes s.series_id and s.id, so the alias is part of that helper's
         // contract.
         $query->select('DISTINCT ' . $db->quoteName('sr.booknumber', 'value'))

--- a/admin/src/Field/DateFormatField.php
+++ b/admin/src/Field/DateFormatField.php
@@ -38,7 +38,7 @@ class DateFormatField extends PredefinedlistField
     protected $type = 'DateFormat';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/ElementOptionsField.php
+++ b/admin/src/Field/ElementOptionsField.php
@@ -36,7 +36,7 @@ class ElementOptionsField extends PredefinedlistField
     protected $type = 'ElementOptions';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/FilesizeField.php
+++ b/admin/src/Field/FilesizeField.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Language\Text;
  *
  * Renders a plain text input, never a <select> — extends FormField rather
  * than ListField, which it never actually used (getOptions() was never
- * called; getInput() is fully overridden). See #1464.
+ * called; getInput() is fully overridden).
  *
  * @package  Proclaim.Admin
  * @since    7.0.0

--- a/admin/src/Field/LayoutEditorField.php
+++ b/admin/src/Field/LayoutEditorField.php
@@ -256,7 +256,7 @@ class LayoutEditorField extends FormField
      *
      * Derived from the field's own form state instead of a hardcoded
      * "jform[params]", which broke silently outside the one hardcoded
-     * form/group. See #1461.
+     * form/group.
      *
      * @return  string
      *

--- a/admin/src/Field/LinkOptionsField.php
+++ b/admin/src/Field/LinkOptionsField.php
@@ -36,7 +36,7 @@ class LinkOptionsField extends PredefinedlistField
     protected $type = 'LinkOptions';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/MediaPlaylistsField.php
+++ b/admin/src/Field/MediaPlaylistsField.php
@@ -22,7 +22,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Database\DatabaseInterface;
 
 /**
- * Media Playlists field (#1273 phase 6.2b).
+ * Media Playlists field.
  *
  * A searchable, tag-style multi-select of the Proclaim Playlists a media file is
  * assigned to — modelled on {@see PodcastsField}. Options are scoped to the

--- a/admin/src/Field/MimeTypeField.php
+++ b/admin/src/Field/MimeTypeField.php
@@ -60,7 +60,7 @@ class MimeTypeField extends ListField
 
         // A stored value the catalogue no longer offers must still be selectable,
         // or the field silently renders blank and the next save wipes it. Records
-        // written before the audio/mp3 correction (#1397) are exactly that case,
+        // written before the audio/mp3 correction are exactly that case,
         // as is any type filled in by metadata detection, which draws on the wider
         // Cwmmime map.
         $value = (string) $this->value;

--- a/admin/src/Field/RowOptionsField.php
+++ b/admin/src/Field/RowOptionsField.php
@@ -36,7 +36,7 @@ class RowOptionsField extends PredefinedlistField
     protected $type = 'RowOptions';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/ScriptureSeparatorField.php
+++ b/admin/src/Field/ScriptureSeparatorField.php
@@ -38,7 +38,7 @@ class ScriptureSeparatorField extends PredefinedlistField
     protected $type = 'ScriptureSeparator';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/SeriesLinkOptionsField.php
+++ b/admin/src/Field/SeriesLinkOptionsField.php
@@ -36,7 +36,7 @@ class SeriesLinkOptionsField extends PredefinedlistField
     protected $type = 'SeriesLinkOptions';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/ShowVersesField.php
+++ b/admin/src/Field/ShowVersesField.php
@@ -38,7 +38,7 @@ class ShowVersesField extends PredefinedlistField
     protected $type = 'ShowVerses';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/TeacherLinkOptionsField.php
+++ b/admin/src/Field/TeacherLinkOptionsField.php
@@ -36,7 +36,7 @@ class TeacherLinkOptionsField extends PredefinedlistField
     protected $type = 'TeacherLinkOptions';
 
     /**
-     * A fixed set of options, not DB-backed. See #1464.
+     * A fixed set of options, not DB-backed.
      *
      * @var  array
      *

--- a/admin/src/Field/TemplateListField.php
+++ b/admin/src/Field/TemplateListField.php
@@ -84,7 +84,7 @@ class TemplateListField extends ListField
         // safe to cache across instances. Caching the merged result (as this
         // used to) meant a second TemplateList field with different XML
         // options in the same request silently got the first instance's
-        // stale merged list. See #1460.
+        // stale merged list.
         return array_merge(parent::getOptions(), self::$templates);
     }
 

--- a/admin/src/Field/TopicsFormField.php
+++ b/admin/src/Field/TopicsFormField.php
@@ -171,7 +171,7 @@ class TopicsFormField extends FormField
         // $this->name (the field's own computed name) rather than a
         // hardcoded "jform[topic_ids]" — the visible <select> below has no
         // name at all, so this hidden input is what a subform or any other
-        // non-top-level form context would actually submit. See #1461.
+        // non-top-level form context would actually submit.
         $html = '<input type="hidden" id="' . $this->id . '_input" name="' . $this->name . '" value="'
             . implode(',', $selectedIds) . '">';
 

--- a/admin/src/Helper/CwmDebug.php
+++ b/admin/src/Helper/CwmDebug.php
@@ -82,7 +82,7 @@ class CwmDebug
         // throw. Swallow it, matching CwmlogHelper::write(): logging must never
         // be the reason a request fails. The buffer append stays outside the
         // try so a logger failure doesn't also lose the on-screen entry.
-        // See #1569.
+        //
         try {
             Log::add($entry, Log::DEBUG, 'com_proclaim.debug');
         } catch (\Throwable) {
@@ -122,7 +122,7 @@ class CwmDebug
         // directory made Log::add() throw RuntimeException('Cannot write to
         // log file.') from inside those catch blocks, replacing the real error
         // with an unrelated one and destroying the diagnostic. Swallow it, as
-        // CwmlogHelper::write() already does. See #1569.
+        // CwmlogHelper::write() already does.
         try {
             Log::add($entry, Log::ERROR, 'com_proclaim');
         } catch (\Throwable) {
@@ -207,7 +207,7 @@ class CwmDebug
         // than "fixed" to write complete SQL to disk: com_proclaim.debug.php
         // is web-reachable under some Joomla layouts, and writing more raw SQL
         // there is the wrong direction for a report about SQL exposure.
-        // See #1569.
+        //
         $truncated = \strlen($sql) > 500 ? substr($sql, 0, 500) . '...' : $sql;
 
         self::log($label . ': ' . $truncated, 'query');

--- a/admin/src/Helper/CwmImageCleanup.php
+++ b/admin/src/Helper/CwmImageCleanup.php
@@ -486,8 +486,7 @@ class CwmImageCleanup
         // already an approximate LIKE-scan of the params JSON blob (a
         // substring match, so it over-counts and fails safe rather than
         // under-counts) -- so a real fix would need a proper
-        // reference-counted asset table. Accepted as a residual risk; see
-        // #1563.
+        // reference-counted asset table. Accepted as a residual risk.
         if (self::countOtherReferences($db, $oldFilename, $serverId, $recordId) > 0) {
             Log::add(
                 'Image cleanup: skipping ' . $oldFilename . ' — still referenced by another record',

--- a/admin/src/Helper/CwmaiHelper.php
+++ b/admin/src/Helper/CwmaiHelper.php
@@ -378,7 +378,7 @@ class CwmaiHelper
         // URL-embedded key leaks into transport-failure exception messages
         // (Joomla's Stream transport builds those from the failing URL) and
         // gets echoed straight back to the browser by both AJAX callers on
-        // error, plus into the debug log whenever JBSMDEBUG is on. See #1550.
+        // error, plus into the debug log whenever JBSMDEBUG is on.
         $response = $http->get(
             'https://generativelanguage.googleapis.com/v1beta/models',
             ['x-goog-api-key' => $apiKey],
@@ -770,8 +770,8 @@ class CwmaiHelper
         // abnormal finishReason (which assertNormalFinish() below already
         // handles). Without this check, $content and $finishReason both
         // silently default to '' and parseJsonResponse('') throws the raw,
-        // unhelpful "Invalid JSON —" error this class was already fixed once
-        // to eliminate (#1495/#1443/#1444) -- for a different trigger. See #1550.
+        // unhelpful "Invalid JSON —" error, for a different trigger than the
+        // one this class already guards against.
         if (!isset($data['candidates']) || !\is_array($data['candidates']) || empty($data['candidates'])) {
             $blockReason = $data['promptFeedback']['blockReason'] ?? 'unknown';
 

--- a/admin/src/Helper/Cwmalias.php
+++ b/admin/src/Helper/Cwmalias.php
@@ -69,7 +69,7 @@ class Cwmalias
                     // whichever row the database returned first, silently rendering
                     // one record's page as another's. On #__bsms_teachers, which
                     // does carry UNIQUE KEY `idx_alias`, the duplicate INSERT threw
-                    // instead and aborted the whole backfill mid-run. See #1565.
+                    // instead and aborted the whole backfill mid-run.
                     $alias = self::makeUniqueAlias(
                         $db,
                         $r['table'],

--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -272,7 +272,7 @@ class CwmanalyticsHelper
      * *referring* site and routinely carries things that are not ours to hold:
      * search terms, session tokens, addresses in newsletter links, password
      * reset and invite tokens. Expiring the column later does not help --
-     * what is never stored cannot leak. See #1612.
+     * what is never stored cannot leak.
      *
      * UTM tags are unaffected: they are captured separately into utm_source,
      * utm_medium and utm_campaign from the request, not parsed back out here.
@@ -459,7 +459,7 @@ class CwmanalyticsHelper
      *
      * Governs the personal-data tier only. Proclaim stores nothing on the
      * visitor's device, so this is not answering the ePrivacy cookie-consent
-     * question. See #1613.
+     * question.
      *
      * @return  bool  True if opted out (skip personal-data columns).
      *

--- a/admin/src/Helper/CwmbibleVersionHelper.php
+++ b/admin/src/Helper/CwmbibleVersionHelper.php
@@ -23,7 +23,7 @@ use Joomla\Registry\Registry;
 /**
  * Business logic for listing available Bible translations, extracted from
  * Field/BibleVersionField.php so the field stays a thin Joomla-form
- * adapter over this helper. See #1484.
+ * adapter over this helper.
  *
  * @since  10.5.6
  */

--- a/admin/src/Helper/CwmcountHelper.php
+++ b/admin/src/Helper/CwmcountHelper.php
@@ -236,7 +236,7 @@ class CwmcountHelper
                     } else {
                         // core.admin already excluded above, so an empty $accessible here
                         // means a real zero-access user, not a super admin -- restrict to
-                        // unassigned records instead of adding no predicate. See #1561.
+                        // unassigned records instead of adding no predicate.
                         $query->where($db->quoteName('t.location_id') . ' IS NULL');
                     }
                 }
@@ -264,7 +264,7 @@ class CwmcountHelper
                     } else {
                         // core.admin already excluded above, so an empty $accessible here
                         // means a real zero-access user, not a super admin -- restrict to
-                        // unassigned records instead of adding no predicate. See #1561.
+                        // unassigned records instead of adding no predicate.
                         $query->where($db->quoteName('s.location_id') . ' IS NULL');
                     }
                 }

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -316,7 +316,7 @@ class CwmdbHelper
             // stripped a fixed prefix-length from the front regardless,
             // yielding the mangled '#__s_bsms_studies'. That bogus name was
             // handed to every consumer of this list: the backup/restore and
-            // migration loops, and Cwmbackup's export allow-list. See #1566.
+            // migration loops, and Cwmbackup's export allow-list.
             if (str_starts_with($table, $prefix . $bsms)) {
                 $table = substr_replace($table, '#__', 0, $prelength);
 

--- a/admin/src/Helper/CwmdescriptionHelper.php
+++ b/admin/src/Helper/CwmdescriptionHelper.php
@@ -421,7 +421,7 @@ class CwmdescriptionHelper
         foreach ($rows as $row) {
             // The book name comes from the scripture library rather than a
             // #__bsms_books JOIN: the table stored the same language keys this
-            // resolves, against the same numbers (#1687). getBookName()
+            // resolves, against the same numbers. getBookName()
             // translates, so no Text::_() call is needed here.
             $ref = ScriptureHelper::getBookName((int) ($row->booknumber ?? 0))
                 . ' ' . ($row->chapter_begin ?? '');

--- a/admin/src/Helper/CwmfilterHelper.php
+++ b/admin/src/Helper/CwmfilterHelper.php
@@ -127,7 +127,7 @@ abstract class CwmfilterHelper
             if ($book > 0) {
                 // Use junction table for unlimited scripture references. The flat
                 // pair could only answer for a study's first two, so filtering on
-                // a third reference found nothing (#1623).
+                // a third reference found nothing.
                 $query->join(
                     'INNER',
                     $db->quoteName('#__bsms_study_scriptures', 'xf_ss') . ' ON '

--- a/admin/src/Helper/CwmlocationHelper.php
+++ b/admin/src/Helper/CwmlocationHelper.php
@@ -223,7 +223,7 @@ class CwmlocationHelper
      * A non-admin user with zero accessible locations (a real, valid config --
      * not the same thing as a super admin, see isSuperAdmin()) is restricted to
      * records with no location assigned at all, rather than seeing every
-     * location. See #1561.
+     * location.
      *
      * @param   QueryInterface  $query   The query to filter.
      * @param   string          $alias   Table alias owning the location_id column.
@@ -260,7 +260,7 @@ class CwmlocationHelper
      * the two let every consumer fail open (treat "zero access" as "no
      * restriction"). Callers that need to distinguish the two cases must
      * check this method directly rather than inferring admin status from an
-     * empty location array. See #1561.
+     * empty location array.
      *
      * @param   int  $userId  Joomla user ID (0 = current user).
      *
@@ -343,8 +343,8 @@ class CwmlocationHelper
             ->where($db->quoteName('s.location_id') . ' IS NOT NULL')
             ->where($db->quoteName('s.location_id') . ' > 0');
 
-        // ⚠️ A second UNION branch read studies.teacher_id until #1731 retired
-        // it. The junction path above is the whole answer now.
+        // ⚠️ The junction path above is the whole answer; studies.teacher_id is
+        // retired.
         $query1->bind(':userId', $userId, ParameterType::INTEGER);
 
         $db->setQuery($query1);
@@ -388,7 +388,7 @@ class CwmlocationHelper
 
         $db->setQuery($query, 0, 1);
 
-        // ⚠️ A second check read studies.teacher_id until #1731 retired it. The
+        // ⚠️ studies.teacher_id is retired. The
         // junction is the whole answer now.
         return (bool) $db->loadResult();
     }

--- a/admin/src/Helper/CwmmediaProtectionHelper.php
+++ b/admin/src/Helper/CwmmediaProtectionHelper.php
@@ -28,7 +28,7 @@ use Joomla\Http\HttpFactory;
  * under the web root are handed out by the web server, which never enters PHP
  * and so never sees a view level. The `access` field therefore reads like a
  * lock while the door is open, and that is exactly the combination an
- * administrator building a subscriber-only series would set and trust (#1774).
+ * administrator building a subscriber-only series would set and trust.
  *
  * This exists so the admin can be told, at the moment of setting it, rather
  * than discovering it later. It is a diagnosis, not a fix: real protection
@@ -45,7 +45,7 @@ class CwmmediaProtectionHelper
      * Compared against `Uri::root()` rather than the request's Host header:
      * the Host header is client-supplied and rewritable by any proxy in front
      * of the site, so it can differ from the site's configured hostname with
-     * no attacker involved (#1552).
+     * no attacker involved.
      *
      * A URL pointing at another host is somebody else's to protect, and a
      * relative or empty one tells us nothing — both answer false, because

--- a/admin/src/Helper/CwmmediaStreamer.php
+++ b/admin/src/Helper/CwmmediaStreamer.php
@@ -23,11 +23,11 @@ use Joomla\CMS\Factory;
  * If-Modified-Since, from local disk or by proxying an external host.
  *
  * Extracted verbatim from CwmpodcastTrackHelper, where it was written for the
- * podcast download-tracking redirect (#1424) and hardened against SSRF in
- * 10.5.5 (#1426). None of it was ever podcast-specific: the podcast parts —
+ * podcast download-tracking redirect and hardened against SSRF in
+ * 10.5.5. None of it was ever podcast-specific: the podcast parts —
  * bot detection, GUID resolution, hit recording — stayed behind. It lives here
  * so the front-end download route can use the same implementation rather than
- * growing a second one (#1774).
+ * growing a second one.
  *
  * ⚠️ This class answers *how* to send a file, never *whether* to. It performs
  * no access check, because its original caller is a deliberately public
@@ -48,7 +48,7 @@ class CwmmediaStreamer
      * Serve the tracked media directly (local disk or a proxied fetch from an
      * external host), honoring Range/HEAD/If-Modified-Since so the URL Apple's
      * crawler sees answers correctly without needing to follow a redirect
-     * first (#1424).
+     * first.
      *
      * @param   string  $target           Absolute URL of the live media
      * @param   string  $mimeType         Content-Type to declare
@@ -208,7 +208,7 @@ class CwmmediaStreamer
      *
      * Falls back to a plain redirect if curl isn't available, or if the
      * upstream fetch fails before any response reached the client — matches
-     * this endpoint's pre-#1424 behavior in both cases rather than hanging.
+     * this endpoint's earlier behaviour in both cases rather than hanging.
      *
      * @param   string  $url              Absolute URL of the external media
      * @param   string  $rangeHeader      Raw incoming Range header, if any
@@ -232,7 +232,7 @@ class CwmmediaStreamer
             Factory::getApplication()->redirect($url, 302);
         }
 
-        // SSRF guard (#1426): this method makes the request itself and relays
+        // SSRF guard: this method makes the request itself and relays
         // the response to an unauthenticated caller — unlike the redirect it
         // replaces, which only ever sent the *client's* browser/app to fetch
         // $url. $url is admin-configured (server.params.path), not
@@ -292,7 +292,7 @@ class CwmmediaStreamer
             // bounds how long a worker stays pinned. A LOW_SPEED guard
             // (not a hard total-time cap) aborts only a genuinely stalled
             // transfer, so legitimately large episode files can still
-            // stream for as long as they need to. See #1552.
+            // stream for as long as they need to.
             CURLOPT_LOW_SPEED_LIMIT => 1,
             CURLOPT_LOW_SPEED_TIME  => 60,
             CURLOPT_HEADERFUNCTION  => static function ($curlHandle, string $headerLine): int {
@@ -314,9 +314,9 @@ class CwmmediaStreamer
                 // the common case, given the "external host" storage model
                 // this method exists for) reached the client as a bare 3xx
                 // status with no Location and no body. This restores the
-                // pre-#1424 trust model for that case: the *client* follows
+                // earlier trust model for that case: the *client* follows
                 // the redirect itself, same as it always did, not curl -- no
-                // new SSRF surface. See #1552.
+                // new SSRF surface.
                 if (preg_match('/^(Content-Type|Content-Length|Content-Range|Accept-Ranges|Last-Modified|ETag|Cache-Control|Expires|Location):/i', $trimmed)) {
                     header($trimmed);
                 }
@@ -383,7 +383,7 @@ class CwmmediaStreamer
         return $hostOnly !== '' && $targetHost !== '' && $hostOnly === $targetHost;
     }
     /**
-     * SSRF guard for streamRemoteFile() (#1426): resolve a hostname to an IP
+     * SSRF guard for streamRemoteFile(): resolve a hostname to an IP
      * that is safe to fetch on this server's behalf, or null if it isn't.
      *
      * "Safe" means a public, routable address — not loopback (127.0.0.1,

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -362,8 +362,8 @@ class CwmmigrationHelper
         $dupCount = (int) $db->loadResult();
 
         if ($dupCount > 0) {
-            // ⚠️ Only while the column exists. #1731 retires it, and this runs
-            // from data fixes on databases either side of that.
+            // ⚠️ Only while the column exists. It is retired, and this runs from
+            // data fixes on databases either side of that.
             $db->setQuery(
                 'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote('teacher_id')
             );
@@ -517,7 +517,7 @@ class CwmmigrationHelper
             return 0;
         }
 
-        // Nothing to migrate once the column is gone (#1731).
+        // Nothing to migrate once the column is gone.
         $db->setQuery(
             'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote('teacher_id')
         );
@@ -1511,7 +1511,7 @@ class CwmmigrationHelper
      * only for ALTER TABLE, CREATE TABLE and RENAME TABLE, so an INSERT beside a
      * DROP COLUMN is skipped while the drop is replayed -- Database Maintenance
      * → Fix, and the 9.x upgrade wizard, would run the drop alone and lose every
-     * teacher attribution. The same reasoning as #1744.
+     * teacher attribution.
      *
      * Safe to call whenever: it returns immediately once the column is gone.
      *

--- a/admin/src/Helper/Cwmparams.php
+++ b/admin/src/Helper/Cwmparams.php
@@ -98,7 +98,7 @@ class Cwmparams
             // breaking all 12+ Cwmparams::getAdmin()->params callers. Fall
             // back to a usable shape instead, mirroring what
             // getTemplateparams() already does for a deleted template.
-            // See #1567.
+            //
             if (!$admin) {
                 $admin         = new \stdClass();
                 $admin->id     = 1;

--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -24,7 +24,7 @@ use Joomla\Database\ParameterType;
 use Joomla\Input\Input;
 
 /**
- * Playlist sync engine (#1273).
+ * Playlist sync engine.
  *
  * Bulk-imports a YouTube channel's playlists as first-class Proclaim Playlist
  * entities, then reconciles each playlist's videos against existing
@@ -33,7 +33,7 @@ use Joomla\Input\Input;
  * each media file's stored URL (params.filename).
  *
  * This engine is deliberately UI-agnostic: the Playlists toolbar action and the
- * scheduled task (#1273 phase 3) both call the same code path.
+ * scheduled task (phase 3) both call the same code path.
  *
  * @package  Proclaim.Admin
  * @since    10.3.3

--- a/admin/src/Helper/CwmpodcastTrackHelper.php
+++ b/admin/src/Helper/CwmpodcastTrackHelper.php
@@ -19,7 +19,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 /**
- * Counting/dedupe logic for the podcast download tracking redirect (#1281).
+ * Counting/dedupe logic for the podcast download tracking redirect.
  *
  * The redirect endpoint (cwmpodcast.track) calls record() to count a download,
  * then 302-redirects to the live media. Counting is IAB-style: a given client
@@ -248,7 +248,7 @@ class CwmpodcastTrackHelper
      * Serve the tracked media, honouring Range/HEAD/If-Modified-Since.
      *
      * The streaming itself moved to CwmmediaStreamer so the front-end download
-     * route can share one implementation instead of growing a second (#1774).
+     * route can share one implementation instead of growing a second.
      * This wrapper stays because the podcast redirect is its own entry point
      * and reads better named for what it does here.
      *

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -67,7 +67,7 @@ class CwmproclaimHelper
      * BIBLESTUDY_VERSION constant, which admin/api.php only populated by
      * parsing proclaim.xml off the filesystem, and only when the current
      * client was 'administrator' — everywhere else, including the API
-     * application, it was an empty string. See #1429.
+     * application, it was an empty string.
      *
      * @return  string  Semver version string, or '0.0.0' if unavailable
      *
@@ -515,8 +515,8 @@ class CwmproclaimHelper
 
         // Books come from the junction, so a study with more than two references
         // offers all of them rather than the two the flat columns could hold
-        // (#1623). The name comes from the scripture library, which holds the
-        // language keys #__bsms_books used to store (#1687).
+        // . The name comes from the scripture library, which holds the
+        // language keys #__bsms_books used to store.
         $query->select('DISTINCT ' . $db->quoteName('sr.booknumber', 'value'))
             ->from($db->quoteName('#__bsms_studies', 's'))
             ->join(

--- a/admin/src/Helper/CwmprotectedStorage.php
+++ b/admin/src/Helper/CwmprotectedStorage.php
@@ -42,7 +42,7 @@ use Joomla\Filesystem\Folder;
  * proxies media rather than redirecting to it — the exception being embedded
  * platforms like YouTube, which are players rather than files and were never
  * protectable by anyone. The feed no longer lists restricted items either
- * (#1781), so the origin URL of a private remote file is never published.
+ * , so the origin URL of a private remote file is never published.
  *
  * What this directory adds is the remaining case: a file that has nowhere
  * private to live, because the site hosts it itself.
@@ -52,7 +52,7 @@ use Joomla\Filesystem\Folder;
  * carries the same Apache/IIS guards Proclaim already ships elsewhere, and the
  * canary probe says whether they are doing anything. On a server that refuses
  * the probe this is a real boundary; on one that does not, Proclaim reports
- * that rather than implying protection it does not have (#1774).
+ * that rather than implying protection it does not have.
  *
  * @package  Proclaim.Admin
  * @since    10.5.8

--- a/admin/src/Helper/CwmschemaorgHelper.php
+++ b/admin/src/Helper/CwmschemaorgHelper.php
@@ -908,8 +908,8 @@ class CwmschemaorgHelper
      *
      * Deliberately not wrapped in a transaction. Each item's schema row is
      * independently valid, so a run cut short by a timeout leaves consistent
-     * data that the returned cursor can resume from — which is what finding 6 of
-     * issue #1562 wanted "no rollback" to buy. A transaction spanning thousands
+     * data that the returned cursor can resume from, which is what "no rollback"
+     * buys here. A transaction spanning thousands
      * of upserts would instead hold row locks for the length of the whole sync.
      *
      * @param   string  $mode    Sync mode (new, smart, force)

--- a/admin/src/Helper/Cwmthumbnail.php
+++ b/admin/src/Helper/Cwmthumbnail.php
@@ -134,7 +134,7 @@ class Cwmthumbnail
      * '..', so 'images/biblestudy/studies/../../../administrator' satisfied the
      * prefix test and still resolved outside the allowed tree once the
      * filesystem walked it -- the same defect fixed in CwmImageMigration
-     * (#1537) and CwmImageCleanup (#1563).
+     *  and CwmImageCleanup.
      *
      * Resolution is lexical rather than realpath()-based: callers legitimately
      * pass paths that do not exist yet (deleteFolder() reports success for an
@@ -285,7 +285,7 @@ class Cwmthumbnail
      * smart quotes, commas and other characters that break filesystem paths and
      * URLs are stripped — the previous behaviour passed the raw original filename
      * through unchanged, producing names such as
-     * "Anticipating the Return of Christ … 1105 am by.jpg" (#1272). The result is
+     * "Anticipating the Return of Christ … 1105 am by.jpg". The result is
      * truncated to MAX_BASENAME_LENGTH characters and falls back to "image" when
      * slugification yields an empty string.
      *
@@ -331,7 +331,7 @@ class Cwmthumbnail
         $extension = strtolower(pathinfo($originalPath, PATHINFO_EXTENSION));
 
         // Generate a filesystem- and URL-safe filename from the title (falling
-        // back to the original basename), slugified and length-capped. See #1272.
+        // back to the original basename), slugified and length-capped.
         $baseFilename = self::buildSafeBaseFilename($title, $originalPath);
 
         // Add a short version hash based on file content to bust browser cache

--- a/admin/src/Helper/CwmyoutubeFileCache.php
+++ b/admin/src/Helper/CwmyoutubeFileCache.php
@@ -75,7 +75,7 @@ class CwmyoutubeFileCache
             // This is the last-resort fallback the class docblock promises
             // "ensures module can always show a video instead of 'no video
             // available'" -- a silent write failure here means that
-            // guarantee silently stops holding with no trace. See #1551.
+            // guarantee silently stops holding with no trace.
             CwmyoutubeLogHelper::log(
                 CwmyoutubeLogHelper::LEVEL_ERROR,
                 'Failed to write last-known-video fallback cache',
@@ -667,7 +667,7 @@ class CwmyoutubeFileCache
      *
      * The writing itself now lives in CwmmediaProtectionHelper, which needed
      * the same guards for protected media and is where the check that they
-     * actually work also lives (#1774). One copy, two callers.
+     * actually work also lives. One copy, two callers.
      *
      * @param   string  $dir  Directory to guard
      *

--- a/admin/src/Helper/CwmyoutubeQuota.php
+++ b/admin/src/Helper/CwmyoutubeQuota.php
@@ -112,7 +112,7 @@ class CwmyoutubeQuota
      * @deprecated 10.5.6 No longer consulted by currentQuotaDate()
      *             -- the quota-day boundary is now computed directly from the
      *             America/Los_Angeles timezone (DST-aware), since no single
-     *             static UTC hour is correct year-round. See #1549. Will be
+     *             static UTC hour is correct year-round. Will be
      *             removed in a future major version.
      *
      * @param   int  $serverId  YouTube server record ID
@@ -205,7 +205,7 @@ class CwmyoutubeQuota
     {
         // A write failure this request means we can no longer trust the
         // local counter to reflect real usage -- fail closed rather than
-        // silently letting unlimited calls through. See #1549.
+        // silently letting unlimited calls through.
         if (!empty(self::$persistenceBroken[$serverId])) {
             return false;
         }
@@ -296,7 +296,7 @@ class CwmyoutubeQuota
      * hour around that boundary, combined with a genuine quota-exceeded
      * response landing in the mismatched window, could self-amplify into
      * up to ~23 hours of falsely reporting "exhausted" after Google's real
-     * quota had already reset. See #1549.
+     * quota had already reset.
      *
      * @return  string  Date string like "2026-02-28"
      *
@@ -374,7 +374,7 @@ class CwmyoutubeQuota
         } catch (\JsonException $e) {
             // File exists but isn't valid JSON -- distinct from "no file
             // yet" and worth surfacing, since it silently drops today's
-            // accumulated usage count. See #1549.
+            // accumulated usage count.
             CwmyoutubeLogHelper::log(
                 CwmyoutubeLogHelper::LEVEL_WARNING,
                 'Quota file contained invalid JSON, resetting to zero',
@@ -392,7 +392,7 @@ class CwmyoutubeQuota
      * under a single exclusive lock held for the whole read-modify-write
      * sequence -- prevents the lost-update race where two concurrent
      * recordUsage()/markExhausted() calls both read the same starting
-     * value and one silently overwrites the other's increment. See #1549.
+     * value and one silently overwrites the other's increment.
      *
      * @param   int       $serverId  Server ID
      * @param   callable  $mutator   array $data -> array $newData

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -283,7 +283,7 @@ class Cwmassets
      * rule set inherits from `com_proclaim`, so every effective permission is
      * the same answer the fallback already produced. Verified on a development
      * database across 14 groups x 17 sections x 5 actions — 1190 cells, none
-     * changed (#1653).
+     * changed.
      *
      * Written through `Table\Asset::setLocation()`/`store()` rather than a raw
      * INSERT, so the nested set stays correct without a `rebuild()` pass. A
@@ -727,7 +727,7 @@ class Cwmassets
      *
      * Item assets used to be parented to `com_proclaim`, which meant a rule on
      * `com_proclaim.<section>` never reached them — a record with per-record
-     * permissions escaped its section entirely (#1653).
+     * permissions escaped its section entirely.
      *
      * Falls back to the component for a section access.xml does not declare, so
      * `message_type`, `cwmadmin` and `studytopics` keep their old parent until
@@ -1155,7 +1155,7 @@ class Cwmassets
             // Through Table\Asset, not a raw DELETE: #__assets is a nested set,
             // and removing a row without closing its lft/rgt gap leaves numbers
             // only a full rebuild() reclaims — which fixAllAssets() skips on its
-            // fast path precisely because it is expensive (#1724).
+            // fast path precisely because it is expensive.
             $asset = new \Joomla\CMS\Table\Asset($db);
 
             if (!$asset->load($assetId)) {

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -70,7 +70,7 @@ class Cwmrestore
      * compromised admin account or a supply-chain-tainted backup file shared
      * between sites has far more reach than this feature needs. Restricting to
      * the statement shapes and tables Cwmbackup actually produces is defense in
-     * depth, not a hard sandbox -- see #1522 for the full threat discussion.
+     * depth, not a hard sandbox -- for the full threat discussion.
      *
      * @param   string  $statement  A single SQL statement (already trimmed, non-empty, non-comment)
      *

--- a/admin/src/Lib/CwmscriptureMigration.php
+++ b/admin/src/Lib/CwmscriptureMigration.php
@@ -23,7 +23,7 @@ use Joomla\Database\DatabaseInterface;
 /**
  * Finishes what the schema update started.
  *
- * The flat columns this used to read are gone as of #1623. Moving the rows is
+ * The flat columns this once read are gone. Moving the rows is
  * now done by the SQL update file, which has to run before the DROP in the same
  * file -- Joomla executes schema updates before postflight, so PHP is too late.
  * What SQL could not do is translate a book name, so the rows it writes carry an
@@ -45,7 +45,7 @@ class CwmscriptureMigration
     private const BATCH_SIZE = 100;
 
     /**
-     * The flat scripture columns #__bsms_studies carried until #1623.
+     * The flat scripture columns #__bsms_studies once carried.
      *
      * @var string[]
      * @since 10.5.8

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -210,9 +210,9 @@ class CwmcommentsModel extends ListModel
                 $query->where($db->quoteName('comment.id') . ' = ' . (int) substr($search, 3));
             } else {
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
-                // ⚠️ Searched `book.bookname` until #1687 dropped the
-                // #__bsms_books join that supplied the alias, which left every
-                // search on this list throwing "Unknown column".
+                // ⚠️ Must not search `book.bookname`: there is no #__bsms_books
+                // join here to supply the alias, and referencing it throws
+                // "Unknown column" for every search on this list.
                 $reference = $db->createQuery()
                     ->select('1')
                     ->from($db->quoteName('#__bsms_study_scriptures', 'csr'))
@@ -307,7 +307,7 @@ class CwmcommentsModel extends ListModel
      *
      * Was a #__bsms_books JOIN in the list query. That table stores language
      * keys, not names, so the join fetched a key the scripture library already
-     * holds against the same number (#1687).
+     * holds against the same number.
      *
      * Set on the item rather than resolved in the layout because this list has
      * a template a site can override, and an override may read $item->bookname.

--- a/admin/src/Model/CwminfoModel.php
+++ b/admin/src/Model/CwminfoModel.php
@@ -20,9 +20,9 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
  * Model backing the `/v1/proclaim/info` API resource.
  *
  * Not a database entity — a singleton item exposing metadata a caller cannot
- * otherwise reliably obtain over the API. See #1429: external tooling reading
- * the DB schema version to guess the installed release got stale answers,
- * because the schema version only advances on releases that ship DB changes.
+ * otherwise reliably obtain over the API. ⚠️ The DB schema version is not a
+ * substitute: it only advances on releases that ship DB changes, so external
+ * tooling using it to guess the installed release gets stale answers.
  *
  * @since  10.5.6
  */

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -168,7 +168,7 @@ class CwmmediafileModel extends AdminModel
             // writer already stores. The edit form's fields are plain text with no
             // filter, so a hand-typed "7" persisted as "7" — reaching the feed as
             // an invalid 00:27:7, and reading as "already set" to the repair and
-            // detection routines, which compare against '00' (#1391).
+            // detection routines, which compare against '00'.
             // A blank field is left blank: clearing it is how an administrator
             // marks a duration as unknown, and the detection routines read blank
             // and '00' alike as "not set".
@@ -193,7 +193,7 @@ class CwmmediafileModel extends AdminModel
             }
 
             // Create a platform live broadcast when all three gates pass
-            // (#1298 phase 1): the addon is capable, the server streams
+            // (phase 1): the addon is capable, the server streams
             // Direct, and the administrator opted this record in. Platform-
             // agnostic here — the addon owns the API. The opt-in is a
             // transient trigger, not a setting: it is consumed on success
@@ -402,7 +402,7 @@ class CwmmediafileModel extends AdminModel
     /**
      * Auto-detect missing metadata for a media file.
      * The study's title, for naming a live broadcast after its sermon
-     * (#1298). Empty string when the study cannot be found — the addon
+     * . Empty string when the study cannot be found — the addon
      * treats a missing title as invalid input rather than creating an
      * unnamed broadcast.
      *

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -1115,7 +1115,7 @@ class CwmmessageModel extends AdminModel
             // core.admin already excluded above, so an empty $accessible here
             // means a real zero-access user, not a super admin -- in_array()
             // against an empty array is always false, so this denies rather
-            // than silently skipping the check. See #1561.
+            // than silently skipping the check.
             if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }
@@ -1410,7 +1410,7 @@ class CwmmessageModel extends AdminModel
         // Applies to both new and existing records — e.g. adding an existing
         // standalone message to a series for the first time should still get
         // a number. Ignores non-numeric legacy studynumber values when
-        // computing the next one; see #1505.
+        // computing the next one;
         if ((int) $table->series_id > 0 && (string) $table->studynumber === '') {
             $db = Factory::getContainer()->get(DatabaseInterface::class);
 

--- a/admin/src/Model/CwmpermissionsModel.php
+++ b/admin/src/Model/CwmpermissionsModel.php
@@ -30,7 +30,7 @@ use Joomla\CMS\Table\Asset;
  * Permissions for one `com_proclaim.<section>` asset.
  *
  * One section per request: all 17 grids on one form exceeds PHP's
- * `max_input_vars`, and the excess is discarded silently (#1653).
+ * `max_input_vars`, and the excess is discarded silently.
  *
  * @since  10.5.8
  */

--- a/admin/src/Model/CwmpodcastModel.php
+++ b/admin/src/Model/CwmpodcastModel.php
@@ -243,7 +243,7 @@ class CwmpodcastModel extends AdminModel
             // core.admin already excluded above, so an empty $accessible here
             // means a real zero-access user, not a super admin -- in_array()
             // against an empty array is always false, so this denies rather
-            // than silently skipping the check. See #1561.
+            // than silently skipping the check.
             if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }

--- a/admin/src/Model/CwmserieModel.php
+++ b/admin/src/Model/CwmserieModel.php
@@ -536,7 +536,7 @@ class CwmserieModel extends AdminModel
             // core.admin already excluded above, so an empty $accessible here
             // means a real zero-access user, not a super admin -- in_array()
             // against an empty array is always false, so this denies rather
-            // than silently skipping the check. See #1561.
+            // than silently skipping the check.
             if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }

--- a/admin/src/Model/CwmserverModel.php
+++ b/admin/src/Model/CwmserverModel.php
@@ -479,7 +479,7 @@ class CwmserverModel extends AdminModel
             // core.admin already excluded above, so an empty $accessible here
             // means a real zero-access user, not a super admin -- in_array()
             // against an empty array is always false, so this denies rather
-            // than silently skipping the check. See #1561.
+            // than silently skipping the check.
             if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -264,7 +264,7 @@ class CwmtemplateModel extends AdminModel
             // core.admin already excluded above, so an empty $accessible here
             // means a real zero-access user, not a super admin -- in_array()
             // against an empty array is always false, so this denies rather
-            // than silently skipping the check. See #1561.
+            // than silently skipping the check.
             if (!\in_array($locationId, $accessible, true)) {
                 throw new \RuntimeException(Text::_('JBS_BAT_LOCATION_ACCESS_DENIED'));
             }

--- a/admin/src/Table/CwmadminTable.php
+++ b/admin/src/Table/CwmadminTable.php
@@ -159,7 +159,7 @@ class CwmadminTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmcommentTable.php
+++ b/admin/src/Table/CwmcommentTable.php
@@ -234,7 +234,7 @@ class CwmcommentTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmlocationTable.php
+++ b/admin/src/Table/CwmlocationTable.php
@@ -236,7 +236,7 @@ class CwmlocationTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmmediafileTable.php
+++ b/admin/src/Table/CwmmediafileTable.php
@@ -299,7 +299,7 @@ class CwmmediafileTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         if ($result) {
@@ -336,7 +336,7 @@ class CwmmediafileTable extends Table
         $this->deletePhysicalFile();
 
         // Cancel an upcoming platform live broadcast this record owns
-        // (#1298 phase 3) — same best-effort rule as the physical file
+        // (phase 3) — same best-effort rule as the physical file
         $this->cancelLiveBroadcast();
 
         // Clean up locally stored caption/subtitle VTT files
@@ -350,7 +350,7 @@ class CwmmediafileTable extends Table
 
     /**
      * Cancel this record's upcoming platform live broadcast, best-effort
-     * (#1298 phase 3).
+     * (phase 3).
      *
      * Deleting a Proclaim record that owns a scheduled broadcast would
      * otherwise leave an orphan on the platform — the exact mess the live

--- a/admin/src/Table/CwmmessageTable.php
+++ b/admin/src/Table/CwmmessageTable.php
@@ -407,7 +407,7 @@ class CwmmessageTable extends Table
         // Reject a newly-introduced duplicate episode number within a series.
         // Only re-validates when series_id or studynumber actually changed on
         // this save — pre-existing duplicates stay editable for unrelated
-        // field changes (title, date, etc.); see #1505.
+        // field changes (title, date, etc.);
         if ((int) $this->series_id > 0 && trim((string) $this->studynumber) !== '') {
             $db      = $this->getDatabase();
             $changed = empty($this->id);
@@ -646,7 +646,7 @@ class CwmmessageTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmmessagetypeTable.php
+++ b/admin/src/Table/CwmmessagetypeTable.php
@@ -252,7 +252,7 @@ class CwmmessagetypeTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmplaylistTable.php
+++ b/admin/src/Table/CwmplaylistTable.php
@@ -339,7 +339,7 @@ class CwmplaylistTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmpodcastTable.php
+++ b/admin/src/Table/CwmpodcastTable.php
@@ -701,7 +701,7 @@ class CwmpodcastTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmserieTable.php
+++ b/admin/src/Table/CwmserieTable.php
@@ -323,7 +323,7 @@ class CwmserieTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmserverTable.php
+++ b/admin/src/Table/CwmserverTable.php
@@ -278,7 +278,7 @@ class CwmserverTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmstudytopicsTable.php
+++ b/admin/src/Table/CwmstudytopicsTable.php
@@ -87,7 +87,7 @@ class CwmstudytopicsTable extends Table
         // A link row between a study and a topic is not something anyone
         // permissions. Table enables asset tracking for any table carrying an
         // asset_id column, which minted an asset per link for a section
-        // access.xml never declared (#1653).
+        // access.xml never declared.
         $this->_trackAssets = false;
     }
 
@@ -112,7 +112,7 @@ class CwmstudytopicsTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmteacherTable.php
+++ b/admin/src/Table/CwmteacherTable.php
@@ -312,7 +312,7 @@ class CwmteacherTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmtemplateTable.php
+++ b/admin/src/Table/CwmtemplateTable.php
@@ -257,7 +257,7 @@ class CwmtemplateTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -284,7 +284,7 @@ class CwmtemplatecodeTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/Table/CwmtopicTable.php
+++ b/admin/src/Table/CwmtopicTable.php
@@ -244,7 +244,7 @@ class CwmtopicTable extends Table
 
         // Unconditional: Table::store() runs its asset block even when the
         // INSERT threw, so a failed save leaves a com_proclaim.<section>.0 row
-        // behind for a record that was never created (#1723).
+        // behind for a record that was never created.
         Cwmassets::stripEmptyAssetRow($this);
 
         return $result;

--- a/admin/src/View/Cwmadmin/HtmlView.php
+++ b/admin/src/View/Cwmadmin/HtmlView.php
@@ -348,7 +348,7 @@ class HtmlView extends BaseHtmlView
         $toolbar->preferences('com_proclaim', 'JBS_ADM_PERMISSIONS');
 
         // ⚠️ Per-section permissions get their own screen: 17 grids on this form
-        // exceeds PHP's max_input_vars and the whole save fails silently (#1653).
+        // exceeds PHP's max_input_vars and the whole save fails silently.
         if (Factory::getApplication()->getIdentity()->authorise('core.admin', 'com_proclaim')) {
             $toolbar->linkButton('sectionpermissions', 'JBS_ADM_PERMISSIONS_TITLE')
                 ->url('index.php?option=com_proclaim&view=cwmpermissions')

--- a/admin/src/View/Cwmmediafile/HtmlView.php
+++ b/admin/src/View/Cwmmediafile/HtmlView.php
@@ -286,7 +286,7 @@ class HtmlView extends BaseHtmlView
      * under the web root is handed out by the web server, which never enters
      * PHP. An administrator setting up a subscriber-only series would
      * reasonably read that field as protection, so say otherwise at the point
-     * they set it rather than leaving it to be discovered (#1774).
+     * they set it rather than leaving it to be discovered.
      *
      * Silent for a new item, which has no id, no stored filename and nothing
      * to be wrong about yet.
@@ -344,7 +344,7 @@ class HtmlView extends BaseHtmlView
 
         // What to advise depends on what this server actually does with the
         // protected directory, so say that rather than offering a remedy that
-        // may not work here (#1774).
+        // may not work here.
         $message = match (CwmprotectedStorage::status()) {
             CwmmediaProtectionHelper::PROTECTED => 'JBS_MED_RESTRICTED_BUT_PUBLIC_CAN_MOVE',
             CwmmediaProtectionHelper::EXPOSED   => 'JBS_MED_RESTRICTED_BUT_PUBLIC_NO_HELP',

--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -296,7 +296,7 @@ class HtmlView extends BaseHtmlView
      * administrators to dismiss warnings without reading them.
      *
      * The verdict itself is cached and only re-taken weekly, so this costs a
-     * param read on an ordinary page load (#1783).
+     * param read on an ordinary page load.
      *
      * @return  void
      *

--- a/admin/tmpl/cwmmediafile/edit.php
+++ b/admin/tmpl/cwmmediafile/edit.php
@@ -136,7 +136,7 @@ echo 'index.php?option=com_proclaim&view=cwmmediafile&layout=edit&id=' . (int)$t
                 // (YouTube, Vimeo) — elsewhere the picker can only ever come up empty.
                 // Rendered hidden rather than omitted so an existing assignment still
                 // posts back instead of being silently cleared, and so the server-change
-                // handler can reveal it without a page reload. See #1392.
+                // handler can reveal it without a page reload.
                 $supportsPlaylists = $this->addon !== null && $this->addon->supportsPlaylists();
                 ?>
                 <div id="playlist-field-container"<?php echo $supportsPlaylists ? '' : ' class="d-none"'; ?>>

--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -530,7 +530,7 @@ final class Proclaim extends Adapter implements SubscriberInterface
             }
         }
 
-        // Add Scripture/Book: one Scripter taxonomy per reference (#1623).
+        // Add Scripture/Book: one Scripter taxonomy per reference.
         try {
             foreach (CwmscriptureHelper::getScripturesForStudy((int) $item->id) as $ref) {
                 // Not the stored reference_text, which is frozen in whatever

--- a/plugins/webservices/proclaim/src/Extension/Proclaim.php
+++ b/plugins/webservices/proclaim/src/Extension/Proclaim.php
@@ -303,7 +303,7 @@ class Proclaim extends CMSPlugin implements SubscriberInterface
      * Not a RESOURCES entry: info is a singleton (component metadata, not a
      * database entity — see CwminfoModel), so it gets one GET route straight to
      * displayItem rather than the list + list/:id pair createReadOnlyRoutes()
-     * registers for real resources. See #1429.
+     * registers for real resources.
      *
      * @param   ApiRouter  $router    The API router
      * @param   bool       $isPublic  Whether the route is publicly accessible

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -754,7 +754,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * 10.1.0 widened this key to include series_id, as one ALTER that added the
      * column, dropped the old key and added the new one. That statement could not
-     * stay in SQL (#1664):
+     * stay in SQL:
      *
      *   - MySQL has no DROP INDEX IF EXISTS, so a database missing the key stops
      *     it with error 1091 and takes the whole update down with it.
@@ -964,7 +964,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * `install.mysql.utf8.sql` seeds `#__action_log_config` with one row per
      * loggable entity, and `10.1.0-20260207.sql` adds to it, but nothing has
-     * ever taken them out again — five rows survived every uninstall (#1676).
+     * ever taken them out again — five rows survived every uninstall.
      *
      * Deliberately not part of `dropTablesIfRequested()`. That is gated on the
      * administrator's `drop_tables` setting because it destroys sermons; these
@@ -1004,7 +1004,7 @@ class com_proclaimInstallerScript extends InstallerScript
      * the clearing — and reports it with
      * `Log::add(..., Log::WARNING, 'jerror')`, which Joomla routes into the
      * message queue. The administrator sees a red
-     * "Could not delete folder" beside a successful update (#1407).
+     * "Could not delete folder" beside a successful update.
      *
      * It cannot be caught: FileStorage::_deleteFolder() logs and returns false
      * rather than throwing, so the try/catch around clean() never sees it.
@@ -1153,7 +1153,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
             // Deduplicate: the query filters on element but not folder, and a
             // suite like JCH Optimize registers several plugins under the same
-            // element — which printed "JCH Optimize, JCH Optimize" (#1407). Any
+            // element — which printed "JCH Optimize, JCH Optimize". Any
             // one of them being enabled is reason enough to warn, so collapsing
             // to distinct names is the right answer rather than filtering by
             // folder, whose names vary between releases.
@@ -1388,7 +1388,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 // module; this IS the teardown, so say so. Without it every call
                 // here returned false with
                 // JLIB_INSTALLER_ERROR_CANNOT_UNINSTALL_CHILD_OF_PACKAGE and the
-                // rows leaked (#1676).
+                // rows leaked.
                 $installer->setPackageUninstall(true);
 
                 $result = $installer->uninstall('module', $id);
@@ -1420,7 +1420,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 $installer = new Installer();
                 $installer->setDatabase($this->dbo);
 
-                // See uninstallModules() — same guard, same reason (#1676).
+                // See uninstallModules() — same guard, same reason.
                 $installer->setPackageUninstall(true);
 
                 $result = $installer->uninstall('plugin', $id);
@@ -1636,7 +1636,7 @@ class com_proclaimInstallerScript extends InstallerScript
         //     uninstallSubExtensions() had just removed
         //   - renderPostInstallation() showing the "installation complete" page
         //   - scriptureConsumer('register') putting the consumer row straight
-        //     back after uninstall() had removed it (#1679)
+        //     back after uninstall() had removed it
         //
         // Most of it failed quietly because removeExtensionFiles() has already
         // taken the source away by then, which is why only the row — a plain DB
@@ -1723,7 +1723,7 @@ class com_proclaimInstallerScript extends InstallerScript
         // ⚠️ The scripture migration is the one that also runs on a fresh install.
         // install.mysql.utf8.sql seeds the sample study with legacy flat columns
         // and no junction row, so an install that skipped this shipped a study
-        // whose reference the junction never knew about (#1623).
+        // whose reference the junction never knew about.
         try {
             $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
 


### PR DESCRIPTION
Second batch of #1826, covering `admin/` and `proclaim.script.php`. **147 citations removed** across 81 files; batch 1 (`site/`, `build/media_source/`) is #1827.

## How they broke down

| shape | count | treatment |
|---|---|---|
| trailing pointers | 130 | lifted out cleanly |
| number carrying part of the sentence | 17 | rewritten in the present tense |

The rewrites are the interesting half. Stating the rule as a property of the code, rather than as what changed, keeps the warning and loses the history:

> ⚠️ Searched `book.bookname` until #1687 dropped the `#__bsms_books` join that supplied the alias, which left every search on this list throwing "Unknown column".

becomes

> ⚠️ Must not search `book.bookname`: there is no `#__bsms_books` join here to supply the alias, and referencing it throws "Unknown column" for every search on this list.

Same trap, and it now reads to someone who never heard of the issue. Similarly `pre-#1424 behavior` → `earlier behaviour`, and two phase markers keep the phase and drop the number.

## ⚠️ Three matches were vendored third-party code

`guzzlehttp` and `firebase/php-jwt` carry their **own** issue references, and `curl #4835` is curl's bug, not ours. The file list excluded `vendor/` from the start so nothing there was touched — confirmed against the diff, since editing another project's comments would be both wrong and invisible in review.

## Verification

- **Comments-only:** no non-comment, non-blank changed line in the diff
- **Vendor untouched:** 0 files under `vendor/` modified
- `composer lint` clean
- Full PHP suite: **2367 tests, 7766 assertions**

## Where the sweep stands

| scope | citations | status |
|---|---|---|
| `site/`, `build/media_source/` | 69 | #1827 |
| `admin/`, `proclaim.script.php` | 147 | this PR |
| `plugins/` | 2 | remaining |

That completes 216 of the 218. The last two are in `plugins/`, and the five hex-colour false positives identified in #1827 are correctly left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
