### PR TITLE
fix: let a replayed migration skip work already applied instead of aborting

### DIFF
--- a/admin/sql/updates/mysql/10.0.0-20220921.sql
+++ b/admin/sql/updates/mysql/10.0.0-20220921.sql
@@ -7,4 +7,4 @@ alter table `#__bsms_podcast`
 alter table `#__bsms_series`
     modify series_thumbnail VARCHAR(255) DEFAULT NULL;
 alter table `#__bsms_podcast`
-    add column `podcastlink` VARCHAR(100) DEFAULT NULL AFTER `website`;
+    add column `podcastlink` VARCHAR(100) DEFAULT NULL AFTER `website` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20251225.sql
+++ b/admin/sql/updates/mysql/10.1.0-20251225.sql
@@ -1,69 +1,69 @@
 -- Add created_by and modified_by fields to tables that are missing them
 
 -- bsms_message_type
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show`;
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_podcast
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `linktype`;
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `linktype` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_series
-ALTER TABLE `#__bsms_series` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_series` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_servers
-ALTER TABLE `#__bsms_servers` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `params`;
-ALTER TABLE `#__bsms_servers` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_servers` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_servers` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_servers` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `params` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_studies (messages/sermons)
-ALTER TABLE `#__bsms_studies` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `publish_down`;
-ALTER TABLE `#__bsms_studies` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_studies` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_studies` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_studies` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_studies` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `publish_down` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_studies` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_studies` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_studies` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_studies` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_teachers
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show`;
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `landing_show` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_templatecode
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `asset_id`;
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `asset_id` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_templates
-ALTER TABLE `#__bsms_templates` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `asset_id`;
-ALTER TABLE `#__bsms_templates` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_templates` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_templates` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_templates` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `asset_id` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- bsms_topics
-ALTER TABLE `#__bsms_topics` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `params`;
-ALTER TABLE `#__bsms_topics` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created`;
-ALTER TABLE `#__bsms_topics` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by`;
-ALTER TABLE `#__bsms_topics` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias`;
-ALTER TABLE `#__bsms_topics` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified`;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `params` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `created_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `created` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `created_by_alias` VARCHAR(255) NOT NULL DEFAULT '' AFTER `created_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `created_by_alias` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `modified_by` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `modified` /** CAN FAIL **/;
 
 -- Add indexes for created_by where useful
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_createdby` (`created_by`);
-ALTER TABLE `#__bsms_series` ADD KEY `idx_createdby` (`created_by`);
-ALTER TABLE `#__bsms_teachers` ADD KEY `idx_createdby` (`created_by`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_createdby` (`created_by`) /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD KEY `idx_createdby` (`created_by`) /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD KEY `idx_createdby` (`created_by`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260207.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260207.sql
@@ -18,7 +18,7 @@ INSERT IGNORE INTO `#__action_logs_extensions` (`extension`) VALUES ('com_procla
 --
 
 -- Studies: Core list filtering (published + access + series + sort by date)
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_access_series` (`published`, `access`, `series_id`, `studydate`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_access_series` (`published`, `access`, `series_id`, `studydate`) /** CAN FAIL **/;
 
 -- Studies: Teacher filter pattern
 -- The statement that created idx_teacher_published is deliberately gone. #1731
@@ -33,13 +33,13 @@ ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_access_series` (`published`
 -- #1706, and the same fix already applied to idx_booknumber_published.
 
 -- Studies: Location filter pattern
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_location_published` (`location_id`, `published`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_location_published` (`location_id`, `published`) /** CAN FAIL **/;
 
 -- Studies: Temporal publish_up/down date range filtering
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_dates` (`published`, `publish_up`, `publish_down`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_published_dates` (`published`, `publish_up`, `publish_down`) /** CAN FAIL **/;
 
 -- Studies: Message type filter pattern
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_messagetype_published` (`messagetype`, `published`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_messagetype_published` (`messagetype`, `published`) /** CAN FAIL **/;
 
 -- Studies: Book number filter pattern
 -- The statement that created idx_booknumber_published is deliberately gone.
@@ -54,35 +54,35 @@ ALTER TABLE `#__bsms_studies` ADD KEY `idx_messagetype_published` (`messagetype`
 -- #1706.
 
 -- Studies: Language filter for multilingual sites
-ALTER TABLE `#__bsms_studies` ADD KEY `idx_language_published` (`language`, `published`);
+ALTER TABLE `#__bsms_studies` ADD KEY `idx_language_published` (`language`, `published`) /** CAN FAIL **/;
 
 -- Comments: Study + published composite (study_id was NOT indexed)
-ALTER TABLE `#__bsms_comments` ADD KEY `idx_study_published` (`study_id`, `published`, `comment_date`);
+ALTER TABLE `#__bsms_comments` ADD KEY `idx_study_published` (`study_id`, `published`, `comment_date`) /** CAN FAIL **/;
 
 -- Media files: Study + published aggregation covering index
-ALTER TABLE `#__bsms_mediafiles` ADD KEY `idx_study_published` (`study_id`, `published`, `createdate`);
+ALTER TABLE `#__bsms_mediafiles` ADD KEY `idx_study_published` (`study_id`, `published`, `createdate`) /** CAN FAIL **/;
 
 -- Media files: Podcast filter pattern
-ALTER TABLE `#__bsms_mediafiles` ADD KEY `idx_podcast_published` (`podcast_id`, `published`);
+ALTER TABLE `#__bsms_mediafiles` ADD KEY `idx_podcast_published` (`podcast_id`, `published`) /** CAN FAIL **/;
 
 --
 -- Priority 2: Published + access composites for entity tables
 --
 
 -- Series: Published + access composite for access control queries
-ALTER TABLE `#__bsms_series` ADD KEY `idx_published_access` (`published`, `access`);
+ALTER TABLE `#__bsms_series` ADD KEY `idx_published_access` (`published`, `access`) /** CAN FAIL **/;
 
 -- Series: Teacher + published composite for teacher detail pages
-ALTER TABLE `#__bsms_series` ADD KEY `idx_teacher_published` (`teacher`, `published`);
+ALTER TABLE `#__bsms_series` ADD KEY `idx_teacher_published` (`teacher`, `published`) /** CAN FAIL **/;
 
 -- Teachers: Published + access composite
-ALTER TABLE `#__bsms_teachers` ADD KEY `idx_published_access` (`published`, `access`);
+ALTER TABLE `#__bsms_teachers` ADD KEY `idx_published_access` (`published`, `access`) /** CAN FAIL **/;
 
 -- Topics: Published + access composite
-ALTER TABLE `#__bsms_topics` ADD KEY `idx_published_access` (`published`, `access`);
+ALTER TABLE `#__bsms_topics` ADD KEY `idx_published_access` (`published`, `access`) /** CAN FAIL **/;
 
 -- Locations: Published + access composite
-ALTER TABLE `#__bsms_locations` ADD KEY `idx_published_access` (`published`, `access`);
+ALTER TABLE `#__bsms_locations` ADD KEY `idx_published_access` (`published`, `access`) /** CAN FAIL **/;
 
 -- Study-Topics junction: covering composite for dual-direction lookups.
 --

--- a/admin/sql/updates/mysql/10.1.0-20260211.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260211.sql
@@ -3,41 +3,41 @@
 -- (Each ALTER must be a separate statement for Joomla ChangeSet parser compatibility)
 --
 
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_teachers` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_teachers` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_series` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_series` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_series` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_topics` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_topics` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_topics` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_topics` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_topics` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_message_type` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_message_type` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_message_type` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_servers` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_servers` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_servers` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_servers` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_servers` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_podcast` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_podcast` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_podcast` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_templates` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_templates` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_templates` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_templates` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templates` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by`;
-ALTER TABLE `#__bsms_templatecode` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_templatecode` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_templatecode` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
-ALTER TABLE `#__bsms_comments` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `language`;
-ALTER TABLE `#__bsms_comments` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out`;
-ALTER TABLE `#__bsms_comments` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_comments` ADD COLUMN `checked_out` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `language` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_comments` ADD COLUMN `checked_out_time` DATETIME DEFAULT NULL AFTER `checked_out` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_comments` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;
 
 -- Add missing index to locations (columns already exist)
-ALTER TABLE `#__bsms_locations` ADD KEY `idx_checkout` (`checked_out`);
+ALTER TABLE `#__bsms_locations` ADD KEY `idx_checkout` (`checked_out`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260215.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260215.sql
@@ -5,7 +5,7 @@
 --
 
 ALTER TABLE `#__bsms_studies`
-    ADD COLUMN `image` TEXT DEFAULT NULL AFTER `thumbnailm`;
+    ADD COLUMN `image` TEXT DEFAULT NULL AFTER `thumbnailm` /** CAN FAIL **/;
 
 -- Back-fill image from thumbnailm for existing records that have thumb_ prefix
 UPDATE `#__bsms_studies`

--- a/admin/sql/updates/mysql/10.1.0-20260216.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260216.sql
@@ -5,7 +5,7 @@
 --
 
 ALTER TABLE `#__bsms_series`
-    ADD COLUMN `image` TEXT DEFAULT NULL AFTER `series_thumbnail`;
+    ADD COLUMN `image` TEXT DEFAULT NULL AFTER `series_thumbnail` /** CAN FAIL **/;
 
 -- Back-fill image from series_thumbnail for existing records that have thumb_ prefix
 UPDATE `#__bsms_series`

--- a/admin/sql/updates/mysql/10.1.0-20260219.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260219.sql
@@ -3,6 +3,6 @@
 -- and a composite index for the scheduled-publish task query.
 --
 
-ALTER TABLE `#__bsms_series` ADD COLUMN `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `modified_by`;
-ALTER TABLE `#__bsms_series` ADD COLUMN `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `publish_up`;
-ALTER TABLE `#__bsms_series` ADD KEY `idx_published_dates` (`published`, `publish_up`, `publish_down`);
+ALTER TABLE `#__bsms_series` ADD COLUMN `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `modified_by` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD COLUMN `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `publish_up` /** CAN FAIL **/;
+ALTER TABLE `#__bsms_series` ADD KEY `idx_published_dates` (`published`, `publish_up`, `publish_down`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260221.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260221.sql
@@ -3,8 +3,8 @@
 
 -- Index for filtering messages by location + publish status + date (most common list query pattern)
 ALTER TABLE `#__bsms_studies`
-    ADD INDEX `idx_location_pub_date` (`location_id`, `published`, `studydate`);
+    ADD INDEX `idx_location_pub_date` (`location_id`, `published`, `studydate`) /** CAN FAIL **/;
 
 -- Index for the hybrid security filter (location + Joomla access level)
 ALTER TABLE `#__bsms_studies`
-    ADD INDEX `idx_location_access` (`location_id`, `access`);
+    ADD INDEX `idx_location_access` (`location_id`, `access`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260222.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260222.sql
@@ -1,12 +1,12 @@
 -- Phase 8: Add location_id to series and podcast tables for multi-campus support
 ALTER TABLE `#__bsms_series`
-    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `teacher`;
+    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `teacher` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `published`;
+    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `published` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_series`
-    ADD KEY `idx_series_location` (`location_id`);
+    ADD KEY `idx_series_location` (`location_id`) /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_podcast`
-    ADD KEY `idx_podcast_location` (`location_id`);
+    ADD KEY `idx_podcast_location` (`location_id`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260223.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260223.sql
@@ -2,7 +2,7 @@
 -- NULL = shared server visible to all campuses
 -- Specific ID = campus-restricted server
 ALTER TABLE `#__bsms_servers`
-    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `type`;
+    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `type` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_servers`
-    ADD KEY `idx_location_published` (`location_id`, `published`);
+    ADD KEY `idx_location_published` (`location_id`, `published`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260225.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260225.sql
@@ -10,13 +10,13 @@
 --
 
 ALTER TABLE `#__bsms_analytics_events`
-    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK #__bsms_series' AFTER `study_id`;
+    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK #__bsms_series' AFTER `study_id` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_analytics_events`
-    ADD KEY `idx_series_created` (`series_id`, `created`);
+    ADD KEY `idx_series_created` (`series_id`, `created`) /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_analytics_monthly`
-    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL AFTER `study_id`;
+    ADD COLUMN `series_id` INT UNSIGNED NULL DEFAULT NULL AFTER `study_id` /** CAN FAIL **/;
 
 -- The uq_aggregate rework that used to sit here — DROP INDEX followed by a wider
 -- ADD UNIQUE KEY over the same name — is now done by proclaim.script.php's

--- a/admin/sql/updates/mysql/10.1.0-20260226.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260226.sql
@@ -25,4 +25,4 @@ CREATE TABLE IF NOT EXISTS `#__bsms_platform_stats` (
 
 -- Add stats_synced_at to servers (safe if already present)
 ALTER TABLE `#__bsms_servers`
-    ADD COLUMN `stats_synced_at` DATETIME NULL DEFAULT NULL;
+    ADD COLUMN `stats_synced_at` DATETIME NULL DEFAULT NULL /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260227.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260227.sql
@@ -1,12 +1,12 @@
 -- Phase 10: Add location_id to templates and templatecode for multi-campus support
 ALTER TABLE `#__bsms_templates`
-    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `access`;
+    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `access` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_templates`
-    ADD KEY `idx_template_location` (`location_id`);
+    ADD KEY `idx_template_location` (`location_id`) /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_templatecode`
-    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `published`;
+    ADD COLUMN `location_id` INT(3) DEFAULT NULL AFTER `published` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_templatecode`
-    ADD KEY `idx_templatecode_location` (`location_id`);
+    ADD KEY `idx_templatecode_location` (`location_id`) /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260228.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260228.sql
@@ -2,7 +2,7 @@
 ALTER TABLE `#__bsms_mediafiles`
     ADD COLUMN `content_origin` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
     COMMENT '0=ministry-created, 1=external/third-party'
-    AFTER `plays`;
+    AFTER `plays` /** CAN FAIL **/;
 
 -- Remove legacy version tracking table (replaced by #__schemas)
 DROP TABLE IF EXISTS `#__bsms_update`;

--- a/admin/sql/updates/mysql/10.1.0-20260303b.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260303b.sql
@@ -1,3 +1,3 @@
 -- Add platform_links column for multi-platform podcast subscription links
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `platform_links` TEXT NULL DEFAULT NULL AFTER `alternateimage`;
+    ADD COLUMN `platform_links` TEXT NULL DEFAULT NULL AFTER `alternateimage` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.1.0-20260304.sql
+++ b/admin/sql/updates/mysql/10.1.0-20260304.sql
@@ -5,13 +5,13 @@
 -- verified and the other three were invisible — a database missing them would be
 -- reported as up to date, and the schema fix would never add them (#1664).
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `itunes_category` VARCHAR(100) NOT NULL DEFAULT 'Religion & Spirituality' AFTER `linktype`;
+    ADD COLUMN `itunes_category` VARCHAR(100) NOT NULL DEFAULT 'Religion & Spirituality' AFTER `linktype` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `itunes_subcategory` VARCHAR(100) NOT NULL DEFAULT 'Christianity' AFTER `itunes_category`;
+    ADD COLUMN `itunes_subcategory` VARCHAR(100) NOT NULL DEFAULT 'Christianity' AFTER `itunes_category` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `itunes_explicit` VARCHAR(5) NOT NULL DEFAULT 'false' AFTER `itunes_subcategory`;
+    ADD COLUMN `itunes_explicit` VARCHAR(5) NOT NULL DEFAULT 'false' AFTER `itunes_subcategory` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_podcast`
-    ADD COLUMN `itunes_type` VARCHAR(10) NOT NULL DEFAULT 'episodic' AFTER `itunes_explicit`;
+    ADD COLUMN `itunes_type` VARCHAR(10) NOT NULL DEFAULT 'episodic' AFTER `itunes_explicit` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.3.0-20260322.sql
+++ b/admin/sql/updates/mysql/10.3.0-20260322.sql
@@ -113,4 +113,4 @@ SET `params` = REPLACE(`params`, '"far ', '"fa-regular ')
 WHERE `params` LIKE '%"far %';
 
 -- Add organization name column to teachers table (issue #1198)
-ALTER TABLE `#__bsms_teachers` ADD COLUMN `org_name` VARCHAR(255) DEFAULT NULL AFTER `title`;
+ALTER TABLE `#__bsms_teachers` ADD COLUMN `org_name` VARCHAR(255) DEFAULT NULL AFTER `title` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.3.3-20260513.sql
+++ b/admin/sql/updates/mysql/10.3.3-20260513.sql
@@ -5,10 +5,10 @@
 -- supports the indexed-for-search acceptance criterion.
 
 ALTER TABLE `#__bsms_studies`
-    ADD COLUMN `transcript` MEDIUMTEXT DEFAULT NULL AFTER `studytext`;
+    ADD COLUMN `transcript` MEDIUMTEXT DEFAULT NULL AFTER `studytext` /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_studies`
-    ADD FULLTEXT KEY `idx_transcript` (`transcript`);
+    ADD FULLTEXT KEY `idx_transcript` (`transcript`) /** CAN FAIL **/;
 
 -- Playlist entity (#1273): a first-class playlist (e.g. a YouTube playlist),
 -- distinct from a Series. May optionally back a Series via series_id, but also
@@ -74,10 +74,10 @@ CREATE TABLE IF NOT EXISTS `#__bsms_playlist_items` (
 -- #1273 phase 6 (OAuth write-back): per-playlist opt-in for pushing local title
 -- changes back to the remote platform (e.g. YouTube playlists.update). Default 0
 -- so write-back is strictly opt-in; the conflict gate keeps prior read-sync behaviour.
-ALTER TABLE `#__bsms_playlists` ADD COLUMN `writeback_enabled` TINYINT(1) NOT NULL DEFAULT '0' COMMENT 'Push local title changes back to the remote platform' AFTER `sync_enabled`;
+ALTER TABLE `#__bsms_playlists` ADD COLUMN `writeback_enabled` TINYINT(1) NOT NULL DEFAULT '0' COMMENT 'Push local title changes back to the remote platform' AFTER `sync_enabled` /** CAN FAIL **/;
 
 -- #1273 phase 6.2b (per-media playlist field): distinguish junction rows created
 -- by a user's explicit media-file playlist assignment ('manual') from rows
 -- imported/confirmed on the platform ('remote'). Lets manual assignments be pushed
 -- to the platform and be removed locally on de-select without touching import rows.
-ALTER TABLE `#__bsms_playlist_items` ADD COLUMN `source` VARCHAR(16) NOT NULL DEFAULT 'remote' COMMENT 'remote = imported/confirmed on platform; manual = assigned via the media-file playlist field' AFTER `position`;
+ALTER TABLE `#__bsms_playlist_items` ADD COLUMN `source` VARCHAR(16) NOT NULL DEFAULT 'remote' COMMENT 'remote = imported/confirmed on platform; manual = assigned via the media-file playlist field' AFTER `position` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.3.3-20260711.sql
+++ b/admin/sql/updates/mysql/10.3.3-20260711.sql
@@ -7,7 +7,7 @@
 -- Per-episode counter, incremented by the tracking-redirect endpoint.
 ALTER TABLE `#__bsms_mediafiles`
     ADD COLUMN `podcast_downloads` INT(10) UNSIGNED NOT NULL DEFAULT 0
-    COMMENT 'Podcast-app downloads counted via the tracking redirect (IAB-style 24h dedupe)' AFTER `downloads`;
+    COMMENT 'Podcast-app downloads counted via the tracking redirect (IAB-style 24h dedupe)' AFTER `downloads` /** CAN FAIL **/;
 
 -- Frozen, URL-independent RSS <guid> for podcast items. Stamped once on the first
 -- feed build with the item's then-current value (identical to what shipped before,
@@ -15,7 +15,7 @@ ALTER TABLE `#__bsms_mediafiles`
 -- URL or enclosure change can no longer move an episode's identity.
 ALTER TABLE `#__bsms_mediafiles`
     ADD COLUMN `podcast_guid` VARCHAR(400) DEFAULT NULL
-    COMMENT 'Frozen RSS <guid> for podcast items; stamped on first feed build' AFTER `podcast_downloads`;
+    COMMENT 'Frozen RSS <guid> for podcast items; stamped on first feed build' AFTER `podcast_downloads` /** CAN FAIL **/;
 
 -- Per-podcast switch: when 1, the feed rewrites <enclosure> URLs through the redirect.
 -- Default 1 (on) — download tracking is valuable to every ministry and safe now that
@@ -24,7 +24,7 @@ ALTER TABLE `#__bsms_mediafiles`
 -- opt out per podcast (e.g. if they already run a prefix like Podtrac).
 ALTER TABLE `#__bsms_podcast`
     ADD COLUMN `track_downloads` TINYINT(1) NOT NULL DEFAULT 1
-    COMMENT '1 = rewrite feed enclosures through the download-tracking redirect' AFTER `published`;
+    COMMENT '1 = rewrite feed enclosures through the download-tracking redirect' AFTER `published` /** CAN FAIL **/;
 
 -- 24h dedupe log: one row per (media, client-hash). A client is counted again
 -- only after 24h (IAB rolling window). Stale rows are pruned per-media on write.

--- a/admin/sql/updates/mysql/10.5.1-20260801.sql
+++ b/admin/sql/updates/mysql/10.5.1-20260801.sql
@@ -15,4 +15,4 @@
 ALTER TABLE `#__bsms_podcast`
     ADD COLUMN `copyright` VARCHAR(255) DEFAULT NULL
         COMMENT 'Rights holder for the feed copyright tag; falls back to the site name'
-        AFTER `editor_email`;
+        AFTER `editor_email` /** CAN FAIL **/;

--- a/admin/sql/updates/mysql/10.5.6-20260807.sql
+++ b/admin/sql/updates/mysql/10.5.6-20260807.sql
@@ -22,7 +22,7 @@ DELETE t1 FROM `#__bsms_studytopics` t1
 -- A study may hold a topic once. Enforced by the database rather than by the
 -- application remembering to check.
 ALTER TABLE `#__bsms_studytopics`
-    ADD UNIQUE KEY `uq_study_topic` (`study_id`, `topic_id`);
+    ADD UNIQUE KEY `uq_study_topic` (`study_id`, `topic_id`) /** CAN FAIL **/;
 
 -- Remove associations whose study no longer exists. Nothing deleted these when
 -- the study was deleted, and topic counts and filter dropdowns join against
@@ -85,10 +85,10 @@ SET s.`studynumber` = '';
 -- unconstrained, because NULLs are distinct from each other in a unique index.
 ALTER TABLE `#__bsms_studies`
     ADD COLUMN `studynumber_uk` VARCHAR(100)
-    GENERATED ALWAYS AS (IF(`series_id` > 0 AND `studynumber` <> '', `studynumber`, NULL)) STORED;
+    GENERATED ALWAYS AS (IF(`series_id` > 0 AND `studynumber` <> '', `studynumber`, NULL)) STORED /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_studies`
-    ADD UNIQUE KEY `uq_series_studynumber` (`series_id`, `studynumber_uk`);
+    ADD UNIQUE KEY `uq_series_studynumber` (`series_id`, `studynumber_uk`) /** CAN FAIL **/;
 
 -- #1560: nothing stopped two overlapping playlist imports from both creating a
 -- row for the same remote playlist. CwmplaylistSyncHelper::importChannelPlaylists()
@@ -187,16 +187,16 @@ WHERE lp.`remote_playlist_id` <> '';
 -- treatment uq_series_studynumber gives an absent episode number above.
 ALTER TABLE `#__bsms_playlists`
     ADD COLUMN `remote_playlist_uk` VARCHAR(64)
-    GENERATED ALWAYS AS (IF(`remote_playlist_id` <> '', `remote_playlist_id`, NULL)) STORED;
+    GENERATED ALWAYS AS (IF(`remote_playlist_id` <> '', `remote_playlist_id`, NULL)) STORED /** CAN FAIL **/;
 
 ALTER TABLE `#__bsms_playlists`
-    ADD UNIQUE KEY `uq_server_remote_playlist` (`server_id`, `remote_playlist_uk`);
+    ADD UNIQUE KEY `uq_server_remote_playlist` (`server_id`, `remote_playlist_uk`) /** CAN FAIL **/;
 
 -- The unique index covers the generated column, which no query names. Lookups by
 -- (remote_playlist_id, server_id) -- every sync run does one per remote playlist
 -- -- would otherwise still fall back to idx_server alone.
 ALTER TABLE `#__bsms_playlists`
-    ADD KEY `idx_remote_playlist` (`remote_playlist_id`, `server_id`);
+    ADD KEY `idx_remote_playlist` (`remote_playlist_id`, `server_id`) /** CAN FAIL **/;
 
 -- #1622: CwmteacherModel::canDelete() enqueued a "cannot delete" message and
 -- then returned a plain permission check, so the teacher was deleted anyway --

--- a/tests/unit/Sql/MigrationStatementContractTest.php
+++ b/tests/unit/Sql/MigrationStatementContractTest.php
@@ -48,6 +48,13 @@ class MigrationStatementContractTest extends ProclaimTestCase
     private const UPDATES_DIR = JPATH_ROOT . '/admin/sql/updates/mysql';
 
     /**
+     * Installer::CAN_FAIL_MARKER — the opt-out that lets one statement fail
+     * without aborting the update. Duplicated rather than imported because the
+     * unit suite does not load the CMS installer.
+     */
+    private const CAN_FAIL_MARKER = '/** CAN FAIL **/';
+
+    /**
      * Every ALTER TABLE in the migration set, one case per statement.
      *
      * @return  array<string, array{0: string, 1: string}>
@@ -120,6 +127,144 @@ class MigrationStatementContractTest extends ProclaimTestCase
             . "database where the index is already absent, and cannot be made conditional in MySQL. "
             . "Do it in proclaim.script.php behind a SHOW INDEX check instead.\n\n  " . $statement
         );
+    }
+
+    /**
+     * Every additive ALTER in the migration set, paired with its RAW text.
+     *
+     * Raw, not normalised: the contract is about a byte offset. Collapsing
+     * whitespace would make `/** CAN FAIL **\/ ;` — which Joomla does not
+     * accept — indistinguishable from the form it does.
+     *
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function addStatementProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(self::UPDATES_DIR . '/*.sql') ?: [] as $file) {
+            $name  = basename($file);
+            $index = 0;
+            $sql   = preg_replace('/^\s*--.*$/m', '', (string) file_get_contents($file)) ?? '';
+
+            foreach (self::rawStatementsIn($sql) as $statement) {
+                if (stripos(ltrim($statement), 'ALTER TABLE') !== 0) {
+                    continue;
+                }
+
+                if (!preg_match('/\bADD\s+/i', $statement)) {
+                    continue;
+                }
+
+                $cases[$name . ' #' . ++$index] = [$name, $statement];
+            }
+        }
+
+        // An empty provider would make this check pass by doing nothing.
+        self::assertNotSame([], $cases, 'No additive ALTER statements found — is the updates directory still there?');
+
+        return $cases;
+    }
+
+    /**
+     * Every additive ALTER must carry the CAN FAIL marker.
+     *
+     * On the install/update path Installer::parseSchemaUpdates() executes each
+     * statement raw, and an unmarked failure is not a skipped statement: it
+     * returns false, InstallerAdapter::parseQueries() throws, and the entire
+     * update rolls back. A column that install.mysql.utf8.sql also creates will
+     * collide with error 1060 on any site whose recorded schema version is
+     * behind its real schema — which is every site when #__schemas is missing,
+     * because parseSchemaUpdates() then falls back to 0.0.0 and replays the
+     * whole history. 10.5.3 hit exactly this and was confirmed against a real
+     * 10.5.2 -> 10.5.3 upgrade before the marker was added.
+     *
+     * ADD KEY is included, not just ADD COLUMN. Marking only the columns moves
+     * the abort rather than removing it: a replay then clears the column and
+     * dies on the index that follows it with error 1061 instead.
+     *
+     * The marker costs nothing on the other path: DatabaseDriver::splitSql(),
+     * which is what ChangeSet reads with, strips comments, so MysqlChangeItem
+     * never sees it and the check query is unchanged.
+     *
+     * ⚠️ The marker must abut the semicolon. Installer::splitSql() looks back
+     * exactly CAN_FAIL_MARKER_LENGTH bytes from the `;`, so one space between
+     * the two silently defeats it.
+     *
+     * @param   string  $file       Migration file the statement came from.
+     * @param   string  $statement  The raw statement, up to but excluding its `;`.
+     *
+     * @return  void
+     */
+    #[DataProvider('addStatementProvider')]
+    public function testAdditiveAltersAreMarkedCanFail(string $file, string $statement): void
+    {
+        $this->assertStringEndsWith(
+            self::CAN_FAIL_MARKER,
+            $statement,
+            "{$file} has an additive ALTER with no " . self::CAN_FAIL_MARKER . " marker immediately "
+            . "before its semicolon. Without it, replaying this file against a database that already "
+            . "has the column or index aborts and rolls back the whole update instead of skipping "
+            . "the statement.\n\n  "
+            . trim(preg_replace('/\s+/', ' ', $statement) ?? '')
+        );
+    }
+
+    /**
+     * Split a file into raw statements, preserving every byte up to each `;`.
+     *
+     * Quote-aware, because this check reads the end of a statement and several
+     * COMMENT literals contain a semicolon — 'imported/confirmed on platform;
+     * manual = assigned via …'. Splitting on a bare explode() cuts inside the
+     * literal and truncates the statement short of its marker, which reads as a
+     * missing marker on SQL that is in fact correct.
+     *
+     * ⚠️ statementsIn() below has this same flaw. It has not bitten there
+     * because the fragments it produces still carry one top-level clause each.
+     *
+     * @param   string  $sql  File contents, line comments already removed.
+     *
+     * @return  list<string>
+     */
+    private static function rawStatementsIn(string $sql): array
+    {
+        $statements = [];
+        $buffer     = '';
+        $quote      = null;
+
+        for ($i = 0, $n = \strlen($sql); $i < $n; $i++) {
+            $char = $sql[$i];
+
+            if ($quote !== null) {
+                $buffer .= $char;
+
+                if ($char === '\\' && $quote !== '`') {
+                    $buffer .= $sql[++$i] ?? '';
+                } elseif ($char === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($char === "'" || $char === '"' || $char === '`') {
+                $quote   = $char;
+                $buffer .= $char;
+
+                continue;
+            }
+
+            if ($char === ';') {
+                $statements[] = $buffer;
+                $buffer       = '';
+
+                continue;
+            }
+
+            $buffer .= $char;
+        }
+
+        return $statements;
     }
 
     /**


### PR DESCRIPTION
## Problem

`Installer::parseSchemaUpdates()` runs update SQL raw and treats any unmarked failure as fatal — it returns `false`, `InstallerAdapter::parseQueries()` throws, and the whole update rolls back.

Only 8 of 140 additive `ALTER` statements carried the `/** CAN FAIL **/` opt-out, all of them in `10.5.3-20260801.sql`. Every one of the other 132 targets a column or index that `install.mysql.utf8.sql` also creates, so each collides — **1060** for a column, **1061** for an index — on any site whose recorded schema version is behind its real schema. That is *every* site when the `#__schemas` row is missing, because `parseSchemaUpdates()` then falls back to `0.0.0` and replays the entire history.

This is not theoretical: `10.5.3`'s own file header records a confirmed abort of exactly this kind on a real 10.5.2 → 10.5.3 upgrade.

## Fix

Mark all additive `ALTER` statements `/** CAN FAIL **/` so a replay skips work already applied instead of aborting the update.

Marking the columns alone would only move the abort — a replay would clear `ADD COLUMN \`studynumber_uk\`` and then die on the `ADD UNIQUE KEY` that indexes it one statement later. Additive ALTERs are marked as a set.

The marker costs nothing on the other execution path: `ChangeSet` reads with `DatabaseDriver::splitSql()`, which strips comments, so `MysqlChangeItem` never sees the marker and derives an identical check query (confirmed by building a real `ChangeItem` against Joomla core).

## Trade-off taken deliberately

⚠️ Marking an `ADD UNIQUE KEY` also swallows **1062**, so a dedupe that fails now leaves the constraint silently absent rather than aborting the update. Accepted: an aborted update is the worse outcome, and the dedupe DML runs immediately before it in the same file.

This is safe only because every `ALTER` here carries a single clause — already enforced by `testAlterStatementsCarryOneClause`. On a compound `ALTER` the marker would turn a hard failure into a silent partial migration.

## Test

`testAdditiveAltersAreMarkedCanFail` holds the line at **140 cases**. It reads raw bytes rather than normalised statements because the contract is *positional*: `Installer::splitSql()` looks back exactly `CAN_FAIL_MARKER_LENGTH` from the semicolon, so `/** CAN FAIL **/ ;` is silently **not** a marker. That needs a quote-aware splitter of its own — three `COMMENT` literals contain a semicolon, and a plain `explode(';')` truncates the statement short of its marker and reports correct SQL as unmarked.

## Verification

- `Migration SQL Contract Tests` suite: **473 tests, 492 assertions, all passing**
- PHP CS Fixer clean on the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
