### PR TITLE
chore: drop narrative comments from the admin tree

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -27,11 +27,10 @@ try {
 // On admin pages the debug check runs immediately; on the site side we
 // default to off and let Cwmdownload (the only front-end consumer) check
 // on demand, avoiding a DB query on every module/page load.
-// A URL parameter is not authorisation. `?jbsmdbg=1` previously switched
-// JBSMDEBUG on for *any* client, so an anonymous site visitor could enable the
-// component's debug buffer -- and CwmsermonsController::filterAjax() ships that
-// buffer to the browser as `_debug`, handing out raw SQL for the sermon listing
-// query. Honour the parameter only for a user who actually holds core.admin.
+//
+// ⚠️ A URL parameter is not authorisation. CwmsermonsController::filterAjax()
+// ships the debug buffer to the browser as `_debug`, raw SQL included, so
+// honour `?jbsmdbg=1` only for a user who actually holds core.admin.
 //
 // Checked on both clients rather than restricted to the administrator client:
 // Cwmdownload logs through CwmDebug on the front end, so an admin debugging a
@@ -83,13 +82,11 @@ if (is_dir($modProclaimPath)) {
 // Register web asset registries so assets are available when views/modules request them.
 // Actual useStyle/useScript calls are made by individual views and module dispatchers.
 //
-// Guarded because this file does NOT only run in web applications, despite what
-// the comment below used to claim. plg_task_proclaim requires it from its
-// constructor, and com_scheduler imports every task plugin just to list the
-// routines they offer — so `php cli/joomla.php scheduler:run` reached this line
-// with a ConsoleApplication, which has no getDocument(), and died before any
-// task ran. Every scheduled task on the site was affected, including other
-// extensions' and Joomla's own.
+// ⚠️ Guarded because this file does NOT only run in web applications.
+// plg_task_proclaim requires it from its constructor, and com_scheduler imports
+// every task plugin just to list the routines they offer, so
+// `php cli/joomla.php scheduler:run` reaches this line with a
+// ConsoleApplication, which has no getDocument().
 //
 // Asset registries mean nothing without a document, so skipping them off the
 // web costs nothing. CMSWebApplicationInterface is what declares getDocument();

--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -1519,9 +1519,9 @@ abstract class CWMAddon
         $safeEmbedUrl = htmlspecialchars($embedUrl, ENT_QUOTES, 'UTF-8');
 
         // href is the embed URL, not a javascript: placeholder. Fancybox reads
-        // data-src and intercepts the click, so behaviour is unchanged, but a
-        // Content-Security-Policy no longer blocks the control and the visitor
-        // can middle-click or copy it like any other link.
+        // data-src and intercepts the click, so a Content-Security-Policy does
+        // not block the control and the visitor can middle-click or copy it
+        // like any other link.
         return '<a class="fancybox_player playhit" data-id="' . $mediaId
             . '" aria-hidden="false" data-src="' . $safeEmbedUrl
             . '" data-header="' . $headerText . '" data-footer="' . $footerText

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -180,12 +180,12 @@ class CwmmediafileController extends FormController
         // Load the addon
         $addon = CWMAddon::getInstance($addonType);
 
-        // Dispatch only to handlers the addon explicitly opted in. The old
-        // method_exists() check made every public method on every addon
-        // callable by request-supplied name -- including createLiveEvent()
-        // and cancelLiveEvent(), which act on the connected platform account.
-        // Those are invoked server-side (CwmmediafileModel/CwmmediafileTable)
-        // and deliberately stay off the allow-list.
+        // Dispatch only to handlers the addon explicitly opted in. A bare
+        // method_exists() check would make every public method on every addon
+        // callable by request-supplied name -- including createLiveEvent() and
+        // cancelLiveEvent(), which act on the connected platform account. Those
+        // are invoked server-side (CwmmediafileModel/CwmmediafileTable) and
+        // deliberately stay off the allow-list.
         if (!\in_array($handler, $addon->getXhrHandlers(), true) || !method_exists($addon, $handler)) {
             throw new \RuntimeException(
                 Text::sprintf('Handler: "%s" does not exist!', htmlspecialchars($handler, ENT_QUOTES, 'UTF-8')),

--- a/admin/src/Field/BookListField.php
+++ b/admin/src/Field/BookListField.php
@@ -97,8 +97,7 @@ class BookListField extends ListField
         foreach ($books as $book) {
             $name = ScriptureHelper::getBookName((int) $book->value);
 
-            // A number the library cannot name would render as a blank entry,
-            // which the old query could not produce: the row existed or it did not.
+            // A number the library cannot name would render as a blank entry.
             if ($name !== '') {
                 $options[] = HTMLHelper::_('select.option', $book->value, $name);
             }

--- a/admin/src/Field/TemplateListField.php
+++ b/admin/src/Field/TemplateListField.php
@@ -81,10 +81,9 @@ class TemplateListField extends ListField
 
         // parent::getOptions() reads THIS field instance's own XML <option>
         // children, which differ per form — only the DB-derived list above is
-        // safe to cache across instances. Caching the merged result (as this
-        // used to) meant a second TemplateList field with different XML
-        // options in the same request silently got the first instance's
-        // stale merged list.
+        // safe to cache across instances. ⚠️ Caching the merged result would
+        // give a second TemplateList field with different XML options in the
+        // same request the first instance's stale merged list.
         return array_merge(parent::getOptions(), self::$templates);
     }
 

--- a/admin/src/Helper/Cwmalias.php
+++ b/admin/src/Helper/Cwmalias.php
@@ -84,9 +84,6 @@ class Cwmalias
                     $db->setQuery($query);
 
                     // One unwritable row must not abandon the rest of the backfill.
-                    // Before this, a single failure (e.g. the unique-index collision
-                    // above) surfaced as an uncaught exception and left the operation
-                    // half-applied with no indication of how far it got.
                     try {
                         $db->execute();
                         $done++;

--- a/admin/src/Helper/Cwmhtml.php
+++ b/admin/src/Helper/Cwmhtml.php
@@ -267,9 +267,7 @@ class Cwmhtml
         }
 
         // Never null. HTMLHelper::_('select.options', ...) foreach()es this
-        // straight away and core has no null guard, so a failed query used to
-        // emit a TypeError warning into the middle of the batch dialog's markup.
-        // locationList() already did this correctly.
+        // straight away and core has no null guard.
         return [];
     }
 
@@ -327,9 +325,7 @@ class Cwmhtml
         }
 
         // Never null. HTMLHelper::_('select.options', ...) foreach()es this
-        // straight away and core has no null guard, so a failed query used to
-        // emit a TypeError warning into the middle of the batch dialog's markup.
-        // locationList() already did this correctly.
+        // straight away and core has no null guard.
         return [];
     }
 
@@ -387,9 +383,7 @@ class Cwmhtml
         }
 
         // Never null. HTMLHelper::_('select.options', ...) foreach()es this
-        // straight away and core has no null guard, so a failed query used to
-        // emit a TypeError warning into the middle of the batch dialog's markup.
-        // locationList() already did this correctly.
+        // straight away and core has no null guard.
         return [];
     }
 

--- a/admin/src/Helper/CwmlogHelper.php
+++ b/admin/src/Helper/CwmlogHelper.php
@@ -84,9 +84,9 @@ final class CwmlogHelper
      * Category => log file. Separate files keep an API security review from
      * having to wade through template migrations.
      *
-     * The first two filenames are inherited from admin/api.php, which used to own
-     * this registration — existing sites already have those files and may have log
-     * rotation pointed at them, so the names are kept.
+     * The first two filenames are inherited from admin/api.php's registration:
+     * existing sites already have those files and may have log rotation pointed
+     * at them, so the names are kept.
      *
      * @var    array<string, string>
      * @since  10.3.4

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -1065,13 +1065,10 @@ class CwmmigrationHelper
         // Write through Cwmparams, which merges into the stored params Registry
         // and clears the _system cache.
         //
-        // This previously ran its own UPDATE that set #__extensions.params to
-        // json_encode($existing) -- the mapping array alone, as the whole params
-        // column. Every other Proclaim setting on the site was replaced by it,
-        // and because the write bypassed ComponentHelper's cache the damage was
-        // invisible until the next request. Scenario 2A of
-        // migrateAccessToLocations() is the only caller, so a multi-campus
-        // migration wiped the component's configuration as a side effect.
+        // ⚠️ Through Cwmparams::setCompParams(), never a raw UPDATE of
+        // #__extensions.params — a direct write replaces every other Proclaim
+        // setting with this mapping alone, and bypasses ComponentHelper's cache
+        // so the damage stays invisible until the next request.
         Cwmparams::setCompParams(
             ['location_group_mapping' => json_encode($existing, JSON_THROW_ON_ERROR)]
         );

--- a/admin/src/Helper/CwmplaylistSyncHelper.php
+++ b/admin/src/Helper/CwmplaylistSyncHelper.php
@@ -1173,8 +1173,8 @@ final class CwmplaylistSyncHelper
             try {
                 $decoded = json_decode($params, true, 512, JSON_THROW_ON_ERROR);
             } catch (\JsonException $e) {
-                // Previously decoded to null and left $videoId null, so the
-                // requested playlist additions were dropped without a word.
+                // A response that will not decode means the requested additions
+                // are not happening — say so rather than dropping them silently.
                 CwmlogHelper::warning(
                     'Media file ' . $mediafileId . ' has an unreadable params column; its manual '
                     . 'playlist assignments were not applied: ' . $e->getMessage()

--- a/admin/src/Helper/CwmproclaimHelper.php
+++ b/admin/src/Helper/CwmproclaimHelper.php
@@ -63,11 +63,7 @@ class CwmproclaimHelper
      * Get the installed Proclaim version.
      *
      * Reads `#__extensions.manifest_cache`, which every Joomla application
-     * (site, admin, API, CLI) can query. This replaces the old
-     * BIBLESTUDY_VERSION constant, which admin/api.php only populated by
-     * parsing proclaim.xml off the filesystem, and only when the current
-     * client was 'administrator' — everywhere else, including the API
-     * application, it was an empty string.
+     * (site, admin, API, CLI) can query.
      *
      * @return  string  Semver version string, or '0.0.0' if unavailable
      *
@@ -99,7 +95,7 @@ class CwmproclaimHelper
         } catch (\Throwable $e) {
             self::$version = '0.0.0';
 
-            // Still '0.0.0' — callers rely on that fallback — but no longer silent.
+            // Still '0.0.0' — callers rely on that fallback — but logged.
             CwmlogHelper::error(
                 'Could not read the installed Proclaim version from #__extensions.manifest_cache; '
                 . 'reporting 0.0.0. ' . $e->getMessage()
@@ -514,9 +510,7 @@ class CwmproclaimHelper
         $query   = $db->createQuery();
 
         // Books come from the junction, so a study with more than two references
-        // offers all of them rather than the two the flat columns could hold
-        // . The name comes from the scripture library, which holds the
-        // language keys #__bsms_books used to store.
+        // offers all of them. The name comes from the scripture library.
         $query->select('DISTINCT ' . $db->quoteName('sr.booknumber', 'value'))
             ->from($db->quoteName('#__bsms_studies', 's'))
             ->join(

--- a/admin/src/Helper/CwmprotectedStorage.php
+++ b/admin/src/Helper/CwmprotectedStorage.php
@@ -41,8 +41,8 @@ use Joomla\Filesystem\Folder;
  * must never hand out a URL that works without permission.** Proclaim already
  * proxies media rather than redirecting to it — the exception being embedded
  * platforms like YouTube, which are players rather than files and were never
- * protectable by anyone. The feed no longer lists restricted items either
- * , so the origin URL of a private remote file is never published.
+ * protectable by anyone. The feed does not list restricted items either, so
+ * the origin URL of a private remote file is never published.
  *
  * What this directory adds is the remaining case: a file that has nowhere
  * private to live, because the site hosts it itself.

--- a/admin/src/Helper/CwmserverMigrationHelper.php
+++ b/admin/src/Helper/CwmserverMigrationHelper.php
@@ -343,11 +343,10 @@ class CwmserverMigrationHelper
         // match the live renderer's precedence in Cwmmedia.php, which sets
         // $player->player from docMan_id, then unconditionally overrides it
         // from article_id, then unconditionally overrides it again from
-        // virtueMart_id -- i.e. last-match-wins, so virtuemart beats
-        // article beats docman. Checking in [docman, article, virtuemart]
-        // order and returning on first match (as this loop used to) is the
-        // exact inverse and can migrate content to a different addon than
-        // what the site was actually rendering.
+        // virtueMart_id -- i.e. last-match-wins, so virtuemart beats article
+        // beats docman. ⚠️ Checking in [docman, article, virtuemart] order and
+        // returning on first match is the exact inverse, and migrates content
+        // to a different addon than the site is rendering.
         $legacyIdFields = [
             ['4', 'docMan_id',     'docman'],
             ['5', 'article_id',    'article'],

--- a/admin/src/Helper/CwmtemplatemigrationHelper.php
+++ b/admin/src/Helper/CwmtemplatemigrationHelper.php
@@ -590,11 +590,8 @@ class CwmtemplatemigrationHelper
                     // Only copy the stale old-name value over the new name if
                     // the new name isn't already populated -- otherwise this
                     // clobbers a value an admin already saved under the new
-                    // name (e.g. picked a different teacher via lteacher_id
-                    // after this template's teacher_id migration hadn't run
-                    // yet) with the older, no-longer-current value. Matches
-                    // the guard applyParamsToTemplates() uses for the same
-                    // reason.
+                    // name. Matches the guard applyParamsToTemplates() uses for
+                    // the same reason.
                     if ($registry->get($newName) === null) {
                         $registry->set($newName, $oldValue);
                     }

--- a/admin/src/Helper/Cwmthumbnail.php
+++ b/admin/src/Helper/Cwmthumbnail.php
@@ -184,10 +184,10 @@ class Cwmthumbnail
     /**
      * Collapse '.' and '..' segments without requiring the path to exist.
      *
-     * Path::clean() normalises separators but leaves '..' in place, which is
-     * what allowed the old prefix checks to be walked out of. realpath() would
-     * collapse them but returns false for paths that do not exist yet, and
-     * callers legitimately pass those.
+     * Path::clean() normalises separators but leaves '..' in place, so a prefix
+     * check alone can be walked out of. realpath() would collapse them but
+     * returns false for paths that do not exist yet, and callers legitimately
+     * pass those.
      *
      * Relative-vs-absolute is preserved rather than assumed: JPATH_ROOT is not
      * always absolute (phpunit.xml defines it as '.'), so forcing a leading

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -725,9 +725,8 @@ class Cwmassets
     /**
      * The asset a section's item rows should hang from.
      *
-     * Item assets used to be parented to `com_proclaim`, which meant a rule on
-     * `com_proclaim.<section>` never reached them — a record with per-record
-     * permissions escaped its section entirely.
+     * ⚠️ An item asset parented to `com_proclaim` escapes its section entirely:
+     * a rule on `com_proclaim.<section>` never reaches it.
      *
      * Falls back to the component for a section access.xml does not declare, so
      * `message_type`, `cwmadmin` and `studytopics` keep their old parent until
@@ -835,17 +834,14 @@ class Cwmassets
      * Clean ALL Proclaim assets: clean orphans, delete empty-rules rows,
      * fix parent_id on surviving rows, rebuild the nested-set tree.
      *
-     * **Inverted from the pre-10.3.0 behavior**: this method no longer
-     * creates an asset row for every Proclaim record with default rules.
-     * On mature sites that produced thousands of `com_proclaim.*` rows
-     * whose `rules` column was the empty template — Joomla still had to
-     * load them all during `Access::preload()`, accounting for ~72% of
-     * the admin page-load time on some installs.
+     * Does not create an asset row for every Proclaim record with default
+     * rules. Joomla loads every `com_proclaim.*` row during `Access::preload()`,
+     * so empty-template rows cost admin page-load time for nothing.
      *
-     * Net effect: Proclaim's asset tree now contains only the com_proclaim
-     * parent plus any records where an admin has genuinely customised the
-     * rules. Permission checks still work for everything else because
-     * Joomla walks the ancestor chain up to the parent.
+     * Net effect: Proclaim's asset tree contains only the com_proclaim parent
+     * plus any records where an admin has genuinely customised the rules.
+     * Permission checks still work for everything else because Joomla walks the
+     * ancestor chain up to the parent.
      *
      * @return void
      *
@@ -1203,15 +1199,14 @@ class Cwmassets
     /**
      * Repair a single record's asset link.
      *
-     * **Behavior changed in 10.3.0**: this no longer creates a new asset
-     * row for records that lack one. If a record has no `asset_id` (or
-     * points at a missing row) and the only thing we could create would
-     * be an empty-rules placeholder, we leave it alone — permission
-     * checks fall through to the `com_proclaim` parent asset, which is
-     * what we want. Creating them instead accumulates thousands of empty rows
-     * that slow `Access::preload('com_proclaim')` down for no benefit.
+     * Does not create a new asset row for records that lack one. If a record
+     * has no `asset_id` (or points at a missing row) and the only thing we
+     * could create would be an empty-rules placeholder, we leave it alone —
+     * permission checks fall through to the `com_proclaim` parent asset, which
+     * is what we want. Creating them instead accumulates thousands of empty
+     * rows that slow `Access::preload('com_proclaim')` down for no benefit.
      *
-     * What it still does:
+     * What it does:
      *   - Relink a record to an existing, real-rules asset row by name.
      *   - Delete the record's asset row if the rules turned out to be
      *     empty/default, and null `asset_id` on the record.

--- a/admin/src/Model/CwmassetsModel.php
+++ b/admin/src/Model/CwmassetsModel.php
@@ -338,11 +338,10 @@ class CwmassetsModel extends ListModel
     /**
      * Collect per-table asset status counts.
      *
-     * **Behavior changed in 10.3.0**: Proclaim no longer registers a
-     * per-record #__assets row for every item. Records with `asset_id = 0`
-     * inherit permission checks from the com_proclaim parent, and that is
-     * now the normal, desired state. The returned shape reflects the new
-     * model — see `Cwmassets::getAssetStatus()` for key meanings.
+     * Proclaim does not register a per-record #__assets row for every item.
+     * Records with `asset_id = 0` inherit permission checks from the
+     * com_proclaim parent, and that is the normal, desired state — see
+     * `Cwmassets::getAssetStatus()` for key meanings.
      *
      * @return  array
      *

--- a/admin/src/Model/CwmmediafileModel.php
+++ b/admin/src/Model/CwmmediafileModel.php
@@ -297,12 +297,11 @@ class CwmmediafileModel extends AdminModel
                 $filenameChanged = ($oldFilename !== $newFilename) || ($oldServerId !== $newServerId);
             }
 
-            // Clearing a detected field is how an administrator asks for it to be
-            // worked out again — the obvious gesture, which the gate above used to
-            // swallow because the filename had not changed. Detecting the clear
-            // itself (rather than "is anything missing?") keeps this to the one
-            // save that cleared it, so platforms that can never supply a value do
-            // not re-hit their API on every subsequent save.
+            // Clearing a detected field is how an administrator asks for it to
+            // be worked out again. Detecting the clear itself (rather than "is
+            // anything missing?") keeps this to the one save that cleared it, so
+            // platforms that can never supply a value do not re-hit their API on
+            // every subsequent save.
             $clearedForRedetect = $oldParams !== null
                 && $this->metadataWasCleared($oldParams, $params);
 

--- a/admin/src/Service/HTML/CWMHtml5Inline.php
+++ b/admin/src/Service/HTML/CWMHtml5Inline.php
@@ -47,7 +47,7 @@ class CWMHtml5Inline
     ): string {
         $popupMarg = 0;
 
-        // Used to set for MP3 and audio player look
+        // MP3 and audio player look.
         if (isset($player->mp3) && $player->mp3 === true) {
             $media->playerheight = 30;
         } else {

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -338,10 +338,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
 
             // One rule for every tile: show a destination only to someone who
             // could do something once they arrive. access.xml defines a section
-            // per entity, so each tile asks about its own -- previously a few
-            // were gated on core.admin (Super User only, hiding them from
-            // legitimate managers) and the rest on nothing at all, which sent
-            // users to a 403 the component dispatcher raises.
+            // per entity, so each tile asks about its own.
             $canSee = static fn (string $section): bool =>
                 $cpanelUser->authorise('core.edit', 'com_proclaim.' . $section)
                 || $cpanelUser->authorise('core.create', 'com_proclaim.' . $section)

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -949,7 +949,7 @@ class com_proclaimInstallerScript extends InstallerScript
         // Clean up the action log registration
         $this->cleanupActionLogConfig();
 
-        // We no longer depend on lib_cwmscripture — stop blocking its removal
+        // Proclaim is going away — stop blocking the library's removal.
         $this->scriptureConsumer('unregister');
 
         // Show the post-uninstalling page
@@ -962,8 +962,7 @@ class com_proclaimInstallerScript extends InstallerScript
      * Remove Proclaim's rows from Joomla's action-log tables.
      *
      * `install.mysql.utf8.sql` seeds `#__action_log_config` with one row per
-     * loggable entity, and `10.1.0-20260207.sql` adds to it, but nothing has
-     * ever taken them out again — five rows survived every uninstall.
+     * loggable entity, and `10.1.0-20260207.sql` adds to it.
      *
      * Deliberately not part of `dropTablesIfRequested()`. That is gated on the
      * administrator's `drop_tables` setting because it destroys sermons; these
@@ -1787,8 +1786,7 @@ class com_proclaimInstallerScript extends InstallerScript
         // install's SQL already creates the current schema, so there is nothing
         // to migrate — running these against freshly seeded default rows only
         // produces spurious warnings (e.g. the podcast-link "could not be
-        // matched" notice) and, historically, fatals when a moved helper no
-        // longer exists.
+        // matched" notice).
         if ($type === 'update') {
             // Fix legacy image paths in mediafile params (images/biblestudy/ -> media/com_proclaim/images/)
             try {


### PR DESCRIPTION
Second pass of the narrative-marker half of #1826, scoped to `admin/`. Follows the same method as #1830 for `site/`.

**Comment-only — no line outside a comment is touched**, and every docblock tag survives. Both verified mechanically:

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(//|\*|/\*|\*/)'
→ (empty)

@param/@return/@since/@throws/@var/@deprecated counts, per file, before vs after
→ all preserved
```

### 90 blocks flagged → 28 changed

The other **62 stay**, and this is the part a regex could not have done:

- **False positives on "is used to"** — `(used to detect email campaigns)`, `Used to confirm what actually changed`, `format string used to bucket time-series rows`.
- **"a record that was never created"** — 15 `*Table.php` files share a comment explaining why `stripEmptyAssetRow()` is unconditional. That is a live trap (a *failed* `store()` still writes the asset row), not history.
- **Present-tense "no longer"** — `an asset row whose source record no longer exists`, `@deprecated … no longer maintained`, `a broadcast YouTube no longer lists is success`.
- **Migration helpers legitimately talking about old data** — `the old bare-ID folder`, `rows that still contain the old paths`. The old thing is the input, not a previous implementation.

### Warnings were restated, not deleted

Where a removed sentence was carrying the reason someone must not simplify the code back, it is rewritten in the present tense and marked ⚠️ rather than dropped:

| File | Kept as |
|---|---|
| `admin/api.php` | A URL parameter is not authorisation — `filterAjax()` ships the debug buffer to the browser |
| `admin/api.php` | This file does **not** only run in web applications — `scheduler:run` reaches it with a `ConsoleApplication` |
| `CwmmediafileController` | A bare `method_exists()` would expose `createLiveEvent()`/`cancelLiveEvent()` to request-supplied names |
| `CwmmigrationHelper` | Params must go through `Cwmparams::setCompParams()`, never a raw `#__extensions.params` UPDATE |
| `TemplateListField` | Caching the merged result hands the next instance a stale list |
| `CwmserverMigrationHelper` | The docman/article/virtuemart precedence is last-match-wins; the inverse migrates to the wrong addon |

### Verification

- `composer lint` — 0 of 612
- `composer lint:comments` — clean
- `php -l` on all 21 changed files
- Docblock tag counts unchanged per file

### Remaining

`plugins/` narrative markers; this issue stays open for them.

Part of #1826.