### PR TITLE
test: assert the update reported what it did, and gated the migrations

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -54,19 +54,19 @@ echo "========================================================================"
 echo " UPGRADE TEST — ${BASEVER}  ->  ${NEWVER}"
 echo "========================================================================"
 
-echo "-- [1/16] reset test site(s) to a clean slate"
+echo "-- [1/17] reset test site(s) to a clean slate"
 php build/reset-testsite.php
 
-echo "-- [2/16] fetch released baseline ${BASEVER}"
+echo "-- [2/17] fetch released baseline ${BASEVER}"
 bash build/build-baseline.sh "$BASEVER"
 
-echo "-- [3/16] install baseline ${BASEVER} (the 'before' state)"
+echo "-- [3/17] install baseline ${BASEVER} (the 'before' state)"
 "$BIN/cwm-install-zip" --zip "$BASEZIP"
 
-echo "-- [4/16] seed a downloaded translation + provider cache (upgrade must not eat them)"
+echo "-- [4/17] seed a downloaded translation + provider cache (upgrade must not eat them)"
 php build/verify-scripture-upgrade.php seed
 
-echo "-- [5/16] build new full package ${NEWVER}"
+echo "-- [5/17] build new full package ${NEWVER}"
 bash build/build-package.sh "$NEWVER"
 
 if [ ! -f "$NEWZIP" ]; then
@@ -74,10 +74,18 @@ if [ ! -f "$NEWZIP" ]; then
     exit 1
 fi
 
-echo "-- [6/16] install ${NEWVER} over ${BASEVER} (triggers update() + migrations)"
+echo "-- [6/17] install ${NEWVER} over ${BASEVER} (triggers update() + migrations)"
 "$BIN/cwm-install-zip" --zip "$NEWZIP"
 
-echo "-- [7/16] verify registration + migrations"
+# Immediately after the upgrade, before anything else installs over it: the log
+# describes one install, and phase 17 reinstalls on top. What the update decided
+# about the legacy migrations is recorded nowhere else — the CLI installer drops
+# the on-screen report, and both a gated and an ungated update leave the same
+# schema behind for every other assertion here to agree on.
+echo "-- [7/17] verify the update reported what it did (and gated the migrations)"
+php build/verify-install-log.php update "$BASEVER"
+
+echo "-- [8/17] verify registration + migrations"
 "$BIN/cwm-verify" --target test
 php build/verify-migrations.php "$NEWVER"
 # The upgraded state is what a real site is in, and it is the state that
@@ -85,21 +93,21 @@ php build/verify-migrations.php "$NEWVER"
 # every other assertion here passed.
 php build/verify-schema-check.php
 
-echo "-- [8/16] verify the downloaded translation and cached passages survived"
+echo "-- [9/17] verify the downloaded translation and cached passages survived"
 php build/verify-scripture-upgrade.php verify
 
-echo "-- [9/16] verify the consumer registry schema landed and the shipped extensions registered"
+echo "-- [10/17] verify the consumer registry schema landed and the shipped extensions registered"
 php build/verify-scripture-uninstall.php schema
 php build/verify-scripture-uninstall.php assert-first-party-registered
 
 # The remaining phases uninstall things, so they run last — the site is expendable
-# from here on and reset-testsite.php rebuilds it on the next run. Phase 16 puts
+# from here on and reset-testsite.php rebuilds it on the next run. Phase 17 puts
 # ${NEWVER} back at the end, because test:e2e runs against this install straight
 # after and must not be handed the baseline.
 # tail -n1: these modes print one value, but any PHP notice would land on stdout
 # ahead of it. Taking the last line keeps a stray warning from corrupting the
 # path or id — which would otherwise make the CLI fail for the wrong reason and
-# turn phase 10 into a false pass.
+# turn phase 11 into a false pass.
 SITE="$(php build/verify-scripture-uninstall.php site-path | tail -n1)"
 JCLI="${SITE}/cli/joomla.php"
 
@@ -109,12 +117,12 @@ if [ ! -f "$JCLI" ]; then
     exit 1
 fi
 
-# Phase 11 asserts that removing pkg_proclaim drops the shared scripture tables,
+# Phase 12 asserts that removing pkg_proclaim drops the shared scripture tables,
 # which is only true when nothing else uses them. Any other consumer -- Living
 # Word is the one that actually bit us (lib_cwmscripture#37) -- makes keeping
 # them correct, so the assertion would be testing for a bug.
 #
-# Clear them here rather than in phase 11 itself: phases 12 and 13 install their
+# Clear them here rather than in phase 12 itself: phases 13 and 14 install their
 # own consumers to prove the opposite case, and an unrelated one already present
 # would let those pass without their fixtures doing anything.
 #
@@ -149,13 +157,13 @@ if [ -n "$OTHER_CONSUMERS" ]; then
             echo "     removed extension id ${CID}"
         else
             echo "ERROR: could not remove scripture consumer id ${CID}." >&2
-            echo "       Phase 11 would then fail for the wrong reason." >&2
+            echo "       Phase 12 would then fail for the wrong reason." >&2
             exit 1
         fi
     done
 fi
 
-echo "-- [10/16] STILL NEEDED: removing the library alone must be refused"
+echo "-- [11/17] STILL NEEDED: removing the library alone must be refused"
 LIBID="$(php build/verify-scripture-uninstall.php ext-id library cwmscripture | tail -n1)"
 
 if php "$JCLI" extension:remove -n "$LIBID" >/dev/null 2>&1; then
@@ -167,7 +175,7 @@ fi
 echo "   extension:remove exited non-zero, as expected"
 php build/verify-scripture-uninstall.php assert-library-present
 
-echo "-- [11/16] A package removal must leave the whole scripture stack alone"
+echo "-- [12/17] A package removal must leave the whole scripture stack alone"
 # Inverted deliberately at 10.5.7 (#1675). This used to assert that removing
 # pkg_proclaim DROPPED the shared tables when nothing else used them. Proclaim no
 # longer owns any of it: pkg_cwmscripture is not a child of pkg_proclaim, so the
@@ -201,7 +209,7 @@ php build/verify-scripture-uninstall.php assert-tables-present
 # dropped table (#1662).
 php build/verify-scripture-uninstall.php assert-registry-pruned
 
-echo "-- [12/16] STILL NEEDED: a registered consumer blocks a STANDALONE library uninstall"
+echo "-- [13/17] STILL NEEDED: a registered consumer blocks a STANDALONE library uninstall"
 # Repointed at the standalone path (#1675). The consumer guard used to be
 # exercised by a package removal; now that Proclaim never removes the library,
 # lib_cwmscripture's own dropTablesIfOrphaned() is the only code that can drop
@@ -220,7 +228,7 @@ echo "   extension:remove exited non-zero, as expected"
 php build/verify-scripture-uninstall.php assert-tables-present
 php build/verify-scripture-uninstall.php assert-library-present
 
-echo "-- [13/16] SKIPPED: unregistered-consumer detection is no longer isolatable here"
+echo "-- [14/17] SKIPPED: unregistered-consumer detection is no longer isolatable here"
 # Retired at 10.5.7 (#1675), not silently dropped.
 #
 # This asserted that a consumer found only by ConsumerScanner — never registered
@@ -269,7 +277,7 @@ cp "$LIBSRC" "$LIBZIP"
 # The baseline no longer supplies the hazard: lib_cwmscripture has shipped a
 # disarmed uninstall SQL since 1.1.5, so these two phases plant the pre-1.1.5
 # file themselves and then assert it really is armed before relying on it.
-echo "-- [14/16] NEGATIVE CONTROL: library-only update with no disarm must destroy data"
+echo "-- [15/17] NEGATIVE CONTROL: library-only update with no disarm must destroy data"
 "$BIN/cwm-install-zip" --zip "$BASEZIP" >/dev/null
 php build/verify-scripture-uninstall.php arm
 php build/verify-scripture-uninstall.php assert-sql-armed
@@ -277,7 +285,7 @@ php build/verify-scripture-uninstall.php seed-translation
 php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1 || true
 php build/verify-scripture-uninstall.php assert-translation-destroyed
 
-echo "-- [15/16] library-only update AFTER the disarm must preserve data"
+echo "-- [16/17] library-only update AFTER the disarm must preserve data"
 "$BIN/cwm-install-zip" --zip "$BASEZIP" >/dev/null
 php build/verify-scripture-uninstall.php arm
 php build/verify-scripture-uninstall.php assert-sql-armed
@@ -294,14 +302,14 @@ php build/verify-scripture-uninstall.php assert-translation-survived
 # ${NEWVER} feature as a product failure. Leave the site on what was tested.
 #
 # Reset first rather than installing ${NEWVER} straight over ${BASEVER}. The
-# uninstall phases retain the Proclaim data tables by design, so phase 11's
+# uninstall phases retain the Proclaim data tables by design, so phase 12's
 # removal leaves ${NEWVER}-shaped tables behind, and the baseline reinstalls in
 # 14/15 then rewrite #__schemas back to ${BASEVER} over them. An update from
 # there re-runs migrations whose work is already present, and
 # 10.5.6-20260807.sql's unguarded `ALTER TABLE ... DROP INDEX idx_study_topic`
 # fails with MySQL 1091. A clean install is also what the API acceptance spec
 # ("REST API acceptance (package install)") is written against.
-echo "-- [16/16] reset and clean-install ${NEWVER} for anything that runs after this"
+echo "-- [17/17] reset and clean-install ${NEWVER} for anything that runs after this"
 php build/reset-testsite.php
 "$BIN/cwm-install-zip" --zip "$NEWZIP" >/dev/null
 "$BIN/cwm-verify" --target test

--- a/build/verify-install-log.php
+++ b/build/verify-install-log.php
@@ -1,0 +1,352 @@
+<?php
+
+/**
+ * Verify what the install script recorded about the install it just did.
+ *
+ * The CLI installer prints "Extension installed successfully." and nothing
+ * else. Everything the update reports about itself — which legacy migrations
+ * were needed, which were skipped, how long each took — goes to enqueueMessage
+ * (dropped entirely under CLI) and to the install log. So the gate could
+ * install an upgrade, pass every other assertion, and still tell you nothing
+ * about the part of the release that is *about* upgrading.
+ *
+ * That is the gap this closes. The log is the only durable record, so the gate
+ * reads it back.
+ *
+ * The load-bearing assertion is the version gate (#1842). Every legacy
+ * migration is skipped when the site is already past the release the migration
+ * shipped in; without the gate all of them run on every update, which is what
+ * made a routine update take minutes. Both states install cleanly and leave an
+ * identical schema, so no other check in this harness can tell them apart —
+ * only the log can.
+ *
+ * ⚠️ This covers the gate's SKIP branch only. The harness upgrades one release
+ * at a time, and every migration shipped at or before that baseline, so none of
+ * them is ever supposed to run here. Asserting that a migration that IS needed
+ * runs and transforms the data correctly needs an older database restored
+ * before the upgrade, which this harness has no fixture for. These eight steps
+ * are 10.x-era data fixes; a 9.x site is carried forward by the upgrade wizard
+ * in the Admin Center, which is a different path and is not exercised here.
+ *
+ * Assertions, per role=test install:
+ *   - the log exists and its last block is the install just performed
+ *   - preflight saw the expected type, and upgraded FROM the expected version
+ *     (an unread source version reads as 'n/a' and makes the gate run
+ *     everything — a silent, total regression of #1842)
+ *   - every migration step was skipped, none ran, none failed
+ *   - as many steps were considered as there are migrations in the script, so
+ *     "nothing ran" cannot pass by nothing having been attempted
+ *   - postflight reported both its timing lines, and its own step count agrees
+ *     with the steps logged individually
+ *
+ * Usage: php build/verify-install-log.php <type> [from-version]
+ *          <type>          install | update, as preflight recorded it
+ *          [from-version]  required for update; the release upgraded from
+ *
+ * Exit:  0 clean, 1 assertion(s) failed.
+ *
+ * @package    Proclaim.Build
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+declare(strict_types=1);
+
+use CWM\BuildTools\Dev\PropertiesReader;
+
+$root = \dirname(__DIR__);
+
+require $root . '/libraries/vendor/autoload.php';
+
+$expectedType = $argv[1] ?? '';
+$expectedFrom = $argv[2] ?? '';
+
+if (!\in_array($expectedType, ['install', 'update'], true)) {
+    fwrite(STDERR, "Usage: php build/verify-install-log.php <install|update> [from-version]\n");
+
+    exit(1);
+}
+
+if ($expectedType === 'update' && $expectedFrom === '') {
+    fwrite(STDERR, "An update must be told which version it upgraded from.\n");
+    fwrite(STDERR, "Without it 'from n/a' — the regression this checks for — would pass.\n");
+
+    exit(1);
+}
+
+/**
+ * How many legacy migrations the install script registers.
+ *
+ * The count comes from the script rather than a constant here so that adding a
+ * migration does not silently widen what "every step was considered" means. A
+ * step that never reaches the log is a step whose gate nobody is checking.
+ *
+ * @param   string  $scriptFile  Path to proclaim.script.php
+ *
+ * @return  int  Number of step() call sites, or -1 when it cannot be counted
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function countRegisteredSteps(string $scriptFile): int
+{
+    if (!is_file($scriptFile)) {
+        return -1;
+    }
+
+    return preg_match_all('/\$this->step\(/', (string) file_get_contents($scriptFile));
+}
+
+/**
+ * Where a Joomla install writes its logs.
+ *
+ * Read from the site's own configuration rather than assumed, because a site
+ * that moved its log path would otherwise look like a site that logged nothing
+ * — a missing file being read as a failure to log is the one wrong answer this
+ * check must not give.
+ *
+ * @param   string  $installPath  Site root
+ *
+ * @return  string  Absolute path to the log directory
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function logPathFor(string $installPath): string
+{
+    $configFile = $installPath . '/configuration.php';
+    $configured = '';
+
+    if (is_file($configFile)) {
+        $matched = preg_match(
+            '/\$log_path\s*=\s*[\'"]([^\'"]+)[\'"]/',
+            (string) file_get_contents($configFile),
+            $m
+        );
+
+        if ($matched === 1) {
+            $configured = $m[1];
+        }
+    }
+
+    if ($configured === '') {
+        return $installPath . '/administrator/logs';
+    }
+
+    // Joomla stores this absolute, but a hand-edited configuration.php may not.
+    return str_starts_with($configured, '/') ? $configured : $installPath . '/' . $configured;
+}
+
+/**
+ * The messages of the last install recorded in a Joomla text log.
+ *
+ * A log accumulates across installs. Only the entries from the most recent
+ * preflight describe the install under test; anything earlier belongs to a run
+ * this check is not making assertions about.
+ *
+ * @param   string  $logFile  Path to the log
+ *
+ * @return  string[]  Messages, in order, from the last preflight onwards
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function lastInstallBlock(string $logFile): array
+{
+    $messages = [];
+
+    foreach (file($logFile, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+        if ($line === '' || str_starts_with($line, '#')) {
+            continue;
+        }
+
+        $fields = explode("\t", $line);
+
+        if (\count($fields) < 5) {
+            continue;
+        }
+
+        // Rejoin: the message is everything past the four fixed fields.
+        $messages[] = implode("\t", \array_slice($fields, 4));
+    }
+
+    for ($i = \count($messages) - 1; $i >= 0; $i--) {
+        if (str_starts_with($messages[$i], 'preflight: ')) {
+            return \array_slice($messages, $i);
+        }
+    }
+
+    return [];
+}
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to verify.\n");
+
+    exit(0);
+}
+
+$registered = countRegisteredSteps($root . '/proclaim.script.php');
+$failures   = 0;
+
+foreach ($installs as $install) {
+    echo "=== verify install log on {$install->id} ({$install->path}) ===\n";
+
+    $logFile = logPathFor($install->path) . '/com_proclaim.install.php';
+
+    if (!is_file($logFile)) {
+        fwrite(STDERR, "  FAIL no install log at {$logFile} —\n");
+        fwrite(STDERR, "       preflight opens the logger before anything else runs, so an\n");
+        fwrite(STDERR, "       absent log means it never ran or the category lost its logger.\n");
+        $failures++;
+
+        continue;
+    }
+
+    $block = lastInstallBlock($logFile);
+
+    if ($block === []) {
+        fwrite(STDERR, "  FAIL {$logFile} records no preflight line.\n");
+        $failures++;
+
+        continue;
+    }
+
+    // --- preflight: the type, and the version the gate reasons from ---------
+    $matched = preg_match('/^preflight: (\S+), from ([^,]+), PHP /', $block[0], $m);
+
+    if ($matched !== 1) {
+        fwrite(STDERR, "  FAIL could not read the preflight line: {$block[0]}\n");
+        $failures++;
+
+        continue;
+    }
+
+    [, $type, $from] = $m;
+
+    if ($type !== $expectedType) {
+        fwrite(STDERR, "  FAIL preflight recorded type '{$type}', expected '{$expectedType}' —\n");
+        fwrite(STDERR, "       an upgrade Joomla treats as a fresh install skips update() entirely.\n");
+        $failures++;
+    } else {
+        echo "  OK   preflight recorded an {$type}\n";
+    }
+
+    if ($expectedType === 'update') {
+        if ($from !== $expectedFrom) {
+            fwrite(STDERR, "  FAIL preflight read the installed version as '{$from}', expected '{$expectedFrom}' —\n");
+            fwrite(STDERR, "       every migration gate compares against this. Read as 'n/a' it is\n");
+            fwrite(STDERR, "       treated as unknown, and unknown runs everything.\n");
+            $failures++;
+        } else {
+            echo "  OK   preflight upgraded from {$from}\n";
+        }
+    }
+
+    // --- the migration steps ------------------------------------------------
+    $skipped = 0;
+    $ran     = [];
+    $failed  = [];
+
+    foreach ($block as $message) {
+        $matched = preg_match('/^ {2}(skip|ran|FAIL)\s+(\S.*)$/', $message, $m);
+
+        if ($matched !== 1) {
+            continue;
+        }
+
+        match ($m[1]) {
+            'skip' => $skipped++,
+            'ran'  => $ran[]    = trim($m[2]),
+            'FAIL' => $failed[] = trim($m[2]),
+        };
+    }
+
+    $considered = $skipped + \count($ran) + \count($failed);
+
+    if ($failed !== []) {
+        fwrite(STDERR, "  FAIL " . \count($failed) . " migration step(s) threw —\n");
+        fwrite(STDERR, "       a step that fails is recorded and the update carries on, so this\n");
+        fwrite(STDERR, "       is the only place it is ever reported:\n");
+
+        foreach ($failed as $line) {
+            fwrite(STDERR, "         {$line}\n");
+        }
+
+        $failures++;
+    }
+
+    if ($expectedType !== 'update') {
+        // A fresh install's SQL creates the current schema, so the migrations
+        // are never attempted at all — there is no gate here to assert on.
+        echo "  OK   {$considered} migration step(s) considered (fresh install migrates nothing)\n";
+    } elseif ($registered < 0) {
+        fwrite(STDERR, "  FAIL could not read proclaim.script.php to count its migrations.\n");
+        $failures++;
+    } elseif ($considered !== $registered) {
+        fwrite(STDERR, "  FAIL the log accounts for {$considered} migration step(s), but the script\n");
+        fwrite(STDERR, "       registers {$registered}. 'Nothing ran' proves nothing about the\n");
+        fwrite(STDERR, "       migrations that were never attempted.\n");
+        $failures++;
+    } else {
+        echo "  OK   all {$registered} registered migration step(s) reached the log\n";
+    }
+
+    if ($ran !== []) {
+        fwrite(STDERR, "  FAIL " . \count($ran) . " legacy migration(s) ran upgrading from {$expectedFrom}:\n");
+
+        foreach ($ran as $line) {
+            fwrite(STDERR, "         {$line}\n");
+        }
+
+        fwrite(STDERR, "       Every migration shipped in a release at or before {$expectedFrom},\n");
+        fwrite(STDERR, "       so all of them should have been gated out. This is what the gate\n");
+        fwrite(STDERR, "       exists to prevent.\n");
+        fwrite(STDERR, "       If this release genuinely adds a migration newer than {$expectedFrom},\n");
+        fwrite(STDERR, "       that one is expected to run — teach this check about it.\n");
+        $failures++;
+    } elseif ($skipped > 0) {
+        echo "  OK   all {$skipped} legacy migration(s) gated out, none ran\n";
+    }
+
+    // --- postflight reported on itself --------------------------------------
+    $elapsed = false;
+    $summary = -1;
+
+    foreach ($block as $message) {
+        if (str_contains($message, 'elapsed since preflight')) {
+            $elapsed = true;
+        }
+
+        if (preg_match('/^postflight: (\d+) step\(s\) in /', $message, $m) === 1) {
+            $summary = (int) $m[1];
+        }
+    }
+
+    if (!$elapsed) {
+        fwrite(STDERR, "  FAIL postflight never reported the time spent before it ran —\n");
+        fwrite(STDERR, "       unpack, file copy and schema replay are invisible without it.\n");
+        $failures++;
+    }
+
+    if ($summary < 0) {
+        fwrite(STDERR, "  FAIL postflight never reported its summary line —\n");
+        fwrite(STDERR, "       the install did not reach the end of postflight.\n");
+        $failures++;
+    } elseif ($summary !== $considered) {
+        fwrite(STDERR, "  FAIL postflight counted {$summary} step(s); {$considered} were logged —\n");
+        fwrite(STDERR, "       the per-step lines and the summary disagree about what happened.\n");
+        $failures++;
+    } else {
+        echo "  OK   postflight reported its timings and {$summary} step(s)\n";
+    }
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\nINSTALL LOG VERIFICATION FAILED ({$failures} assertion(s)).\n");
+
+    exit(1);
+}
+
+echo "Install log verification passed.\n";


### PR DESCRIPTION
## What

Adds `build/verify-install-log.php` and wires it into `composer test:upgrade` as a new step 7, immediately after the upgrade install.

## Why

The CLI installer prints `Extension installed successfully.` and nothing else. The migration report added in #1843 goes to `enqueueMessage`, which has no destination under CLI, so the release gate could install an upgrade, pass every assertion it had, and still say nothing about the part of the release that is *about* upgrading.

A gated update and an ungated one both install cleanly and leave an identical schema — no other check in the harness can tell them apart. The install log added in #1844 is the only durable record of the difference, so the gate now reads it back.

## What it asserts

Per role=test install, against the last block in `com_proclaim.install.php` (log directory resolved from the site's own `configuration.php`):

- preflight recorded an `update`, **from the expected version** — an unread source version reads as `n/a`, which makes the gate treat every migration as needed
- every registered migration reached the log
- none ran, none failed
- postflight reported both timing lines, and its own step count agrees with the individual step lines

The registered count is read from `proclaim.script.php` rather than written down in the check. Without it, *no migration running* would be indistinguishable from *no migration being attempted*.

## Scope — what this does not cover

This covers the gate's **skip branch only**. The harness upgrades one release at a time and all eight steps shipped at or before that baseline, so none is ever expected to run here. Asserting that a migration that *is* needed runs and transforms data correctly wants an older database restored before the upgrade, which the harness has no fixture for.

Those eight steps are 10.x-era data fixes (`$since` 10.1.0–10.5.8). A 9.x site is carried forward by the Admin Center upgrade wizard, which is a different path and is not exercised here. Both limits are stated in the file's docblock.

## Verification

Real `10.5.8 -> 10.5.9-dev` upgrade:

```
-- [7/17] verify the update reported what it did (and gated the migrations)
  OK   preflight recorded an update
  OK   preflight upgraded from 10.5.8
  OK   all 8 registered migration step(s) reached the log
  OK   all 8 legacy migration(s) gated out, none ran
  OK   postflight reported its timings and 8 step(s)
...
UPGRADE TEST PASSED 10.5.8 -> 10.5.9-dev.
```

Negative test against a fresh-install log — rejected on all three counts, including the `from n/a` reading that is the signature of the gate breaking:

```
  FAIL preflight recorded type 'install', expected 'update'
  FAIL preflight read the installed version as 'n/a', expected '10.5.8'
  FAIL the log accounts for 0 migration step(s), but the script registers 8
```

Also green: PHPUnit (2397), Jest (235), `test:install`, e2e (83/83), and all four lint gates.

Steps renumbered 16 → 17, including the prose phase references in the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)