### PR TITLE
refactor(build): migrate the API and Scripture install verifiers to TestSite

### DIFF
--- a/build/verify-api-install.php
+++ b/build/verify-api-install.php
@@ -30,6 +30,8 @@
 
 declare(strict_types=1);
 
+use CWM\BuildTools\Dev\ExtensionQuery;
+use CWM\BuildTools\Dev\TestSite;
 use CWM\BuildTools\Dev\PropertiesReader;
 
 $root = \dirname(__DIR__);
@@ -66,45 +68,31 @@ foreach ($installs as $install) {
     }
 
     // --- #1309 + #1331: plugin row, enabled, with seeded params -------------
-    $configFile = $install->path . '/configuration.php';
-
-    if (!is_file($configFile)) {
-        fwrite(STDERR, "  FAIL configuration.php not found — is this a Joomla install?\n");
+    //
+    // Connection, credentials and prefix come from cwm/build-tools' TestSite,
+    // which is the single implementation of "read configuration.php, connect,
+    // know the prefix". It parses the file as text rather than requiring it, so
+    // this no longer executes arbitrary PHP from the site and defines JConfig
+    // in this process; and it connects through PDO with ERRMODE_EXCEPTION, so a
+    // broken query raises instead of returning false and reading as "not
+    // installed".
+    try {
+        $site = TestSite::fromPath($install->path);
+        $db   = $site->db();
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  FAIL ' . $e->getMessage() . "\n");
         $failures++;
 
         continue;
     }
 
-    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
-        require $file;
-        $c = new \JConfig();
+    // folder is matched as well as element: `element = 'proclaim'` alone also
+    // names the finder, schemaorg, system and task plugins, and the row that
+    // came back first would decide the verdict.
+    $query = new ExtensionQuery($site);
+    $row   = $query->find('plugin', 'proclaim', 'webservices');
 
-        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
-    })($configFile);
-
-    $port = 3306;
-
-    if (str_contains($host, ':')) {
-        [$host, $port] = explode(':', $host, 2);
-        $port          = (int) $port;
-    }
-
-    $db = mysqli_connect($host, $user, $pass, $name, $port);
-
-    if ($db === false) {
-        fwrite(STDERR, "  FAIL could not connect to database {$name}.\n");
-        $failures++;
-
-        continue;
-    }
-
-    $row = mysqli_fetch_assoc(mysqli_query(
-        $db,
-        "SELECT enabled, params FROM {$prefix}extensions
-         WHERE type = 'plugin' AND folder = 'webservices' AND element = 'proclaim'"
-    ) ?: null);
-
-    if ($row === null || $row === false) {
+    if ($row === null) {
         fwrite(STDERR, "  FAIL plg_webservices_proclaim has no #__extensions row —\n");
         fwrite(STDERR, "       the package never installed it (the #1309 signature).\n");
         $failures++;
@@ -126,7 +114,6 @@ foreach ($installs as $install) {
         }
     }
 
-    mysqli_close($db);
 }
 
 if ($failures > 0) {

--- a/build/verify-api-install.php
+++ b/build/verify-api-install.php
@@ -31,8 +31,8 @@
 declare(strict_types=1);
 
 use CWM\BuildTools\Dev\ExtensionQuery;
-use CWM\BuildTools\Dev\TestSite;
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
 
 $root = \dirname(__DIR__);
 

--- a/build/verify-scripture-install.php
+++ b/build/verify-scripture-install.php
@@ -30,7 +30,9 @@
 
 declare(strict_types=1);
 
+use CWM\BuildTools\Dev\ExtensionQuery;
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
 
 $root = \dirname(__DIR__);
 
@@ -63,37 +65,29 @@ foreach ($installs as $install) {
         continue;
     }
 
-    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
-        require $file;
-        $c = new \JConfig();
-
-        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
-    })($configFile);
-
-    $port = 3306;
-
-    if (str_contains($host, ':')) {
-        [$host, $port] = explode(':', $host, 2);
-        $port          = (int) $port;
-    }
-
-    $db = mysqli_connect($host, $user, $pass, $name, $port);
-
-    if ($db === false) {
-        fwrite(STDERR, "  FAIL could not connect to database {$name}.\n");
+    // Connection, credentials and prefix from TestSite: configuration.php is
+    // parsed as text rather than required, so this no longer executes the
+    // site's PHP and defines JConfig here, and PDO raises on a broken query
+    // instead of returning false and reading as "not installed".
+    try {
+        $site   = TestSite::fromPath($install->path);
+        $db     = $site->db();
+        $prefix = $site->prefix();
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  FAIL ' . $e->getMessage() . "\n");
         $failures++;
 
         continue;
     }
 
-    // --- the library itself registered and enabled --------------------------
-    $row = mysqli_fetch_assoc(mysqli_query(
-        $db,
-        "SELECT enabled FROM {$prefix}extensions
-         WHERE type = 'library' AND element = 'cwmscripture'"
-    ) ?: null);
+    $query = new ExtensionQuery($site);
 
-    if ($row === null || $row === false) {
+    // --- the library itself registered and enabled --------------------------
+    // The library registers under its <libraryname>, so element is
+    // 'cwmscripture' -- shared with two plugins, which is why type matters.
+    $row = $query->find('library', 'cwmscripture');
+
+    if ($row === null) {
         fwrite(STDERR, "  FAIL lib_cwmscripture has no #__extensions row — the package never installed it.\n");
         $failures++;
     } elseif ((int) $row['enabled'] !== 1) {
@@ -105,12 +99,11 @@ foreach ($installs as $install) {
 
     // --- its three tables actually exist (the skipped-install-SQL signature) -
     foreach (['bsms_bible_translations', 'bsms_bible_verses', 'bsms_scripture_cache'] as $table) {
-        $exists = mysqli_num_rows(mysqli_query(
-            $db,
-            "SHOW TABLES LIKE '{$prefix}{$table}'"
-        ) ?: null);
-
-        if ($exists === 1) {
+        // hasTable() matches the name exactly through information_schema.
+        // `SHOW TABLES LIKE '{$prefix}{$table}'` treated every underscore in
+        // these names as a single-character wildcard, so it would also have
+        // matched bsmsXbibleYtranslations had one existed.
+        if ($site->hasTable('#__' . $table)) {
             echo "  OK   {$prefix}{$table} exists\n";
         } else {
             fwrite(STDERR, "  FAIL {$prefix}{$table} missing — the library's install SQL never ran\n");
@@ -121,13 +114,11 @@ foreach ($installs as $install) {
     }
 
     // --- the translation catalog is seeded, not just structured -------------
-    $count = mysqli_fetch_row(mysqli_query(
-        $db,
-        "SELECT COUNT(*) FROM {$prefix}bsms_bible_translations"
-    ) ?: null);
+    $count = (int) $db->query('SELECT COUNT(*) FROM ' . $site->table('#__bsms_bible_translations'))
+        ->fetchColumn();
 
-    if ($count !== null && $count !== false && (int) $count[0] > 0) {
-        echo "  OK   translation catalog seeded ({$count[0]} translations)\n";
+    if ($count > 0) {
+        echo "  OK   translation catalog seeded ({$count} translations)\n";
     } else {
         fwrite(STDERR, "  FAIL bsms_bible_translations is empty — tables without the catalog seed\n");
         fwrite(STDERR, "       (the nfsda.org manual-fix scenario). The library install SQL seeds it.\n");
@@ -135,13 +126,9 @@ foreach ($installs as $install) {
     }
 
     // --- scripturelinks installed AND enabled -------------------------------
-    $row = mysqli_fetch_assoc(mysqli_query(
-        $db,
-        "SELECT enabled FROM {$prefix}extensions
-         WHERE type = 'plugin' AND folder = 'content' AND element = 'scripturelinks'"
-    ) ?: null);
+    $row = $query->find('plugin', 'scripturelinks', 'content');
 
-    if ($row === null || $row === false) {
+    if ($row === null) {
         fwrite(STDERR, "  FAIL plg_content_scripturelinks has no #__extensions row —\n");
         fwrite(STDERR, "       the package never installed it.\n");
         $failures++;
@@ -153,7 +140,6 @@ foreach ($installs as $install) {
         echo "  OK   plg_content_scripturelinks installed and enabled\n";
     }
 
-    mysqli_close($db);
 }
 
 if ($failures > 0) {


### PR DESCRIPTION
Two of the twelve hand-rolled site-DB files in #102, off `mysqli` and onto
`Dev\TestSite` / `Dev\ExtensionQuery`.

| file | was | now |
|---|---|---|
| `build/verify-api-install.php` | `require configuration.php` → `new \JConfig()` → `mysqli_connect` | `TestSite::fromPath()` + `ExtensionQuery::find()` |
| `build/verify-scripture-install.php` | same, plus `SHOW TABLES LIKE '{$prefix}{$table}'` | plus `$site->hasTable()` |

`require`-ing `configuration.php` executed arbitrary PHP from disk and defined
a `JConfig` class in the verifier's process; `TestSite` parses it as text.

The table checks are the more interesting change. `SHOW TABLES LIKE` treats `_`
as a single-character wildcard, and every Joomla prefix ends in one, so
`j6test_bsms_x` also matched `j6testXbsms_x`. `hasTable()` asks
`information_schema` with an equality match instead.

## Verified

Both run against the live `j6-test` site and produce **byte-identical output**
to their pre-migration versions — diffed by checking out the `mysqli` version,
running it, and comparing:

```
$ diff before.txt after.txt && echo IDENTICAL
IDENTICAL
```

Both exit 0. The `Package install + API acceptance` job exercises
`verify-api-install.php` on every run and is green.

Refs #102