### PR TITLE
fix(build): report every failing check in test-install, not just the first

### DIFF
--- a/build/test-install.sh
+++ b/build/test-install.sh
@@ -44,25 +44,45 @@ fi
 echo "-- [3/10] install ${ZIP} (fresh)"
 "$BIN/cwm-install-zip" --zip "$ZIP"
 
+# Verification steps record their result and carry on; the reset/build/install
+# steps above still abort, because there is nothing to verify if the package
+# never landed.
+#
+# Under `set -e` a bare check aborts the run, so the first failure hid the other
+# six: a known registration drift would mask an unrelated schema regression, and
+# the fix for one would only reveal the next. Adopted from CWMLivingWord's copy
+# of this script, which already worked this way -- comparing the two for
+# Joomla-Bible-Study/cwm-build-tools#142 is what surfaced the difference.
+FAILURES=()
+
 echo "-- [4/10] verify extension registration"
-"$BIN/cwm-verify" --target test
+"$BIN/cwm-verify" --target test || FAILURES+=("extension registration (cwm-verify)")
 
 echo "-- [5/10] verify migrations landed"
-php build/verify-migrations.php "$VERSION"
+php build/verify-migrations.php "$VERSION" || FAILURES+=("migrations (verify-migrations)")
 
 echo "-- [6/10] verify the REST API landed (#1309/#1310/#1331 guards)"
-php build/verify-api-install.php
+php build/verify-api-install.php || FAILURES+=("REST API (verify-api-install)")
 
 echo "-- [7/10] verify the scripture library landed (tables, seed, plugin enabled)"
-php build/verify-scripture-install.php
+php build/verify-scripture-install.php || FAILURES+=("scripture library (verify-scripture-install)")
 
 echo "-- [8/10] seed the site menu items the front end is reached through (#1701)"
-php build/seed-testsite-menus.php
+php build/seed-testsite-menus.php || FAILURES+=("menu seeding (seed-testsite-menus)")
 
 echo "-- [9/10] verify the front end renders (#1701 guards)"
-php build/verify-frontend.php
+php build/verify-frontend.php || FAILURES+=("front end (verify-frontend)")
 
 echo "-- [10/10] verify Joomla's own schema check is clean"
-php build/verify-schema-check.php
+php build/verify-schema-check.php || FAILURES+=("Joomla schema check (verify-schema-check)")
+
+echo
+if [ ${#FAILURES[@]} -gt 0 ]; then
+    echo "CLEAN-INSTALL TEST FAILED for ${VERSION}:"
+    for f in "${FAILURES[@]}"; do
+        echo "  - ${f}"
+    done
+    exit 1
+fi
 
 echo "CLEAN-INSTALL TEST PASSED for ${VERSION}."


### PR DESCRIPTION
`build/test-install.sh` runs under `set -euo pipefail` with **six bare
verification steps**. The first to fail aborts the run, so the other five never
execute:

```bash
echo "-- [5/10] verify migrations landed"
php build/verify-migrations.php "$VERSION"      # <-- aborts everything after it
```

A known registration drift masked an unrelated schema regression, and fixing
one only revealed the next — one full clean-install round trip per failure, on a
script that rebuilds packages and reinstalls a site.

Verification steps now record and carry on, with a summary. The reset, build and
install steps still abort: there is nothing to verify if the package never
landed.

## Verified against the live test site, with the real script

| run | result |
|---|---|
| unmodified | all 10 steps run, **exit 0**, `PASSED` |
| step 6 forced to fail | all 10 steps run, **exit 1**, summary names step 6 |

```
-- [6/10] verify the REST API landed (#1309/#1310/#1331 guards)
-- [7/10] verify the scripture library landed ...
-- [8/10] seed the site menu items ...
-- [9/10] verify the front end renders ...
-- [10/10] verify Joomla's own schema check is clean
CLEAN-INSTALL TEST FAILED for 10.5.10-dev:
  - REST API (verify-api-install)
```

Before this change that run stopped at step 6.

Also checked `${#FAILURES[@]}` on an empty array under `set -u` in bash 3.2
(what macOS ships) — clean, so a passing run is unaffected.

## Where it came from

CWMLivingWord's copy of this script already worked this way and carried a
comment explaining why. Comparing the two for
Joomla-Bible-Study/cwm-build-tools#142 surfaced it — the divergence between the
copies was the useful part, not the duplication.

Refs Joomla-Bible-Study/cwm-build-tools#142