### PR TITLE
chore: drop narrative comments from the site views

### DIFF
--- a/site/src/Dispatcher/Dispatcher.php
+++ b/site/src/Dispatcher/Dispatcher.php
@@ -64,13 +64,9 @@ class Dispatcher extends ComponentDispatcher
 
         // Proclaim's core stylesheet, for the same reason and in the same place:
         // every front-end view needs it, and registering here puts it ahead of
-        // any sheet a view adds, so a view can still override it.
-        //
-        // It used to arrive only through Cwmlisting::getFluidListing(), so the
-        // views that do not call that helper rendered without it. That was not
-        // only a missing focus ring: cwmseriespodcastlist styles its thumbnail
-        // grid from this sheet, and without it the grid collapsed into a stack
-        // five times taller than intended.
+        // any sheet a view adds, so a view can still override it. Views style
+        // layout from it, not just focus rings — cwmseriespodcastlist gets its
+        // thumbnail grid here.
         $this->app->getDocument()->getWebAssetManager()->useStyle('com_proclaim.cwmcore');
 
         // Once per component request, ahead of the views, so a rule can reach

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -148,13 +148,6 @@ class Cwmdownload
         // redirect uses, so there is one Range/HEAD/If-Modified-Since handler
         // rather than two.
         //
-        // What this replaces was weaker in two ways: it sent Content-Length and
-        // readfile() with no Range support, so a browser could not seek in
-        // gated audio or video; and its remote branch fopen()ed an
-        // admin-configured URL and relayed the response to the caller with no
-        // SSRF guard — the shape that was patched for the podcast endpoint in
-        // 10.5.5 but never here.
-        //
         // Access was already checked above. The streamer answers how to send a
         // file, never whether to.
 

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -398,8 +398,8 @@ class Cwmlanding
             $grouped[$row->type][] = $row;
         }
 
-        // The books branch could not name its own rows in SQL; do it here, where
-        // the union's shared column shape no longer constrains anything. Keyed
+        // The books branch cannot name its own rows in SQL; do it here, where
+        // the union's shared column shape does not constrain the result. Keyed
         // on `id`, which for that branch is the book number.
         if (!empty($grouped['books'])) {
             foreach ($grouped['books'] as $row) {
@@ -579,10 +579,8 @@ class Cwmlanding
             case 'books':
                 // `text` is a placeholder here, filled by nameBooks() once the
                 // union has loaded. Every branch of this union has to produce
-                // the same five columns, and a book's name is no longer
-                // available to SQL: #__bsms_books held language keys the
-                // scripture library already carries, so the join it needed
-                // earned nothing.
+                // the same five columns, and a book's name is not available to
+                // SQL — the scripture library holds it.
                 //
                 // Books come from the junction, so a study with more than two
                 // references contributes all of them.
@@ -1133,10 +1131,8 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             // Books come from the junction, so a study with more than two
-            // references contributes all of them rather than the two the flat
-            // columns could hold. The name is attached afterwards from
-            // the scripture library, which holds the language keys
-            // #__bsms_books used to store.
+            // references contributes all of them. The name is attached
+            // afterwards from the scripture library.
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
             // b.access.
@@ -1190,14 +1186,11 @@ class Cwmlanding
     /**
      * Attach a book name to each row returned by the books queries.
      *
-     * Those queries used to join #__bsms_books for a `bookname` column holding a
-     * JBS_BBK_* language key, which the callers then passed to Text::_(). The
-     * scripture library holds the same keys against the same numbers, so the
-     * join earned nothing.
+     * The scripture library holds the JBS_BBK_* keys against the same book
+     * numbers, so the name is resolved here rather than joined in SQL.
      *
-     * Rows whose number the library cannot name are dropped. The join could not
-     * produce one — the row existed or it did not — and an entry with no label
-     * links somewhere the reader cannot identify.
+     * Rows whose number the library cannot name are dropped: an entry with no
+     * label links somewhere the reader cannot identify.
      *
      * @param   array  $rows  Rows carrying a booknumber.
      *
@@ -1727,10 +1720,8 @@ class Cwmlanding
             $language = $this->getLanguageFilter($params);
 
             // Books come from the junction, so a study with more than two
-            // references contributes all of them rather than the two the flat
-            // columns could hold. The name is attached afterwards from
-            // the scripture library, which holds the language keys
-            // #__bsms_books used to store.
+            // references contributes all of them. The name is attached
+            // afterwards from the scripture library.
             //
             // The studies keep the alias `b`, which addAccessFilter() writes as
             // b.access.

--- a/site/src/Helper/Cwmmedia.php
+++ b/site/src/Helper/Cwmmedia.php
@@ -79,21 +79,16 @@ class Cwmmedia
      * FA6 equivalents ("fa-solid fa-play", "fa-brands fa-youtube"). Safe to call
      * on values that are already FA6 — returns them unchanged.
      *
-     * Two things this has to get right, both of which it originally did not:
+     * Two rules the mapping has to honour:
      *
-     * 1. Brands need the brand family. Rewriting the FA4 prefix `fa fa-` to
-     *    `fa-solid fa-` produced `fa-solid fa-youtube`, which is tofu — the Free
-     *    font has no glyph at the YouTube codepoint. Worse, the FA4 form was
-     *    *working* before the rewrite, because Joomla's v4 shim
-     *    (`.fa.fa-youtube { font-family: "Font Awesome 6 Brands" }`) keys on the
-     *    bare `.fa` class that the rewrite strips.
-     * 2. Some FA4 names only exist as shims. `fa-video-camera` has no plain rule
-     *    in joomla-fontawesome.css, only `.fa.fa-video-camera`, so it must be
-     *    renamed to the FA6 name `fa-video` rather than merely re-prefixed.
+     * 1. ⚠️ Brands need the brand family, not `fa-solid`. `fa-solid fa-youtube`
+     *    is tofu — the Free font has no glyph at that codepoint.
+     * 2. Some FA4 names exist only as shims. `fa-video-camera` has no plain rule
+     *    in joomla-fontawesome.css, only `.fa.fa-video-camera`, so it is renamed
+     *    to the FA6 name `fa-video` rather than merely re-prefixed.
      *
-     * Because the brand fix-up runs on the final token list, it also repairs
-     * values already damaged in the database by the 10.3.0 migration: a stored
-     * `fa-solid fa-youtube` comes back out as `fa-brands fa-youtube`.
+     * The brand fix-up runs on the final token list, so it also repairs values
+     * already stored as `fa-solid fa-youtube`.
      *
      * @param   string  $class  Icon CSS class string
      *
@@ -325,7 +320,7 @@ class Cwmmedia
             $link_type = 3;
         }
 
-        // Used to override everything if used for the use of the Podcast playlist system.
+        // Podcast playlist mode forces a direct link.
         if ($params->get('pcplaylist')) {
             $link_type = 0;
         }
@@ -375,7 +370,7 @@ class Cwmmedia
     }
 
     /**
-     * Used to get the button and/or icon for the image
+     * Get the button and/or icon for the media.
      *
      * @param   Registry  $imageparams  ?
      * @param   Registry  $params       ?
@@ -529,13 +524,12 @@ class Cwmmedia
          * internal_popup = whether direct or HTML5 player should be a popup/new window or inline
          * From media file:
          * player 0 = direct link (browser handles), 1 = HTML5 player, 4 = Docman, 5 = article, 6 = Virtuemart, 8 = embed code, 100 = use global
-         * internal_popup 0 = inline, 1 = popup, 2 = global settings
+         * internal_popup 1 = popup/new window, 2 = inline, 3 = squeezebox
          *
          * Deprecated players (migrated to 1 on install): 3 = AV plugin, 7 = legacy
-         * Get the $player->player: 0 = direct link, 1 = HTML5 player, 2 = AVR (no longer supported),
+         * Get the $player->player: 0 = direct link, 1 = HTML5 player, 2 = AVR (unsupported),
          * 4 = Docman, 5 = article, 6 = Virtuemart, 8 = embed code
-         * $player->type 0 = inline, 1 = popup/new window 3 = Use Global Settings (from params)
-         * In 6.2.3 we changed inline = 2
+         * $player->type 1 = popup/new window, 2 = inline, 3 = use global settings (from params)
          */
         $player->player   = 0;
         $item_mediaplayer = (int)$media->params->get('player');
@@ -1114,7 +1108,7 @@ class Cwmmedia
     }
 
     /**
-     * Used to get the button and/or icon for the image
+     * Get the download button and/or icon.
      *
      * @param   Registry  $download  ?
      *

--- a/site/src/Helper/Cwmpodcast.php
+++ b/site/src/Helper/Cwmpodcast.php
@@ -908,11 +908,10 @@ class Cwmpodcast
      * Build the download-tracking enclosure URL as a real, extension-bearing
      * path instead of a bare task query string.
      *
-     * Apple's Podcaster's Guide to RSS is explicit that the enclosure's file
+     * ⚠️ Apple's Podcaster's Guide to RSS is explicit that the enclosure's file
      * extension "determines whether or not content appears in the podcast
-     * directory" — a production feed audited against this exact fix reported
-     * 0% of tracked episodes with a valid extension, and Apple had stopped
-     * ingesting new episodes and delisted previously-published ones.
+     * directory". A feed whose enclosures are bare task query strings stops
+     * being ingested, and already-published episodes are delisted.
      *
      * When the site has SEF routing on, Router::parse() (site/src/Service/
      * Router.php) understands the resulting `/component/proclaim/
@@ -1568,11 +1567,10 @@ class Cwmpodcast
             if (empty($mimeType)) {
                 $warnings[] = Text::sprintf('JBS_PDC_VALIDATE_MEDIA_NO_MIME', $media->studytitle ?: 'ID: ' . $media->id);
             } elseif (!$isYouTube && !empty($filename)) {
-                // A stored type that contradicts the file. The feed no longer trusts
-                // it — the enclosure type is derived from the extension — but
-                // the stored value is still wrong, and is a sign the record was
-                // created or imported incorrectly. YouTube URLs have no meaningful
-                // extension, so they are skipped rather than warned about.
+                // A stored type that contradicts the file. The enclosure type is
+                // derived from the extension, so the feed is right either way, but
+                // the stored value still signals a bad import. YouTube URLs have no
+                // meaningful extension, so they are skipped rather than warned about.
                 $derived = Cwmmime::fromExtension($filename);
 
                 if ($derived !== null && $derived !== $mimeType) {

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -82,8 +82,7 @@ class Cwmrelatedstudies
 
         // Dimension 2: Same teacher (2 points).
         //
-        // From the junction: a study can have several teachers, and the column
-        // this used to read is gone.
+        // From the junction: a study can have several teachers.
         foreach (CwmstudyteacherHelper::getTeachersForStudy($studyId) as $teacher) {
             $teacherId = (int) ($teacher->teacherId ?? $teacher->teacher_id ?? 0);
 

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -281,9 +281,8 @@ class Cwmserieslist extends Cwmlisting
 
     /**
      * ⚠️ series_detail_sort is a saved template param that goes straight into
-     * ORDER BY. quoteName() makes it safe, not valid: any column that no longer
-     * exists takes the page down with it, which is how a retired column reaches
-     * a live site.
+     * ORDER BY. quoteName() makes it safe, not valid: a column that does not
+     * exist takes the page down with it.
      *
      * @param   mixed  $column  The saved param value
      *

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -646,8 +646,7 @@ class Cwmshowscripture
         // Ask the library for the name rather than translating the key here.
         // ScriptureHelper::getBookName() loads lib_cwmscripture's own language
         // file first; a bare Text::_() only resolves if something else happened
-        // to load a file carrying JBS_BBK_*, which used to be com_proclaim's own
-        // duplicate copy of those keys.
+        // to load a file carrying JBS_BBK_*.
         $name = !empty($row->booknumber)
             ? CwmscriptureHelper::getBookName((int) $row->booknumber)
             : '';

--- a/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
+++ b/site/src/View/Cwmseriespodcastdisplay/HtmlView.php
@@ -116,20 +116,12 @@ class HtmlView extends BaseHtmlView
         $this->template = $this->state->get('template');
 
         if (!$item) {
-            // A bare return here rendered nothing at all: the template never
-            // ran, so the response was an empty 200 inside the site chrome —
-            // indexable, and with nothing for the visitor to act on. The
-            // router usually redirects to the list before this is reached,
-            // which is why it went unnoticed.
-            //
             // Same shape as Cwmsermon: 404 for crawlers, a real page for
-            // people.
+            // people. Returning without rendering would answer an empty 200.
             //
             // ⚠️ Set through the application, not http_response_code(). Joomla
-            // builds the response from its own object and sends those headers
-            // at the end of the request, so a raw status set here is discarded
-            // — measured, Cwmsermon's not-found page still answers 200 despite
-            // asking for 404 that way.
+            // sends headers from its own response object at the end of the
+            // request, so a raw status set here is discarded.
             $app->setHeader('status', 404, true);
             $this->getDocument()->setTitle(Text::_('JBS_CMN_SERIES_NOT_FOUND'));
             $this->setLayout('notfound');

--- a/site/tmpl/cwmseriespodcastdisplay/default.php
+++ b/site/tmpl/cwmseriespodcastdisplay/default.php
@@ -98,13 +98,7 @@ $CWMedia = new Cwmmedia();
                                     <?php
                                     // A button, not a link: this swaps the source of the player
                                     // already on the page rather than going anywhere, so there is
-                                    // no href that would mean anything. It used to be
-                                    // href="javascript:loadVideo(…)", which no Content-Security-Policy
-                                    // allows and which assistive technology announces as a link to a
-                                    // destination that does not exist.
-                                    //
-                                    // The thumbnail used to be passed as a second argument;
-                                    // window.loadVideo() takes only the path and always ignored it.
+                                    // no href that would mean anything.
                                     ?>
                                     <button type="button" class="btn btn-link p-0 align-baseline"
                                             data-proclaim-audio="<?php echo htmlspecialchars($path1, ENT_QUOTES, 'UTF-8'); ?>">

--- a/site/tmpl/cwmterms/default.php
+++ b/site/tmpl/cwmterms/default.php
@@ -26,9 +26,7 @@ use Joomla\CMS\Language\Text;
         <?php if (!empty($this->media)) : ?>
         <div class="termslink">
             <?php
-                // Without a media id there is nothing to continue to — reaching
-                // the view directly used to warn "Attempt to read property on
-                // null" straight into the page output.
+                // Without a media id there is nothing to continue to.
                 echo '<a href="index.php?option=com_proclaim&task=cwmsermons.download&id=' . (int) $this->media->study_id
                 . '&mid=' . (int) $this->media->id . '">'
                 . Text::_('JBS_CMN_CONTINUE_TO_DOWNLOAD') . '</a>';


### PR DESCRIPTION
First pass of the narrative-marker half of #1826, scoped to `site/`. The citation half is already done and gated by `composer lint:comments`; this part cannot be automated, so it is a read of every flagged block.

**Comment-only — no line outside a comment is touched.** Verified mechanically:

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-]\s*(//|\*|/\*|\*/)' | grep -vE '^[+-]\s*$'
→ (empty)
```

### What was scanned

A block-aware scan for `used to`, `the old`, `no longer`, `previously`, `formerly`, `originally`, `had been`, `before this` and similar, reading only real comment text (reusing the extraction from `build/lint-comments.php`) and grouping consecutive comment lines so each hit could be judged against the code it sits above.

**23 blocks in 12 files → 4 remain.** Net −47 comment lines.

### The four that stay

These are not narrative, and a regex could not have told the difference:

- **`Cwmpodcast::…`** — Apple's rule that the enclosure extension determines directory inclusion. External constraint, and the reason the method exists.
- **`Cwmlisting`** — the colspan arithmetic reproduces `<table>` proportional-width semantics. Without that sentence, `round(span / rowTotal * 12)` is an arbitrary formula.
- **`Cwmmedia::AVMediaCode()`** — a standard `@deprecated … no longer maintained` tag.
- **`Cwmserieslist`** — the ⚠️ on `series_detail_sort` reaching `ORDER BY`; a live trap, trailing clause trimmed.

### Two blocks were documenting the code wrongly

Worth a look, because these were found by reading rather than by the marker:

`Cwmmedia`'s player reference table gave `internal_popup` as `0 = inline, 1 = popup, 2 = global settings` and `$player->type` as `0 = inline`, followed by a stray line reading "In 6.2.3 we changed inline = 2" that corrected it.

`admin/forms/template.xml` declares:

```xml
<option value="1">JBS_CMN_POPUP_NEW_WINDOW</option>
<option value="2">JBS_CMN_INLINE</option>
<option value="3">JBS_CMN_SQUEEZEBOX</option>
```

and `$isHtml5Inline` tests `(int) $player->type === 2`. So every value in both lines was wrong, and the "In 6.2.3" line was the only accurate part. The table is corrected against the form and the live comparison; the trailing note is then redundant.

Separately, two docblocks opened `Used to get the button and/or icon for the image`. That reads as history, but means "is used to" — both now state what the method returns.

### Verification

- `composer lint` — 0 of 612
- `composer lint:comments` — clean
- `php -l` on all 11 changed files

### Remaining

`admin/` and `plugins/` narrative markers are still to do; this issue stays open for them.

Part of #1826.