### PR TITLE
fix: leave the shared scripture tables alone across a restore

### DIFF
--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -102,21 +102,63 @@ class Cwmrestore
     }
 
     /**
-     * Tables to preserve during restore.
+     * Tables a restore must leave exactly as it found them.
      *
-     * These tables contain downloaded/cached data that is expensive to
-     * regenerate and is NOT part of the user's content backup.  They are
-     * excluded from the DROP phase so locally downloaded Bibles survive
-     * a restore cycle.  If the backup SQL file happens to contain its own
-     * version of these tables, `CREATE TABLE IF NOT EXISTS` is a no-op and
-     * the existing data wins.
+     * These belong to lib_cwmscripture, not to this component. They only carry
+     * the `bsms_` prefix because the library inherited Proclaim's historical
+     * naming, which is why the prefix-driven table list sweeps them up at all.
+     * None of them is part of the user's *content*, and all of them describe
+     * the target site rather than the backed-up one.
+     *
+     * ⚠️ The catalogue travels with the verses. #__bsms_bible_verses was
+     * preserved alone up to 10.5.9, and #__bsms_bible_translations — which
+     * records which of those verses are downloaded, via `installed` — was
+     * dropped and replaced from the backup. Splitting the pair makes the Local
+     * Translations panel wrong in both directions: restoring a backup taken
+     * before a download leaves ~93,000 orphaned verses with the catalogue
+     * claiming nothing is installed, and restoring one taken after a download
+     * into a site without it claims translations that have no verses.
+     *
+     * The provider cache expires and rebuilds itself, so carrying another
+     * site's rows in only risks serving stale passages. The consumer registry
+     * is derived state guarding a destructive operation — it must describe the
+     * extensions installed *here*, so it is never taken from a backup.
      *
      * @var string[]
      * @since 10.1.0
      */
     private static array $preserveTables = [
         '#__bsms_bible_verses',
+        '#__bsms_bible_translations',
+        '#__bsms_scripture_cache',
+        '#__bsms_scripture_consumers',
     ];
+
+    /**
+     * Does this statement target a table the restore must not touch?
+     *
+     * ⚠️ Excluding a table from the DROP phase is not enough on its own. The
+     * backup file still carries that table's own `INSERT INTO` statements, and
+     * isSafeRestoreStatement() is a security allow-list — it asks whether the
+     * target is a Proclaim table, not whether it is preserved — so those
+     * inserts ran against the "preserved" table anyway. The docblock above used
+     * to argue that `CREATE TABLE IF NOT EXISTS` made the backup's copy a
+     * no-op, which is true of the DDL and says nothing about the rows.
+     *
+     * @param   string  $statement  A single SQL statement
+     *
+     * @return  bool  True when the statement should be skipped entirely
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function targetsPreservedTable(string $statement): bool
+    {
+        if (!preg_match('/`?(?<table>#__bsms_[a-z0-9_]+)`?/i', $statement, $matches)) {
+            return false;
+        }
+
+        return \in_array(strtolower($matches['table']), self::$preserveTables, true);
+    }
 
     /**
      * Get Objects for tables
@@ -135,7 +177,13 @@ class Cwmrestore
         $objects   = [];
 
         foreach ($tables as $table) {
-            if (substr_count($table, $bsms)) {
+            // Anchored, not a substring test. getTableList() returns every table
+            // in the schema, so on shared-database hosting a sibling install's
+            // `myjos_bsms_studies` matched here while substr_replace() stripped a
+            // fixed prefix length regardless, yielding a mangled
+            // `#__s_bsms_studies`. CwmdbHelper::getObjects() was corrected for
+            // exactly this; that fix never reached this copy.
+            if (str_starts_with($table, $prefix . $bsms)) {
                 $table     = substr_replace($table, '#__', 0, $prelength);
 
                 // Skip tables that should survive a restore
@@ -310,6 +358,12 @@ class Cwmrestore
                 $app->enqueueMessage(Text::_('JBS_IBM_NOT_DB'), 'error');
 
                 return false;
+            }
+
+            // Preserved tables are excluded from the DROP phase; skipping their
+            // statements here is what actually leaves the rows alone.
+            if (self::targetsPreservedTable($query)) {
+                continue;
             }
 
             $db->setQuery($query);
@@ -556,6 +610,12 @@ class Cwmrestore
                 $app->enqueueMessage(Text::_('JBS_IBM_NOT_DB'), 'error');
 
                 return false;
+            }
+
+            // Preserved tables are excluded from the DROP phase; skipping their
+            // statements here is what actually leaves the rows alone.
+            if (self::targetsPreservedTable($query)) {
+                continue;
             }
 
             $db->setQuery($query);

--- a/tests/unit/Admin/Lib/CwmrestoreTest.php
+++ b/tests/unit/Admin/Lib/CwmrestoreTest.php
@@ -203,4 +203,109 @@ class CwmrestoreTest extends ProclaimTestCase
             'expected both DatabaseModel creation sites to go through MVCFactory -- see #1523'
         );
     }
+
+    /**
+     * The shared scripture tables belong to lib_cwmscripture, not to this
+     * component. They are swept into the prefix-driven table list only because
+     * the library inherited Proclaim's `bsms_` naming.
+     */
+    public static function preservedTableProvider(): array
+    {
+        return [
+            'downloaded verses'  => ['#__bsms_bible_verses'],
+            'download catalogue' => ['#__bsms_bible_translations'],
+            'provider cache'     => ['#__bsms_scripture_cache'],
+            'consumer registry'  => ['#__bsms_scripture_consumers'],
+        ];
+    }
+
+    #[DataProvider('preservedTableProvider')]
+    public function testSharedScriptureTablesAreExcludedFromTheDropPhase(string $table): void
+    {
+        $preserved = new \ReflectionProperty(Cwmrestore::class, 'preserveTables');
+
+        $this->assertContains(
+            $table,
+            $preserved->getValue(),
+            "{$table} belongs to lib_cwmscripture and must survive a restore"
+        );
+    }
+
+    /**
+     * The catalogue travels with the verses.
+     *
+     * Up to 10.5.9 only #__bsms_bible_verses was preserved, so the table
+     * recording which of those verses are downloaded (`installed`) was dropped
+     * and replaced from the backup. That made the Local Translations panel wrong
+     * in both directions -- orphaned verses reported as not installed, or
+     * translations reported installed with no verses behind them.
+     */
+    public function testTheVerseTableAndItsCatalogueArePreservedTogether(): void
+    {
+        $preserved = (new \ReflectionProperty(Cwmrestore::class, 'preserveTables'))->getValue();
+
+        $this->assertSame(
+            \in_array('#__bsms_bible_verses', $preserved, true),
+            \in_array('#__bsms_bible_translations', $preserved, true),
+            'preserving one of the verse/catalogue pair without the other is incoherent'
+        );
+    }
+
+    /**
+     * ⚠️ Excluding a table from the DROP phase does not stop the backup's own
+     * INSERT statements for it. isSafeRestoreStatement() is a security
+     * allow-list -- it asks whether the target is a Proclaim table, not whether
+     * it is preserved -- so those rows landed in the "preserved" table anyway.
+     */
+    public function testStatementsTargetingAPreservedTableAreSkipped(): void
+    {
+        $targets = new \ReflectionMethod(Cwmrestore::class, 'targetsPreservedTable');
+
+        $this->assertTrue($targets->invoke(null, "INSERT INTO `#__bsms_bible_verses` SET `id`='1';"));
+        $this->assertTrue($targets->invoke(null, "INSERT INTO `#__bsms_scripture_consumers` SET `element`='com_other';"));
+        $this->assertTrue($targets->invoke(null, 'DROP TABLE IF EXISTS `#__bsms_bible_translations`;'));
+
+        $this->assertFalse(
+            $targets->invoke(null, "INSERT INTO `#__bsms_studies` SET `id`='1';"),
+            "the component's own content tables must still be restored"
+        );
+    }
+
+    /**
+     * Both execution loops must skip preserved tables. Guarding only one leaves
+     * the other restore path overwriting the rows.
+     */
+    public function testBothRestorePathsSkipPreservedTables(): void
+    {
+        // The two statement-execution loops live in restoreDB() and installdb() —
+        // the same pair the isSafeRestoreStatement() guards above are asserted on.
+        foreach (['restoreDB', 'installdb'] as $method) {
+            $this->assertMatchesRegularExpression(
+                '/targetsPreservedTable\(/',
+                self::methodBody($method),
+                "{$method}() must skip statements targeting a preserved table"
+            );
+        }
+    }
+
+    /**
+     * CwmdbHelper::getObjects() was corrected to an anchored prefix match after
+     * an unanchored substr_count() matched a sibling install's table on shared
+     * hosting and yielded a mangled `#__s_bsms_studies`. This copy kept the bug.
+     */
+    public function testTableDiscoveryIsAnchoredToThePrefix(): void
+    {
+        $body = self::methodBody('getObjects');
+
+        $this->assertMatchesRegularExpression(
+            '/str_starts_with\(\$table,\s*\$prefix\s*\.\s*\$bsms\)/',
+            $body,
+            'table discovery must anchor to the prefix, not substring-match it'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/substr_count\(\$table,\s*\$bsms\)/',
+            $body,
+            'the unanchored match matches sibling installs on shared hosting'
+        );
+    }
 }


### PR DESCRIPTION
Implements the decision recorded on #1867. ⚠️ **This is shipped code** — unlike the rest of the 10.5.10 harness work, this changes what happens on a real site's restore.

## Background

`Cwmbackup` allow-lists tables via `CwmdbHelper::getObjects()`, which is **prefix-driven** — every `<prefix>bsms_*` table. `lib_cwmscripture` inherited Proclaim's historical `bsms_` naming, so its four tables are swept in by accident of naming rather than by decision. `Cwmrestore` then dropped all but one of them.

## Bug 1 — the catalogue was separated from its verses

`$preserveTables` held exactly one entry, `#__bsms_bible_verses`. So `#__bsms_bible_translations` — which records which of those verses are downloaded, via `installed` — was dropped and replaced from the backup.

Splitting that pair makes the Local Translations panel wrong in **both** directions:

- restore a backup taken *before* a download → ~93,000 orphaned verses on disk, catalogue says nothing is installed;
- restore one taken *after* a download into a site without it → catalogue claims translations that have no verses.

## Bug 2 — "preserved" tables were never actually preserved

⚠️ Excluding a table from the DROP phase never stopped the backup's own rows landing in it. `isSafeRestoreStatement()` is a **security** allow-list — it asks whether the target is a Proclaim table, not whether it is preserved — so the file's `INSERT INTO` statements executed against the "preserved" table anyway.

The old docblock argued that `CREATE TABLE IF NOT EXISTS` made the backup's copy a no-op. That is true of the DDL and says nothing about the rows. Both execution loops (`restoreDB` and `installdb`) now skip statements targeting a preserved table.

## Bug 3 — a drifted copy of an already-fixed bug

`Cwmrestore::getObjects()` still matched with unanchored `substr_count($table, 'bsms_')`. `CwmdbHelper::getObjects()` was corrected to anchored `str_starts_with` after a sibling install's `myjos_bsms_studies` matched on shared hosting and `substr_replace()` stripped a fixed prefix length regardless, yielding a mangled `#__s_bsms_studies`. Its comment notes that bogus name "was handed to every consumer of this list: the backup/restore and migration loops" — the fix never reached this copy.

## The policy now applied

| table | backup | restore |
|---|---|---|
| `bsms_bible_verses` | yes | preserve |
| `bsms_bible_translations` | yes | **preserve** (new) |
| `bsms_scripture_cache` | yes | **preserve** (new) — expires and rebuilds; foreign rows risk stale passages |
| `bsms_scripture_consumers` | yes | **preserve** (new) — derived state describing *this* site |

Backup is unchanged: a backup should be a complete snapshot, and including data is never the harmful direction.

On the registry — it self-heals on read (`ConsumerRegistry::installedExcluding()` unregisters stale rows and is backstopped by hardcoded first-party entries plus an on-disk namespace scan), so a foreign one would recover. Not restoring it is correctness hygiene rather than the data-loss scenario #1867 originally described; that overstatement is corrected on the issue.

## Tests

Added to the existing `CwmrestoreTest`: the preserve set, that the verse/catalogue pair travels together, that **both** restore loops skip preserved statements while the component's own content tables still restore, and that discovery is anchored.

⚠️ **Mutation-checked** — removing `#__bsms_bible_translations` from the list fails three of the new assertions, so they are load-bearing rather than tautological. One of them also caught a genuine error in my own first draft (it asserted against `importdb`/`restoreDB` when the two execution loops are in `restoreDB`/`installdb`).

Full suite: **2558 tests, 8038 assertions, OK.** `composer lint:fix` and `lint:syntax` clean.

## Remaining scope on #1867

The end-to-end round-trip test is still to write, and its key assertion stays the *consequence*, not the contents: after restoring into a site with a different extension set, does a consumer uninstall still refuse to drop the shared tables? That needs harness work rather than unit tests, so it is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)