### PR TITLE
docs: record that issues are tracked on the project board, not a milestone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,8 +151,13 @@ Include:
 ### Issue Hygiene
 
 - **Triage on read**: if you open an issue that's missing a label (`priority:*`, `area:*`, `status:*`), a milestone, or template fields (repro steps, version info), fill in what you can before moving on — don't leave it for someone else to re-derive later.
+- **Set the issue Type**: `Task`, `Bug`, or `Feature`. This is a separate field from the labels, not a duplicate of them — `gh issue edit <n> --type Feature`. Types apply to issues only; a PR can't carry one.
+- **Put it on the board**: issues belong to the **Proclaim Development** project, with `Status` set to where the work actually is — `Triage` → `Backlog` → `In Progress` → `In Review` → `Done`.
+- **Fill in the sidebar fields** where you know them: `Priority`, `Effort`, and the `Start date` / `Target date` pair. `Priority` mirrors the `priority: *` label rather than replacing it — set both.
 - **Multi-issue features**: apply the `epic` label and use an `epic/{N}-{slug}` integration branch, with sub-PRs targeting that branch instead of `development`.
 - **Link branches to their issue**: don't just name a branch after the issue number — run `gh issue develop <issue-number> --branch <name>` (or use the issue's "Create a branch" button) so the branch and its PR show up under the issue's Development section automatically.
+
+[Issue #1857](https://github.com/Joomla-Bible-Study/Proclaim/issues/1857) is a worked example of all of the above.
 
 ### PR Hygiene
 
@@ -160,7 +165,8 @@ PRs need the same metadata as issues — a linked branch alone isn't enough:
 
 - **Mirror the linked issue's labels** (`priority:*`, `area:*`, `bug`/`enhancement`) onto the PR. Docs-only or other PRs with no linked issue just skip labels.
 - **Assign the PR** (and its linked issue, if not already) to whoever is doing the work.
-- **Milestone**: use the milestone matching `active_development` in `build/versions.json` (e.g. `10.5.6`) for patch/bugfix work; create it if it doesn't exist yet. Larger breaking work goes in the next major milestone (e.g. `v11.0.0`) instead.
+- **Milestone**: use the milestone matching `active_development` in `build/versions.json` (e.g. `10.5.10`) for patch/bugfix work; create it if it doesn't exist yet. Larger breaking work goes in the next major milestone (e.g. `v11.0.0`) instead.
+- **A milestone is the release the work ships in — nothing else.** Accepted work with no target release is `Status: Backlog` on the project board, *not* a `Backlog` milestone. The old `Backlog` milestone is closed; don't reopen the habit by copying the milestone off whatever PR merged last.
 
 ## Versioning
 


### PR DESCRIPTION
## Why

The **PR Hygiene** section already said to use the `active_development` version as the milestone, but nothing said what to do with work that has *no* target release. In practice that gap was filled with a `Backlog` milestone — 121 issues, plus the four PRs merged before this one — which puts scheduling information in the field that means "the release this ships in".

Backlog is a **Status** on the *Proclaim Development* board. The milestone is the release.

## What changed

**Issue Hygiene** gains the three things the sidebar now carries that the section never mentioned:

- the **Type** field (`Task` / `Bug` / `Feature`) — a separate field from the labels, and issue-only, since a PR can't carry one
- **board membership** with a `Status` (`Triage` → `Backlog` → `In Progress` → `In Review` → `Done`)
- the **Priority / Effort / Start date / Target date** fields — with `Priority` noted as *mirroring* the `priority: *` label rather than replacing it, because #1857 carries both and setting only one leaves the label filters half-populated

**PR Hygiene** gains an explicit prohibition on the `Backlog` milestone. Written as a prohibition rather than an omission because the failure mode is copying the milestone off whatever PR merged last — which is exactly how the four before this one got theirs.

#1857 is linked as a worked example, so the convention has something concrete behind it rather than only a description.

## Also done alongside this PR

- Milestone **10.5.10** created; #1852, #1853, #1855, #1856 and #1858 moved onto it
- The **`Backlog` milestone is closed** — its 121 closed issues keep the association, but the picker can no longer offer it

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)