### PR TITLE
refactor(build): migrate verify-frontend to TestSite, fixing the same second-install fatal

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,6 +60,24 @@ on:
       - 'build/build-subpackages.sh'
       - 'build/verify-api-install.php'
       - 'build/verify-migrations.php'
+      # ⚠️ test-install.sh and test-upgrade.sh invoke twelve build/ scripts
+      # between them, and only four were listed here. The other eight were
+      # executed by this job on every run while never triggering it, so a
+      # change to one reached CI only when it happened to ride along with a
+      # gated file. verify-frontend.php was migrated off mysqli in #1892 and
+      # this job -- the only thing that runs it -- did not start. Same shape as
+      # #1755, #1754 and #1879 above.
+      #
+      # These are build-harness scripts that change rarely, so unlike the
+      # admin/src entries above this costs almost nothing in extra runs.
+      - 'build/build-baseline.sh'
+      - 'build/seed-testsite-menus.php'
+      - 'build/verify-frontend.php'
+      - 'build/verify-install-log.php'
+      - 'build/verify-schema-check.php'
+      - 'build/verify-scripture-install.php'
+      - 'build/verify-scripture-uninstall.php'
+      - 'build/verify-scripture-upgrade.php'
       - 'playwright.config.js'
       # The harness resets the site through cwm-reset-testsite and resolves its
       # upgrade baseline through cwm-baseline, both of which live in

--- a/build/verify-frontend.php
+++ b/build/verify-frontend.php
@@ -37,6 +37,7 @@
 declare(strict_types=1);
 
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
 
 $root = \dirname(__DIR__);
 
@@ -103,56 +104,37 @@ foreach ($installs as $install) {
         continue;
     }
 
-    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
-        require $file;
-        $c = new \JConfig();
-
-        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
-    })($configFile);
-
-    $port = 3306;
-
-    if (str_contains($host, ':')) {
-        [$host, $portString] = explode(':', $host, 2);
-        $port                = (int) $portString;
-    }
-
-    $db = @mysqli_connect($host, $user, $pass, $name, $port);
-
-    if (!$db) {
-        fwrite(STDERR, '  cannot connect: ' . mysqli_connect_error() . "\n");
+    try {
+        $site = TestSite::fromPath($install->path);
+        $db   = $site->db();
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  cannot connect: ' . $e->getMessage() . "\n");
         $failures++;
 
         continue;
     }
 
-    $items  = [];
-    $result = mysqli_query(
-        $db,
-        "SELECT id, alias, link FROM {$prefix}menu WHERE client_id = 0 AND note = '" . SEED_NOTE . "' ORDER BY id"
+    $statement = $db->prepare(
+        'SELECT id, alias, link FROM ' . $site->table('#__menu')
+        . ' WHERE client_id = 0 AND note = ? ORDER BY id'
     );
-
-    while ($result && $row = mysqli_fetch_assoc($result)) {
-        $items[] = $row;
-    }
+    $statement->execute([SEED_NOTE]);
+    $items = $statement->fetchAll(PDO::FETCH_ASSOC);
 
     // The book the seeded study cites, read from the stored reference rather
     // than resolved through the library: this script asserts what the page
     // says, so it must not get its expectation from the same code that
     // produces the page.
     $expectedBook = null;
-    $reference    = mysqli_fetch_row(mysqli_query(
-        $db,
-        "SELECT s.reference_text FROM {$prefix}bsms_study_scriptures AS s "
-        . "INNER JOIN {$prefix}bsms_studies AS st ON st.id = s.study_id "
-        . 'WHERE st.published = 1 AND s.reference_text <> \'\' ORDER BY s.id LIMIT 1'
-    ) ?: null);
+    $reference    = $db->query(
+        'SELECT s.reference_text FROM ' . $site->table('#__bsms_study_scriptures') . ' AS s '
+        . 'INNER JOIN ' . $site->table('#__bsms_studies') . ' AS st ON st.id = s.study_id '
+        . "WHERE st.published = 1 AND s.reference_text <> '' ORDER BY s.id LIMIT 1"
+    )->fetchColumn();
 
-    if ($reference !== null) {
-        $expectedBook = trim(preg_replace('/\s+\d.*$/', '', (string) $reference[0]));
+    if ($reference !== false) {
+        $expectedBook = trim(preg_replace('/\s+\d.*$/', '', (string) $reference));
     }
-
-    mysqli_close($db);
 
     if ($items === []) {
         fwrite(STDERR, "  no seeded menu items — run build/seed-testsite-menus.php first.\n");


### PR DESCRIPTION
Fourth file off hand-rolled `mysqli` (#102), and the **third** carrying the
`JConfig` redeclare — same shape as #1891:

```php
[$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
    require $file;
    $c = new \JConfig();
    ...
})($configFile);
```

inside `foreach ($installs as $install)`. Classes are process-global, so the
second `role=test` install is fatal. Demonstrated by declaring one:

| | result |
|---|---|
| before | **exit 255**, dies after printing the second install's header |
| after | **exit 0**, both installs verified |

That's three of the four migrated files with the same latent fatal, which is a
decent argument that the primitive was worth extracting.

## Also fixed: a failure that told you to do the wrong thing

`mysqli_query()` returns `false` on error, and the old loop read that as an
empty result set:

```php
while ($result && $row = mysqli_fetch_assoc($result)) {
```

A failed query therefore reported *"no seeded menu items — run
build/seed-testsite-menus.php first"* — sending the reader off to reseed a site
whose query had actually failed. PDO with `ERRMODE_EXCEPTION` cannot produce
that outcome. Same class of defect as the rest of #102: a check that passes, or
fails, while testing something other than what it claims.

The menu lookup also binds `SEED_NOTE` rather than interpolating it. It is a
project-owned constant so this was never exploitable — it just matches the
shape the other migrated files now use.

## Verified

Byte-identical against the live `j6-test` site in **both** states:

| state | result |
|---|---|
| unseeded | exits 1 on the empty menu — identical |
| seeded (`build/seed-testsite-menus.php`) | all 4 page checks pass, exit 0 — identical |

The seeded run matters because it exercises both queries. The reference lookup
resolves `Colossians 3:5-11`, so `$expectedBook` is non-null and the
Books-section assertion that depends on it actually runs instead of being
skipped.

`php-cs-fixer` clean locally before pushing: 0 of 617.

Refs #102