### PR TITLE
ci: run the workflows on 11.0.0-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "development", "10.x" ]
+    branches: [ "development", "10.x", "11.0.0-dev" ]
     paths-ignore:
       - '**.md'
       - 'admin/language/**'
@@ -10,7 +10,7 @@ on:
       - 'build/mockups/**'
       - '.claude/**'
   pull_request:
-    branches: [ "development", "10.x" ]
+    branches: [ "development", "10.x", "11.0.0-dev" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "development", "10.x" ]
+    branches: [ "development", "10.x", "11.0.0-dev" ]
   pull_request:
-    branches: [ "development", "10.x" ]
+    branches: [ "development", "10.x", "11.0.0-dev" ]
   schedule:
     - cron: '15 6 * * 5'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ on:
     # Nightly, 05:17 UTC — off the busy top-of-hour cron load.
     - cron: '17 5 * * *'
   pull_request:
-    branches: [ "development", "10.x" ]
+    branches: [ "development", "10.x", "11.0.0-dev" ]
     paths:
       - 'api/**'
       - 'plugins/webservices/**'


### PR DESCRIPTION
The 11.0.0 integration branch has **no CI**.

All three workflows are scoped to `development` and `10.x`:

```yaml
push:         branches: [ "development", "10.x" ]
pull_request: branches: [ "development", "10.x" ]
```

So a push to `11.0.0-dev` matches nothing, and a PR targeting it matches nothing. The 9.x wizard removal (`0f6ce3f8f`, 2,261 deletions) landed on local verification alone, and anything merged into the branch afterwards would have been unchecked too.

Adds `11.0.0-dev` to `ci.yml`, `codeql.yml` and `e2e.yml`.

### Why on `development` rather than just on the branch

If it lived only on `11.0.0-dev`, the next `development` → `11.0.0-dev` merge would revert it. Putting it on `development` makes it the canonical config, and the branch picks it up on the same merge that keeps it current.

⚠️ A `pull_request` run uses the workflow file from the **base** branch, so this has no effect on PRs into `11.0.0-dev` until `development` is merged into it. That merge is the next step.

### Verification

- All four workflow files parse as valid YAML
- Resulting triggers:

| workflow | push | pull_request |
|---|---|---|
| ci | development, 10.x, 11.0.0-dev | development, 10.x, 11.0.0-dev |
| codeql | development, 10.x, 11.0.0-dev | development, 10.x, 11.0.0-dev |
| e2e | — (schedule/dispatch) | development, 10.x, 11.0.0-dev |