### PR TITLE
chore: drop two comments that restate their condition

### DIFF
--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -231,7 +231,6 @@ final class Proclaim extends Adapter implements SubscriberInterface
 
         // We only want to handle messages here
         if ($context === 'com_proclaim.cwmmessage' || $context === 'com_proclaim.message' || $context === 'com_proclaim.form') {
-            // Query the database for the old access level if the item isn't new
             if (!$isNew) {
                 $this->checkItemAccess($row);
             }
@@ -239,7 +238,6 @@ final class Proclaim extends Adapter implements SubscriberInterface
 
         // Check for access levels from the Series.
         if ($context === 'com_proclaim.cwmserie' || $context === 'com_proclaim.series') {
-            // Query the database for the old access level if the item isn't new.
             if (!$isNew) {
                 $this->checkSeriesAccess($row);
             }


### PR DESCRIPTION
Final pass of the narrative-marker half of #1826, scoped to `plugins/`.

**The plugins tree had no narrative comments.** A marker scan flagged 6 blocks across 2 files; all 6 describe the present:

| Flagged | Why it stays |
|---|---|
| `Map of old com_biblestudy view names to new com_proclaim equivalents` | The old component is the redirect map's *input*, not a previous implementation |
| `Redirect legacy com_biblestudy URLs … maps the old view name` | What the method does today |
| `The old series access level before saving` | A property holding the pre-save value |
| `Method to get the SQL query used to retrieve …` | "is used to" |

So the only change is two comments that restate their own condition:

```php
// We only want to handle messages here
if ($context === 'com_proclaim.cwmmessage' || …) {
-    // Query the database for the old access level if the item isn't new
    if (!$isNew) {
        $this->checkItemAccess($row);
```

The branch comment above already says which context the arm handles, and `if (!$isNew)` reads itself. Same shape in the series arm below it.

(The two arms look like duplicated logic at a glance but are not — they call `checkItemAccess()` and `checkSeriesAccess()` respectively.)

`plugins/content/scripturelinks` is a submodule and out of scope, consistent with `composer lint:comments`.

### Verification

- Comment-only: no line outside a comment is touched
- `composer lint` — 0 of 612
- `composer lint:comments` — clean
- `php -l` clean

### This closes out #1826

| Half | Scope | PR |
|---|---|---|
| Citations | site | #1827 |
| Citations | admin, plugins | #1828 |
| Citations | CI gate | #1829 |
| Narrative | site | #1830 |
| Narrative | admin | #1831 |
| Narrative | plugins | this |

Closes #1826.