### PR TITLE
chore: record the 10.5.9 release and open the 10.5.10 cycle

### DIFF
--- a/build/versions.json
+++ b/build/versions.json
@@ -2,16 +2,16 @@
     "_comment": "Development version tracking - semantic versioning: major.minor.patch",
     "_updated": "2026-08-14",
     "current": {
-        "version": "10.5.8",
+        "version": "10.5.9",
         "description": "Last stable release (from GitHub releases)"
     },
     "next": {
-        "patch": "10.5.9",
+        "patch": "10.5.10",
         "minor": "10.6.0",
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.5.9",
+        "version": "10.5.10-dev",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   ],
   "config": {
     "optimize-autoloader": true,
+    "process-timeout": 0,
     "platform": {
       "php": "8.3.0"
     },


### PR DESCRIPTION
Post-release bookkeeping for 10.5.9, plus the composer setting that caused the interruption.

## versions.json

`cwm-release` aborted at step 7 (ARS publish) when the 1Password token read failed transiently, so **step 8 never ran** — `current` was still `10.5.8` while 10.5.9 was already tagged, released on GitHub and published to ARS. `verify-update-stream` reads `current`, so it was checking the previous release.

- `current.version` → `10.5.9`
- `next.patch` → `10.5.10`
- `active_development.version` → `10.5.10-dev`, opening the next cycle

The ARS publish was completed separately with `cwm-ars-publish` (release ID 85, item 94) — nothing was left half-published, since the token is read before any API call.

## process-timeout

`composer release` runs the whole `test:release` gate before publishing, which is far longer than composer's 300s default process timeout. A dry run died with a `Process.php` timeout mid-gate — a failure that says nothing about the release. Setting `config.process-timeout: 0` removes that trap for the next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)