### PR TITLE
fix: stop the upgrade harness reporting bible data loss that never happened

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -247,6 +247,11 @@ if [ -n "$OTHER_CONSUMERS" ]; then
     php build/verify-scripture-upgrade.php verify
 fi
 
+# Teardown once, after the last assertion that needs the probe rows, and outside
+# the consumer block so it runs either way. It used to be the tail of `verify`,
+# which quietly made that mode single-use -- see the note in the probe.
+php build/verify-scripture-upgrade.php cleanup
+
 echo "-- [11/17] STILL NEEDED: removing the library alone must be refused"
 LIBID="$(php build/verify-scripture-uninstall.php ext-id library cwmscripture | tail -n1)"
 

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -190,6 +190,16 @@ if [ -n "$OTHER_CONSUMERS" ]; then
     # "No library 'cwmscripture' registered" against whichever assertion ran
     # first -- reporting a missing fixture as a failure of the code under test.
     php build/verify-scripture-uninstall.php assert-library-present
+
+    # ⚠️ The reinstall above is a *library* install, and LibraryAdapter::install()
+    # calls checkExtensionInFilesystem() -> uninstall() before it installs, which
+    # is the exact path that used to run lib_cwmscripture's uninstall SQL and wipe
+    # every locally downloaded translation. It ships disarmed, but a library
+    # version that shipped it armed again would destroy the downloaded bibles here
+    # and the run would still report PASSED: phase 9 verified this seed *before*
+    # the reinstall, and phase 12 seeds its own data *after* it, so the window in
+    # between is checked by nothing else.
+    php build/verify-scripture-upgrade.php verify
 fi
 
 echo "-- [11/17] STILL NEEDED: removing the library alone must be refused"

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -50,6 +50,22 @@ fi
 BASEZIP="build/dist/pkg_proclaim-${BASEVER}.zip"
 NEWZIP="build/dist/pkg_proclaim-${NEWVER}.zip"
 
+# Phases 15/16 plant a pre-1.1.5 armed uninstall SQL *and* the <uninstall><sql>
+# manifest declaration that makes Joomla run it. `disarm` deliberately reverts
+# only the file -- phase 16 has to prove the disarmed file is what saves the
+# data while the declaration still stands -- so the declaration is cleaned up
+# here instead.
+#
+# ⚠️ A trap, not a final phase. reset-testsite.php clears only the Proclaim
+# family, so anything left behind survives into the next run (#1860); a run that
+# died between phase 15's `arm` and phase 16's `disarm` handed the next run an
+# armed library, and phase 10's restore was the first thing to trip it. Cleanup
+# that only runs on success cannot fix a leak whose cause is not finishing.
+#
+# restore-manifest touches the filesystem only and always exits 0, so it cannot
+# mask the failure that triggered it.
+trap 'php build/verify-scripture-uninstall.php restore-manifest || true' EXIT
+
 echo "========================================================================"
 echo " UPGRADE TEST — ${BASEVER}  ->  ${NEWVER}"
 echo "========================================================================"
@@ -142,13 +158,14 @@ if [ -n "$OTHER_CONSUMERS" ]; then
     # through _getExtensionId($type, $element, $client, $group) -- by element.
     # package_id is never consulted on that path.
     #
-    # pkg_livingword declares lib_cwmscripture, plg_content_scripturelinks and
-    # plg_task_cwmscripture as its own children, so all three go with it.
-    # plg_system_cwmscripture, which it does not declare, survives -- the
-    # correlation is exact (#1860, and the same damage as #1820).
+    # pkg_livingword <= 5.7.0 declared lib_cwmscripture, plg_content_scripturelinks
+    # and plg_task_cwmscripture as its own children, so all three went with it.
+    # plg_system_cwmscripture, which it did not declare, survived -- the
+    # correlation was exact (#1860, and the same damage as #1820).
     #
-    # So the stack is restored afterwards rather than defended beforehand. That
-    # holds for any consumer whose manifest overlaps ours, not just LivingWord.
+    # So the stack is restored afterwards rather than defended beforehand, and
+    # only when something is actually gone. That holds for any consumer whose
+    # manifest overlaps ours, not just LivingWord.
     echo "   clearing other scripture consumers before the uninstall phases:"
 
     for CID in $OTHER_CONSUMERS; do
@@ -161,29 +178,53 @@ if [ -n "$OTHER_CONSUMERS" ]; then
         fi
     done
 
-    # Read the version rather than globbing for the newest zip on disk: several
-    # pkg_cwmscripture builds accumulate in build/dist, and picking the newest
-    # file is how a package once shipped a zip that was not the pinned one.
-    SCRIPTUREVER="$(php -r '
-        $m = @simplexml_load_file("plugins/content/scripturelinks/build/pkg_cwmscripture.xml");
-        echo $m === false ? "" : (string) $m->version;
-    ')"
-    SCRIPTUREZIP="plugins/content/scripturelinks/build/dist/pkg_cwmscripture-${SCRIPTUREVER}.zip"
-
-    if [ -z "$SCRIPTUREVER" ] || [ ! -f "$SCRIPTUREZIP" ]; then
-        echo "ERROR: pkg_cwmscripture build artifact not found: '${SCRIPTUREZIP}'." >&2
-        echo "       Phase 5 builds it; without it the stack cannot be restored." >&2
+    # Only restore what was actually taken. A consumer that declares our
+    # extensions as its own children takes them with it; one packaged correctly
+    # (LivingWord >= 5.7.1 ships pkg_cwmscripture whole, undeclared) takes none.
+    #
+    # ⚠️ The restore is a *library* install, so it routes through
+    # LibraryAdapter::install() -> checkExtensionInFilesystem() -> uninstall(),
+    # and InstallerAdapter::uninstall() runs parseQueries() regardless of
+    # isPackageUninstall() -- i.e. whatever uninstall SQL is on disk executes.
+    # Running that when nothing needs restoring is a destructive operation with
+    # no upside, which is what made an unconditional reinstall the wrong shape.
+    # Not `|| true`: an empty result has to mean "nothing was taken", never "the
+    # probe could not tell". Swallowing a failed probe here would skip a restore
+    # the run needs and report it as a healthy stack.
+    if ! MISSING_STACK="$(php build/verify-scripture-uninstall.php missing-scripture-stack)"; then
+        echo "ERROR: could not determine which scripture extensions survived." >&2
         exit 1
     fi
 
-    echo "   restoring the scripture stack those removals may have taken:"
+    if [ -z "$MISSING_STACK" ]; then
+        echo "   the scripture stack survived the removals — nothing to restore"
+    else
+        echo "   the removals took part of the scripture stack:"
+        echo "$MISSING_STACK" | sed 's/^/     missing: /'
 
-    if ! php "$JCLI" extension:install --path="$SCRIPTUREZIP" >/dev/null 2>&1; then
-        echo "ERROR: could not reinstall ${SCRIPTUREZIP}." >&2
-        exit 1
+        # Read the version rather than globbing for the newest zip on disk:
+        # several pkg_cwmscripture builds accumulate in build/dist, and picking
+        # the newest file is how a package once shipped a zip that was not the
+        # pinned one.
+        SCRIPTUREVER="$(php -r '
+            $m = @simplexml_load_file("plugins/content/scripturelinks/build/pkg_cwmscripture.xml");
+            echo $m === false ? "" : (string) $m->version;
+        ')"
+        SCRIPTUREZIP="plugins/content/scripturelinks/build/dist/pkg_cwmscripture-${SCRIPTUREVER}.zip"
+
+        if [ -z "$SCRIPTUREVER" ] || [ ! -f "$SCRIPTUREZIP" ]; then
+            echo "ERROR: pkg_cwmscripture build artifact not found: '${SCRIPTUREZIP}'." >&2
+            echo "       Phase 5 builds it; without it the stack cannot be restored." >&2
+            exit 1
+        fi
+
+        if ! php "$JCLI" extension:install --path="$SCRIPTUREZIP" >/dev/null 2>&1; then
+            echo "ERROR: could not reinstall ${SCRIPTUREZIP}." >&2
+            exit 1
+        fi
+
+        echo "     reinstalled pkg_cwmscripture ${SCRIPTUREVER}"
     fi
-
-    echo "     reinstalled pkg_cwmscripture ${SCRIPTUREVER}"
 
     # ⚠️ Assert here, not at the next phase's first use. Every phase from 11 on
     # needs a library to test against, so without this the damage surfaces as
@@ -191,14 +232,18 @@ if [ -n "$OTHER_CONSUMERS" ]; then
     # first -- reporting a missing fixture as a failure of the code under test.
     php build/verify-scripture-uninstall.php assert-library-present
 
-    # ⚠️ The reinstall above is a *library* install, and LibraryAdapter::install()
-    # calls checkExtensionInFilesystem() -> uninstall() before it installs, which
-    # is the exact path that used to run lib_cwmscripture's uninstall SQL and wipe
-    # every locally downloaded translation. It ships disarmed, but a library
-    # version that shipped it armed again would destroy the downloaded bibles here
-    # and the run would still report PASSED: phase 9 verified this seed *before*
-    # the reinstall, and phase 12 seeds its own data *after* it, so the window in
-    # between is checked by nothing else.
+    # ⚠️ Nothing else checks this window: phase 9 verifies the seed *before* a
+    # restore can run and phase 12 seeds its own data *after* it, so data
+    # destroyed in between left the run reporting PASSED.
+    #
+    # The library ships with no <uninstall><sql> since 1.1.5, so a restore is
+    # inert on a clean site. What makes the window real is that the SQL Joomla
+    # runs is the *file on disk*, not the file the release shipped: phases 15/16
+    # plant a pre-1.1.5 armed file on purpose, reset-testsite.php does not clear
+    # the library (#1860), and no system plugin can sweep it here because both
+    # disarm sweeps require an admin com_installer page load and this harness is
+    # CLI. The EXIT trap above is what keeps that fixture from reaching this line
+    # on the next run; this assertion is what catches it if the trap ever fails.
     php build/verify-scripture-upgrade.php verify
 fi
 

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -62,10 +62,12 @@ $modes = [
     'assert-tables-gone',
     'assert-no-other-consumer',
     'other-consumer-ids',
+    'missing-scripture-stack',
     'assert-sql-armed',
     'assert-sql-disarmed',
     'arm',
     'disarm',
+    'restore-manifest',
     'assert-translation-survived',
     'assert-translation-destroyed',
 ];
@@ -121,6 +123,16 @@ DROP TABLE IF EXISTS `#__bsms_bible_translations`;
 
 SQL;
 
+/**
+ * What the disarm writes back — exactly what plg_system_cwmscripture writes on
+ * an admin com_installer page load. Shared by the 'disarm' step and by the
+ * 'restore-manifest' cleanup so the two cannot drift into disagreeing about
+ * what "disarmed" looks like; sqlIsArmed() must read this as inert.
+ */
+const DISARMED_UNINSTALL_SQL = "--\n"
+    . "-- Neutralised by the upgrade harness, mirroring plg_system_cwmscripture.\n"
+    . "-- Do not reintroduce DROP TABLE statements here.\n--\n";
+
 $reader   = new PropertiesReader($root . '/build.properties');
 $installs = $reader->installsFor('test');
 
@@ -159,12 +171,145 @@ $connect = static function (object $install): array {
     return [$db === false ? null : $db, $prefix];
 };
 
+// --- cleanup mode: undo the planted hazard, on every test install -----------
+// Runs from a shell trap, so it touches the filesystem only and never fails: a
+// trap that can exit non-zero would mask the real failure that triggered it.
+//
+// 'arm' plants two things — the armed SQL file and an <uninstall><sql> block in
+// the installed manifest. 'disarm' deliberately reverts only the file, because
+// phase 16 has to prove that disarming the *file* is what saves the data while
+// the manifest still declares it. That leaves the declaration behind, and
+// reset-testsite.php does not clear the library (#1860), so without this the
+// fixture outlives the run and the next run's first library install inherits it.
+if ($mode === 'restore-manifest') {
+    foreach ($installs as $install) {
+        $manifest = $install->path . '/administrator/manifests/libraries/cwmscripture.xml';
+        $sqlFile  = $install->path . '/libraries/cwmscripture/sql/uninstall.mysql.utf8.sql';
+
+        // Disarm first. If the manifest write fails the file is already inert,
+        // which is the half that actually destroys data.
+        if (is_file($sqlFile)) {
+            $buffer = @file_get_contents($sqlFile);
+
+            if ($buffer !== false && sqlIsArmed($buffer)) {
+                if (@file_put_contents($sqlFile, DISARMED_UNINSTALL_SQL) === false) {
+                    echo "  WARN could not disarm {$sqlFile}.\n";
+                } else {
+                    echo "  OK   disarmed the planted uninstall SQL\n";
+                }
+            }
+        }
+
+        if (!is_file($manifest)) {
+            continue;
+        }
+
+        $doc                     = new DOMDocument();
+        $doc->preserveWhiteSpace = false;
+        $doc->formatOutput       = true;
+
+        if (!@$doc->load($manifest)) {
+            echo "  WARN {$manifest} is not parseable XML — leaving it alone.\n";
+
+            continue;
+        }
+
+        $xpath   = new DOMXPath($doc);
+        $removed = 0;
+
+        // Removes any <uninstall> carrying an <sql> child, not only one this run
+        // planted: a previous run that died before its own trap fired is exactly
+        // the state this exists to clean up.
+        foreach (iterator_to_array($xpath->query('/extension/uninstall[sql]')) as $node) {
+            $node->parentNode->removeChild($node);
+            $removed++;
+        }
+
+        foreach (iterator_to_array($xpath->query('/extension/comment()')) as $node) {
+            if (str_contains($node->nodeValue ?? '', 'Planted by the upgrade harness')) {
+                $node->parentNode->removeChild($node);
+            }
+        }
+
+        if ($removed === 0) {
+            continue;
+        }
+
+        if (@$doc->save($manifest) === false) {
+            echo "  WARN could not rewrite {$manifest}.\n";
+
+            continue;
+        }
+
+        echo "  OK   removed the planted <uninstall><sql> declaration from the library manifest\n";
+    }
+
+    exit(0);
+}
+
 // --- value-printing modes: first test install only, for the shell to consume --
-if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids'], true)) {
+if (\in_array($mode, ['site-path', 'ext-id', 'other-consumer-ids', 'missing-scripture-stack'], true)) {
     $install = $installs[0];
 
     if ($mode === 'site-path') {
         echo $install->path . "\n";
+
+        exit(0);
+    }
+
+    if ($mode === 'missing-scripture-stack') {
+        // Which members of the shared scripture stack the consumer removals
+        // actually took, one "type/folder/element" per line, nothing when all
+        // four survive. Phase 10 reinstalls only when this prints something.
+        //
+        // A consumer that declares our extensions as its own children takes them
+        // with it (PackageAdapter::removeExtensionFiles() resolves by element),
+        // but a consumer packaged correctly takes none — so the reinstall has to
+        // be driven by what is missing, not by whether a consumer was present.
+        // The reinstall is a library install, which routes through
+        // LibraryAdapter::install() -> checkExtensionInFilesystem() -> uninstall()
+        // and so runs whatever uninstall SQL is on disk; doing that when nothing
+        // needs restoring is risk with no upside.
+        [$db, $prefix] = $connect($install);
+
+        if ($db === null) {
+            fwrite(STDERR, "Could not connect to the test database.\n");
+
+            exit(1);
+        }
+
+        // folder is '' for a library and distinguishes the two plugins that
+        // share the element 'cwmscripture' (task and system).
+        $stack = [
+            ['library', '', 'cwmscripture'],
+            ['plugin', 'content', 'scripturelinks'],
+            ['plugin', 'task', 'cwmscripture'],
+            ['plugin', 'system', 'cwmscripture'],
+        ];
+
+        $missing = [];
+
+        foreach ($stack as [$type, $folder, $element]) {
+            $folderSql = $folder === ''
+                ? "AND (`folder` = '' OR `folder` IS NULL)"
+                : "AND `folder` = '" . mysqli_real_escape_string($db, $folder) . "'";
+
+            $row = mysqli_fetch_row(mysqli_query(
+                $db,
+                "SELECT `extension_id` FROM `{$prefix}extensions`
+                 WHERE `type` = '" . mysqli_real_escape_string($db, $type) . "'
+                   AND `element` = '" . mysqli_real_escape_string($db, $element) . "'
+                 {$folderSql} LIMIT 1"
+            ) ?: null);
+
+            if ($row === null || $row === false) {
+                $missing[] = $type . '/' . $folder . '/' . $element;
+            }
+        }
+
+        mysqli_close($db);
+
+        echo implode("\n", $missing) . (empty($missing) ? '' : "\n");
 
         exit(0);
     }
@@ -733,11 +878,13 @@ foreach ($installs as $install) {
 
                 // disarm — exactly what plg_system_cwmscripture does on an admin
                 // com_installer page load.
-                file_put_contents(
-                    $sqlFile,
-                    "--\n-- Neutralised by the upgrade harness, mirroring plg_system_cwmscripture.\n"
-                    . "-- Do not reintroduce DROP TABLE statements here.\n--\n"
-                );
+                //
+                // Reverts the file only, deliberately: phase 16 has to prove the
+                // disarmed *file* is what saves the data while the manifest still
+                // declares <uninstall><sql>. Removing the declaration here would
+                // make that phase pass because nothing was declared. The
+                // declaration is cleaned up by 'restore-manifest' instead.
+                file_put_contents($sqlFile, DISARMED_UNINSTALL_SQL);
                 echo "  OK   disarmed the installed library's uninstall SQL\n";
 
                 break;

--- a/build/verify-scripture-upgrade.php
+++ b/build/verify-scripture-upgrade.php
@@ -10,14 +10,19 @@
  * dropped, the library's ensureTables() recreated them empty, and the Local
  * Translations panel came back with nothing downloaded.
  *
- * Runs in two passes from build/test-upgrade.sh, around the upgrade step:
+ * Runs in three passes from build/test-upgrade.sh, around the upgrade step:
  *
  *   php build/verify-scripture-upgrade.php seed     # after the baseline install
  *   php build/verify-scripture-upgrade.php verify   # after the new build lands
+ *   php build/verify-scripture-upgrade.php cleanup  # once, after the last verify
  *
  * The seed writes one sentinel translation marked installed plus a handful of
  * verses; the verify pass asserts both are still there, byte for byte. Mirrors
  * build/verify-scripture-install.php.
+ *
+ * ⚠️ verify is read-only and may be called as often as needed. Teardown is a
+ * separate mode on purpose: while it was the tail of verify, a second verify
+ * always failed against rows the first had deleted.
  *
  * @package    Proclaim.Build
  * @copyright  (C) 2026 CWM Team All rights reserved
@@ -36,8 +41,8 @@ require $root . '/libraries/vendor/autoload.php';
 
 $mode = $argv[1] ?? '';
 
-if (!\in_array($mode, ['seed', 'verify'], true)) {
-    fwrite(STDERR, "Usage: php build/verify-scripture-upgrade.php seed|verify\n");
+if (!\in_array($mode, ['seed', 'verify', 'cleanup'], true)) {
+    fwrite(STDERR, "Usage: php build/verify-scripture-upgrade.php seed|verify|cleanup\n");
 
     exit(2);
 }
@@ -172,6 +177,27 @@ foreach ($installs as $install) {
         continue;
     }
 
+    // --- cleanup ------------------------------------------------------------
+    // ⚠️ Teardown is its own mode, never the tail of `verify`. It used to run at
+    // the end of the verify pass ("leave the site clean for whatever runs next"),
+    // which made verify single-use: the second call always failed, because the
+    // first had deleted the rows it asserts on. That is not a hypothetical --
+    // phase 10's assertion was added against a fixture phase 9 had already torn
+    // down, and it reported destroyed bible data on a site where nothing was
+    // wrong. Keep verify read-only so it can be called at every point that needs
+    // proof the data is still there.
+    if ($mode === 'cleanup') {
+        mysqli_query($db, "DELETE FROM `{$cache}` WHERE `translation` = '" . PROBE_ABBR . "'");
+        mysqli_query($db, "DELETE FROM `{$verses}` WHERE `translation` = '" . PROBE_ABBR . "'");
+        mysqli_query($db, "DELETE FROM `{$translations}` WHERE `abbreviation` = '" . PROBE_ABBR . "'");
+
+        echo "  OK   removed the probe rows\n";
+
+        mysqli_close($db);
+
+        continue;
+    }
+
     // --- verify -------------------------------------------------------------
     $row = mysqli_fetch_assoc(mysqli_query(
         $db,
@@ -221,11 +247,6 @@ foreach ($installs as $install) {
         fwrite(STDERR, "       another provider round trip (and API.Bible FUMS calls) to rebuild.\n");
         $failures++;
     }
-
-    // Leave the site clean for whatever runs next.
-    mysqli_query($db, "DELETE FROM `{$cache}` WHERE `translation` = '" . PROBE_ABBR . "'");
-    mysqli_query($db, "DELETE FROM `{$verses}` WHERE `translation` = '" . PROBE_ABBR . "'");
-    mysqli_query($db, "DELETE FROM `{$translations}` WHERE `abbreviation` = '" . PROBE_ABBR . "'");
 
     mysqli_close($db);
 }


### PR DESCRIPTION
## What this fixes

`composer test:upgrade` reported the downloaded bible translations, verses and provider cache as destroyed, on sites where nothing was wrong. It failed only when another scripture consumer (LivingWord) was installed, which made it look like removing a consumer was eating shared scripture data.

**It was not. There is no product data loss.** Downloaded bibles survive install, upgrade and consumer removal, and the guards behave as designed.

## Root cause

`build/verify-scripture-upgrade.php` deleted the probe rows at the end of the **`verify`** branch, under *"Leave the site clean for whatever runs next."* That made `verify` single-use. Reproducible in one line, nothing in between:

```
seed    ->  OK   seeded 5 probe verses / 3 cache rows
verify  ->  OK   OK   OK
verify  ->  FAIL FAIL FAIL
```

Phase 9 verifies the seed and tears it down. `f69bcec2e` then added a second `verify` inside phase 10, asserting against rows the first call had already deleted.

⚠️ It surfaced only with a consumer installed because phase 10's block is wrapped in `if [ -n "$OTHER_CONSUMERS" ]` — so the second `verify` never fired otherwise. That correlation is what pointed at the removal cascade, and it was an artifact of where the assertion sat, not of anything the removal did.

## Evidence the product is fine

- **MySQL general query log** over an isolated removal that reproduced the failure: eight `DROP TABLE ... livingword_*` (com_livingword's own uninstall SQL, correct) and exactly two `SELECT ... FROM bsms_scripture_consumers` — the guard consulting the registry and backing off. **Zero** DROP/DELETE/TRUNCATE against any bible table.
- **Unconditional file-write instrumentation** on the installed library: `lib_cwmscripture::uninstall()` is never called during a consumer removal, so `dropTablesIfOrphaned()` is not on that path at all.
- Firing `cwmscripture.downloadCoreTranslations` directly (31.8s, KJV → 93,288 verses) and then removing the consumer left every probe row intact.

⚠️ The `20/0/0` end state that reads as drop-and-reseed is `21/5/3` minus exactly the probe rows. With no other translation downloaded, "tables dropped and reseeded" and "probe rows deleted" predict **identical** numbers — the arithmetic cannot distinguish them.

## Changes

**`ea7fd8e50` — the probe is read-only**
`verify` no longer mutates. Teardown moved to an explicit `cleanup` mode, called once after the last assertion and outside the consumer block so it runs either way. `verify` can now be asserted at every point that needs proof the data is still there, which is what `f69bcec2e` was reaching for.

**`d277e558a` — two real harness defects found on the way**

1. *Phase 10's restore was unconditional.* It reinstalled `pkg_cwmscripture` whenever any consumer was present, whether or not the removals took anything. That reinstall routes through `LibraryAdapter::install()` → `checkExtensionInFilesystem()` → `uninstall()`, and `InstallerAdapter::uninstall()` runs `parseQueries()` with no `isPackageUninstall()` gate and no consumer check — so whatever uninstall SQL is on disk executes. Since pkg_livingword 5.7.1 stopped declaring our extensions as its own children there is usually nothing to restore, making it a destructive-capable no-op. A new `missing-scripture-stack` probe reports which of the four stack members are actually gone, and the reinstall runs only for a non-empty result. Its failure is not swallowed — an empty result must mean "nothing was taken", never "the probe could not tell".

2. *The negative-control fixture outlived the run.* `arm` plants the pre-1.1.5 armed SQL **and** injects the `<uninstall><sql>` manifest declaration; `disarm` reverts only the file, deliberately, because phase 16 must prove the disarmed file is what saves the data while the declaration still stands. Nothing removed the declaration, and `reset-testsite.php` clears only the Proclaim family (#1860). New `restore-manifest` mode undoes both halves from an **EXIT trap** — cleanup that only runs on success cannot fix a leak whose cause is not finishing. It touches the filesystem only and always exits 0, so it cannot mask the failure that triggered it.

## Verification

- `seed` → `verify` ×3 all pass; `cleanup` → `verify` fails, so teardown still works.
- Full `test:upgrade` with a consumer installed: **17/17, exit 0**, with phase 10 actually executing (consumer `4733` removed, stack intact, both verifies green).
- ⚠️ Confirmed non-vacuous — `grep -c "clearing other scripture consumers"` returns 1. An earlier run passed 17/17 only because no consumer was installed and the whole block was skipped in silence; that blind spot is tracked in #1866.
- `restore-manifest` verified against the real leaked fixture on j6-test: block removed, manifest still parses, `arm`/`restore` round trip clean, second run a no-op.
- `composer lint:fix` clean.

## Related

- Closes nothing directly. #1865 was filed during this investigation and **closed as invalid** with the proof above.
- #1866 — `test:upgrade` reports PASSED while silently skipping phase 10. This is what let a broken assertion masquerade as a product bug.
- #1867 — backup/restore round trip for scripture data and the consumer registry is untested.
- #1864 — headless library-only update can still bypass both disarm sweeps.

## Note for review

`f69bcec2e` (already on this branch) records an explanation that its own report contradicts — it says the library "ships disarmed" while reporting real data loss. Both later commits supersede it. Worth squashing this PR so that body does not land on `development`.

There is no `10.5.10` milestone, so none is set — the only open milestone is `v11.0.0`, which is not where this belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)