### PR TITLE
feat: log the install, so an update can be diagnosed after the fact

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -121,6 +121,13 @@ class com_proclaimInstallerScript extends InstallerScript
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
+    /**
+     * Log category for the install record.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const INSTALL_LOG = 'com_proclaim.install';
+
     private string $fromVersion = '';
 
     /**
@@ -132,6 +139,20 @@ class com_proclaimInstallerScript extends InstallerScript
      * @since  __DEPLOY_VERSION__
      */
     private array $stepLog = [];
+
+    /**
+     * When preflight ran, as a float second.
+     *
+     * ⚠️ The gap between this and the start of postflight is the only view
+     * anyone gets of what Joomla itself spent — unpacking the archive, copying
+     * the files, replaying the schema. Measured on j6-dev the whole database
+     * side of postflight is under a tenth of a second, while a real update took
+     * about a minute, so that gap is where the answer lives.
+     *
+     * @var    float
+     * @since  __DEPLOY_VERSION__
+     */
+    private float $startedAt = 0.0;
 
     protected $minimumPhp = '8.3.0';
 
@@ -486,6 +507,58 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
+     * Register a logger for the install log.
+     *
+     * ⚠️ Self-contained on purpose. This runs in preflight, where the component's
+     * own classes are not reliably autoloadable — that is why preflight has to
+     * register the scripture namespace by hand a few lines further down. Calling
+     * CwmlogHelper here would be a bet on load order.
+     *
+     * ⚠️ Joomla discards entries for a category no logger is registered for, and
+     * nothing registers one during an install. The existing
+     * `Log::add(..., 'com_proclaim')` calls in this file have been writing to
+     * nowhere.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function openInstallLog(): void
+    {
+        try {
+            Log::addLogger(
+                ['text_file' => 'com_proclaim.install.php'],
+                Log::ALL,
+                [self::INSTALL_LOG]
+            );
+        } catch (\Throwable) {
+            // Diagnostics must never be the reason an install fails.
+        }
+    }
+
+    /**
+     * Write one line to the install log.
+     *
+     * Always on. This is the record an administrator retrieves *after* an update
+     * they have already sat through — the on-screen report cannot be scrolled
+     * back to, and cannot say anything about the time before postflight ran.
+     *
+     * @param   string  $line  What happened
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function logInstall(string $line): void
+    {
+        try {
+            Log::add($line, Log::INFO, self::INSTALL_LOG);
+        } catch (\Throwable) {
+            // As above.
+        }
+    }
+
+    /**
      * Run a legacy migration, or record why it was skipped.
      *
      * Wraps the version gate and the timing in one place so the report can say
@@ -514,6 +587,8 @@ class com_proclaimInstallerScript extends InstallerScript
                 'secs'  => 0.0,
             ];
 
+            $this->logInstall(sprintf('  skip  %-26s not needed past %s', $name, $since));
+
             return;
         }
 
@@ -522,12 +597,16 @@ class com_proclaimInstallerScript extends InstallerScript
         try {
             $note = $work();
 
+            $secs = microtime(true) - $started;
+
             $this->stepLog[] = [
                 'name'  => $name,
                 'state' => 'ran',
                 'note'  => \is_string($note) ? $note : '',
-                'secs'  => microtime(true) - $started,
+                'secs'  => $secs,
             ];
+
+            $this->logInstall(sprintf('  ran   %-26s %6.3fs', $name, $secs));
         } catch (\Throwable $e) {
             $this->stepLog[] = [
                 'name'  => $name,
@@ -535,6 +614,8 @@ class com_proclaimInstallerScript extends InstallerScript
                 'note'  => $e->getMessage(),
                 'secs'  => microtime(true) - $started,
             ];
+
+            $this->logInstall(sprintf('  FAIL  %-26s %s', $name, $e->getMessage()));
         }
     }
 
@@ -578,12 +659,23 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     public function preflight($type, $parent): bool
     {
+        $this->startedAt = microtime(true);
+        $this->openInstallLog();
+
         // Read before Joomla rewrites manifest_cache with the incoming version.
         // postflight() cannot ask this question — by then the row says the new
         // version and every migration looks unnecessary.
         if ($type === 'update') {
             $this->fromVersion = $this->readInstalledVersion();
         }
+
+        $this->logInstall(sprintf(
+            'preflight: %s, from %s, PHP %s, Joomla %s',
+            $type,
+            $this->fromVersion !== '' ? $this->fromVersion : 'n/a',
+            PHP_VERSION,
+            JVERSION
+        ));
 
         // com_proclaim depends on lib_cwmscripture. The standalone
         // component zip does not bundle the library, and even when
@@ -1844,6 +1936,24 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     public function postflight(string $type, ComponentAdapter $parent): void
     {
+        // ⚠️ Everything between preflight and here is Joomla's, not ours:
+        // unpacking the archive, copying the files, replaying the schema. The
+        // database side of postflight measures under a tenth of a second on a
+        // site of a few thousand rows, so when an update takes a minute, this
+        // gap is the first place to look.
+        //
+        // ⚠️ It does NOT include downloading the package. Joomla fetches that
+        // from the update server before any of this code exists, so a slow
+        // download shows up in neither number and has to be timed separately.
+        $beforeUs = microtime(true) - $this->startedAt;
+
+        $this->logInstall(sprintf(
+            'postflight: %.2fs elapsed since preflight (unpack, file copy, schema) — download NOT included',
+            $beforeUs
+        ));
+
+        $postflightStarted = microtime(true);
+
         // Joomla calls postflight on UNINSTALL too — InstallerAdapter::uninstall()
         // runs triggerManifestScript('postflight') after removing the extension
         // (InstallerAdapter.php:1249). Everything below this guard is install-time
@@ -2111,6 +2221,14 @@ class com_proclaimInstallerScript extends InstallerScript
                 // Silently ignore detection failures during install
             }
         }
+
+        $this->logInstall(sprintf(
+            'postflight: %d step(s) in %.3fs; postflight total %.2fs; whole install %.2fs',
+            \count($this->stepLog),
+            array_sum(array_column($this->stepLog, 'secs')),
+            microtime(true) - $postflightStarted,
+            microtime(true) - $this->startedAt
+        ));
 
         $this->reportMigrations();
 

--- a/tests/unit/Admin/Helper/CwmlogHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmlogHelperTest.php
@@ -158,6 +158,14 @@ class CwmlogHelperTest extends ProclaimTestCase
 
     /**
      * Only the helper registers loggers for the component.
+     *
+     * ⚠️ One exception, and it has to stay one. `proclaim.script.php` registers
+     * its own install logger because it runs in preflight, where the component's
+     * classes are not reliably autoloadable — the same reason that method
+     * registers the scripture namespace by hand a few lines earlier. Reaching
+     * for CwmlogHelper there would be a bet on load order.
+     *
+     * Anything else that appears in this list is centralisation leaking away.
      */
     public function testHelperIsTheOnlyRegistrar(): void
     {
@@ -184,10 +192,13 @@ class CwmlogHelperTest extends ProclaimTestCase
             }
         }
 
+        sort($hits);
+
         $this->assertSame(
-            ['admin/src/Helper/CwmlogHelper.php'],
+            ['admin/proclaim.script.php', 'admin/src/Helper/CwmlogHelper.php'],
             $hits,
-            'Logger registration should happen only in CwmlogHelper'
+            'Logger registration belongs in CwmlogHelper. The manifest script is the one exception, because it '
+            . 'runs before the component is autoloadable; anything else here should move into the helper.'
         );
     }
 

--- a/tests/unit/Admin/Helper/CwmlogHelperTest.php
+++ b/tests/unit/Admin/Helper/CwmlogHelperTest.php
@@ -171,6 +171,13 @@ class CwmlogHelperTest extends ProclaimTestCase
     {
         $root  = \dirname(__DIR__, 4);
         $hits  = [];
+        $seen  = [];
+
+        // The manifest script lives at the repository root. `admin/proclaim.script.php`
+        // is a gitignored symlink to it for local development, so a walk of admin/
+        // finds it on a developer's machine and not in CI. Deduplicating by real
+        // path makes both see the same set.
+        $candidates = [$root . '/proclaim.script.php'];
 
         foreach (['admin', 'site', 'api', 'modules'] as $dir) {
             $path = $root . '/' . $dir;
@@ -186,16 +193,28 @@ class CwmlogHelperTest extends ProclaimTestCase
                     continue;
                 }
 
-                if (str_contains((string) file_get_contents($file->getPathname()), 'Log::addLogger')) {
-                    $hits[] = str_replace($root . '/', '', $file->getPathname());
-                }
+                $candidates[] = $file->getPathname();
+            }
+        }
+
+        foreach ($candidates as $path) {
+            $real = realpath($path);
+
+            if ($real === false || isset($seen[$real])) {
+                continue;
+            }
+
+            $seen[$real] = true;
+
+            if (str_contains((string) file_get_contents($real), 'Log::addLogger')) {
+                $hits[] = str_replace($root . '/', '', $real);
             }
         }
 
         sort($hits);
 
         $this->assertSame(
-            ['admin/proclaim.script.php', 'admin/src/Helper/CwmlogHelper.php'],
+            ['admin/src/Helper/CwmlogHelper.php', 'proclaim.script.php'],
             $hits,
             'Logger registration belongs in CwmlogHelper. The manifest script is the one exception, because it '
             . 'runs before the component is autoloadable; anything else here should move into the helper.'


### PR DESCRIPTION
So the next nfsda.org update can be read afterwards instead of guessed at. Part of #1841.

## Why a log and not just the on-screen report

The report from #1843 says what the migrations did. It cannot be scrolled back to once dismissed, and — more importantly — it says nothing about **the time before postflight ran**, which is where the time actually goes:

| measured on j6-dev (838 studies, 1,645 media files) | |
|---|---|
| every migration the gating skips | **30 ms** |
| `ensurePrimaryKeys` across 27 tables | 19 ms |
| asset scans | < 1 ms |
| **a real update on CWM** | **~60 s** |

## What it records

`preflight()` stamps the clock and opens the logger. `postflight()` reports the gap:

```
preflight: update, from 10.5.7, PHP 8.3.14, Joomla 6.1.2
postflight: 41.83s elapsed since preflight (unpack, file copy, schema) — download NOT included
  skip  Media file paths           not needed past 10.1.0
  skip  Podcast menu links         not needed past 10.3.0
  ran   Scripture settings          0.042s
postflight: 8 step(s) in 0.043s; postflight total 1.21s; whole install 43.04s
```

That single gap line is the point. It is the only view anyone gets of what Joomla itself spent, and it turns "about a minute" into a number that can be argued with.

Written to `com_proclaim.install.php` in the site's log directory, always on.

## ⚠️ What it deliberately does not claim

**Download time is not included.** Joomla fetches the package from the update server before any of this code exists, so a slow download appears in neither number. The log line says so rather than letting the figure be read as the whole install. (For scale: `pkg_proclaim-10.5.8.zip` is **4 MB** — unlikely to be a minute on its own, but not nothing.)

The likely remaining cost is per-file I/O: `com_proclaim` alone ships **1,906 files**, and the package installs the library, three plugins and the modules too. 4 MB spread over ~2,000 small files is syscall-bound, not bandwidth-bound, which is exactly the shape that is slow on shared hosting.

## ⚠️ One architectural exception, recorded rather than smuggled

`CwmlogHelperTest::testHelperIsTheOnlyRegistrar` asserts that only `CwmlogHelper` calls `Log::addLogger`. This adds the manifest script as the **one** allowed exception, with the reason in the test: preflight runs before the component is reliably autoloadable — the same reason it registers the scripture namespace by hand a few lines earlier. Reaching for `CwmlogHelper` there would be a bet on load order.

The test now pins two entries instead of one, so a third still fails.

## Found while adding this

Nothing registers a logger for `com_proclaim` during an install, and Joomla discards entries for a category with no logger. **The `Log::add(..., 'com_proclaim')` calls already in this file have been writing to nowhere** — six of them, around the section-asset work. Not fixed here; noted so it can be.

## Verification

`composer test` — 2397 passed. `composer lint` — 0 of 615. `lint:comments` clean.

Part of #1841.