### PR TITLE
chore(ci): stop writing database keys nothing reads into build.properties

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,10 +229,6 @@ jobs:
           builder.ci.role=test
           builder.ci.path=${SITE_DIR}
           builder.ci.url=${SITE_URL}
-          builder.ci.db_host=127.0.0.1
-          builder.ci.db_user=root
-          builder.ci.db_pass=joomla_ci
-          builder.ci.db_name=joomla_ci
           builder.ci.username=admin
           builder.ci.password=admin1234567
           builder.ci.email=admin@example.com


### PR DESCRIPTION
`cwm-setup` no longer prompts for or stores `db_host` / `db_user` / `db_pass` /
`db_name` (Joomla-Bible-Study/cwm-build-tools#131) — every command that touches
a database resolves credentials from the install's own `configuration.php`.
This workflow was still generating them by hand.

Nothing in this repository read them: every build script went through
`TestSite` in #102.

So this removes a throwaway CI password from a generated file, and four lines
that would mislead whoever edits this block next.