### PR TITLE
feat: time each legacy migration, and report what the update did

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -123,6 +123,16 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     private string $fromVersion = '';
 
+    /**
+     * What each migration step did, for the report echoed at the end.
+     *
+     * Each entry: name, state (ran|skipped|failed), a short note, seconds.
+     *
+     * @var    array<int, array{name: string, state: string, note: string, secs: float}>
+     * @since  __DEPLOY_VERSION__
+     */
+    private array $stepLog = [];
+
     protected $minimumPhp = '8.3.0';
 
     /**
@@ -397,6 +407,134 @@ class com_proclaimInstallerScript extends InstallerScript
             return (string) ($decoded['version'] ?? '');
         } catch (\Throwable) {
             return '';
+        }
+    }
+
+    /**
+     * Report what the migrations did, on the page the administrator lands on.
+     *
+     * ⚠️ Delivered with enqueueMessage(), not echo. Joomla does capture printed
+     * output into the extension message, but postflight ends by setting a
+     * redirect to Proclaim's own view, and a queued message survives that where
+     * printed output is not guaranteed to.
+     *
+     * ⚠️ The markup is constrained by Joomla's own sanitiser. `Joomla.sanitizeHtml`
+     * renders queued messages client-side against an allowlist that has no
+     * `table`, `tr` or `td`, and no `style` attribute anywhere — a table with
+     * inline styles arrives as stripped text. Hence a list, and classes only.
+     *
+     * Says nothing when there is nothing worth saying: a fresh install, or an
+     * update where every step was skipped and none of them took any time.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function reportMigrations(): void
+    {
+        if ($this->stepLog === []) {
+            return;
+        }
+
+        $ran     = array_filter($this->stepLog, static fn ($s) => $s['state'] === 'ran');
+        $failed  = array_filter($this->stepLog, static fn ($s) => $s['state'] === 'failed');
+        $skipped = \count($this->stepLog) - \count($ran) - \count($failed);
+        $total   = array_sum(array_column($this->stepLog, 'secs'));
+
+        if ($ran === [] && $failed === [] && $total < 0.05) {
+            return;
+        }
+
+        $esc  = static fn (string $t) => htmlspecialchars($t, ENT_QUOTES, 'UTF-8');
+        $from = $this->fromVersion !== '' ? $this->fromVersion : 'an unrecorded version';
+
+        $items = '';
+
+        foreach ($this->stepLog as $entry) {
+            $mark = match ($entry['state']) {
+                'ran'    => '&#10003;',
+                'failed' => '&#10007;',
+                default  => '&#8722;',
+            };
+
+            $items .= '<li>' . $mark . ' <strong>' . $esc($entry['name']) . '</strong>'
+                . ($entry['note'] !== '' ? ' <small>' . $esc($entry['note']) . '</small>' : '')
+                . ($entry['state'] === 'skipped'
+                    ? ''
+                    : ' <small>' . number_format($entry['secs'], 2) . 's</small>')
+                . '</li>';
+        }
+
+        $summary = sprintf(
+            '%d ran, %d skipped%s in %ss, upgrading from %s.',
+            \count($ran),
+            $skipped,
+            $failed === [] ? '' : ', ' . \count($failed) . ' failed,',
+            number_format($total, 1),
+            $esc($from)
+        );
+
+        try {
+            Factory::getApplication()->enqueueMessage(
+                '<strong>Proclaim migrations</strong><br>' . $summary
+                . '<ul class="list-unstyled mb-0">' . $items . '</ul>',
+                $failed === [] ? 'info' : 'warning'
+            );
+        } catch (\Throwable) {
+            // A report is not worth failing an otherwise successful update over.
+        }
+    }
+
+    /**
+     * Run a legacy migration, or record why it was skipped.
+     *
+     * Wraps the version gate and the timing in one place so the report can say
+     * what happened. Before this, an update that did nothing looked exactly like
+     * an update that did everything: a spinner, then silence.
+     *
+     * A step that throws is recorded and the update carries on. None of these is
+     * load-bearing enough to abandon an otherwise successful update over, and a
+     * failure that is reported is far better than one that aborts the install.
+     *
+     * @param   string    $name   Step name, as it appears in the report
+     * @param   string    $since  Release the migration shipped in
+     * @param   callable  $work   The migration; may return a short note
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function step(string $name, string $since, callable $work): void
+    {
+        if (!$this->upgradingFromBefore($since)) {
+            $this->stepLog[] = [
+                'name'  => $name,
+                'state' => 'skipped',
+                'note'  => 'not needed past ' . $since,
+                'secs'  => 0.0,
+            ];
+
+            return;
+        }
+
+        $started = microtime(true);
+
+        try {
+            $note = $work();
+
+            $this->stepLog[] = [
+                'name'  => $name,
+                'state' => 'ran',
+                'note'  => \is_string($note) ? $note : '',
+                'secs'  => microtime(true) - $started,
+            ];
+        } catch (\Throwable $e) {
+            $this->stepLog[] = [
+                'name'  => $name,
+                'state' => 'failed',
+                'note'  => $e->getMessage(),
+                'secs'  => microtime(true) - $started,
+            ];
         }
     }
 
@@ -1874,65 +2012,50 @@ class com_proclaimInstallerScript extends InstallerScript
         // find out, on every update, forever. Nine of them made a routine update
         // take minutes on a site with real content.
         if ($type === 'update') {
-            // Fix legacy image paths in mediafile params (images/biblestudy/ -> media/com_proclaim/images/)
-            if ($this->upgradingFromBefore('10.1.0')) {
-                try {
-                    CwmmigrationHelper::fixMediafileLegacyPaths();
-                } catch (\Exception $e) {
-                    Factory::getApplication()->enqueueMessage(
-                        'Mediafile path migration notice: ' . $e->getMessage(),
-                        'warning'
-                    );
-                }
-            }
+            // Legacy image paths in mediafile params (images/biblestudy/ -> media/com_proclaim/images/)
+            $this->step('Media file paths', '10.1.0', static function () {
+                CwmmigrationHelper::fixMediafileLegacyPaths();
+            });
 
-            // Migrate studyimage param values to thumbnailm column
-            if ($this->upgradingFromBefore('10.1.0')) {
-                try {
-                    $this->migrateStudyImageParams();
-                } catch (\Exception $e) {
-                    Factory::getApplication()->enqueueMessage(
-                        'StudyImage migration notice: ' . $e->getMessage(),
-                        'warning'
-                    );
-                }
-            }
+            // studyimage param values to the thumbnailm column
+            $this->step('Study images', '10.1.0', function () {
+                $this->migrateStudyImageParams();
+            });
 
-            // Drop vestigial text/pdf columns from templates table.
-            // Done in PHP because ALTER TABLE DROP COLUMN is not idempotent.
-            if ($this->upgradingFromBefore('10.3.2')) {
+            // Vestigial text/pdf columns on the templates table. Done in PHP
+            // because ALTER TABLE DROP COLUMN is not idempotent.
+            $this->step('Template columns', '10.3.2', function () {
                 $this->dropLegacyTemplateColumns();
-            }
+            });
 
-            // Drop pre-10.1 / pre-10.0 orphaned tables that linger on sites
-            // upgraded across multiple major versions (Joomla skips already-
-            // applied migrations on jump-upgrades, so the per-version DROPs
-            // never run).
-            if ($this->upgradingFromBefore('10.1.0')) {
+            // pre-10.1 / pre-10.0 orphaned tables, which linger on sites upgraded
+            // across several major versions — Joomla skips already-applied
+            // migrations on a jump upgrade, so the per-version DROPs never ran.
+            $this->step('Orphaned tables', '10.1.0', function () {
                 $this->dropLegacyTables();
-            }
+            });
 
-            // Migrate existing alternate link data to platform_links JSON
-            if ($this->upgradingFromBefore('10.1.0')) {
+            // Alternate link data into platform_links JSON
+            $this->step('Podcast alternate links', '10.1.0', function () {
                 $this->migratePodcastAlternateLinks();
-            }
+            });
 
-            // Copy legacy image field to podcastimage where podcastimage is empty
-            if ($this->upgradingFromBefore('10.1.0')) {
+            // Legacy image field into podcastimage, where podcastimage is empty
+            $this->step('Podcast images', '10.1.0', function () {
                 $this->migratePodcastImageField();
-            }
+            });
 
-            // Match legacy podcastlink URLs to Joomla menu item IDs. This is the
+            // Legacy podcastlink URLs matched to Joomla menu item IDs. This is the
             // one that reported "N podcast link(s) could not be matched" on every
             // update, about rows it had already declined to match before.
-            if ($this->upgradingFromBefore('10.3.0')) {
+            $this->step('Podcast menu links', '10.3.0', function () {
                 $this->migratePodcastLinkToMenuItem();
-            }
+            });
 
-            // Migrate scripture settings from component params to plugin params
-            if ($this->upgradingFromBefore('10.5.8')) {
+            // Scripture settings from component params to plugin params
+            $this->step('Scripture settings', '10.5.8', function () {
                 $this->migrateScriptureParamsToPlugin();
-            }
+            });
         }
 
         if ($type === 'install' || $type === 'update') {
@@ -1988,6 +2111,8 @@ class com_proclaimInstallerScript extends InstallerScript
                 // Silently ignore detection failures during install
             }
         }
+
+        $this->reportMigrations();
 
         // For updates, we use the migration process
         $parent->getParent()->setRedirectURL(

--- a/tests/unit/Admin/Lib/MigrationReportTest.php
+++ b/tests/unit/Admin/Lib/MigrationReportTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * The update tells the administrator what it did.
+ *
+ * An update that skipped every migration looked exactly like one that ran them
+ * all: a spinner, then silence. The step runner records what happened and this
+ * reports it.
+ *
+ * ⚠️ The markup is constrained by machinery outside this repository. Joomla
+ * renders queued messages client-side through `Joomla.sanitizeHtml`, against an
+ * allowlist that contains no `table`, `tr` or `td` and no `style` attribute on
+ * anything. A report built as a styled table arrives as stripped text, and
+ * nothing here or in CI would have said so. These assertions are that allowlist.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+class MigrationReportTest extends ProclaimTestCase
+{
+    /**
+     * Tags Joomla's message sanitiser accepts, from
+     * media/system/js/core.js `DefaultAllowlist` (Joomla 6.1).
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const ALLOWED_TAGS = [
+        'a', 'area', 'b', 'br', 'col', 'code', 'div', 'em', 'hr', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'i', 'img', 'li', 'ol', 'p', 'pre', 's', 'small', 'span', 'sub', 'sup', 'strong', 'u', 'ul',
+        'button', 'input', 'select', 'textarea', 'option', 'details', 'summary',
+    ];
+
+    /**
+     * @return  string  The manifest script's source
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function script(): string
+    {
+        return (string) file_get_contents(\dirname(__DIR__, 4) . '/proclaim.script.php');
+    }
+
+    /**
+     * Just the report builder, so tag assertions do not pick up the whole file.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function reportBody(): string
+    {
+        $source = self::script();
+        $start  = strpos($source, 'private function reportMigrations(): void');
+
+        self::assertNotFalse($start, 'reportMigrations() could not be found.');
+
+        $end = strpos($source, "\n    }\n", $start);
+
+        return substr($source, $start, $end - $start);
+    }
+
+    /**
+     * @return  array<string, array{0: string}>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function forbiddenMarkup(): array
+    {
+        return [
+            'a table'         => ['<table'],
+            'a table row'     => ['<tr'],
+            'a table cell'    => ['<td'],
+            'a table header'  => ['<th'],
+            'an inline style' => ['style="'],
+        ];
+    }
+
+    /**
+     * @param   string  $needle  Markup the sanitiser would strip
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[DataProvider('forbiddenMarkup')]
+    #[TestDox('the report does not use $_dataName, which the sanitiser strips')]
+    public function testTheReportAvoidsStrippedMarkup(string $needle): void
+    {
+        self::assertStringNotContainsString(
+            $needle,
+            self::reportBody(),
+            'Joomla renders queued messages through Joomla.sanitizeHtml, whose allowlist has no table elements '
+            . 'and no style attribute. This would reach the administrator as stripped text, with no error '
+            . 'anywhere to say why.'
+        );
+    }
+
+    /**
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('every tag the report emits is on the sanitiser allowlist')]
+    public function testEveryTagIsAllowed(): void
+    {
+        preg_match_all('~<([a-z][a-z0-9]*)~i', self::reportBody(), $matches);
+
+        $used = array_unique(array_map('strtolower', $matches[1]));
+        $bad  = array_diff($used, self::ALLOWED_TAGS);
+
+        self::assertSame(
+            [],
+            array_values($bad),
+            'These tags are not on Joomla.sanitizeHtml\'s allowlist and would be stripped: '
+            . implode(', ', $bad)
+        );
+    }
+
+    /**
+     * ⚠️ enqueueMessage survives the redirect postflight sets; printed output is
+     * not guaranteed to.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('the report is queued rather than printed')]
+    public function testTheReportIsQueued(): void
+    {
+        $body = self::reportBody();
+
+        self::assertStringContainsString(
+            'enqueueMessage(',
+            $body,
+            'postflight ends by setting a redirect to Proclaim\'s own view. A queued message survives that; '
+            . 'printed output relies on com_installer rendering its extension message, which the redirect '
+            . 'bypasses.'
+        );
+
+        self::assertStringNotContainsString(
+            'echo ',
+            $body,
+            'The report must not print.'
+        );
+    }
+
+    /**
+     * A report on every update, saying nothing happened, is just more noise.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('a wholly uneventful update reports nothing')]
+    public function testSilenceWhenNothingHappened(): void
+    {
+        $body = self::reportBody();
+
+        self::assertStringContainsString(
+            '$this->stepLog === []',
+            $body,
+            'A fresh install records no steps and must produce no report.'
+        );
+
+        self::assertMatchesRegularExpression(
+            '~\$ran === \[\] && \$failed === \[\] && \$total < ~',
+            $body,
+            'An update where every step was skipped and nothing took measurable time should stay quiet.'
+        );
+    }
+
+    /**
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('the report is called from postflight, and every step is timed')]
+    public function testWiring(): void
+    {
+        $source = self::script();
+
+        self::assertStringContainsString(
+            '$this->reportMigrations();',
+            $source,
+            'The report is built but never delivered.'
+        );
+
+        self::assertStringContainsString(
+            'microtime(true)',
+            $source,
+            'Steps are not timed, so the report cannot say how long anything took — which is the question '
+            . 'nobody could answer when this was investigated.'
+        );
+
+        self::assertSame(
+            8,
+            preg_match_all('~\$this->step\(~', $source),
+            'Every legacy migration should go through step(), so it is both gated and recorded.'
+        );
+    }
+}

--- a/tests/unit/Admin/Lib/MigrationVersionGateTest.php
+++ b/tests/unit/Admin/Lib/MigrationVersionGateTest.php
@@ -145,27 +145,40 @@ class MigrationVersionGateTest extends ProclaimTestCase
 
         self::assertNotFalse($start, 'The update-only migration block could not be found.');
 
-        // The block runs to the next top-level `if ($type === 'install'`.
         $end = strpos($source, "if (\$type === 'install' || \$type === 'update')", $start);
 
         self::assertNotFalse($end, 'The end of the migration block could not be found.');
 
         $block = substr($source, $start, $end - $start);
 
+        // A migration called directly, rather than through step(), is neither
+        // gated nor recorded — which is how every update came to re-run all of
+        // them.
         preg_match_all('~^\s{12}(?:\$this->|CwmmigrationHelper::)(\w+)\(\);~m', $block, $ungated);
+
+        $bare = array_values(array_diff($ungated[1], ['step']));
 
         self::assertSame(
             [],
-            $ungated[1],
-            'These migrations run without a version gate, so every update re-runs them: '
-            . implode(', ', $ungated[1])
-            . '. Wrap each in if ($this->upgradingFromBefore(\'X.Y.Z\')) naming the release it shipped in.'
+            $bare,
+            'These migrations are called directly instead of through step(), so they are neither version-gated '
+            . 'nor timed: ' . implode(', ', $bare)
+            . '. Wrap each in $this->step(\'Name\', \'X.Y.Z\', fn () => ...).'
+        );
+
+        // Every step() call must name the release it shipped in.
+        preg_match_all('~\$this->step\(\s*\'[^\']+\',\s*\'(\d+\.\d+\.\d+)\'~', $block, $versions);
+
+        self::assertSame(
+            preg_match_all('~\$this->step\(~', $block),
+            \count($versions[1]),
+            'A step() call is missing its version argument, so it would run on every update.'
         );
 
         self::assertGreaterThanOrEqual(
             8,
-            preg_match_all('~upgradingFromBefore\(\'~', $block),
-            'Fewer gates than expected — a migration may have lost one.'
+            \count($versions[1]),
+            'Fewer gated steps than expected — a migration may have lost its gate.'
         );
     }
 


### PR DESCRIPTION
Scenario two from the [demo](https://claude.ai/code/artifact/7a08aa69-21c7-4725-b465-a24eab4de4f4), starting with the timing instrumentation. Part of #1841, on top of the gating in #1842.

## What it does

Each migration now goes through `step()`, which applies the version gate, times the work, and records the outcome:

```php
$this->step('Podcast menu links', '10.3.0', function () {
    $this->migratePodcastLinkToMenuItem();
});
```

The gate moves out of eight repeated `if`-blocks into one place, so a migration cannot be added without naming the release it shipped in. At the end, a report:

> **Proclaim migrations**
> 2 ran, 7 skipped in 2.1s, upgrading from 10.5.7.
> ✓ **Scripture settings** 0.04s
> − **Media file paths** *not needed past 10.1.0*
> − **Podcast menu links** *not needed past 10.3.0*
> …

## ⚠️ Two things the implementation had to bend to

**It is queued, not printed.** Joomla does capture printed output into the extension message — that is how JSitemap gets text onto the installer page. But Proclaim's `postflight()` ends by setting a redirect to its own view, and a queued message survives a redirect where printed output is not guaranteed to.

**The markup is constrained by Joomla's own sanitiser.** Queued messages are rendered client-side through `Joomla.sanitizeHtml`, against `DefaultAllowlist` in `media/system/js/core.js`. That list has **no `table`, `tr`, `td` or `th`**, and **no `style` attribute on anything**.

My first draft — and the one in the demo — was a styled table. It would have reached you as stripped text, with nothing in CI or the code to say why. The report is now a `<ul>` with classes only, and `MigrationReportTest` pins the allowlist so the next draft cannot regress it.

## It stays quiet when there is nothing to say

A fresh install records no steps. An update where everything was skipped and nothing took measurable time prints nothing at all, rather than announcing that nothing happened. A report on every update is just more noise.

## Verification

`composer test` — 2397 passed. `composer lint` — 0 of 615. `lint:comments` clean.

Mutation-tested, each failing a test:

| Mutation | Caught |
|---|---|
| report uses a `<table>` | ✅ |
| report adds an inline `style` | ✅ |
| `reportMigrations()` never called | ✅ |
| a migration bypasses `step()` | ✅ |
| timing removed | ✅ |

`MigrationVersionGateTest` was updated to the new shape and is now stronger: it asserts every `step()` call carries a version argument, where before it only looked for gates inline.

## What this does not do

No live progress bar. That is scenario three, and it needs the deferrable-vs-must-run-now classification first — deferring work that stands between the old and new data shape would leave a site half-migrated. Nothing here defers anything.

Part of #1841.