### PR TITLE
fix(build): tell the upgrade guard which version is being released (#1871)

### DIFF
--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -41,9 +41,34 @@ if [ -z "$NEWVER" ] || [ -z "$BASEVER" ]; then
     exit 1
 fi
 
-if [ "$NEWVER" = "$BASEVER" ]; then
-    echo "ERROR: active-development version ($NEWVER) equals the last release ($BASEVER)." >&2
-    echo "       The upgrade path only fires when the new build is newer — bump before testing." >&2
+# The version this run is validating an upgrade *to*, which is not always the
+# version the artifact is labelled with.
+#
+# cwm-release exports CWM_RELEASE_VERSION for the test:release gate, because the
+# gate runs before the bump and nothing on disk names the release yet
+# (Joomla-Bible-Study/cwm-build-tools#101). Without it the guard below compares
+# the last release against the development pointer, which answers a different
+# question than the one it is asked during a release.
+#
+# It deliberately does not become NEWVER. `cwm-build --version` only substitutes
+# the output *filename*; the manifest inside the zip is whatever is on disk, so
+# the label has to keep tracking the manifests or the package claims a version
+# it does not carry. Nothing downstream — build-package.sh, verify-migrations.php
+# — sees anything different from before.
+#
+# Unset outside a release — a nightly, a PR, or a hand run — and then
+# active_development is genuinely the build under test.
+TARGETVER="${CWM_RELEASE_VERSION:-$NEWVER}"
+
+if [ "$TARGETVER" = "$BASEVER" ]; then
+    if [ -n "${CWM_RELEASE_VERSION:-}" ]; then
+        echo "ERROR: the version being released ($TARGETVER) is already the last release." >&2
+        echo "       There is nothing to upgrade from. Release a newer version." >&2
+    else
+        echo "ERROR: active-development version ($NEWVER) equals the last release ($BASEVER)." >&2
+        echo "       The upgrade path only fires when the new build is newer — bump before testing." >&2
+    fi
+
     exit 1
 fi
 
@@ -102,6 +127,17 @@ trap 'php build/verify-scripture-uninstall.php restore-manifest || true' EXIT
 
 echo "========================================================================"
 echo " UPGRADE TEST — ${BASEVER}  ->  ${NEWVER}"
+
+# Say so when the artifact is not labelled with the version being released. The
+# tree under test is the one that ships; only the stamp differs, because the
+# gate runs before the bump. Unstated, that gap reads as though the release
+# version itself was exercised — and a phase that appears to have tested
+# something it did not is the failure mode #1866, #1869 and #1870 all closed.
+if [ "$TARGETVER" != "$NEWVER" ]; then
+    echo " Releasing ${TARGETVER} — the build is labelled ${NEWVER} until the bump."
+    echo " The tree under test is what ships; the version stamped on it is not."
+fi
+
 echo "========================================================================"
 
 echo "-- [1/17] reset test site(s) to a clean slate"


### PR DESCRIPTION
Closes #1871.

The guard at the top of `build/test-upgrade.sh` compared `active_development` against
`current.version` and called them "the new build" and "the last release". During
`cwm-release` neither label is true: the gate runs **before** the bump, so
`active_development` still holds the previous bump rather than the version going out. The
guard was answering a different question than the one it is asked at the only moment it
can block a release.

`cwm-build-tools` now exports `CWM_RELEASE_VERSION` for the `test:release` gate
(Joomla-Bible-Study/cwm-build-tools#101), so the target is available without anything
having been mutated:

```sh
TARGETVER="${CWM_RELEASE_VERSION:-$NEWVER}"
```

Unset outside a release — a nightly, a PR, `composer test:upgrade` by hand — and it falls
back to `active_development`, which in those runs genuinely is the build under test. So
this works against any `cwm/build-tools` version, including the current one.

The guard now reads as *"the version being released is already the last release"* — a real
error — and says so in those words when a release is in flight. The old wording is kept
for the non-release case, where "bump before testing" is still the right advice.

## What this deliberately does not do

`TARGETVER` does not become `NEWVER`. That was the fix originally proposed on the issue and
it is wrong twice over:

- `cwm-build --version` substitutes `{version}` into the output **filename** only
  (`PackageBuilder::build()` upstream); the manifest inside the zip is whatever is on disk.
  Relabelling the artifact with a version its manifests do not carry trades a misfiring
  guard for a lying package.
- It would hand `verify-migrations.php` a version whose `$EXPECTATIONS` entry does not
  exist yet. For a release shipping `admin/sql/updates/mysql/<target>.sql` that path is a
  hard fail — a *new* release blocker introduced by a fix for a silent one.

So `NEWVER` stays the build label and nothing downstream sees any change.
`build-package.sh`, `verify-migrations.php` and every phase are passed exactly what they
were passed before.

## The gap that remains, now stated

During a release the artifact is built from the tree that ships but stamped with the
pointer. Stamping it correctly means bumping the manifests, which is the property the
pre-bump ordering exists to protect — so this cannot be closed here. The banner states it
instead of printing a version pair that reads as though the release version was exercised:

```
 UPGRADE TEST — 10.5.6  ->  10.5.7-beta1
 Releasing 10.5.7 — the build is labelled 10.5.7-beta1 until the bump.
 The tree under test is what ships; the version stamped on it is not.
```

A phase that appears to have tested something it did not is what #1866, #1869 and #1870
each closed. This is the same shape, at the top of the file instead of inside a phase.

## Verification ceiling

The harness needs a live Joomla test site and was **not** executed. What was done:
`bash -n`, `shellcheck` (no new findings — the remaining SC2016/SC2001/SC2012 notes are
pre-existing), and reading every call site of both variables to confirm nothing downstream
changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
