### PR TITLE
fix(build): make test:upgrade actually change version, and prove it did

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.5.9</version>
-    <creationDate>2026-08-15</creationDate>
+    <version>10.5.10-dev</version>
+    <creationDate>2026-08-18</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -72,6 +72,64 @@ if [ "$TARGETVER" = "$BASEVER" ]; then
     exit 1
 fi
 
+# ⚠️ The version in versions.json is a label; the version the package *declares*
+# is what Joomla upgrades against. They are maintained in different places and
+# were silently different for the whole of every development cycle (#1862):
+# versions.json said 10.5.10-dev while every manifest still read 10.5.9, because
+# manifests were only bumped at release. `cwm-build --version` names the
+# artifact and does not touch them.
+#
+# So this harness printed "10.5.9 -> 10.5.10-dev" while installing a package
+# that declared 10.5.9 at both ends — a from == to upgrade. Migrations gated on
+# the version being upgraded *from* (#1842, #1858) were therefore exercised in
+# the one state where a gate that never fires and a gate that works look
+# identical.
+#
+# Checked here rather than after the 17 phases: the run takes minutes, and every
+# assertion in it would pass regardless.
+# Read the path from cwm-build.config.json rather than hardcoding one.
+# admin/proclaim.xml is a symlink cwm-link creates and is not tracked, so a
+# fresh CI clone does not have it — a guard that reads it would fail there for
+# a reason that has nothing to do with what it checks.
+PKGMANIFEST="$(php -r '
+    $c = json_decode(file_get_contents("cwm-build.config.json"), true);
+    echo $c["manifests"]["package"] ?? "";
+')"
+
+if [ -z "$PKGMANIFEST" ] || [ ! -f "$PKGMANIFEST" ]; then
+    echo "ERROR: could not locate the package manifest via cwm-build.config.json." >&2
+    exit 1
+fi
+
+MANIFESTVER="$(php -r '
+    $x = @simplexml_load_file($argv[1]);
+    echo $x === false ? "" : (string) $x->version;
+' "$PKGMANIFEST")"
+
+if [ -z "$MANIFESTVER" ]; then
+    echo "ERROR: could not read <version> from ${PKGMANIFEST}." >&2
+    exit 1
+fi
+
+if [ "$MANIFESTVER" != "$TARGETVER" ]; then
+    echo "ERROR: ${PKGMANIFEST} declares ${MANIFESTVER}, but this run claims to test" >&2
+    echo "       an upgrade to ${TARGETVER}." >&2
+    echo "" >&2
+
+    if [ "$MANIFESTVER" = "$BASEVER" ]; then
+        echo "       The manifests still carry the last released version, so the" >&2
+        echo "       'upgrade' would install ${BASEVER} over ${BASEVER} and prove nothing." >&2
+        echo "" >&2
+        echo "       Open the cycle properly:" >&2
+        echo "         composer version -- -v ${TARGETVER}" >&2
+    else
+        echo "       versions.json and the manifests disagree. Reconcile them before" >&2
+        echo "       trusting this harness." >&2
+    fi
+
+    exit 1
+fi
+
 BASEZIP="build/dist/pkg_proclaim-${BASEVER}.zip"
 NEWZIP="build/dist/pkg_proclaim-${NEWVER}.zip"
 
@@ -170,6 +228,11 @@ echo "-- [6/17] install ${NEWVER} over ${BASEVER} (triggers update() + migration
 # schema behind for every other assertion here to agree on.
 echo "-- [7/17] verify the update reported what it did (and gated the migrations)"
 php build/verify-install-log.php update "$BASEVER"
+# The line above asserts where the update came FROM. This asserts where it
+# ended up: an install that silently did not apply leaves the manifests correct
+# and the site behind, and the pre-flight guard cannot tell those apart because
+# it only ever reads files (#1862).
+php build/verify-installed-version.php "$NEWVER"
 
 echo "-- [8/17] verify registration + migrations"
 "$BIN/cwm-verify" --target test

--- a/build/verify-installed-version.php
+++ b/build/verify-installed-version.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Assert the site now runs the version this run claims to have installed.
+ *
+ * The harness already checks the *from* side: verify-install-log.php asserts
+ * the update reported upgrading from the expected release (#1842's gate). It
+ * checked nothing about where it ended up, and that is the half #1862 was
+ * about — the built package declared the baseline version at both ends, so
+ * every assertion in a 17-phase run agreed while the transition under test had
+ * not happened.
+ *
+ * test-upgrade.sh guards the *intent* before building: the package manifest
+ * must declare the target version. This guards the *outcome*: an install that
+ * silently did not apply leaves the manifests correct and the site behind, and
+ * intent alone cannot tell those apart.
+ *
+ * Reads what the site believes it has — #__extensions.manifest_cache — rather
+ * than the files on disk, because that is what Joomla wrote at install time and
+ * what every version-gated code path consults.
+ *
+ * Usage: php build/verify-installed-version.php <expected-version>
+ *
+ * Exit codes:
+ *   0  every checked extension reports the expected version
+ *   1  a mismatch, a missing extension, or no usable install
+ *   2  wrong invocation
+ *
+ * @package    Proclaim.Build
+ * @since      __DEPLOY_VERSION__
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use CWM\BuildTools\Dev\ExtensionQuery;
+use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
+
+$root = \dirname(__DIR__);
+
+require $root . '/libraries/vendor/autoload.php';
+
+$expected = $argv[1] ?? '';
+
+if ($expected === '') {
+    fwrite(STDERR, "Usage: php build/verify-installed-version.php <expected-version>\n");
+
+    exit(2);
+}
+
+$reader   = new PropertiesReader($root . '/build.properties');
+$installs = $reader->installsFor('test');
+
+if ($installs === []) {
+    fwrite(STDERR, "No role=test install in build.properties — nothing to check.\n");
+
+    // ⚠️ Not exit(0). A verification with no target verified nothing.
+    exit(1);
+}
+
+// The package and the component are bumped together and installed together, so
+// a disagreement between them is itself worth catching.
+$targets = [
+    ['package', 'pkg_proclaim'],
+    ['component', 'com_proclaim'],
+];
+
+$failures = 0;
+
+foreach ($installs as $install) {
+    echo "=== installed version on {$install->id} ({$install->path}) ===\n";
+
+    try {
+        $site = TestSite::fromPath($install->path);
+        $site->db();
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  FAIL ' . $e->getMessage() . "\n");
+        $failures++;
+
+        continue;
+    }
+
+    $query = new ExtensionQuery($site);
+
+    foreach ($targets as [$type, $element]) {
+        if (!$query->exists($type, $element)) {
+            fwrite(STDERR, "  FAIL {$element} is not registered on this site.\n");
+            $failures++;
+
+            continue;
+        }
+
+        $found = $query->version($type, $element);
+
+        if ($found === $expected) {
+            echo "  OK   {$element} reports {$found}\n";
+
+            continue;
+        }
+
+        fwrite(STDERR, "  FAIL {$element} reports " . ($found ?? 'no version') . ", expected {$expected}.\n");
+        fwrite(STDERR, "       The install did not take, or it installed a package built from\n");
+        fwrite(STDERR, "       manifests carrying a different version (#1862).\n");
+        $failures++;
+    }
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\nInstalled-version check FAILED ({$failures} assertion(s)).\n");
+
+    exit(1);
+}
+
+echo "Installed version verified: {$expected}.\n";

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="administrator" method="upgrade">
     <name>mod_proclaimicon</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.9</version>
-    <creationDate>2026-08-15</creationDate>
+    <version>10.5.10-dev</version>
+    <creationDate>2026-08-18</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaim</namespace>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="site" method="upgrade">
     <name>mod_proclaim_podcast</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 Christian Web Ministries All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.5.9</version>
-    <creationDate>2026-08-15</creationDate>
+    <version>10.5.10-dev</version>
+    <creationDate>2026-08-18</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimYoutube</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.9",
+  "version": "10.5.10-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.5.9",
+      "version": "10.5.10-dev",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.9",
+  "version": "10.5.10-dev",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="finder" method="upgrade">
     <name>plg_finder_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="schemaorg" method="upgrade">
     <name>plg_schemaorg_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="system" method="upgrade">
     <name>plg_system_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="task" method="upgrade">
 	<name>plg_task_proclaim</name>
 	<author>CWM Team</author>
-	<creationDate>2026-08-15</creationDate>
+	<creationDate>2026-08-18</creationDate>
 	<copyright>(C) 2026 Proclaim All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.5.9</version>
+	<version>10.5.10-dev</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="webservices" method="upgrade">
     <name>plg_webservices_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-15</creationDate>
+    <creationDate>2026-08-18</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.5.9</version>
+    <version>10.5.10-dev</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,8 +6,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.9</version>
-    <creationDate>2026-08-15</creationDate>
+    <version>10.5.10-dev</version>
+    <creationDate>2026-08-18</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Component\Proclaim</namespace>


### PR DESCRIPTION
Closes #1862.

The harness printed `UPGRADE TEST PASSED 10.5.9 -> 10.5.10-dev` while
installing a package that **declared 10.5.9 at both ends**.

`versions.json` carries the label; the manifests carry what Joomla actually
upgrades against — and they were only bumped at release. So for the whole of
every development cycle the built package declared the last released version.
`cwm-build --version` names the artifact and does not touch manifests.

That made every run a `from == to` upgrade, which matters because migrations
gated on the version being upgraded *from* (#1842, #1858) were exercised in the
one state where **a gate that never fires and a gate that works leave the same
schema behind** — which is what every other assertion in the 17-phase run
agrees on.

## Three parts

**1. Open the cycle properly.** Every manifest now carries `10.5.10-dev`, which
is what `versions.json` has said all along. `cwm_validate_release_version`
rejects a `-dev` version outright, so this cannot leak into a release — the
release bump replaces it.

**2. Guard the intent, before building.** The package manifest must declare the
version the run claims to test:

```
ERROR: build/pkg_proclaim.xml declares 10.5.9, but this run claims to test
       an upgrade to 10.5.10-dev.

       The manifests still carry the last released version, so the
       'upgrade' would install 10.5.9 over 10.5.9 and prove nothing.

       Open the cycle properly:
         composer version -- -v 10.5.10-dev
```

Checked *before* the phases: the run takes minutes and every assertion in it
would pass anyway. The path is read from `cwm-build.config.json` rather than
hardcoded — `admin/proclaim.xml` is an untracked symlink `cwm-link` creates, so
a guard reading it would fail in a fresh CI clone for a reason unrelated to
what it checks.

**3. Guard the outcome, after installing.**
`build/verify-installed-version.php` asserts the site now reports the new
version. `verify-install-log.php` already asserted where the update came
*from*; nothing asserted where it ended up, and an install that silently does
not apply leaves the manifests correct and the site behind. Intent alone cannot
tell those apart.

It reads `manifest_cache` — what Joomla wrote at install time and what
version-gated code consults — not the files on disk.

## Verified end to end

The guard fires on the old state and passes on the new; both directions
checked, including a simulated mismatch.

Full 17-phase run green, and the site now reports:

```
com_proclaim   10.5.10-dev
pkg_proclaim   10.5.10-dev
```

where the issue recorded `10.5.9` for both. **This is the first run of this
harness that has performed the transition it describes** — and the
version-gated code passes it, so there was no latent bug hiding behind the
no-op.

`php-cs-fixer` clean: 0 of 618.

## Not folded in

`test-install.sh` builds from the same manifests, so the pre-flight guard
covers the package for it too. Adding a matching outcome assertion there would
mean renumbering its ten phase labels for a lower-value check — worth doing
separately if wanted.

Closes #1862