### PR TITLE
fix: bind the comment moderation toggles without inline handlers

### DIFF
--- a/admin/tmpl/cwmcomments/default.php
+++ b/admin/tmpl/cwmcomments/default.php
@@ -41,6 +41,7 @@ if ($saveOrder) {
 
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')
+    ->useScript('list-view')
     ->useScript('form.validate')
     ->addInlineScript(
         '
@@ -200,37 +201,23 @@ echo Route::_('index.php?option=com_proclaim&view=cwmcomments'); ?>" method="pos
                                     echo HTMLHelper::_('grid.id', $i, $item->id); ?>
                                 </td>
                                 <td class="text-center d-none d-md-table-cell">
-                                    <?php if ($item->published == 1) : ?>
-                                        <a href="javascript:void(0);"
-                                           onclick="return Joomla.listItemTask('cb<?php echo $i; ?>', 'cwmcomments.unpublish')"
-                                           class="tbody-icon<?php echo !$canChange ? ' disabled' : ''; ?>"
-                                           title="<?php echo Text::_('JBS_CMT_APPROVED'); ?>">
-                                            <span class="badge text-bg-success">
-                                                <span class="icon-check text-white" aria-hidden="true"></span>
-                                                <?php echo Text::_('JBS_CMT_APPROVED'); ?>
-                                            </span>
-                                        </a>
-                                    <?php elseif ($item->published == 0) : ?>
-                                        <a href="javascript:void(0);"
-                                           onclick="return Joomla.listItemTask('cb<?php echo $i; ?>', 'cwmcomments.publish')"
-                                           class="tbody-icon<?php echo !$canChange ? ' disabled' : ''; ?>"
-                                           title="<?php echo Text::_('JBS_CMT_PENDING_APPROVAL'); ?>">
-                                            <span class="badge text-bg-warning">
-                                                <span class="icon-clock text-dark" aria-hidden="true"></span>
-                                                <?php echo Text::_('JBS_CMT_PENDING_APPROVAL'); ?>
-                                            </span>
-                                        </a>
-                                    <?php else : ?>
-                                        <a href="javascript:void(0);"
-                                           onclick="return Joomla.listItemTask('cb<?php echo $i; ?>', 'cwmcomments.publish')"
-                                           class="tbody-icon<?php echo !$canChange ? ' disabled' : ''; ?>"
-                                           title="<?php echo Text::_('JTRASHED'); ?>">
-                                            <span class="badge text-bg-secondary">
-                                                <span class="icon-trash text-white" aria-hidden="true"></span>
-                                                <?php echo Text::_('JTRASHED'); ?>
-                                            </span>
-                                        </a>
-                                    <?php endif; ?>
+                                    <?php
+                                    // Approved toggles back to pending. Both of the other
+                                    // states approve, so they share a task.
+                                    [$stateClass, $stateIcon, $stateLabel, $stateTask] = match ((int) $item->published) {
+                                        1       => ['text-bg-success', 'icon-check text-white', Text::_('JBS_CMT_APPROVED'), 'unpublish'],
+                                        0       => ['text-bg-warning', 'icon-clock text-dark', Text::_('JBS_CMT_PENDING_APPROVAL'), 'publish'],
+                                        default => ['text-bg-secondary', 'icon-trash text-white', Text::_('JTRASHED'), 'publish'],
+                                    };
+                                    ?>
+                                    <button type="button"
+                                            class="js-grid-item-action badge border-0 <?php echo $stateClass; ?>"
+                                            data-item-id="cb<?php echo $i; ?>"
+                                            data-item-task="cwmcomments.<?php echo $stateTask; ?>"
+                                            <?php echo $canChange ? '' : 'disabled'; ?>>
+                                        <span class="<?php echo $stateIcon; ?>" aria-hidden="true"></span>
+                                        <?php echo $stateLabel; ?>
+                                    </button>
                                 </td>
                                 <td class="nowrap has-context" style="width:10%;">
                                     <div class="float-left">


### PR DESCRIPTION
Shape 2 of #1824 — the last one. Tested in a browser against real data, which is what it was waiting for.

## The change

Each of the three moderation states rendered an anchor with a placeholder href and its behaviour in an `onclick`:

```php
<a href="javascript:void(0);"
   onclick="return Joomla.listItemTask('cb<?php echo $i; ?>', 'cwmcomments.unpublish')"
   class="tbody-icon<?php echo !$canChange ? ' disabled' : ''; ?>">
```

They are now buttons carrying `data-item-id` / `data-item-task`, bound by core's `list-view.js`. The three branches collapse into one `match` — they differed only in badge colour, icon, label and task. Net −31/+18 lines.

## ⚠️ The trap that would have shipped a dead control

`list-view.js` walks up **one** level from a clicked `<span>` to find the control:

```js
if (item.nodeName === 'SPAN' && ['A','BUTTON'].includes(item.parentNode.nodeName)) {
  item = item.parentNode;
}
```

The old markup nested spans two deep — `<a><span class="badge"><span class="icon-check">`. Keeping that structure and simply swapping the anchor for a button would leave a click **on the icon** resolving to the badge span, which is neither `A` nor `BUTTON`, so the walk fails, `data-item-task` is absent and the handler returns silently.

So the button **is** the badge rather than wrapping one, leaving a single span level.

## It also makes the permission gate real

`!$canChange` rendered a `disabled` **CSS class** on an anchor whose `onclick` fired regardless — a control that looked inert and was not. A `disabled` **attribute** on a button stops native activation, and `list-view.js` checks `hasAttribute('disabled')` too.

## `list-view.js` is now requested explicitly

It was already on the page, but only because the row checkboxes pull it in. That would have tied the toggles to a column that can be hidden.

This also answers the concern in the issue that shape 2 "needs an asset Proclaim does not register" — the asset is core's `list-view`, and one `useScript` line is the whole cost.

## Verified on j6-dev

Seeded 11 comments across all three states (realistic ones — questions about transcripts and audio dropouts, plus a spam row, left in place as test data).

| Exercise | Result |
|---|---|
| Pending → click → approved | row 25 `published` 0 → 1, "1 item(s) published", header count 3 → 2 pending |
| Approved → click → pending | row 25 `published` 1 → 0 |
| Trashed → click → approved | row 28 `published` -2 → 1 |
| Only the clicked row changes | rows 26, 27 untouched throughout |
| Simulated no-permission render | with `disabled`, task not called; without it, called |
| Console | no errors |
| Badge appearance | unchanged from before (screenshots compared) |

## What I did not verify, and why

**I did not toggle a live CSP.** MAMP has `AllowOverride` off so an `.htaccess` header was ignored, and the alternative is changing the HTTP Headers plugin's settings on your site, which I did not want to do unasked.

That step was in the bench plan to stop the tests passing for the wrong reason — but it is not what distinguishes fixed from broken here. The direct checks do: the template contains **no** `onclick` or `javascript:` at all, and the click works through an external script's delegated listener. That an `onclick` attribute needs `'unsafe-inline'` is a spec guarantee, not something this fix depends on.

Say the word and I will enable the plugin and re-run.

## Still upstream, not ours

Two inline handlers remain on the page and both are outside Proclaim:

- `Joomla.checkAll(this)` — emitted by core's own `HTMLHelper::_('grid.checkall')` (`libraries/src/HTML/Helpers/Grid.php:94`)
- `RegularLabs.CacheCleaner.purge()` and two `href="javascript:"` — Regular Labs Cache Cleaner

Same category as shape 1, whose five `select-link` lines are verbatim copies of `com_contact`/`com_content`.

## #1824 after this

All four shapes are done: shape 4 in #1825, shape 3 in #1833, shape 2 here. Shape 1 stays an upstream matter.

Closes #1824.