### PR TITLE
ci: drop the deleted path, trigger the install job on composer.lock

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,10 +58,20 @@ on:
       - 'build/test-install.sh'
       - 'build/build-package.sh'
       - 'build/build-subpackages.sh'
-      - 'build/reset-testsite.php'
       - 'build/verify-api-install.php'
       - 'build/verify-migrations.php'
       - 'playwright.config.js'
+      # The harness resets the site through cwm-reset-testsite and resolves its
+      # upgrade baseline through cwm-baseline, both of which live in
+      # cwm/build-tools. A version bump replaces that code wholesale, so the
+      # lock belongs here or the job never sees the tooling it runs on: the
+      # v1.23.2 bump merged without this job running.
+      #
+      # 'build/reset-testsite.php' was listed above until that file was deleted
+      # in favour of the shared command, and the entry outlived it — a pattern
+      # matching nothing never triggers and is indistinguishable in review from
+      # one that works (#129 upstream).
+      - 'composer.lock'
       - '.github/workflows/e2e.yml'
 
 concurrency:


### PR DESCRIPTION
Both halves of the problem Joomla-Bible-Study/cwm-build-tools#129 describes, in one filter.

## Stale

`build/reset-testsite.php` was still listed after the file was deleted in favour of the shared `cwm-reset-testsite` command (#1872 / the #102 migration). A pattern matching nothing never triggers, and in review it is indistinguishable from one that works — which is how a filter rots.

Found by the check prototyped in the upstream issue:

```
--- Proclaim
    STALE: build/reset-testsite.php  (matches nothing)
```

## Too narrow

The job runs `build/test-install.sh`, which resets the site through `cwm-reset-testsite` and resolves its upgrade baseline through `cwm-baseline` — both in `cwm/build-tools`. A version bump replaces that code wholesale, and `composer.lock` was not in the filter.

Not hypothetical: **#1886 bumped build-tools to v1.23.2 and merged with seven checks green and this job not among them.** The tooling the harness runs on changed, and the harness never ran.

## Context

This is the third and fourth instance in this one file, after #1755 and #1754 — both recorded in comments a few lines above. The upstream issue proposes linting the stale half, and asks the larger question: whether a `paths:` allow-list is the right shape at all, given that every instance is the same failure — it fails closed on anything nobody thought of.

After this change every path entry resolves to something, and `composer.lock` is listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
