### PR TITLE
fix: retire the component's update sites only against a working package one

### DIFF
--- a/build/script.install.php
+++ b/build/script.install.php
@@ -50,6 +50,14 @@ return new class () implements InstallerScriptInterface {
     private string $minimumJoomla = '5.1.0';
 
     /**
+     * The ARS stream id Proclaim releases are announced on.
+     *
+     * @var string
+     * @since __DEPLOY_VERSION__
+     */
+    private const CURRENT_STREAM = '1';
+
+    /**
      * Runs before install/update to check requirements.
      *
      * @param   string            $type     Install type (install, update, discover_install)
@@ -371,12 +379,10 @@ return new class () implements InstallerScriptInterface {
 
             $packageSites = $sitesFor('pkg_proclaim', 'package');
 
-            // Never leave a site with no way to hear about updates. If the
-            // package has not registered its own update site — a partial
-            // install, or a component-only site that has not taken the package
-            // yet — the component's row is the only channel there is, so it
-            // stays. The next successful package install runs this again.
-            if ($packageSites === []) {
+            // The component's rows go only once the package holds one on the
+            // stream carrying current releases. Anything less would leave the
+            // site with no channel that can deliver an update.
+            if ($this->currentStreamSites($packageSites) === []) {
                 return;
             }
 
@@ -413,6 +419,50 @@ return new class () implements InstallerScriptInterface {
                 'com_proclaim'
             );
         }
+    }
+
+    /**
+     * Which of these update sites point at the stream carrying current releases.
+     *
+     * ARS serves several streams; id=2 stops at 9.2.8, because 9.x to 10.x is a
+     * migration rather than an in-place update.
+     *
+     * @param   int[]  $siteIds  Update site ids to test
+     *
+     * @return  int[]  Those on the current stream
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function currentStreamSites(array $siteIds): array
+    {
+        if ($siteIds === []) {
+            return [];
+        }
+
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $rows = $db->setQuery(
+            $db->createQuery()
+                ->select([$db->quoteName('update_site_id'), $db->quoteName('location')])
+                ->from($db->quoteName('#__update_sites'))
+                ->where(
+                    $db->quoteName('update_site_id') . ' IN ('
+                    . implode(',', array_map('intval', $siteIds)) . ')'
+                )
+        )->loadAssocList() ?: [];
+
+        $current = [];
+
+        foreach ($rows as $row) {
+            // Stored locations occur both plain and HTML-escaped.
+            $location = str_replace('&amp;', '&', (string) $row['location']);
+
+            if (preg_match('/[?&]id=' . self::CURRENT_STREAM . '(?:&|$)/', $location) === 1) {
+                $current[] = (int) $row['update_site_id'];
+            }
+        }
+
+        return $current;
     }
 
     /**

--- a/tests/unit/Admin/Lib/PackageUpdateSiteGuardTest.php
+++ b/tests/unit/Admin/Lib/PackageUpdateSiteGuardTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * The package retires the component's update sites only when it holds a
+ * working one of its own.
+ *
+ * "The package has an update site" and "the package has a channel that can
+ * deliver an update" look like the same test and are not. A package row on the
+ * 9.x stream satisfies the first while announcing nothing, and the component's
+ * rows would be deleted on the strength of it.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since  __DEPLOY_VERSION__
+ */
+class PackageUpdateSiteGuardTest extends ProclaimTestCase
+{
+    /**
+     * @return  string  The package manifest script's source
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function script(): string
+    {
+        return (string) file_get_contents(\dirname(__DIR__, 4) . '/build/script.install.php');
+    }
+
+    /**
+     * @return  string  Just the retirement method
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function retirementBody(): string
+    {
+        $source = self::script();
+        $start  = strpos($source, 'private function removeComponentUpdateSites(): void');
+
+        self::assertNotFalse($start, 'removeComponentUpdateSites() could not be found.');
+
+        $end = strpos($source, "\n    }\n", $start);
+
+        return substr($source, $start, $end - $start);
+    }
+
+    #[TestDox('The guard requires a package row on the current stream, not merely any row')]
+    public function testGuardTestsForAWorkingChannel(): void
+    {
+        $body = self::retirementBody();
+
+        $this->assertStringContainsString(
+            'currentStreamSites($packageSites)',
+            $body,
+            'A package row that announces nothing must not license deleting the '
+            . 'component rows that were working.'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/if \(\$packageSites === \[\]\)/',
+            $body,
+            'Testing the row exists is the weaker check this replaced.'
+        );
+    }
+
+    #[TestDox('The current stream is identified allowing for HTML-escaped locations')]
+    public function testStreamMatchAllowsEscapedLocations(): void
+    {
+        $source = self::script();
+
+        $this->assertStringContainsString(
+            "str_replace('&amp;', '&'",
+            $source,
+            'Stored locations occur both plain and HTML-escaped; matching only the '
+            . 'plain form reads an escaped current-stream row as the 9.x one.'
+        );
+    }
+
+    #[TestDox('A site is never left without a channel')]
+    public function testNothingIsDeletedWithoutAWorkingPackageRow(): void
+    {
+        $body = self::retirementBody();
+
+        $guard  = strpos($body, 'currentStreamSites($packageSites)');
+        $delete = strpos($body, '->delete(');
+
+        $this->assertNotFalse($guard);
+        $this->assertNotFalse($delete);
+        $this->assertLessThan(
+            $delete,
+            $guard,
+            'The guard has to come first, or rows are deleted before anything '
+            . 'establishes the site still has a way to hear about updates.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #1851.

Implements the rule agreed on the issue: **delete every `com_proclaim`-owned update site, stream 1 and stream 2 alike — but only when `pkg_proclaim` holds a stream 1 row.**

## What was wrong

The package already retires `com_proclaim`-owned update sites, but guarded that on the package merely *having* a row:

```php
if ($packageSites === []) {
    return;
}
```

A package row pointing at the 9.x stream satisfies that while announcing nothing — the newest entry on id=2 is 9.2.8. So the component's rows, the ones actually delivering updates, could be deleted on the strength of a channel that cannot deliver one.

The guard now requires the package to hold a row on the stream carrying current releases.

Stored locations turn up both plain and HTML-escaped, so the match allows for both — the escaped form is what a site written by the old installer path carries.

## Verified live on j6-test, against a built package

| Package row | Stale `com_proclaim` row | Result |
|---|---|---|
| stream 1 | present | **deleted** |
| stream 2 | present | **kept** — the site is not left without a channel |
| stream 1 (restored by the install) | still present | **deleted** — the site repairs itself on the next install |

That third row is worth noting: Joomla puts the package's own location back from the manifest, so a site that hits the middle case corrects itself the next time the package installs.

## Tests

3 unit tests, both mutations caught:

| Mutation | Caught |
|---|---|
| revert to `if ($packageSites === [])` | 2 assertions |
| drop the `&amp;` handling | 1 assertion |

One of them asserts the guard appears *before* the first `->delete(`, so the check cannot be reordered after the thing it protects.

Full suite green (2410 tests); `composer test:upgrade` green end to end, 10.5.9 → 10.5.10-dev.

## What this does not do

Component-only sites — no `pkg_proclaim` at all — keep both their rows, including a dead stream 2 one. That follows the rule as agreed: nothing is deleted unless the package holds a working channel. Those sites are not silent; measured on j5-dev, the working stream 1 row already delivers 10.5.9, and the dead row costs one redundant poll per update check.

⚠️ Two claims made earlier on #1851 were wrong and are corrected in [this comment](https://github.com/Joomla-Bible-Study/Proclaim/issues/1851#issuecomment-5300251345): repointing was proposed on the false assumption these sites were silent, and the `&amp;`-escaped URL was described as malformed when it in fact resolves.