### PR TITLE
fix: stop the installer pointing sites at the 9.x update stream

### DIFF
--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -39,6 +39,22 @@ use Joomla\Filesystem\Folder;
  */
 class CwminstallModel extends ListModel
 {
+    /**
+     * The update stream Proclaim releases are announced on.
+     *
+     * ARS serves several streams; id=1 is the one carrying the 10.x history,
+     * and id=2 ends at 9.2.8 because 9.x → 10.x is a migration rather than an
+     * in-place update. Written unescaped: this goes into a database column and
+     * is fetched verbatim, so an `&amp;` here would arrive as a parameter
+     * named `amp;view` and the stream would never render.
+     *
+     * Kept identical to the `<server>` in build/pkg_proclaim.xml.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private const PACKAGE_UPDATE_STREAM = 'https://www.christianwebministries.org/index.php'
+        . '?option=com_ars&view=update&task=stream&format=xml&id=1&dummy=extension.xml';
+
     /** @var int Total number of Versions
      *
      * @since 7.1
@@ -1018,47 +1034,7 @@ class CwminstallModel extends ListModel
                 $this->running = 'Remove Old Update URL\'s';
                 break;
             case 'setupdateurl':
-                // Find Extension ID of component
-                $query = $this->getDatabase()->createQuery();
-                $query
-                    ->select($this->getDatabase()->quoteName('extension_id'))
-                    ->from($this->getDatabase()->quoteName('#__extensions'))
-                    ->where($this->getDatabase()->quoteName('name') . ' = ' . $this->getDatabase()->q('com_proclaim'));
-                $this->getDatabase()->setQuery($query);
-                $eid = $this->getDatabase()->loadResult();
-
-                $conditions = [
-                    $this->getDatabase()->quoteName('name') . ' = ' .
-                    $this->getDatabase()->q('Proclaim Package'),
-                ];
-                $query      = $this->getDatabase()->createQuery();
-                $query->delete($this->getDatabase()->quoteName('#__update_sites'));
-                $query->where('(' . implode(' OR ', $conditions) . ')');
-                $this->getDatabase()->setQuery($query);
-                $this->getDatabase()->execute();
-
-                $conditions = [
-                    $this->getDatabase()->quoteName('extension_id') . ' = ' .
-                    $this->getDatabase()->q($eid),
-                ];
-                $query      = $this->getDatabase()->createQuery();
-                $query->delete($this->getDatabase()->quoteName('#__update_sites_extensions'));
-                $query->where('(' . implode(' OR ', $conditions) . ')');
-                $this->getDatabase()->setQuery($query);
-                $this->getDatabase()->execute();
-
-                $updateurl           = new \stdClass();
-                $updateurl->name     = 'Proclaim Package';
-                $updateurl->type     = 'extension';
-                $updateurl->location = 'https://www.christianwebministries.org/index.php?option=com_ars&amp;view=update&amp;task=stream&amp;id=2&amp;format=xml';
-                $updateurl->enabled  = '1';
-                $this->getDatabase()->insertObject('#__update_sites', $updateurl);
-                $lastid                     = $this->getDatabase()->insertid();
-                $updateurl1                 = new \stdClass();
-                $updateurl1->update_site_id = $lastid;
-                $updateurl1->extension_id   = $eid;
-                $this->getDatabase()->insertObject('#__update_sites_extensions', $updateurl1);
-                $this->running = 'Set New Update URL';
+                $this->running = $this->setComponentUpdateSite();
                 break;
             case 'podcastlinkmissing':
                 // Define the table and column names
@@ -1093,6 +1069,127 @@ class CwminstallModel extends ListModel
                 );
                 break;
         }
+    }
+
+    /**
+     * Give the component an update site only when nothing else provides one.
+     *
+     * Updates belong to pkg_proclaim: its manifest declares the stream and
+     * Joomla registers it during install, so on a package site a second,
+     * component-owned entry only makes the site poll twice and report Proclaim
+     * as a component update. The package's postflight retires those entries;
+     * this step used to recreate one immediately afterwards, which is why they
+     * kept coming back.
+     *
+     * ⚠️ A site with no package still needs a channel — component-only
+     * installs predate the package and are reached solely through their own
+     * entry — so one is created there, pointing at the stream that carries
+     * current releases.
+     *
+     * Existing entries are cleared by their binding rather than by name.
+     * Matching the name alone missed rows registered under a different one and
+     * still deleted their bindings, leaving them orphaned in #__update_sites
+     * and invisible to every later pass.
+     *
+     * @return  string  Progress label for the installer UI
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setComponentUpdateSite(): string
+    {
+        $db  = $this->getDatabase();
+        $eid = (int) $db->setQuery(
+            $db->createQuery()
+                ->select($db->quoteName('extension_id'))
+                ->from($db->quoteName('#__extensions'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+        )->loadResult();
+
+        if ($eid === 0) {
+            return 'Set Update URL (component not registered)';
+        }
+
+        foreach ($this->updateSitesFor($eid) as $siteId) {
+            // ⚠️ An update site can serve more than one extension. Where it
+            // does, only Proclaim's claim on it is released — removing the row
+            // would take the other extension's update channel with it.
+            $shared = (int) $db->setQuery(
+                $db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__update_sites_extensions'))
+                    ->where($db->quoteName('update_site_id') . ' = ' . $siteId)
+                    ->where($db->quoteName('extension_id') . ' <> ' . $eid)
+            )->loadResult();
+
+            if ($shared > 0) {
+                $db->setQuery(
+                    $db->createQuery()
+                        ->delete($db->quoteName('#__update_sites_extensions'))
+                        ->where($db->quoteName('update_site_id') . ' = ' . $siteId)
+                        ->where($db->quoteName('extension_id') . ' = ' . $eid)
+                )->execute();
+
+                continue;
+            }
+
+            // #__updates rows are keyed to the site and would otherwise be
+            // orphaned, leaving phantom entries on Extensions > Update.
+            foreach (['#__updates', '#__update_sites_extensions', '#__update_sites'] as $table) {
+                $db->setQuery(
+                    $db->createQuery()
+                        ->delete($db->quoteName($table))
+                        ->where($db->quoteName('update_site_id') . ' = ' . $siteId)
+                )->execute();
+            }
+        }
+
+        $packageEid = (int) $db->setQuery(
+            $db->createQuery()
+                ->select($db->quoteName('extension_id'))
+                ->from($db->quoteName('#__extensions'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('pkg_proclaim'))
+                ->where($db->quoteName('type') . ' = ' . $db->quote('package'))
+        )->loadResult();
+
+        if ($packageEid > 0 && $this->updateSitesFor($packageEid) !== []) {
+            return 'Set Update URL (package owns updates)';
+        }
+
+        $site           = new \stdClass();
+        $site->name     = 'CWM Proclaim Package';
+        $site->type     = 'extension';
+        $site->location = self::PACKAGE_UPDATE_STREAM;
+        $site->enabled  = 1;
+        $db->insertObject('#__update_sites', $site);
+
+        $binding                 = new \stdClass();
+        $binding->update_site_id = (int) $db->insertid();
+        $binding->extension_id   = $eid;
+        $db->insertObject('#__update_sites_extensions', $binding);
+
+        return 'Set New Update URL';
+    }
+
+    /**
+     * The update sites registered against an extension.
+     *
+     * @param   int  $extensionId  Extension to look up
+     *
+     * @return  int[]  Update site ids
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function updateSitesFor(int $extensionId): array
+    {
+        $db = $this->getDatabase();
+
+        return array_map('intval', $db->setQuery(
+            $db->createQuery()
+                ->select($db->quoteName('update_site_id'))
+                ->from($db->quoteName('#__update_sites_extensions'))
+                ->where($db->quoteName('extension_id') . ' = ' . $extensionId)
+        )->loadColumn() ?: []);
     }
 
     /**

--- a/tests/integration/Admin/Model/CwminstallUpdateSiteTest.php
+++ b/tests/integration/Admin/Model/CwminstallUpdateSiteTest.php
@@ -1,0 +1,377 @@
+<?php
+
+/**
+ * Integration tests for the update site the installer registers.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwminstallModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The `setupdateurl` finish step used to delete the component's update site
+ * bindings and insert a replacement pointing at ARS stream id=2 — the stream
+ * that stops at 9.2.8 because 9.x to 10.x is a migration rather than an
+ * in-place update. It ran on every pass of the installer, including the
+ * "no DB changes" one, so a site was left on a stream that could never offer
+ * it a 10.x release, and the package postflight's retirement of component-owned
+ * sites was undone moments after it happened.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwminstallModel::class)]
+class CwminstallUpdateSiteTest extends IntegrationTestCase
+{
+    /**
+     * The stream carrying current releases.
+     */
+    private const CURRENT_STREAM_ID = 'id=1';
+
+    /**
+     * The 9.x stream. Nothing 10.x is ever announced on it.
+     */
+    private const LEGACY_STREAM = 'https://www.christianwebministries.org/index.php'
+        . '?option=com_ars&view=update&task=stream&id=2&format=xml';
+
+    /**
+     * @var  DatabaseDriver|null
+     */
+    private ?DatabaseDriver $db = null;
+
+    /**
+     * @var  int
+     */
+    private int $componentId = 0;
+
+    /**
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        // true: nested transactions. Anything that commits underneath would
+        // otherwise take the rollback with it and leave the dev database
+        // holding whatever this test seeded.
+        $this->db->transactionStart(true);
+
+        $this->componentId = (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('extension_id'))
+                ->from($this->db->quoteName('#__extensions'))
+                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_proclaim'))
+                ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('component'))
+        )->loadResult();
+
+        if ($this->componentId === 0) {
+            $this->markTestSkipped('com_proclaim is not registered in the test database');
+        }
+
+        // Start from a known shape rather than whatever this dev database has
+        // accumulated: no update site claims Proclaim until a test makes one.
+        $this->clearProclaimUpdateSites();
+    }
+
+    /**
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have been lost -- nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    #[TestDox('A component-only site is given the stream that carries current releases')]
+    public function testComponentOnlySiteGetsTheCurrentStream(): void
+    {
+        $this->seedUpdateSite('Proclaim Package', self::LEGACY_STREAM, $this->componentId);
+
+        $this->runStep();
+
+        $sites = $this->sitesFor($this->componentId);
+
+        $this->assertCount(
+            1,
+            $sites,
+            'A site with no package must keep exactly one update site of its own'
+        );
+
+        $location = $sites[0]['location'];
+
+        $this->assertStringContainsString(
+            self::CURRENT_STREAM_ID,
+            $location,
+            'The component-only site must be pointed at the stream carrying 10.x releases'
+        );
+        $this->assertStringNotContainsString(
+            'id=2',
+            $location,
+            'The 9.x stream can never offer a 10.x release'
+        );
+        $this->assertStringNotContainsString(
+            '&amp;',
+            $location,
+            'An HTML-escaped URL reaches ARS as a parameter named "amp;view" and returns nothing'
+        );
+    }
+
+    #[TestDox('When the package owns updates the component is left without a duplicate site')]
+    public function testPackageOwnedUpdatesLeaveNoComponentSite(): void
+    {
+        $packageId   = $this->seedPackageExtension();
+        $packageSite = $this->seedUpdateSite(
+            'CWM Proclaim Package',
+            'https://www.christianwebministries.org/index.php?option=com_ars&view=update&task=stream&format=xml&id=1',
+            $packageId
+        );
+        $this->seedUpdateSite('Proclaim Package', self::LEGACY_STREAM, $this->componentId);
+
+        $this->runStep();
+
+        $this->assertSame(
+            [],
+            $this->sitesFor($this->componentId),
+            'The package announces updates, so a second component-owned site only polls twice'
+        );
+        $this->assertCount(
+            1,
+            $this->sitesFor($packageId),
+            'The package keeps its own update site'
+        );
+        $this->assertSame(
+            1,
+            $this->siteExists($packageSite),
+            'The package update site row must survive untouched'
+        );
+    }
+
+    #[TestDox('An update site shared with another extension keeps serving that extension')]
+    public function testSharedUpdateSiteSurvives(): void
+    {
+        $siteId = $this->seedUpdateSite('Shared', self::LEGACY_STREAM, $this->componentId);
+
+        // A second extension claiming the same row. Deleting the row wholesale
+        // would take this extension's update channel with it.
+        $other = (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('extension_id'))
+                ->from($this->db->quoteName('#__extensions'))
+                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('com_content'))
+        )->loadResult();
+
+        $this->assertGreaterThan(0, $other, 'com_content must exist to stand in as the other extension');
+
+        $binding                 = new \stdClass();
+        $binding->update_site_id = $siteId;
+        $binding->extension_id   = $other;
+        $this->db->insertObject('#__update_sites_extensions', $binding);
+
+        $this->runStep();
+
+        $this->assertSame(
+            1,
+            $this->siteExists($siteId),
+            'A shared update site row must survive'
+        );
+        $this->assertSame(
+            [],
+            array_filter($this->sitesFor($this->componentId), static fn ($s) => (int) $s['id'] === $siteId),
+            'Proclaim releases its own claim on the shared row'
+        );
+        $this->assertSame(
+            1,
+            (int) $this->db->setQuery(
+                $this->db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($this->db->quoteName('#__update_sites_extensions'))
+                    ->where($this->db->quoteName('update_site_id') . ' = ' . $siteId)
+                    ->where($this->db->quoteName('extension_id') . ' = ' . $other)
+            )->loadResult(),
+            'The other extension keeps its binding'
+        );
+    }
+
+    /**
+     * Run the finish step under test.
+     *
+     * @return  void
+     */
+    private function runStep(): void
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+        $factory->setFormFactory($container->get(FormFactoryInterface::class));
+
+        /** @var CwminstallModel $model */
+        $model = $factory->createModel('Cwminstall', 'Administrator', ['ignore_request' => true]);
+
+        $this->assertInstanceOf(CwminstallModel::class, $model);
+
+        $method = new \ReflectionMethod($model, 'setComponentUpdateSite');
+        $method->invoke($model);
+    }
+
+    /**
+     * @param   string  $name         Update site name
+     * @param   string  $location     Stream URL
+     * @param   int     $extensionId  Extension to bind it to
+     *
+     * @return  int  The new update site id
+     */
+    private function seedUpdateSite(string $name, string $location, int $extensionId): int
+    {
+        $site           = new \stdClass();
+        $site->name     = $name;
+        $site->type     = 'extension';
+        $site->location = $location;
+        $site->enabled  = 1;
+        $this->db->insertObject('#__update_sites', $site);
+
+        $siteId = (int) $this->db->insertid();
+
+        $binding                 = new \stdClass();
+        $binding->update_site_id = $siteId;
+        $binding->extension_id   = $extensionId;
+        $this->db->insertObject('#__update_sites_extensions', $binding);
+
+        return $siteId;
+    }
+
+    /**
+     * A pkg_proclaim row, created only if the test database has none.
+     *
+     * @return  int  Extension id
+     */
+    private function seedPackageExtension(): int
+    {
+        $existing = (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('extension_id'))
+                ->from($this->db->quoteName('#__extensions'))
+                ->where($this->db->quoteName('element') . ' = ' . $this->db->quote('pkg_proclaim'))
+                ->where($this->db->quoteName('type') . ' = ' . $this->db->quote('package'))
+        )->loadResult();
+
+        if ($existing > 0) {
+            return $existing;
+        }
+
+        $row                 = new \stdClass();
+        $row->name           = 'pkg_proclaim';
+        $row->type           = 'package';
+        $row->element        = 'pkg_proclaim';
+        $row->folder         = '';
+        $row->client_id      = 0;
+        $row->enabled        = 1;
+        $row->access         = 1;
+        $row->protected      = 0;
+        $row->manifest_cache = '';
+        $row->params         = '{}';
+        $row->custom_data    = '';
+        $this->db->insertObject('#__extensions', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @param   int  $extensionId  Extension to look up
+     *
+     * @return  array<int, array{id: int, location: string}>
+     */
+    private function sitesFor(int $extensionId): array
+    {
+        $rows = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select([$this->db->quoteName('u.update_site_id', 'id'), $this->db->quoteName('u.location')])
+                ->from($this->db->quoteName('#__update_sites', 'u'))
+                ->join(
+                    'INNER',
+                    $this->db->quoteName('#__update_sites_extensions', 'x'),
+                    $this->db->quoteName('x.update_site_id') . ' = ' . $this->db->quoteName('u.update_site_id')
+                )
+                ->where($this->db->quoteName('x.extension_id') . ' = ' . $extensionId)
+        )->loadAssocList() ?: [];
+
+        return array_values($rows);
+    }
+
+    /**
+     * @param   int  $siteId  Update site id
+     *
+     * @return  int  1 when the row is present
+     */
+    private function siteExists(int $siteId): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__update_sites'))
+                ->where($this->db->quoteName('update_site_id') . ' = ' . $siteId)
+        )->loadResult();
+    }
+
+    /**
+     * Drop every update site claiming Proclaim, so each test starts level.
+     *
+     * @return  void
+     */
+    private function clearProclaimUpdateSites(): void
+    {
+        $ids = array_map('intval', $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('x.update_site_id'))
+                ->from($this->db->quoteName('#__update_sites_extensions', 'x'))
+                ->join(
+                    'INNER',
+                    $this->db->quoteName('#__extensions', 'e'),
+                    $this->db->quoteName('e.extension_id') . ' = ' . $this->db->quoteName('x.extension_id')
+                )
+                ->where($this->db->quoteName('e.element') . ' IN (' . $this->db->quote('com_proclaim')
+                    . ', ' . $this->db->quote('pkg_proclaim') . ')')
+        )->loadColumn() ?: []);
+
+        if ($ids === []) {
+            return;
+        }
+
+        $list = implode(',', $ids);
+
+        foreach (['#__updates', '#__update_sites_extensions', '#__update_sites'] as $table) {
+            $this->db->setQuery(
+                $this->db->createQuery()
+                    ->delete($this->db->quoteName($table))
+                    ->where($this->db->quoteName('update_site_id') . ' IN (' . $list . ')')
+            )->execute();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1851.

## The bug

`CwminstallModel`'s `setupdateurl` finish step deleted the component's update site bindings and inserted a replacement pointing at **ARS stream id=2**. That stream stops at 9.2.8 by design — 9.x → 10.x is a migration, not an in-place update — so a site that ran the installer came out subscribed to a channel that can never offer it a 10.x release.

It runs in **both** finish paths, including the minimal "no DB changes detected" one, so it fired on essentially every pass of the routine.

Three defects in the one step:

1. **The wrong stream.** id=2 can never announce a 10.x release.
2. **An HTML-escaped URL in a PHP string.** In a query string `&amp;` is a parameter named `amp;view`, so `view` and `task` never arrived — the URL returned nothing even for a 9.x site. j5-dev's stored row still shows the `&amp;` intact.
3. **It undid #1667.** The package postflight retires component-owned update sites; this recreated one immediately afterwards. That is the reported "old update stream is not being removed" — it *was* removed, then written back.

## The fix

Updates belong to `pkg_proclaim`: its manifest declares the stream and Joomla registers it during install. So where the package is present, the component now keeps **no** update site — a second one only makes the site poll twice and report Proclaim as a component update.

A site with no package still needs a channel — component-only installs predate the package and are reached solely through their own entry — so one is created there, at the stream carrying current releases, unescaped.

Two further problems in the old cleanup are fixed alongside:

- **Found by binding, not by name.** Matching `name = 'Proclaim Package'` missed rows registered under another name — j6-dev has one called `CWM Proclaim Package` owned by `com_proclaim` — while still deleting their bindings, orphaning them in `#__update_sites` where no later pass could see them.
- **Shared rows survive.** `#__update_sites_extensions` is many-to-many, so a row can serve another extension. Only Proclaim's claim is released; deleting the row would take that extension's update channel with it.

## Upgrade paths, all preserved

| Site shape | Before | After |
|---|---|---|
| Component-only (no package) | com_proclaim → id=2, malformed | com_proclaim → **id=1**, valid |
| Package installed | package site **+** duplicate com_proclaim → id=2 | duplicate removed, package site untouched |
| 9.x → 10.x migration | ends on id=2, never offered 10.x again | ends on id=1 |
| Still on 9.x, never runs the installer | id=2 row | untouched — this code does not run |

## Tests

New `tests/integration/Admin/Model/CwminstallUpdateSiteTest.php` drives the real method against a real database (3 tests, 14 assertions), covering the component-only branch, the package-owned branch and the shared-row case.

**Mutation-verified** — each assertion was confirmed to fail when its guard is removed:

| Mutation | Caught by |
|---|---|
| stream back to `id=2` | `…contains "id=1"` |
| drop the package-owns-updates guard | `two arrays are identical` |
| drop the shared-binding guard | `0 is identical to 1` |

Full suite green (2400 tests), PSR-12 and comment gates clean.

⚠️ **Scope note:** the method is reached through the Admin Center's step dispatcher, so the test drives it directly rather than clicking through the UI. The DB effects are real and rolled back; the browser flow itself was not exercised.

The remaining half of #1851 — whether the package postflight should repoint or delete *historical* id=2 rows on sites that never run the installer — is deliberately left out and the issue stays open for it. Once this lands, no new id=2 rows are created.