### PR TITLE
fix: a failed postflight step no longer rolls back the install

### DIFF
--- a/build/verify-install-log.php
+++ b/build/verify-install-log.php
@@ -36,8 +36,12 @@
  *   - every migration step was skipped, none ran, none failed
  *   - as many steps were considered as there are migrations in the script, so
  *     "nothing ran" cannot pass by nothing having been attempted
- *   - postflight reported both its timing lines, and its own step count agrees
- *     with the steps logged individually
+ *   - no postflight task failed. A task that throws is recorded and the update
+ *     carries on rather than rolling back an install that already happened, so
+ *     this is the only thing between a step that never works and nobody
+ *     noticing
+ *   - postflight reported both its timing lines, and its own step and task
+ *     counts agree with the lines logged individually
  *
  * Usage: php build/verify-install-log.php <type> [from-version]
  *          <type>          install | update, as preflight recorded it
@@ -310,9 +314,43 @@ foreach ($installs as $install) {
         echo "  OK   all {$skipped} legacy migration(s) gated out, none ran\n";
     }
 
+    // --- the rest of postflight ---------------------------------------------
+    //
+    // A task that throws is recorded and the update carries on, because
+    // aborting would roll back an install that has already happened. That makes
+    // a failure quiet, and quiet is only acceptable because this reads it back.
+    $tasks       = 0;
+    $failedTasks = [];
+
+    foreach ($block as $message) {
+        if (preg_match('/^ {2}task\s+(.*?)\s+[\d.]+s(?: FAILED: (.*))?$/', $message, $m) !== 1) {
+            continue;
+        }
+
+        $tasks++;
+
+        if (($m[2] ?? '') !== '') {
+            $failedTasks[] = trim($m[1]) . ' — ' . $m[2];
+        }
+    }
+
+    if ($failedTasks !== []) {
+        fwrite(STDERR, "  FAIL " . \count($failedTasks) . " postflight task(s) did not complete:\n");
+
+        foreach ($failedTasks as $line) {
+            fwrite(STDERR, "         {$line}\n");
+        }
+
+        fwrite(STDERR, "       These no longer abort the install, by design — so this is the\n");
+        fwrite(STDERR, "       only thing standing between a step that never works and nobody\n");
+        fwrite(STDERR, "       noticing.\n");
+        $failures++;
+    }
+
     // --- postflight reported on itself --------------------------------------
-    $elapsed = false;
-    $summary = -1;
+    $elapsed     = false;
+    $summary     = -1;
+    $taskSummary = -1;
 
     foreach ($block as $message) {
         if (str_contains($message, 'elapsed since preflight')) {
@@ -322,6 +360,28 @@ foreach ($installs as $install) {
         if (preg_match('/^postflight: (\d+) step\(s\) in /', $message, $m) === 1) {
             $summary = (int) $m[1];
         }
+
+        if (preg_match('/, (\d+) task\(s\) in /', $message, $m) === 1) {
+            $taskSummary = (int) $m[1];
+        }
+    }
+
+    if ($taskSummary < 0) {
+        fwrite(STDERR, "  FAIL postflight reported no task count —\n");
+        fwrite(STDERR, "       the build under test does not time its own postflight, so the\n");
+        fwrite(STDERR, "       'no task failed' result above was reached by there being nothing\n");
+        fwrite(STDERR, "       to check.\n");
+        $failures++;
+    } elseif ($taskSummary !== $tasks) {
+        fwrite(STDERR, "  FAIL postflight counted {$taskSummary} task(s); {$tasks} reached the log —\n");
+        fwrite(STDERR, "       the per-task lines and the summary disagree about what ran.\n");
+        $failures++;
+    } elseif ($failedTasks === []) {
+        echo "  OK   all {$tasks} postflight task(s) completed\n";
+    } else {
+        // The counts agree; what they agree on is already reported as a failure
+        // above. Claiming completion here as well would contradict it.
+        echo "  OK   all {$tasks} postflight task(s) reached the log\n";
     }
 
     if (!$elapsed) {

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -149,9 +149,9 @@ class com_proclaimInstallerScript extends InstallerScript
      * came to 0.002s of a 6.89s postflight, so everything here is what an
      * update actually costs.
      *
-     * Each entry: name, seconds.
+     * Each entry: name, seconds, and the failure message if it did not finish.
      *
-     * @var    array<int, array{name: string, secs: float}>
+     * @var    array<int, array{name: string, secs: float, error: string}>
      * @since  __DEPLOY_VERSION__
      */
     private array $taskLog = [];
@@ -644,11 +644,19 @@ class com_proclaimInstallerScript extends InstallerScript
      * first and turned out to be free, which left the larger part of an update
      * unaccounted for.
      *
-     * ⚠️ Unlike step(), a throw is re-raised rather than recorded. These are
-     * not optional migrations: several are load-bearing, several already sit
-     * inside their own try/catch with error handling chosen per call, and
-     * swallowing here would quietly change what an installer failure does. The
-     * timing is taken in a finally, so work that throws is still measured.
+     * ⚠️ A throw is recorded and the update carries on. Joomla treats a
+     * RuntimeException out of postflight as grounds to abort and roll the
+     * install back — after the files have been copied and the schema replayed
+     * — so letting one escape destroys a working update to punish
+     * housekeeping. None of the work wrapped here was ever written as a gate
+     * on a good install, and most of it already caught for itself; this
+     * applies that uniformly.
+     *
+     * ⚠️ Non-fatal must not mean unnoticed. Every failure is enqueued for the
+     * administrator, written to the log, and asserted against by
+     * build/verify-install-log.php in the release gate.
+     *
+     * The timing is taken in a finally, so work that throws is still measured.
      *
      * @param   string    $name  Task name, as it appears in the log
      * @param   callable  $work  The work to time
@@ -660,15 +668,38 @@ class com_proclaimInstallerScript extends InstallerScript
     private function task(string $name, callable $work): mixed
     {
         $started = microtime(true);
+        $error   = '';
 
         try {
             return $work();
+        } catch (\Throwable $e) {
+            $error = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+            Factory::getApplication()->enqueueMessage(
+                sprintf(
+                    'Proclaim: the "%s" step of this update did not complete (%s). '
+                    . 'The update itself is installed; the com_proclaim.install log has the detail.',
+                    $name,
+                    $error
+                ),
+                'warning'
+            );
+
+            return null;
         } finally {
             $secs = microtime(true) - $started;
 
-            $this->taskLog[] = ['name' => $name, 'secs' => $secs];
+            $this->taskLog[] = ['name' => $name, 'secs' => $secs, 'error' => $error];
 
-            $this->logInstall(sprintf('  task  %-26s %6.3fs', $name, $secs));
+            // ⚠️ Failures keep the "task" prefix rather than step()'s "FAIL".
+            // build/verify-install-log.php reads that one as a failed migration,
+            // and a failure reported against the wrong thing is worse than the
+            // line it replaces. The gate matches this shape instead.
+            $this->logInstall(
+                $error === ''
+                    ? sprintf('  task  %-26s %6.3fs', $name, $secs)
+                    : sprintf('  task  %-26s %6.3fs FAILED: %s', $name, $secs, $error)
+            );
         }
     }
 

--- a/tests/unit/Admin/Lib/PostflightTaskTest.php
+++ b/tests/unit/Admin/Lib/PostflightTaskTest.php
@@ -8,12 +8,16 @@
  * update actually spends its time in completely unmeasured, so "make updates
  * faster" had nothing to aim at.
  *
- * ⚠️ Two contracts are asserted here that nothing else can see. The timer must
- * re-raise, because the work it wraps is load-bearing and several call sites
- * already choose their own error handling; a swallowing timer would silently
- * turn an installer failure into a success. And the summary line is parsed by
- * build/verify-install-log.php in the release gate, so its leading field is a
- * cross-file contract rather than cosmetic text.
+ * ⚠️ Two contracts are asserted here that nothing else can see.
+ *
+ * A failing task must not abort: Joomla rolls the install back on a
+ * RuntimeException out of postflight, after the files are copied and the schema
+ * replayed, so escaping destroys a working update over housekeeping. The price
+ * is that failures go quiet, which is why the same tests require them to be
+ * enqueued, logged, and caught by the release gate.
+ *
+ * And the summary line is parsed by build/verify-install-log.php, so its
+ * leading field is a cross-file contract rather than cosmetic text.
  *
  * @package    Proclaim.UnitTest
  * @copyright  (C) 2026 CWM Team All rights reserved
@@ -64,22 +68,71 @@ class PostflightTaskTest extends ProclaimTestCase
         return substr($source, $start, $end - $start);
     }
 
-    #[TestDox('The timer re-raises, so wrapping work cannot turn a failed install into a quiet one')]
-    public function testTaskDoesNotSwallowFailures(): void
+    #[TestDox('A failing task does not roll back an install that already happened')]
+    public function testTaskDoesNotAbortTheInstall(): void
     {
         $body = self::methodBody('private function task(string $name, callable $work): mixed');
 
-        $this->assertStringNotContainsString(
-            'catch',
+        $this->assertStringContainsString(
+            'catch (\Throwable',
             $body,
-            'task() must not catch: step() swallows because a migration is optional, '
-            . 'but postflight work is not, and several call sites handle their own errors.'
+            'Joomla aborts and rolls back the install on a RuntimeException out of '
+            . 'postflight — after the files are copied and the schema replayed. Letting '
+            . 'one escape destroys a working update to punish housekeeping.'
         );
         $this->assertStringContainsString(
             'finally',
             $body,
             'The timing must be taken in a finally, or work that throws goes unmeasured — '
             . 'which is exactly the work worth measuring.'
+        );
+    }
+
+    #[TestDox('A failing task is reported, logged and left visible to the release gate')]
+    public function testTaskFailureIsNotSilent(): void
+    {
+        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+
+        $this->assertStringContainsString(
+            'enqueueMessage',
+            $body,
+            'Non-fatal must not mean unnoticed: the administrator has to be told the step '
+            . 'did not finish.'
+        );
+        $this->assertStringContainsString(
+            'FAILED:',
+            $body,
+            'The failure has to reach the install log, which is the only durable record '
+            . 'and what build/verify-install-log.php reads.'
+        );
+
+        // ⚠️ step() logs failures as "  FAIL  ". The release gate parses that as a
+        // failed *migration*, so a task borrowing it would be reported against the
+        // wrong thing.
+        $this->assertStringNotContainsString(
+            "'  FAIL ",
+            $body,
+            'A failed task must keep the task prefix, or the gate misattributes it '
+            . 'as a failed migration.'
+        );
+    }
+
+    #[TestDox('The release gate fails the build when a postflight task did not complete')]
+    public function testGateChecksForFailedTasks(): void
+    {
+        $gate = (string) file_get_contents(\dirname(__DIR__, 4) . '/build/verify-install-log.php');
+
+        $this->assertStringContainsString(
+            'task(s) did not complete',
+            $gate,
+            'Making failures non-fatal without detecting them trades a loud wrong '
+            . 'behaviour for a quiet one.'
+        );
+        $this->assertStringContainsString(
+            'postflight reported no task count',
+            $gate,
+            'A build that logs no tasks at all would otherwise pass the "no task failed" '
+            . 'check by having nothing to check.'
         );
     }
 


### PR DESCRIPTION
Fixes #1854. Implements the direction settled in the #1850 design review.

## The behaviour being changed

```php
try {
    $this->triggerManifestScript('postflight');
} catch (\RuntimeException $e) {
    // Install failed, roll back changes
    $this->parent->abort($e->getMessage());
    return false;
}
```

`InstallerAdapter::install()` rolls the install back on a `RuntimeException` out of postflight — *after* the files are copied and the schema replayed. And only `RuntimeException` is caught; anything else escapes the installer as a fatal.

## Why postflight should never do that

Audit of the fourteen steps:

- **None throws deliberately.** Not one was written as a gate on a working install.
- **8 of 11 already catch for themselves.** The established intent is plainly "report and continue".
- The three that did not — `renameLegacyFolders`, `installSubExtensions`, `scriptureConsumer` — were unprotected by omission.

By postflight the install has effectively happened. Rolling it back because a cache did not clear destroys a good update to punish housekeeping. `task()` now applies uniformly what most of these already did individually.

## The other half: non-fatal must not mean unnoticed

This is the risk the change creates, and it is why the detection ships with it rather than after:

1. **The administrator is told** — each failure is enqueued as a warning naming the step, and saying the update itself is installed.
2. **The log records it** — `  task  Clear caches  0.002s FAILED: <message>`.
3. **The release gate fails on it** — `verify-install-log.php` now reports any failed task and exits non-zero.

⚠️ Failures keep the **`task`** prefix rather than `step()`'s `FAIL`. The gate parses `FAIL` as a failed *migration*, so a task borrowing it would be reported against the wrong thing.

⚠️ The gate also **cross-checks the task count against the summary line**, so a build that stopped timing its postflight cannot pass the "no task failed" check by having nothing to check.

## Verification

**Detection proven against a real log**, by marking one task line failed:

```
  FAIL 1 postflight task(s) did not complete:
         Clear caches — cache directory not writable
INSTALL LOG VERIFICATION FAILED (1 assertion(s))     exit=1
```

**Vacuity guard proven**, by stripping the task lines from a log:

```
  FAIL postflight reported no task count —
       the build under test does not time its own postflight, so the
       'no task failed' result above was reached by there being nothing to check.
```

**Live upgrade green end to end** — `composer test:upgrade`, 10.5.9 → 10.5.10-dev:

```
-- [7/17] verify the update reported what it did (and gated the migrations)
  OK   preflight upgraded from 10.5.9
  OK   all 8 registered migration step(s) reached the log
  OK   all 8 legacy migration(s) gated out, none ran
  OK   all 14 postflight task(s) completed
UPGRADE TEST PASSED 10.5.9 -> 10.5.10-dev.
```

Full suite green (2407 tests). PSR-12 and comment gates clean.

## Note on the tests

`PostflightTaskTest::testTaskDoesNotSwallowFailures` asserted the *previous* decision — that `task()` must not catch. It is replaced by tests for the new contract rather than deleted quietly: a failing task must not abort, and must be enqueued, logged and visible to the gate.

One message wording fix came out of the negative test: the gate printed "1 task did not complete" and "all 13 completed" in the same run. The count check and the failure check are different claims, and the success line no longer claims completion when something failed.