### PR TITLE
fix: restore the scripture stack after clearing consumers, instead of guarding it

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -135,21 +135,20 @@ fi
 OTHER_CONSUMERS="$(php build/verify-scripture-uninstall.php other-consumer-ids | grep -E '^[0-9]+$' || true)"
 
 if [ -n "$OTHER_CONSUMERS" ]; then
-    # Before removing anything: hand the shared scripture stack back to
-    # pkg_cwmscripture. The library and plg_content_scripturelinks are package
-    # children, and package_id points at whichever package installed them last
-    # -- on a site carrying LivingWord that can be pkg_livingword, so removing
-    # it below took the library and the content plugin with it. Every phase
-    # after this then failed on a missing library, and because these removals
-    # persist, so did the next run (#1820).
-    echo "   protecting the scripture stack from the removals below:"
-
-    if ! php build/verify-scripture-uninstall.php protect-scripture-ownership; then
-        echo "ERROR: could not protect the scripture stack; refusing to remove consumers." >&2
-        echo "       Removing them now could take lib_cwmscripture with them." >&2
-        exit 1
-    fi
-
+    # ⚠️ Removing a consumer package takes the shared scripture stack with it,
+    # and correcting package_id cannot prevent that. PackageAdapter::
+    # removeExtensionFiles() reads the consumer's *installed* manifest from
+    # administrator/manifests/packages and resolves every <file> it declares
+    # through _getExtensionId($type, $element, $client, $group) -- by element.
+    # package_id is never consulted on that path.
+    #
+    # pkg_livingword declares lib_cwmscripture, plg_content_scripturelinks and
+    # plg_task_cwmscripture as its own children, so all three go with it.
+    # plg_system_cwmscripture, which it does not declare, survives -- the
+    # correlation is exact (#1860, and the same damage as #1820).
+    #
+    # So the stack is restored afterwards rather than defended beforehand. That
+    # holds for any consumer whose manifest overlaps ours, not just LivingWord.
     echo "   clearing other scripture consumers before the uninstall phases:"
 
     for CID in $OTHER_CONSUMERS; do
@@ -161,6 +160,36 @@ if [ -n "$OTHER_CONSUMERS" ]; then
             exit 1
         fi
     done
+
+    # Read the version rather than globbing for the newest zip on disk: several
+    # pkg_cwmscripture builds accumulate in build/dist, and picking the newest
+    # file is how a package once shipped a zip that was not the pinned one.
+    SCRIPTUREVER="$(php -r '
+        $m = @simplexml_load_file("plugins/content/scripturelinks/build/pkg_cwmscripture.xml");
+        echo $m === false ? "" : (string) $m->version;
+    ')"
+    SCRIPTUREZIP="plugins/content/scripturelinks/build/dist/pkg_cwmscripture-${SCRIPTUREVER}.zip"
+
+    if [ -z "$SCRIPTUREVER" ] || [ ! -f "$SCRIPTUREZIP" ]; then
+        echo "ERROR: pkg_cwmscripture build artifact not found: '${SCRIPTUREZIP}'." >&2
+        echo "       Phase 5 builds it; without it the stack cannot be restored." >&2
+        exit 1
+    fi
+
+    echo "   restoring the scripture stack those removals may have taken:"
+
+    if ! php "$JCLI" extension:install --path="$SCRIPTUREZIP" >/dev/null 2>&1; then
+        echo "ERROR: could not reinstall ${SCRIPTUREZIP}." >&2
+        exit 1
+    fi
+
+    echo "     reinstalled pkg_cwmscripture ${SCRIPTUREVER}"
+
+    # ⚠️ Assert here, not at the next phase's first use. Every phase from 11 on
+    # needs a library to test against, so without this the damage surfaces as
+    # "No library 'cwmscripture' registered" against whichever assertion ran
+    # first -- reporting a missing fixture as a failure of the code under test.
+    php build/verify-scripture-uninstall.php assert-library-present
 fi
 
 echo "-- [11/17] STILL NEEDED: removing the library alone must be refused"

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -62,7 +62,6 @@ $modes = [
     'assert-tables-gone',
     'assert-no-other-consumer',
     'other-consumer-ids',
-    'protect-scripture-ownership',
     'assert-sql-armed',
     'assert-sql-disarmed',
     'arm',
@@ -161,91 +160,11 @@ $connect = static function (object $install): array {
 };
 
 // --- value-printing modes: first test install only, for the shell to consume --
-if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids', 'protect-scripture-ownership'], true)) {
+if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids'], true)) {
     $install = $installs[0];
 
     if ($mode === 'site-path') {
         echo $install->path . "\n";
-
-        exit(0);
-    }
-
-    if ($mode === 'protect-scripture-ownership') {
-        // Hand the shared scripture stack back to the package that ships it,
-        // before any consumer is removed.
-        //
-        // The library and plg_content_scripturelinks are Joomla package
-        // children, and package_id points at whichever package installed them
-        // LAST. On a site carrying LivingWord that can be pkg_livingword — so
-        // `extension:remove` on it takes the library and the content plugin
-        // down as its children, and every phase after step 9 then fails for a
-        // reason unrelated to the code under test. Worse, the removals persist:
-        // the site is left with com_proclaim installed against a library that
-        // no longer exists, and the next run starts from that wreckage (#1820).
-        //
-        // Reassigning is not a workaround for the test's benefit. pkg_cwmscripture
-        // is the package that ships these, so this restores the ownership that
-        // install order happened to overwrite.
-        [$db, $prefix] = $connect($install);
-
-        if ($db === null) {
-            fwrite(STDERR, "Could not connect to the test database.\n");
-
-            exit(1);
-        }
-
-        $owner = mysqli_fetch_row(mysqli_query(
-            $db,
-            "SELECT `extension_id` FROM `{$prefix}extensions`
-             WHERE `type` = 'package' AND `element` = 'pkg_cwmscripture' LIMIT 1"
-        ) ?: null);
-
-        if ($owner === null || $owner === false) {
-            // Nothing to hand ownership to. Say so rather than silently leaving
-            // the stack adoptable by whatever gets removed next.
-            fwrite(STDERR, "pkg_cwmscripture is not installed; cannot protect the scripture stack.\n");
-
-            exit(1);
-        }
-
-        $ownerId = (int) $owner[0];
-
-        // The shared pieces a consumer package can end up owning. The task and
-        // system plugins ship in pkg_cwmscripture too, so they are listed for
-        // completeness -- reassigning an already-correct row is a no-op.
-        $parts = [
-            ['library', 'cwmscripture', null],
-            ['plugin', 'scripturelinks', 'content'],
-            ['plugin', 'cwmscripture', 'task'],
-            ['plugin', 'cwmscripture', 'system'],
-        ];
-
-        $moved = 0;
-
-        foreach ($parts as [$type, $element, $folder]) {
-            $folderSql = $folder === null
-                ? "AND (`folder` = '' OR `folder` IS NULL)"
-                : "AND `folder` = '" . mysqli_real_escape_string($db, $folder) . "'";
-
-            $sql = "UPDATE `{$prefix}extensions`
-                    SET `package_id` = {$ownerId}
-                    WHERE `type` = '" . mysqli_real_escape_string($db, $type) . "'
-                      AND `element` = '" . mysqli_real_escape_string($db, $element) . "'
-                      {$folderSql}
-                      AND `package_id` <> {$ownerId}";
-
-            if (mysqli_query($db, $sql) && mysqli_affected_rows($db) > 0) {
-                $label = $folder === null ? "{$type} {$element}" : "{$type} {$element} ({$folder})";
-                echo "  reassigned {$label} to pkg_cwmscripture\n";
-                $moved++;
-            }
-        }
-
-        echo $moved === 0
-            ? "  scripture stack already owned by pkg_cwmscripture\n"
-            : "  {$moved} extension(s) reassigned — removing a consumer can no longer take them\n";
-
-        mysqli_close($db);
 
         exit(0);
     }


### PR DESCRIPTION
Fixes #1860.

## The guard could never have worked

Phase 10 of `test:upgrade` clears other scripture consumers before the destructive phases, and that removal took `lib_cwmscripture`, `plg_content_scripturelinks` and `plg_task_cwmscripture` with it. Phase 11 then died on `No library 'cwmscripture' registered`, and because `reset-testsite.php` only clears the Proclaim family, the next run started from the same wreckage.

`protect-scripture-ownership` is **removed rather than extended**. `PackageAdapter::removeExtensionFiles()` reads the consumer's *installed* manifest from `administrator/manifests/packages` and resolves each declared `<file>` through `_getExtensionId($type, $element, $client, $group)` — **by element**. `package_id` is never consulted on that path, so re-pointing it corrects a column Joomla does not read here.

`build/pkg_livingword.xml` declares all three as its own children and has no `<scriptfile>` at all. The correlation is exact: `plg_system_cwmscripture`, the one shared extension it does *not* declare, is the only one that survives.

⚠️ The guard also **reported success while failing**. Phase 6 installs `pkg_proclaim`, which bundles `pkg_cwmscripture` and re-parents the stack, so by phase 10 it found nothing to fix and printed *"already owned by pkg_cwmscripture"* — correct ownership — immediately before three extensions were destroyed anyway.

## What replaces it

Reinstall `pkg_cwmscripture` after the clearing loop. This restores whatever was taken and works for **any** consumer whose manifest overlaps ours, not just LivingWord.

- The version comes from `pkg_cwmscripture.xml`, not a glob — several builds accumulate in `build/dist`, and taking the newest file is how a package once shipped a zip that was not the pinned one.
- The assertion sits **immediately after the restore**, not at the next phase's first use. Every phase from 11 on needs a library, so without it the damage surfaces as a missing fixture reported against whichever assertion ran first — which is how this cost a full diagnostic pass to attribute.

## Verification

Reproduced the damage on j6-test with `pkg_livingword` installed — `extension:remove` on the package took the library and both plugins — then ran the added block verbatim:

```
   restoring the scripture stack those removals may have taken:
     reinstalled pkg_cwmscripture 1.2.10
  OK   lib_cwmscripture is still installed — the uninstall was refused
```

All three return, parented to `pkg_cwmscripture`.

⚠️ **A full 17-phase run with LivingWord present is not yet green**, for a reason upstream of this change: phase 9 fails with the seeded translation, verses and cache destroyed during the upgrade. Being tracked separately — it is not caused by, nor fixed by, this PR, which only touches phase 10 onward. The full run passes with no consumer installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)