### PR TITLE
chore(ci): drop two paths-ignore entries that exclude nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'admin/language/**'
-      - 'site/language/**'
-      - 'build/mockups/**'
       - '.claude/**'
   pull_request:
     branches: [ "development", "10.x", "11.0.0-dev" ]


### PR DESCRIPTION
Both reported by `cwm-lint-workflows`, and both check out:

- **`build/mockups/**`** — deleted in `9fdf00bfb`, *"remove obsolete landing page mockup"*. The exclusion outlived the directory.
- **`site/language/**`** — has **no history at all**; `git log` finds nothing for that path on any branch. Almost certainly written alongside `admin/language/**` for symmetry, but the site side has no language directory and never did. (CWMLivingWord's equivalent entry *does* resolve — that project ships site-side language files.)

**`.claude/**` stays**, and was correctly not flagged: this repo **tracks** it — plans and skills are committed, with only `settings.local.json` and `worktrees/` gitignored — so the exclusion matches real files and is doing its job.

## Why bother, given these fail open

A stale `paths-ignore` excludes nothing, so these only meant the job ran on changes it needn't have. Harmless. The reason to remove them is that the lint now runs in `check`, and a linter that always prints something trains people to skim past the run that finally has a real finding.

After this, the linter is silent here:

```
Checked 2 workflow(s) with path filters against 2147 tracked files.
Every filter entry matches something.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
