### PR TITLE
fix: run a legacy migration only for the versions that need it

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -111,6 +111,18 @@ class com_proclaimInstallerScript extends InstallerScript
      * @var    string
      * @since  3.6
      */
+    /**
+     * The version this update is coming from, read before Joomla overwrites it.
+     *
+     * Empty on a fresh install, and on any update where the row cannot be read —
+     * both of which mean "assume the oldest case and run everything", because a
+     * migration skipped in error loses data while one run in error costs time.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private string $fromVersion = '';
+
     protected $minimumPhp = '8.3.0';
 
     /**
@@ -354,6 +366,68 @@ class com_proclaimInstallerScript extends InstallerScript
     ];
 
     /**
+     * The version currently recorded for com_proclaim.
+     *
+     * Reads `#__extensions.manifest_cache` rather than `#__schemas`, which lags
+     * behind the release version — see CwmproclaimHelper::getVersion().
+     *
+     * @return  string  Semver, or '' when it cannot be determined
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function readInstalledVersion(): string
+    {
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->createQuery()
+                ->select($db->quoteName('manifest_cache'))
+                ->from($db->quoteName('#__extensions'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+            $db->setQuery($query);
+
+            $cache = (string) $db->loadResult();
+
+            if ($cache === '') {
+                return '';
+            }
+
+            $decoded = json_decode($cache, true, 512, JSON_THROW_ON_ERROR);
+
+            return (string) ($decoded['version'] ?? '');
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+
+    /**
+     * Whether a migration first shipped in `$version` still has work to do here.
+     *
+     * ⚠️ A migration that ran on the update that introduced it does not need to
+     * run again, but nothing recorded that it had. With no gate, a 10.5.7 site
+     * re-ran every migration written since 10.0 — nine of them, each walking
+     * whole tables to discover there was nothing to do. That is what made
+     * updates take minutes on a site with real content.
+     *
+     * ⚠️ An unknown source version returns true. Skipping a migration that was
+     * needed loses data; running one that was not costs time.
+     *
+     * @param   string  $version  The release the migration shipped in
+     *
+     * @return  bool  True when the site is older than that release
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function upgradingFromBefore(string $version): bool
+    {
+        if ($this->fromVersion === '') {
+            return true;
+        }
+
+        return version_compare($this->fromVersion, $version, '<');
+    }
+
+    /**
      * Function called before the extension installation/update/removal procedure commences
      *
      * @param   string            $type    The type of change (install, update, or discover_install, not uninstall)
@@ -366,6 +440,13 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     public function preflight($type, $parent): bool
     {
+        // Read before Joomla rewrites manifest_cache with the incoming version.
+        // postflight() cannot ask this question — by then the row says the new
+        // version and every migration looks unnecessary.
+        if ($type === 'update') {
+            $this->fromVersion = $this->readInstalledVersion();
+        }
+
         // com_proclaim depends on lib_cwmscripture. The standalone
         // component zip does not bundle the library, and even when
         // installed via pkg_proclaim the library lands one step before
@@ -1787,48 +1868,71 @@ class com_proclaimInstallerScript extends InstallerScript
         // to migrate — running these against freshly seeded default rows only
         // produces spurious warnings (e.g. the podcast-link "could not be
         // matched" notice).
+        // ⚠️ Each of these is gated on the version being upgraded FROM. A
+        // migration that shipped in 10.1.0 has nothing to do on a site already
+        // past 10.1.0, but none of them could tell — they loaded whole tables to
+        // find out, on every update, forever. Nine of them made a routine update
+        // take minutes on a site with real content.
         if ($type === 'update') {
             // Fix legacy image paths in mediafile params (images/biblestudy/ -> media/com_proclaim/images/)
-            try {
-                CwmmigrationHelper::fixMediafileLegacyPaths();
-            } catch (\Exception $e) {
-                Factory::getApplication()->enqueueMessage(
-                    'Mediafile path migration notice: ' . $e->getMessage(),
-                    'warning'
-                );
+            if ($this->upgradingFromBefore('10.1.0')) {
+                try {
+                    CwmmigrationHelper::fixMediafileLegacyPaths();
+                } catch (\Exception $e) {
+                    Factory::getApplication()->enqueueMessage(
+                        'Mediafile path migration notice: ' . $e->getMessage(),
+                        'warning'
+                    );
+                }
             }
 
             // Migrate studyimage param values to thumbnailm column
-            try {
-                $this->migrateStudyImageParams();
-            } catch (\Exception $e) {
-                Factory::getApplication()->enqueueMessage(
-                    'StudyImage migration notice: ' . $e->getMessage(),
-                    'warning'
-                );
+            if ($this->upgradingFromBefore('10.1.0')) {
+                try {
+                    $this->migrateStudyImageParams();
+                } catch (\Exception $e) {
+                    Factory::getApplication()->enqueueMessage(
+                        'StudyImage migration notice: ' . $e->getMessage(),
+                        'warning'
+                    );
+                }
             }
 
             // Drop vestigial text/pdf columns from templates table.
             // Done in PHP because ALTER TABLE DROP COLUMN is not idempotent.
-            $this->dropLegacyTemplateColumns();
+            if ($this->upgradingFromBefore('10.3.2')) {
+                $this->dropLegacyTemplateColumns();
+            }
 
             // Drop pre-10.1 / pre-10.0 orphaned tables that linger on sites
             // upgraded across multiple major versions (Joomla skips already-
             // applied migrations on jump-upgrades, so the per-version DROPs
             // never run).
-            $this->dropLegacyTables();
+            if ($this->upgradingFromBefore('10.1.0')) {
+                $this->dropLegacyTables();
+            }
 
             // Migrate existing alternate link data to platform_links JSON
-            $this->migratePodcastAlternateLinks();
+            if ($this->upgradingFromBefore('10.1.0')) {
+                $this->migratePodcastAlternateLinks();
+            }
 
             // Copy legacy image field to podcastimage where podcastimage is empty
-            $this->migratePodcastImageField();
+            if ($this->upgradingFromBefore('10.1.0')) {
+                $this->migratePodcastImageField();
+            }
 
-            // Match legacy podcastlink URLs to Joomla menu item IDs
-            $this->migratePodcastLinkToMenuItem();
+            // Match legacy podcastlink URLs to Joomla menu item IDs. This is the
+            // one that reported "N podcast link(s) could not be matched" on every
+            // update, about rows it had already declined to match before.
+            if ($this->upgradingFromBefore('10.3.0')) {
+                $this->migratePodcastLinkToMenuItem();
+            }
 
             // Migrate scripture settings from component params to plugin params
-            $this->migrateScriptureParamsToPlugin();
+            if ($this->upgradingFromBefore('10.5.8')) {
+                $this->migrateScriptureParamsToPlugin();
+            }
         }
 
         if ($type === 'install' || $type === 'update') {

--- a/tests/unit/Admin/Lib/MigrationVersionGateTest.php
+++ b/tests/unit/Admin/Lib/MigrationVersionGateTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Legacy migrations must run for the sites that need them, and no others.
+ *
+ * Nine migrations in postflight were gated only on `$type === 'update'`, with no
+ * record of having run and no cheap way to tell whether there was anything to
+ * do. A site on 10.5.7 therefore re-ran migrations written for 10.0 → 10.1,
+ * loading whole tables each time to discover the answer was no. On a site with
+ * real content that turned a routine update into minutes of spinner (#1841).
+ *
+ * ⚠️ The failure modes are not symmetric. Running a migration that was not
+ * needed costs time; skipping one that was needed loses data. Every assertion
+ * here is written from that asymmetry — an unknown source version must run
+ * everything.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+class MigrationVersionGateTest extends ProclaimTestCase
+{
+    /**
+     * @return  string  The manifest script's source
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function script(): string
+    {
+        return (string) file_get_contents(\dirname(__DIR__, 4) . '/proclaim.script.php');
+    }
+
+    /**
+     * The gate's own logic, mirrored so it can be exercised without booting the
+     * installer. Kept honest by testTheMirrorMatchesTheSource() below.
+     *
+     * @param   string  $from   Version being upgraded from ('' when unknown)
+     * @param   string  $since  Release the migration shipped in
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function gate(string $from, string $since): bool
+    {
+        if ($from === '') {
+            return true;
+        }
+
+        return version_compare($from, $since, '<');
+    }
+
+    /**
+     * @return  array<string, array{0: string, 1: string, 2: bool, 3: string}>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function cases(): array
+    {
+        return [
+            'unknown source runs everything'                    => ['', '10.1.0', true, 'A source version that cannot be read must be treated as the oldest case.'],
+            'a 10.5.7 site skips a 10.1.0 migration'            => ['10.5.7', '10.1.0', false, 'This is the case that made updates slow.'],
+            'a 10.0.0 site still runs it'                       => ['10.0.0', '10.1.0', true, 'The migration exists for exactly this site.'],
+            'the release that introduced it does not re-run it' => ['10.1.0', '10.1.0', false, 'It ran on the update that installed 10.1.0.'],
+            'a pre-release of the target still runs it'         => ['10.1.0-beta1', '10.1.0', true, 'A beta predates the release, so the migration has not run.'],
+            'a 10.3.1 site runs a 10.3.2 migration'             => ['10.3.1', '10.3.2', true, 'One patch short is still short.'],
+            'a 9.x source runs everything'                      => ['9.2.8', '10.5.8', true, 'The oldest supported source needs every migration.'],
+        ];
+    }
+
+    /**
+     * @param   string  $from   Source version
+     * @param   string  $since  Migration's release
+     * @param   bool    $runs   Whether it should run
+     * @param   string  $why    Why that is the answer
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[DataProvider('cases')]
+    #[TestDox('$_dataName')]
+    public function testTheGate(string $from, string $since, bool $runs, string $why): void
+    {
+        self::assertSame($runs, self::gate($from, $since), $why);
+    }
+
+    /**
+     * The mirror above is only useful if it is the same rule the script applies.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('the gate mirrored here matches the one in the script')]
+    public function testTheMirrorMatchesTheSource(): void
+    {
+        $source = self::script();
+
+        self::assertStringContainsString(
+            'private function upgradingFromBefore(string $version): bool',
+            $source,
+            'The gate has been renamed or removed; this test is no longer checking anything real.'
+        );
+
+        self::assertMatchesRegularExpression(
+            '~upgradingFromBefore\(string \$version\): bool\s*\{\s*if \(\$this->fromVersion === \'\'\) \{\s*return true;~',
+            $source,
+            'The unknown-source case no longer returns true, so a site whose version cannot be read would '
+            . 'silently skip migrations it needs.'
+        );
+
+        self::assertStringContainsString(
+            "version_compare(\$this->fromVersion, \$version, '<')",
+            $source,
+            'The comparison is no longer a strict less-than, so the release that introduced a migration would '
+            . 're-run it (or a site one release short would skip it).'
+        );
+    }
+
+    /**
+     * ⚠️ Anti-regression: a migration added to that block without a gate would
+     * reintroduce exactly the problem, and nothing else would notice.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('every migration in the update block is gated')]
+    public function testEveryMigrationIsGated(): void
+    {
+        $source = self::script();
+        $start  = strpos($source, 'The remaining legacy data migrations run on UPGRADES only');
+
+        self::assertNotFalse($start, 'The update-only migration block could not be found.');
+
+        // The block runs to the next top-level `if ($type === 'install'`.
+        $end = strpos($source, "if (\$type === 'install' || \$type === 'update')", $start);
+
+        self::assertNotFalse($end, 'The end of the migration block could not be found.');
+
+        $block = substr($source, $start, $end - $start);
+
+        preg_match_all('~^\s{12}(?:\$this->|CwmmigrationHelper::)(\w+)\(\);~m', $block, $ungated);
+
+        self::assertSame(
+            [],
+            $ungated[1],
+            'These migrations run without a version gate, so every update re-runs them: '
+            . implode(', ', $ungated[1])
+            . '. Wrap each in if ($this->upgradingFromBefore(\'X.Y.Z\')) naming the release it shipped in.'
+        );
+
+        self::assertGreaterThanOrEqual(
+            8,
+            preg_match_all('~upgradingFromBefore\(\'~', $block),
+            'Fewer gates than expected — a migration may have lost one.'
+        );
+    }
+
+    /**
+     * The version has to be read before Joomla overwrites it.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('the source version is captured in preflight, not postflight')]
+    public function testTheVersionIsReadEarly(): void
+    {
+        $source    = self::script();
+        $preflight = strpos($source, 'public function preflight(');
+        $capture   = strpos($source, '$this->fromVersion = $this->readInstalledVersion();');
+
+        self::assertNotFalse($capture, 'The source version is never captured.');
+        self::assertNotFalse($preflight, 'preflight() could not be found.');
+
+        self::assertGreaterThan(
+            $preflight,
+            $capture,
+            'The capture must be inside preflight. By postflight, manifest_cache already holds the incoming '
+            . 'version, so every gate would compare the new version against itself and skip everything.'
+        );
+    }
+}


### PR DESCRIPTION
First half of #1841. Removes the time; the progress-feedback half is separate and follows.

## What was happening

Your 10.5.7 → 10.5.8 update on christianwebministries.org ran **eight migrations written for 10.0 and 10.1**. It ran them on the update before that, and would have run them on every update after. Nothing gated them on the version being upgraded from, and nothing recorded that they had already run:

| | |
|---|---|
| `version_compare` in the manifest script | **0** |
| "already migrated" markers | **0** |

They cannot tell cheaply either — they load and loop:

- `migrateStudyImageParams` — every study, JSON-decoding each row's params
- `fixMediafileLegacyPaths` — a walk of the media files
- `migratePodcastLinkToMenuItem` — every podcast, resolving a menu item per row

Several full table walks per update, on a production site, to discover there was nothing to do.

## The fix

`preflight()` reads the installed version from `#__extensions.manifest_cache` **before Joomla overwrites it** with the incoming one. Each migration then runs only when the site is older than the release that introduced it:

```php
if ($this->upgradingFromBefore('10.1.0')) {
    CwmmigrationHelper::fixMediafileLegacyPaths();
}
```

| migration | gated at |
|---|---|
| `fixMediafileLegacyPaths`, `migrateStudyImageParams`, `dropLegacyTables`, `migratePodcastAlternateLinks`, `migratePodcastImageField` | 10.1.0 |
| `migratePodcastLinkToMenuItem` | 10.3.0 |
| `dropLegacyTemplateColumns` | 10.3.2 |
| `migrateScriptureParamsToPlugin` | 10.5.8 |

A 10.5.7 site now skips all eight. A 9.2.8 site still runs every one.

## ⚠️ The failure modes are not symmetric

Running a migration that was not needed costs time. **Skipping one that was needed loses data.** Both design decisions follow from that:

- An **unreadable** source version runs everything, rather than assuming the site is current.
- The comparison is **strictly** less-than, so a site one patch short still migrates, and the release that introduced a migration does not re-run it.

`retireLegacyColumns()` is deliberately **not** gated — it already exits on a cheap `SHOW COLUMNS` check, and it is the guard against the #1744 data loss. Left alone.

## Side effect worth noting

This silences the "N podcast link(s) could not be matched to a menu item" warning you saw. That was a 10.3.0 migration re-reporting on rows it had already declined to match, on every update since.

## Verification

`composer test` — 2388 passed. `composer lint` — 0 of 614. `lint:comments` clean.

Mutation-tested, each failing a test:

| Mutation | Caught |
|---|---|
| a migration loses its gate | ✅ |
| comparison relaxed to `<=` | ✅ |
| unknown source returns false | ✅ |
| the preflight capture is deleted | ✅ |

The gate test **derives the migration list from the source**, so a migration added to that block without a gate fails rather than slipping through — which is how this happened the first time.

Part of #1841.