### PR TITLE
chore(deps): update cwm/build-tools to v1.23.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.23.1",
+            "version": "v1.23.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "8040210504b6a5fe6986e09c44ea7a7b5776e8b7"
+                "reference": "5608c46338bae6ddd42994151a87c774f923fa55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/8040210504b6a5fe6986e09c44ea7a7b5776e8b7",
-                "reference": "8040210504b6a5fe6986e09c44ea7a7b5776e8b7",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/5608c46338bae6ddd42994151a87c774f923fa55",
+                "reference": "5608c46338bae6ddd42994151a87c774f923fa55",
                 "shasum": ""
             },
             "require": {
@@ -663,10 +663,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.23.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.23.2",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-17T18:47:43+00:00"
+            "time": "2026-08-17T21:52:18+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up [v1.23.2](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.23.2). Only `cwm/build-tools` moves in the lock.

Three of the four fixes are on this project's release path:

- **`cwm-ars-publish`** verifies the GitHub release through authenticated `gh` instead of a bare `curl`, which 404s on a private repo regardless of whether the release exists
- **1Password failures name their cause** instead of collapsing into `Could not retrieve API token` — a real release stalled on this, with the evidence pointing at composer until `op`'s stderr turned out to say exactly what was wrong
- **`cwm-baseline`** reports a `gh` failure as an error rather than as exit 3 "no usable baseline", which callers are told to read as *not applicable*

The fourth matters here specifically: **`cwm-reset-testsite` now matches table prefixes literally** rather than treating `_` as a LIKE wildcard. This project's `testSite.reset` declares the `bsms_` prefix, and the result is handed to `DROP TABLE`.

Verified the fixes are present in the vendored tree rather than trusting the version string: `optoken.sh` exists, `ars-publish.sh` calls `cwm_op_token`, and `TestSiteReset` carries the `ESCAPE '!'` clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
