### PR TITLE
feat: time the rest of postflight, not just the migrations

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -141,6 +141,22 @@ class com_proclaimInstallerScript extends InstallerScript
     private array $stepLog = [];
 
     /**
+     * How long each unconditional piece of postflight took.
+     *
+     * Separate from the migration log because the two answer different
+     * questions: that one is "did this site need the migration", this one is
+     * "where did the time go". Measured on a production update, the migrations
+     * came to 0.002s of a 6.89s postflight, so everything here is what an
+     * update actually costs.
+     *
+     * Each entry: name, seconds.
+     *
+     * @var    array<int, array{name: string, secs: float}>
+     * @since  __DEPLOY_VERSION__
+     */
+    private array $taskLog = [];
+
+    /**
      * When preflight ran, as a float second.
      *
      * ⚠️ The gap between this and the start of postflight is the only view
@@ -616,6 +632,43 @@ class com_proclaimInstallerScript extends InstallerScript
             ];
 
             $this->logInstall(sprintf('  FAIL  %-26s %s', $name, $e->getMessage()));
+        }
+    }
+
+    /**
+     * Time a piece of postflight, and record where the time went.
+     *
+     * Postflight's unconditional work — installing the sub-extensions, copying
+     * language files, clearing caches — was never measured, so an update that
+     * felt slow could only be guessed at. The migrations were instrumented
+     * first and turned out to be free, which left the larger part of an update
+     * unaccounted for.
+     *
+     * ⚠️ Unlike step(), a throw is re-raised rather than recorded. These are
+     * not optional migrations: several are load-bearing, several already sit
+     * inside their own try/catch with error handling chosen per call, and
+     * swallowing here would quietly change what an installer failure does. The
+     * timing is taken in a finally, so work that throws is still measured.
+     *
+     * @param   string    $name  Task name, as it appears in the log
+     * @param   callable  $work  The work to time
+     *
+     * @return  mixed  Whatever $work returned
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function task(string $name, callable $work): mixed
+    {
+        $started = microtime(true);
+
+        try {
+            return $work();
+        } finally {
+            $secs = microtime(true) - $started;
+
+            $this->taskLog[] = ['name' => $name, 'secs' => $secs];
+
+            $this->logInstall(sprintf('  task  %-26s %6.3fs', $name, $secs));
         }
     }
 
@@ -1977,139 +2030,145 @@ class com_proclaimInstallerScript extends InstallerScript
             return;
         }
 
-        $this->checkScriptureLibraryVersion();
+        $this->task('Scripture library check', fn () => $this->checkScriptureLibraryVersion());
 
         // Rename old folders before deletion (must happen before removeFiles is called)
         if ($type === 'update') {
-            $this->renameLegacyFolders();
+            $this->task('Rename legacy folders', fn () => $this->renameLegacyFolders());
         }
 
         // After the migration SQL has added uq_study_topic, retire the index it
         // replaces. No-op on a fresh install, where install.sql never creates it.
-        $this->dropRedundantStudyTopicIndex();
+        $this->task('Study topic index', fn () => $this->dropRedundantStudyTopicIndex());
 
         // The analytics aggregate key cannot be reworked in SQL at all; this is
         // where it is brought to its intended columns. No-op when already correct.
-        $this->reconcileAnalyticsAggregateIndex();
+        $this->task('Analytics index', fn () => $this->reconcileAnalyticsAggregateIndex());
 
         // Seeded on update as well as install: access.xml can gain a section in
         // any release, and a section with no asset is a permission the UI can
         // offer but nothing can store.
-        $this->seedSectionAssets();
+        $this->task('Section assets', fn () => $this->seedSectionAssets());
 
         // Install subExtensions
-        $this->installSubExtensions($parent);
+        $this->task('Sub-extensions', fn () => $this->installSubExtensions($parent));
 
         // Copy language files to the system folder
-        $this->copyLanguageFiles();
+        $this->task('Language files', fn () => $this->copyLanguageFiles());
 
         // Show the post-installation page
-        $this->renderPostInstallation($this->status, $parent);
+        $this->task('Post-install page', fn () => $this->renderPostInstallation($this->status, $parent));
 
         //Remove old com_biblestudy menu items on the admin side
-        $this->removeBibleStudyVersion($parent);
+        $this->task('Legacy menu removal', fn () => $this->removeBibleStudyVersion($parent));
 
         // Declare our dependency on lib_cwmscripture so its uninstall guard and
         // shared-table cleanup can see us
-        $this->scriptureConsumer('register');
+        $this->task('Scripture consumer', fn () => $this->scriptureConsumer('register'));
 
         // Stale caches survive an update and can serve markup that references
         // assets this update replaced — see the method for what happened on a
         // live site.
-        $this->clearCaches();
+        $this->task('Clear caches', fn () => $this->clearCaches());
 
         if ($type === 'install' || $type === 'update') {
-            // This is a fresh install. Register for the guided tour directly.
-            try {
-                $helperPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/CwmguidedtourHelper.php';
+            $this->task('Guided tours', static function () {
+                // This is a fresh install. Register for the guided tour directly.
+                try {
+                    $helperPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/CwmguidedtourHelper.php';
 
-                if (file_exists($helperPath)) {
-                    require_once $helperPath;
-                    $tourHelper = new CwmguidedtourHelper();
+                    if (file_exists($helperPath)) {
+                        require_once $helperPath;
+                        $tourHelper = new CwmguidedtourHelper();
 
-                    $tours      = $tourHelper->registerGuidedTours();
-                    $messages   = $tourHelper->registerPostInstallMessages();
+                        $tours      = $tourHelper->registerGuidedTours();
+                        $messages   = $tourHelper->registerPostInstallMessages();
 
-                    if ($tours > 0) {
-                        Factory::getApplication()->enqueueMessage($tours . ' guided tour(s) have been installed.', 'message');
+                        if ($tours > 0) {
+                            Factory::getApplication()->enqueueMessage($tours . ' guided tour(s) have been installed.', 'message');
+                        } else {
+                            Factory::getApplication()->enqueueMessage('No new guided tours were installed.', 'notice');
+                        }
+
+                        if ($messages > 0) {
+                            Factory::getApplication()->enqueueMessage($messages . ' post-installation message(s) have been installed.', 'message');
+                        }
                     } else {
-                        Factory::getApplication()->enqueueMessage('No new guided tours were installed.', 'notice');
+                        Factory::getApplication()->enqueueMessage('Guided tour helper file not found.', 'warning');
                     }
-
-                    if ($messages > 0) {
-                        Factory::getApplication()->enqueueMessage($messages . ' post-installation message(s) have been installed.', 'message');
-                    }
-                } else {
-                    Factory::getApplication()->enqueueMessage('Guided tour helper file not found.', 'warning');
+                } catch (\Exception $e) {
+                    Factory::getApplication()->enqueueMessage('Failed to register guided tour: ' . $e->getMessage(), 'error');
                 }
-            } catch (\Exception $e) {
-                Factory::getApplication()->enqueueMessage('Failed to register guided tour: ' . $e->getMessage(), 'error');
-            }
+            });
         }
 
         // ⚠️ The scripture migration is the one that also runs on a fresh install.
         // install.mysql.utf8.sql seeds the sample study with legacy flat columns
         // and no junction row, so an install that skipped this shipped a study
         // whose reference the junction never knew about.
-        try {
-            $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
+        $this->task('Scripture references', static function () use ($type) {
+            try {
+                $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
 
-            if (file_exists($migrationPath)) {
-                require_once $migrationPath;
-                // These helpers moved to lib_cwmscripture in 10.3.0 and the
-                // migration autoloads the library class via the namespace
-                // registered in preflight(). Only require a legacy in-component
-                // copy if one is still present — a bare require_once of the
-                // (now missing) file is a fatal that the catch below can't trap.
-                $helperDir = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/';
+                if (file_exists($migrationPath)) {
+                    require_once $migrationPath;
+                    // These helpers moved to lib_cwmscripture in 10.3.0 and the
+                    // migration autoloads the library class via the namespace
+                    // registered in preflight(). Only require a legacy in-component
+                    // copy if one is still present — a bare require_once of the
+                    // (now missing) file is a fatal that the catch below can't trap.
+                    $helperDir = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Helper/';
 
-                foreach (['ScriptureReference.php', 'CwmscriptureHelper.php'] as $legacyHelper) {
-                    if (is_file($helperDir . $legacyHelper)) {
-                        require_once $helperDir . $legacyHelper;
+                    foreach (['ScriptureReference.php', 'CwmscriptureHelper.php'] as $legacyHelper) {
+                        if (is_file($helperDir . $legacyHelper)) {
+                            require_once $helperDir . $legacyHelper;
+                        }
+                    }
+
+                    $migrated = CwmscriptureMigration::migrate();
+
+                    if ($migrated > 0 && $type === 'update') {
+                        Factory::getApplication()->enqueueMessage(
+                            $migrated . ' study scripture reference(s) migrated to new format.',
+                            'message'
+                        );
                     }
                 }
-
-                $migrated = CwmscriptureMigration::migrate();
-
-                if ($migrated > 0 && $type === 'update') {
-                    Factory::getApplication()->enqueueMessage(
-                        $migrated . ' study scripture reference(s) migrated to new format.',
-                        'message'
-                    );
-                }
+            } catch (\Exception $e) {
+                Factory::getApplication()->enqueueMessage(
+                    'Scripture migration notice: ' . $e->getMessage(),
+                    'warning'
+                );
             }
-        } catch (\Exception $e) {
-            Factory::getApplication()->enqueueMessage(
-                'Scripture migration notice: ' . $e->getMessage(),
-                'warning'
-            );
-        }
+        });
 
         // ⚠️ Runs on install as well as update, and that is the point. A site
         // coming from 9.x has the flat columns full and no junction, and takes
         // the install route, so nothing in sql/updates ever replays for it.
-        try {
-            $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
+        $this->task('Retire legacy columns', static function () {
+            try {
+                $migrationPath = JPATH_ADMINISTRATOR . '/components/com_proclaim/src/Lib/CwmscriptureMigration.php';
 
-            if (file_exists($migrationPath)) {
-                require_once $migrationPath;
+                if (file_exists($migrationPath)) {
+                    require_once $migrationPath;
 
-                $moved = CwmscriptureMigration::retireLegacyColumns();
-                $moved += CwmmigrationHelper::retireLegacyTeacherColumn();
+                    $moved = CwmscriptureMigration::retireLegacyColumns();
+                    $moved += CwmmigrationHelper::retireLegacyTeacherColumn();
 
-                if ($moved > 0) {
-                    Factory::getApplication()->enqueueMessage(
-                        $moved . ' scripture reference(s) moved out of the legacy columns.',
-                        'message'
-                    );
+                    if ($moved > 0) {
+                        Factory::getApplication()->enqueueMessage(
+                            $moved . ' scripture reference(s) moved out of the legacy columns.',
+                            'message'
+                        );
+                    }
                 }
+            } catch (\Exception $e) {
+                Factory::getApplication()->enqueueMessage(
+                    'Could not retire the legacy scripture columns: ' . $e->getMessage(),
+                    'warning'
+                );
             }
-        } catch (\Exception $e) {
-            Factory::getApplication()->enqueueMessage(
-                'Could not retire the legacy scripture columns: ' . $e->getMessage(),
-                'warning'
-            );
-        }
+        });
 
         // The remaining legacy data migrations run on UPGRADES only. A fresh
         // install's SQL already creates the current schema, so there is nothing
@@ -2222,10 +2281,14 @@ class com_proclaimInstallerScript extends InstallerScript
             }
         }
 
+        // ⚠️ The leading "N step(s) in Ns" is parsed by build/verify-install-log.php,
+        // which cross-checks it against the per-step lines. Keep it at the front.
         $this->logInstall(sprintf(
-            'postflight: %d step(s) in %.3fs; postflight total %.2fs; whole install %.2fs',
+            'postflight: %d step(s) in %.3fs, %d task(s) in %.2fs; postflight total %.2fs; whole install %.2fs',
             \count($this->stepLog),
             array_sum(array_column($this->stepLog, 'secs')),
+            \count($this->taskLog),
+            array_sum(array_column($this->taskLog, 'secs')),
             microtime(true) - $postflightStarted,
             microtime(true) - $this->startedAt
         ));

--- a/tests/unit/Admin/Lib/PostflightTaskTest.php
+++ b/tests/unit/Admin/Lib/PostflightTaskTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Postflight says where the time went.
+ *
+ * The migrations were instrumented first and turned out to cost nothing —
+ * 0.002s of a 6.89s postflight on a production update. That left the part an
+ * update actually spends its time in completely unmeasured, so "make updates
+ * faster" had nothing to aim at.
+ *
+ * ⚠️ Two contracts are asserted here that nothing else can see. The timer must
+ * re-raise, because the work it wraps is load-bearing and several call sites
+ * already choose their own error handling; a swallowing timer would silently
+ * turn an installer failure into a success. And the summary line is parsed by
+ * build/verify-install-log.php in the release gate, so its leading field is a
+ * cross-file contract rather than cosmetic text.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+class PostflightTaskTest extends ProclaimTestCase
+{
+    /**
+     * @return  string  The manifest script's source
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function script(): string
+    {
+        return (string) file_get_contents(\dirname(__DIR__, 4) . '/proclaim.script.php');
+    }
+
+    /**
+     * One method's body, so an assertion cannot be satisfied by a sibling.
+     *
+     * @param   string  $signature  The method's declaration line
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function methodBody(string $signature): string
+    {
+        $source = self::script();
+        $start  = strpos($source, $signature);
+
+        self::assertNotFalse($start, $signature . ' could not be found.');
+
+        $end = strpos($source, "\n    }\n", $start);
+
+        self::assertNotFalse($end, 'Could not find the end of ' . $signature);
+
+        return substr($source, $start, $end - $start);
+    }
+
+    #[TestDox('The timer re-raises, so wrapping work cannot turn a failed install into a quiet one')]
+    public function testTaskDoesNotSwallowFailures(): void
+    {
+        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+
+        $this->assertStringNotContainsString(
+            'catch',
+            $body,
+            'task() must not catch: step() swallows because a migration is optional, '
+            . 'but postflight work is not, and several call sites handle their own errors.'
+        );
+        $this->assertStringContainsString(
+            'finally',
+            $body,
+            'The timing must be taken in a finally, or work that throws goes unmeasured — '
+            . 'which is exactly the work worth measuring.'
+        );
+    }
+
+    #[TestDox('Every timed task is recorded and logged')]
+    public function testTaskRecordsAndLogs(): void
+    {
+        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+
+        $this->assertStringContainsString(
+            '$this->taskLog[]',
+            $body,
+            'A task that is timed but not recorded contributes nothing to the summary.'
+        );
+        $this->assertStringContainsString(
+            '$this->logInstall(',
+            $body,
+            'The per-task line is the only durable record of where an update spent its time.'
+        );
+    }
+
+    #[TestDox('The migration steps and the postflight tasks stay separate')]
+    public function testTaskLogIsNotTheStepLog(): void
+    {
+        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+
+        $this->assertStringNotContainsString(
+            '$this->stepLog',
+            $body,
+            'Tasks written into the migration log would be reported to the administrator '
+            . 'as migrations, and counted as migrations by the release gate.'
+        );
+    }
+
+    #[TestDox('Postflight times more than just the migrations')]
+    public function testPostflightIsInstrumented(): void
+    {
+        $source = self::script();
+
+        preg_match_all("/\\\$this->task\('([^']+)'/", $source, $matches);
+
+        $names = $matches[1];
+
+        $this->assertGreaterThanOrEqual(
+            10,
+            \count($names),
+            'Postflight is where an update spends its time; timing only a couple of its '
+            . 'calls leaves the rest unaccounted for.'
+        );
+        $this->assertSame(
+            \count($names),
+            \count(array_unique($names)),
+            'Two tasks sharing a name cannot be told apart in the log: ' .
+            implode(', ', array_diff_assoc($names, array_unique($names)))
+        );
+    }
+
+    #[TestDox('The summary line still leads with the field the release gate parses')]
+    public function testSummaryLineKeepsTheParsedPrefix(): void
+    {
+        $source = self::script();
+
+        preg_match("/'postflight: [^']*step\(s\)[^']*'/", $source, $found);
+
+        $this->assertNotEmpty($found, 'The postflight summary format string could not be found.');
+
+        $format = trim($found[0], "'");
+
+        // The gate reads the step count out of this line and cross-checks it
+        // against the per-step lines. Rendering the format with plausible
+        // values proves the real output still matches, rather than trusting
+        // that the format string looks close enough.
+        $rendered = \sprintf($format, 8, 0.002, 14, 6.5, 6.89, 9.61);
+
+        $this->assertMatchesRegularExpression(
+            '/^postflight: (\d+) step\(s\) in /',
+            $rendered,
+            'build/verify-install-log.php parses this prefix. Anything added to the summary '
+            . 'must go after it, or the release gate stops being able to read the step count.'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1850.

## Why

Gating the migrations took them off the clock entirely. On a production update (nfsda.org, 10.5.7 → 10.5.9) they came to **0.002s of a 6.89s postflight** — which made postflight 72% of the whole update while the part actually costing the time was the part nobody was measuring. By timestamp, roughly 6.9s passed before the first migration line was reached.

## What

Fourteen call sites are now timed and named: the sub-extension install, the language file copy, the cache clear, the section assets, the scripture work, and the rest.

Measured on a clean install of this branch:

```
  task  Scripture library check     0.000s
  task  Study topic index           0.001s
  task  Analytics index             0.002s
  task  Section assets              0.020s
  task  Sub-extensions              0.196s
  task  Language files              0.004s
  task  Post-install page           0.007s
  task  Legacy menu removal         0.002s
  task  Scripture consumer          0.000s
  task  Clear caches                0.002s
  task  Guided tours                0.003s
  task  Scripture references        0.002s
  task  Retire legacy columns       0.000s
postflight: 0 step(s) in 0.000s, 13 task(s) in 0.24s; postflight total 0.24s; whole install 0.67s
```

The tasks account for the whole of postflight — **nothing is left unattributed**, which was the point. (13 rather than 14 because `Rename legacy folders` is update-only.) j6-test is tiny so every number is small, but the shape shows: `Sub-extensions` is 82% of postflight and is the candidate for nfsda.org's 6.9s.

## Design notes

**The timer is deliberately not `step()`.** `step()` records a throw and carries on, which is right for an optional migration and wrong here — several of these are load-bearing, several already sit inside their own `try`/`catch` with error handling chosen per call, and swallowing would quietly turn a failed install into a successful-looking one. `task()` re-raises, and takes its measurement in a `finally` so work that throws is still measured.

**Tasks stay out of `stepLog`.** The report the administrator sees counts migrations, and so does the release gate; anything else landing there would be reported and counted as one.

**Log only, not on screen.** The per-task lines go to the install log. The migration report is what the administrator gets; a list of internal task names on the update screen would be noise.

**⚠️ Cross-file contract.** The summary line gains a task count *after* the step count. `build/verify-install-log.php` parses that leading field to cross-check the per-step lines, so `testSummaryLineKeepsTheParsedPrefix` renders the format string and asserts the gate's own pattern still matches it. Putting the task count first breaks the gate, and that test catches it.

## Tests

5 unit tests, **each mutation-verified**:

| Mutation | Caught by |
|---|---|
| summary leads with `task(s)` instead of `step(s)` | `…matches PCRE pattern "/^postflight: (\d+) step\(s\) in /"` |
| `task()` writes into `stepLog` | 2 assertions |
| `task()` swallows throws | `must not catch` |

Assertions are bounded to the `task()` method body, so a sibling method cannot satisfy them.

Also verified live: `composer test:upgrade` runs green end to end with the new instrumentation, and gate step 7 still passes against the changed summary line.

Full suite green (2405 tests), PSR-12 / comment / syntax gates clean.