### PR TITLE
fix: stop four more conditional blocks passing while they assert nothing

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -182,7 +182,18 @@ fi
 # reinstalled by hand if a later run needs it.
 # grep to digits only: this mode prints bare ids with no header, so a stray PHP
 # notice on stdout would otherwise be passed to extension:remove as an id.
-OTHER_CONSUMERS="$(php build/verify-scripture-uninstall.php other-consumer-ids | grep -E '^[0-9]+$' || true)"
+# Two separate failures, kept separate. `grep` exiting 1 means "no consumer
+# installed", which is a legitimate state; the probe exiting non-zero means the
+# question could not be answered at all. Piping them together hid the second
+# behind the first, so a broken probe read as "no consumers" and skipped the
+# phase — the shape this whole sweep is about.
+if ! CONSUMER_IDS="$(php build/verify-scripture-uninstall.php other-consumer-ids)"; then
+    echo "ERROR: could not enumerate other scripture consumers." >&2
+    echo "       Treating that as 'none installed' would skip phase 10 silently." >&2
+    exit 1
+fi
+
+OTHER_CONSUMERS="$(printf '%s\n' "$CONSUMER_IDS" | grep -E '^[0-9]+$' || true)"
 
 if [ -n "$OTHER_CONSUMERS" ]; then
     # ⚠️ Removing a consumer package takes the shared scripture stack with it,
@@ -292,8 +303,25 @@ fi
 # which quietly made that mode single-use -- see the note in the probe.
 php build/verify-scripture-upgrade.php cleanup
 
+# ⚠️ Both phases below prove a refusal by asserting extension:remove exits
+# non-zero -- so an id it cannot use produces the same result as a working
+# guard. An empty LIBID (ext-id printing nothing when the lookup fails) makes
+# the CLI exit 2, which reads as "refused, as expected" and passes the phase
+# while testing nothing. Validate the id before trusting the exit code.
+require_ext_id() {
+    case "${1:-}" in
+        ''|*[!0-9]*)
+            echo "ERROR: could not resolve a numeric extension id (got '${1:-}')." >&2
+            echo "       Without one, extension:remove fails for the wrong reason and the" >&2
+            echo "       refusal these phases assert cannot be distinguished from it." >&2
+            exit 1
+            ;;
+    esac
+}
+
 echo "-- [11/17] STILL NEEDED: removing the library alone must be refused"
 LIBID="$(php build/verify-scripture-uninstall.php ext-id library cwmscripture | tail -n1)"
+require_ext_id "$LIBID"
 
 if php "$JCLI" extension:remove -n "$LIBID" >/dev/null 2>&1; then
     echo "ERROR: extension:remove reported success for lib_cwmscripture." >&2
@@ -347,6 +375,7 @@ echo "-- [13/17] STILL NEEDED: a registered consumer blocks a STANDALONE library
 php build/verify-scripture-uninstall.php seed-consumer
 php build/verify-scripture-uninstall.php seed-translation
 LIBID="$(php build/verify-scripture-uninstall.php ext-id library cwmscripture | tail -n1)"
+require_ext_id "$LIBID"
 
 if php "$JCLI" extension:remove -n "$LIBID" >/dev/null 2>&1; then
     echo "ERROR: the library was removed while a registered consumer was present." >&2
@@ -412,7 +441,14 @@ echo "-- [15/17] NEGATIVE CONTROL: library-only update with no disarm must destr
 php build/verify-scripture-uninstall.php arm
 php build/verify-scripture-uninstall.php assert-sql-armed
 php build/verify-scripture-uninstall.php seed-translation
-php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1 || true
+# The update under test. Verified to exit 0 on a working site, so a failure here
+# is real and must stop the phase: phase 16's assertion is "the data survived",
+# which an install that never ran satisfies for free.
+if ! php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1; then
+    echo "ERROR: the library-only update failed, so this phase proves nothing." >&2
+    exit 1
+fi
+
 php build/verify-scripture-uninstall.php assert-translation-destroyed
 
 echo "-- [16/17] library-only update AFTER the disarm must preserve data"
@@ -422,7 +458,11 @@ php build/verify-scripture-uninstall.php assert-sql-armed
 php build/verify-scripture-uninstall.php seed-translation
 php build/verify-scripture-uninstall.php disarm
 php build/verify-scripture-uninstall.php assert-sql-disarmed
-php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1 || true
+if ! php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1; then
+    echo "ERROR: the library-only update failed, so 'the data survived' is vacuous." >&2
+    exit 1
+fi
+
 php build/verify-scripture-uninstall.php assert-translation-survived
 
 # Phases 14 and 15 use the released baseline as their fixture, so the site is

--- a/build/verify-api-install.php
+++ b/build/verify-api-install.php
@@ -40,9 +40,13 @@ $reader   = new PropertiesReader($root . '/build.properties');
 $installs = $reader->installsFor('test');
 
 if ($installs === []) {
-    fwrite(STDERR, "No role=test install in build.properties — nothing to verify.\n");
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 $failures = 0;

--- a/build/verify-frontend.php
+++ b/build/verify-frontend.php
@@ -70,8 +70,12 @@ $installs = $reader->installsFor('test');
 
 if ($installs === []) {
     fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 $failures = 0;

--- a/build/verify-install-log.php
+++ b/build/verify-install-log.php
@@ -186,9 +186,13 @@ $reader   = new PropertiesReader($root . '/build.properties');
 $installs = $reader->installsFor('test');
 
 if ($installs === []) {
-    fwrite(STDERR, "No role=test install in build.properties — nothing to verify.\n");
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 $registered = countRegisteredSteps($root . '/proclaim.script.php');

--- a/build/verify-schema-check.php
+++ b/build/verify-schema-check.php
@@ -58,8 +58,12 @@ $installs = $reader->installsFor('test');
 
 if ($installs === []) {
     fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 echo "========================================================================\n";

--- a/build/verify-scripture-install.php
+++ b/build/verify-scripture-install.php
@@ -40,9 +40,13 @@ $reader   = new PropertiesReader($root . '/build.properties');
 $installs = $reader->installsFor('test');
 
 if ($installs === []) {
-    fwrite(STDERR, "No role=test install in build.properties — nothing to verify.\n");
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 $failures = 0;

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -138,8 +138,12 @@ $installs = $reader->installsFor('test');
 
 if ($installs === []) {
     fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 /**

--- a/build/verify-scripture-upgrade.php
+++ b/build/verify-scripture-upgrade.php
@@ -72,8 +72,12 @@ $installs = $reader->installsFor('test');
 
 if ($installs === []) {
     fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+    fwrite(STDERR, "Declare one (builder.<id>.role = test) so this check has a target.\n");
 
-    exit(0);
+    // ⚠️ Not exit(0). A verification with no target verified nothing, and a
+    // green exit here would let the whole release gate pass while testing
+    // an empty set -- the same silence that made #1866 expensive.
+    exit(1);
 }
 
 $failures = 0;


### PR DESCRIPTION
Follow-up sweep requested after #1866. Same shape throughout: **a branch that silently stops testing something and still reports success.** Four more instances, three of them in code that was under review all session.

## 1. Seven of eight `verify-*.php` probes vacuously pass with no target

Every one exits `0` when `build.properties` declares no `role=test` install — printing *"nothing to check"* and returning green:

`verify-api-install` · `verify-frontend` · `verify-install-log` · `verify-schema-check` · `verify-scripture-install` · `verify-scripture-uninstall` · `verify-scripture-upgrade`

⚠️ So on a machine with no test site configured, `composer test:release` passes having verified an **empty set** — every scripture, migration, schema and frontend assertion included.

`verify-migrations.php` was the lone holdout already doing this correctly (`exit(1)` plus guidance on declaring `builder.<id>.role = test`). The other seven now match that in-repo precedent. Confirmed none of these are referenced by any workflow in `.github/workflows/`, so nothing in CI depends on the lenient behaviour.

## 2. Phases 11 and 13 can pass with an unusable extension id

Both prove a refusal by asserting `extension:remove` exits non-zero. Measured on j6-test:

```
LIBID would be: ''
extension:remove with empty id exits: 2
```

`2` is non-zero, so it reads as *"refused, as expected"*. If `ext-id` ever fails to resolve — it prints nothing on failure, and the value is taken through `| tail -n1` — both phases pass while testing nothing. `require_ext_id` now rejects a non-numeric id before the exit code is trusted.

## 3. Phase 16's `|| true` made its assertion free

Phase 16 asserts *the data survived* a library-only update. An update that never ran satisfies that trivially. Verified the install exits `0` on a working site, so `|| true` was masking nothing real; a failure there is now fatal.

Phase 15 was already safe — a skipped install makes its *"must be destroyed"* assertion fail, which is the safe direction — but is made explicit for symmetry.

## 4. `other-consumer-ids | grep ... || true` conflated two failures

`grep` exiting 1 means "no consumer installed", which is a legitimate state. The **probe** exiting non-zero means the question could not be answered at all. Piped together, the second hid behind the first — so a broken probe read as "no consumers" and skipped phase 10. That is precisely #1866's shape, one line above the fix for it.

## Deliberately unchanged

The `restore-manifest` EXIT trap keeps its `|| true`. Cleanup must never mask the failure that triggered it.

## Verified

Full `composer test:upgrade` with a consumer installed: **17/17, exit 0**, phase 10 exercised (`grep -c` = 1), phases 11/13 still report the refusal, phase 15 still destroys the seeded data (`verses destroyed as expected — the hazard is real and detectable`) and phase 16 still preserves it. `composer lint:fix` clean.

## Not covered here

`test-install.sh` has only two conditionals, both argument/artifact guards that already `exit 1`. The same audit is worth running against the other release-gate scripts — `reset-testsite.php`, `verify-update-stream.php`, `seed-*.php` — which were out of scope for this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)