### PR TITLE
chore: reject issue references in comments from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,11 @@ jobs:
       - name: Check query builder usage
         run: composer lint:queries
 
+      # Like the coding standards below, checked once rather than in both PHP
+      # jobs: what a comment says does not vary by PHP version.
+      - name: Check comments for issue references
+        run: composer lint:comments
+
       # CLAUDE.md requires PSR-12 and says all code must pass PHP CS Fixer before
       # committing, but nothing enforced it, so the standard held only as far as
       # each contributor remembered to run it. Checked once here rather than in

--- a/admin/tmpl/cwmpodcast/edit.php
+++ b/admin/tmpl/cwmpodcast/edit.php
@@ -175,8 +175,7 @@ if ($rawPodcastLink !== '' && !ctype_digit((string) $rawPodcastLink)) {
         </div>
         <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php // Every field that identifies who is behind the show lives here — see #1417.
-              // Was scattered across General, Feed Owner, and Podcasting 2.0.?>
+        <?php // Every field that identifies who is behind the show lives here.?>
         <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'author', Text::_('JBS_PDC_FEED_OWNER')); ?>
         <div class="row">
             <div class="col-lg-9">

--- a/build/lint-comments.php
+++ b/build/lint-comments.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Reject issue references inside code comments.
+ *
+ * A comment carries what a maintainer needs at the line. An issue number is a
+ * pointer to the investigation instead, and git log / git blame already connect
+ * any line to its commit, its pull request and its issue — so the citation adds
+ * nothing to the file and goes stale the moment the numbering context does.
+ *
+ * This exists because the debt grows back. A sweep cleared it across three
+ * repositories once, and within a week new citations had been written; the same
+ * shape returns whenever someone explains a fix at the line instead of in the
+ * commit body. A check makes that visible while it is still cheap to move.
+ *
+ * Two exclusions are deliberate rather than incidental:
+ *
+ *   - A six-digit hex colour contains a four-digit run, so `#996901` matches a
+ *     naive `#\d{3,4}`. Stripping those edits colour values in a stylesheet.
+ *   - `owner/repo#123` points at somebody else's tracker, which blame cannot
+ *     lead anyone to, so it earns its place.
+ *
+ * Vendored trees, the scripturelinks submodule and minified output are other
+ * projects' code and not this standard's to enforce.
+ *
+ * Usage: php build/lint-comments.php
+ * Exit:  0 clean, 1 offenders found.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+$roots = ['admin', 'api', 'site', 'modules', 'plugins', 'build/media_source'];
+
+$skip = [
+    '/vendor/',
+    '/node_modules/',
+    '/libraries/',
+    'scripturelinks',
+    '.min.',
+];
+
+/** A line that is a comment in PHP, JavaScript or CSS. */
+$isComment = '~^\s*(//|\*|/\*)~';
+
+/**
+ * An issue reference: # then three or four digits, not continuing into a hex
+ * colour, and not preceded by an owner/repo pointing at another tracker.
+ */
+$citation = '~(?<![\w./-])#\d{3,4}(?![0-9a-fA-F])~';
+
+$offenders = [];
+
+/**
+ * Real paths already read. `admin/proclaim.script.php` is a symlink to the
+ * manifest script at the repository root, so without this a file reachable
+ * twice is reported twice, and a symlinked directory would recurse forever.
+ */
+$seen = [];
+
+foreach ($roots as $root) {
+    if (!is_dir($root)) {
+        continue;
+    }
+
+    $walker = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($walker as $file) {
+        $path = str_replace('\\', '/', $file->getPathname());
+
+        if (!preg_match('~\.(php|js|css)$~', $path)) {
+            continue;
+        }
+
+        foreach ($skip as $fragment) {
+            if (str_contains($path, $fragment)) {
+                continue 2;
+            }
+        }
+
+        $real = realpath($path);
+
+        if ($real === false || isset($seen[$real])) {
+            continue;
+        }
+
+        $seen[$real] = true;
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+
+        if ($lines === false) {
+            continue;
+        }
+
+        foreach ($lines as $i => $line) {
+            if (preg_match($isComment, $line) && preg_match($citation, $line)) {
+                $offenders[] = [$path, $i + 1, trim($line)];
+            }
+        }
+    }
+}
+
+if ($offenders === []) {
+    echo "No issue references in comments.\n";
+
+    exit(0);
+}
+
+echo "Issue references found in comments (" . \count($offenders) . "):\n\n";
+
+foreach ($offenders as [$path, $line, $text]) {
+    echo "  {$path}:{$line}\n";
+    echo '      ' . (\strlen($text) > 96 ? substr($text, 0, 96) . '…' : $text) . "\n";
+}
+
+echo "\nMove the reference to the commit body or the pull request, and leave the\n";
+echo "comment saying what the code does. `owner/repo#123` for another project's\n";
+echo "tracker is allowed; so is a hex colour.\n";
+
+exit(1);

--- a/build/lint-comments.php
+++ b/build/lint-comments.php
@@ -13,12 +13,14 @@
  * shape returns whenever someone explains a fix at the line instead of in the
  * commit body. A check makes that visible while it is still cheap to move.
  *
- * Two exclusions are deliberate rather than incidental:
+ * Only the comment part of a line is searched, so an inline comment after code
+ * is covered and a `#` inside code or a string literal is not. Tests are not
+ * scanned: a regression test's docblock naming the issue it guards is the one
+ * place the number is the subject rather than a pointer away from it.
  *
- *   - A six-digit hex colour contains a four-digit run, so `#996901` matches a
- *     naive `#\d{3,4}`. Stripping those edits colour values in a stylesheet.
- *   - `owner/repo#123` points at somebody else's tracker, which blame cannot
- *     lead anyone to, so it earns its place.
+ * Four digits are required. Every citation the sweep found had four, Proclaim's
+ * numbering passed 1000 years ago, and three would collide with the CSS
+ * shorthand colours (`#000`, `#666`, `#999`) that appear in comments.
  *
  * Vendored trees, the scripturelinks submodule and minified output are other
  * projects' code and not this standard's to enforce.
@@ -41,14 +43,119 @@ $skip = [
     '.min.',
 ];
 
-/** A line that is a comment in PHP, JavaScript or CSS. */
-$isComment = '~^\s*(//|\*|/\*)~';
+/**
+ * Return only the comment text on a line.
+ *
+ * `$inBlock` carries `/* … *\/` state across lines, so continuation lines of a
+ * docblock are read as comment without relying on them starting with `*`.
+ * Quotes are tracked so a `//` inside a string is code, and a `//` preceded by
+ * `:` is left alone so a URL in code does not read as a comment.
+ *
+ * PSR-12 forbids `#` line comments, and PHP CS Fixer enforces PSR-12 here, so
+ * that form is not handled — `#[` attributes would be the ambiguous case.
+ *
+ * @param   string  $line       The line to read.
+ * @param   bool    $inBlock    Whether a block comment is already open.
+ * @param   bool    $lineForms  Whether `//` opens a comment (false for CSS).
+ *
+ * @return  string  The comment text, empty when the line carries none.
+ */
+function commentText(string $line, bool &$inBlock, bool $lineForms): string
+{
+    $out    = '';
+    $len    = \strlen($line);
+    $quote  = null;
+    $i      = 0;
+
+    while ($i < $len) {
+        $c    = $line[$i];
+        $next = $i + 1 < $len ? $line[$i + 1] : '';
+
+        if ($inBlock) {
+            if ($c === '*' && $next === '/') {
+                $inBlock = false;
+                $i += 2;
+
+                continue;
+            }
+
+            $out .= $c;
+            $i++;
+
+            continue;
+        }
+
+        if ($quote !== null) {
+            if ($c === '\\') {
+                $i += 2;
+
+                continue;
+            }
+
+            if ($c === $quote) {
+                $quote = null;
+            }
+
+            $i++;
+
+            continue;
+        }
+
+        if ($c === '"' || $c === "'") {
+            $quote = $c;
+            $i++;
+
+            continue;
+        }
+
+        if ($c === '/' && $next === '*') {
+            $inBlock = true;
+            $i += 2;
+
+            continue;
+        }
+
+        if ($lineForms && $c === '/' && $next === '/' && ($i === 0 || $line[$i - 1] !== ':')) {
+            $out .= substr($line, $i + 2);
+
+            break;
+        }
+
+        $i++;
+    }
+
+    return $out;
+}
 
 /**
- * An issue reference: # then three or four digits, not continuing into a hex
- * colour, and not preceded by an owner/repo pointing at another tracker.
+ * Find issue references in a comment.
+ *
+ * `owner/repo#123` points at somebody else's tracker, which blame cannot lead
+ * anyone to, so it earns its place and is left alone. A bare `#1234`, or one
+ * introduced by a word such as `PR#1234`, is a pointer into this project's
+ * history and is reported.
+ *
+ * @param   string  $comment  Comment text.
+ *
+ * @return  bool  True when the comment cites an issue.
  */
-$citation = '~(?<![\w./-])#\d{3,4}(?![0-9a-fA-F])~';
+function citesIssue(string $comment): bool
+{
+    if (!preg_match_all('~#\d{4}(?![0-9a-fA-F])~', $comment, $matches, PREG_OFFSET_CAPTURE)) {
+        return false;
+    }
+
+    foreach ($matches[0] as [$_, $offset]) {
+        preg_match('~[\w./-]*$~', substr($comment, 0, $offset), $preceding);
+
+        // A slash in the token before `#` makes it another project's tracker.
+        if (!str_contains($preceding[0], '/')) {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 $offenders = [];
 
@@ -95,8 +202,13 @@ foreach ($roots as $root) {
             continue;
         }
 
+        $lineForms = !str_ends_with($path, '.css');
+        $inBlock   = false;
+
         foreach ($lines as $i => $line) {
-            if (preg_match($isComment, $line) && preg_match($citation, $line)) {
+            $comment = commentText($line, $inBlock, $lineForms);
+
+            if ($comment !== '' && citesIssue($comment)) {
                 $offenders[] = [$path, $i + 1, trim($line)];
             }
         }
@@ -109,7 +221,7 @@ if ($offenders === []) {
     exit(0);
 }
 
-echo "Issue references found in comments (" . \count($offenders) . "):\n\n";
+echo 'Issue references found in comments (' . \count($offenders) . "):\n\n";
 
 foreach ($offenders as [$path, $line, $text]) {
     echo "  {$path}:{$line}\n";

--- a/composer.json
+++ b/composer.json
@@ -138,6 +138,7 @@
     "test:release": ["@test:install", "@test:upgrade", "@test:e2e"],
     "lint:syntax": "find admin/src api/src site/src modules plugins -type f -name '*.php' -print0 | xargs -0 -n 1 -P 8 php -l > /dev/null",
     "lint:queries": "sh build/lint-queries.sh",
+    "lint:comments": "@php build/lint-comments.php",
     "lint": "php-cs-fixer fix --dry-run --diff",
     "lint:fix": "php-cs-fixer fix",
     "check": ["@lint:syntax", "@lint:queries", "@lint", "@test"],

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -621,36 +621,11 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
-     * Drop the pre-10.5.6 (study_id, topic_id) index once its unique replacement exists.
-     *
-     * 10.5.6-20260807.sql replaces the non-unique idx_study_topic with a unique
-     * uq_study_topic over the same pair. Removing the old one is cleanup rather
-     * than correctness — the unique key already serves every lookup it served.
-     *
-     * It runs here instead of in the migration SQL because MySQL has no
-     * DROP INDEX IF EXISTS. A database whose table lacks that index while
-     * #__schemas still names an earlier version replays the file raw through
-     * Installer::parseSchemaUpdates(), which stops on error 1091 and aborts the
-     * entire update.
-     *
-     * Deliberately not written as guarded SQL. Joomla's MysqlChangeItem parses
-     * plain ALTER TABLE statements to decide whether a change has already been
-     * applied, and that is what makes the restore path idempotent — Cwmrestore
-     * clears #__schemas and calls DatabaseModel::fix(), which replays every
-     * migration through ChangeSet. Wrapping DDL in SET/PREPARE would make it
-     * unparseable, so ChangeItem would score it -1 and never run it at all.
-     *
-     * @return  void
-     *
-     * @since   10.5.6
-     */
-    /**
      * Create the `com_proclaim.<section>` assets access.xml declares.
      *
-     * Phase 1 of #1653. Every section is created with empty rules, which
-     * inherit from `com_proclaim` — so effective permissions are unchanged for
-     * every group, section and action. Measured on a development database:
-     * 1190 cells compared, none changed.
+     * Every section is created with empty rules, which inherit from
+     * `com_proclaim`, so effective permissions are unchanged for every group,
+     * section and action.
      *
      * Seeding on update as well as install matters because access.xml can gain
      * a section in any release, and a section with no asset is a permission
@@ -717,6 +692,30 @@ class com_proclaimInstallerScript extends InstallerScript
         }
     }
 
+    /**
+     * Drop the pre-10.5.6 (study_id, topic_id) index once its unique replacement exists.
+     *
+     * 10.5.6-20260807.sql replaces the non-unique idx_study_topic with a unique
+     * uq_study_topic over the same pair. Removing the old one is cleanup rather
+     * than correctness — the unique key already serves every lookup it served.
+     *
+     * It runs here instead of in the migration SQL because MySQL has no
+     * DROP INDEX IF EXISTS. A database whose table lacks that index while
+     * #__schemas still names an earlier version replays the file raw through
+     * Installer::parseSchemaUpdates(), which stops on error 1091 and aborts the
+     * entire update.
+     *
+     * Deliberately not written as guarded SQL. Joomla's MysqlChangeItem parses
+     * plain ALTER TABLE statements to decide whether a change has already been
+     * applied, and that is what makes the restore path idempotent — Cwmrestore
+     * clears #__schemas and calls DatabaseModel::fix(), which replays every
+     * migration through ChangeSet. Wrapping DDL in SET/PREPARE would make it
+     * unparseable, so ChangeItem would score it -1 and never run it at all.
+     *
+     * @return  void
+     *
+     * @since   10.5.6
+     */
     private function dropRedundantStudyTopicIndex(): void
     {
         if (!$this->tableExists('#__bsms_studytopics')) {
@@ -2645,10 +2644,9 @@ class com_proclaimInstallerScript extends InstallerScript
             foreach ($tables as $suffix => $pkColumn) {
                 $fullName = $prefix . $suffix;
 
-                // ⚠️ A table in this list may not exist — #__bsms_books was
-                // retired in #1687. Skipping is not just tidiness: the ALTER
-                // would throw, and the catch is outside this loop, so one
-                // missing table stopped every later table being checked.
+                // A table in this list may not exist — #__bsms_books is retired.
+                // The catch sits outside this loop, so without the skip one
+                // missing table would stop every later table being checked.
                 if (!\in_array($fullName, $existing, true)) {
                     continue;
                 }


### PR DESCRIPTION
Adds the CI check that keeps the comment sweep from growing back.

`build/lint-comments.php` follows the existing `build/lint-queries.sh` pattern: it walks `admin`, `api`, `site`, `modules`, `plugins` and `build/media_source` for `.php`/`.js`/`.css`, flags any comment citing a `#1234`-style issue, and exits 1 with the offending file, line and text. Wired in as `composer lint:comments`, run in the 8.3 job only alongside the coding standards — what a comment says does not vary by PHP version.

### Why

A comment carries what a maintainer needs at the line. An issue number points at the investigation instead, and `git blame` already connects any line to its commit, its PR and its issue. The debt also grows back on its own: an earlier pass was undone within a week.

### It reads the comment, not the line

The first cut anchored at the start of the line, so it only saw comments that *begin* one — `$x = 1; // fixes #1234` passed clean, which is the commonest form and the one that got out of hand. The matcher now extracts the comment part of each line with a small scanner that tracks quotes and carries block-comment state across lines. That covers inline comments after code, ignores `//` inside a string or after `:` in a URL, and stops docblock continuation lines from depending on a leading `*`.

Scanning only the comment also removed four false positives where a hex colour sat in the *code* and a comment happened to follow.

### Deliberate exclusions

- **Hex colours.** Three-digit shorthand written inside a comment (`/* … (was #666) */`) collides with issue numbers, so a citation needs **four** digits — every one the sweep found had four, and Proclaim's numbering passed 1000 years ago. The `(?![0-9a-fA-F])` lookahead keeps `#123456` from matching on its first four.
- **`owner/repo#123`.** Another project's tracker, which blame cannot lead anyone to. This turns on whether the token before `#` holds a slash, so `PR#1234` is still caught — the first cut wrongly excluded it.
- **`tests/`.** A regression test's docblock naming the issue it guards is the one place the number is the subject rather than a pointer away from it. 250 such references exist there today; sweeping them is a separate call.
- Vendored trees, the `scripturelinks` submodule and minified output are other projects' code.

Paths are deduplicated by `realpath()` — `admin/proclaim.script.php` is a symlink to the root manifest script, so without it a file reachable twice is reported twice and a symlinked directory would recurse forever.

### Also in here

- The one inline citation the new matcher finds, in `admin/tmpl/cwmpodcast/edit.php`, plus the narrative line under it.
- Clearing the last two own-line citations turned up a docblock for `dropRedundantStudyTopicIndex()` stranded above `seedSectionAssets()`'s, leaving the former undocumented. Moved back onto its method.

### Verification

Fixture suite covering 8 must-catch and 8 must-ignore shapes — own-line, inline-after-code, block, docblock continuation, `PR#` prefix; against string literals, URL fragments, upstream refs, and 3/4/6-digit hex in both code and comment position. **8 caught, 0 false positives.**

- `composer lint:comments` on this branch: `No issue references in comments.`
- Exit code through the composer wrapper confirmed `1` on a planted offender, `0` when clean.
- `composer lint` — 0 of 612.

Part of #1826.