### PR TITLE
chore(deps): bump cwm/build-tools to ^1.27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.25",
+    "cwm/build-tools": "^1.27",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7596039d0e6dea44a2f2d55d4962e61a",
+    "content-hash": "12af432603700a0a6a35570713cd8248",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.25.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "98d95113a81e90b293406886987be9510413e54b"
+                "reference": "f189882bbf996b2fab24ea36abd47142010086aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/98d95113a81e90b293406886987be9510413e54b",
-                "reference": "98d95113a81e90b293406886987be9510413e54b",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f189882bbf996b2fab24ea36abd47142010086aa",
+                "reference": "f189882bbf996b2fab24ea36abd47142010086aa",
                 "shasum": ""
             },
             "require": {
@@ -664,10 +664,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.25.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.27.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T13:19:39+00:00"
+            "time": "2026-08-18T18:01:04+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Staying current. **Nothing here requires it** — v1.27.0 adds an opt-in
`docker-compose` template that no code reads.

One breaking change falls in the range: **v1.26.0** stopped `cwm-setup`
prompting for and storing `db_host` / `db_user` / `db_pass` / `db_name`, and it
now removes them from an existing `build.properties`. Nothing in this
repository reads those keys, and its committed properties template no longer
offers them.

Smoke-checked after the bump: every `cwm-*` binary loads and runs. (Six —
`cwm-bump`, `cwm-changelog`, `cwm-article`, and the three `cwm-ars-*` — exit 1
on `--help` because they do not implement the flag. That is pre-existing and
identical on the previous version.)