### PR TITLE
chore(deps): apply the available dependency updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.27.0",
+            "version": "v1.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "f189882bbf996b2fab24ea36abd47142010086aa"
+                "reference": "3e0c0d3e77fc95955816ff8498ce69133dde4bb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f189882bbf996b2fab24ea36abd47142010086aa",
-                "reference": "f189882bbf996b2fab24ea36abd47142010086aa",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/3e0c0d3e77fc95955816ff8498ce69133dde4bb4",
+                "reference": "3e0c0d3e77fc95955816ff8498ce69133dde4bb4",
                 "shasum": ""
             },
             "require": {
@@ -664,10 +664,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.27.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.27.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T18:01:04+00:00"
+            "time": "2026-08-18T18:26:38+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",
@@ -948,16 +948,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.18",
+            "version": "v3.95.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683"
+                "reference": "8a06c4ad6bd580b7920bd5ff81b271ca1158507e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a8b4e4216faabf67f4e96110ee99a48c96e4e683",
-                "reference": "a8b4e4216faabf67f4e96110ee99a48c96e4e683",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8a06c4ad6bd580b7920bd5ff81b271ca1158507e",
+                "reference": "8a06c4ad6bd580b7920bd5ff81b271ca1158507e",
                 "shasum": ""
             },
             "require": {
@@ -1041,7 +1041,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.18"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.19"
             },
             "funding": [
                 {
@@ -1049,7 +1049,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-30T15:46:02+00:00"
+            "time": "2026-08-17T16:24:07+00:00"
         },
         {
             "name": "joomla/application",
@@ -1319,16 +1319,16 @@
         },
         {
             "name": "joomla/filesystem",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filesystem.git",
-                "reference": "66e6212d4cb4d36e7dd5a01a94c5f257e3026a52"
+                "reference": "a79ed5044970b81a5aed22049199c1d6bc902d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/66e6212d4cb4d36e7dd5a01a94c5f257e3026a52",
-                "reference": "66e6212d4cb4d36e7dd5a01a94c5f257e3026a52",
+                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/a79ed5044970b81a5aed22049199c1d6bc902d9a",
+                "reference": "a79ed5044970b81a5aed22049199c1d6bc902d9a",
                 "shasum": ""
             },
             "require": {
@@ -1361,9 +1361,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/filesystem/issues",
-                "source": "https://github.com/joomla-framework/filesystem/tree/4.2.0"
+                "source": "https://github.com/joomla-framework/filesystem/tree/4.2.1"
             },
-            "time": "2026-06-25T19:31:52+00:00"
+            "time": "2026-08-18T15:44:34+00:00"
         },
         {
             "name": "joomla/filter",
@@ -3779,12 +3779,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb"
+                "reference": "13a2a6821fab80b766323cf11ac90d4fbc1f4f9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb",
-                "reference": "001a25704f6f9da1e98bb6206ed2abb3fe2e2dbb",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/13a2a6821fab80b766323cf11ac90d4fbc1f4f9d",
+                "reference": "13a2a6821fab80b766323cf11ac90d4fbc1f4f9d",
                 "shasum": ""
             },
             "conflict": {
@@ -3889,7 +3889,7 @@
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cadmium-org/cadmium-cms": "<=0.4.9",
-                "cakephp/authentication": "<3.3.6|>=4,<4.1.1",
+                "cakephp/authentication": "<2.11.1|>=3,<3.3.6|>=4,<4.1.1",
                 "cakephp/cakephp": "<4.5.11|>=4.6,<4.6.4|>=5,<5.1.7|>=5.2,<5.2.13|>=5.3,<5.3.6",
                 "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
                 "cardgate/magento2": "<2.0.33",
@@ -4254,7 +4254,7 @@
                 "leantime/leantime": "<3.3",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "libreform/libreform": ">=2,<=2.0.8",
-                "librenms/librenms": "<=26.4",
+                "librenms/librenms": "<26.5",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<=7.0.0.0-beta1",
@@ -4291,6 +4291,7 @@
                 "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
                 "maximebf/debugbar": "<1.19",
                 "mckenziearts/livewire-markdown-editor": "<1.3",
+                "mcp/sdk": ">=0.5,<0.7.1",
                 "mdanter/ecc": "<2",
                 "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
                 "mediawiki/cargo": "<3.8.3",
@@ -4400,7 +4401,7 @@
                 "pagekit/pagekit": "<=1.0.18",
                 "paragonie/ecc": "<2.0.1",
                 "paragonie/random_compat": "<2",
-                "paragonie/sodium_compat": "<1.24|>=2,<2.5",
+                "paragonie/sodium_compat": "<1.24.1|>=2,<2.5.1",
                 "passbolt/passbolt_api": "<4.6.2",
                 "paymenter/paymenter": "<=1.5.4",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
@@ -4455,6 +4456,7 @@
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
+                "plank/laravel-mediable": "<7",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<5.42.1",
@@ -4898,7 +4900,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-13T14:57:02+00:00"
+            "time": "2026-08-18T18:36:55+00:00"
         },
         {
             "name": "sabre/event",

--- a/site/src/Helper/Cwmlisting.php
+++ b/site/src/Helper/Cwmlisting.php
@@ -2950,7 +2950,7 @@ class Cwmlisting
             'com_proclaim.addtoany',
             'https://static.addtoany.com/menu/page.js',
             ['version' => false],
-            ['defer'   => true, 'async' => true]
+            ['defer' => true, 'async' => true]
         );
 
         return $html;


### PR DESCRIPTION
From the weekly vendor check (#1874).

## Applied — four patch-level PHP updates

```
cwm/build-tools           v1.27.0  -> v1.27.1
friendsofphp/php-cs-fixer v3.95.18 -> v3.95.19
joomla/filesystem         4.2.0    -> 4.2.1
roave/security-advisories 001a257  -> 13a2a68
```

`cwm/build-tools v1.27.1` is worth taking now rather than waiting: it fixes
`cwm-sync-configs --help` **writing to your project** instead of printing help.

No security advisories outstanding. The npm half of that report has already
resolved itself since it was filed — `intl-tel-input`, `@axe-core/playwright`,
`globals` and `terser` are all current.

## Not applied: Babel 7 → 8

Tried, rather than declined on principle. The result is worth recording:

| | |
|---|---|
| `build:js` | **passes** |
| `media/js/**` output | **byte-identical**, all 144 artifacts |
| `lint:js` | passes |
| `npm test` | **17 of 17 suites fail** |

```
[BABEL] The 'useBuiltIns' option has been removed.
Please use babel-plugin-polyfill-corejs3 instead.
```

Babel 8 removed `useBuiltIns`, and this project sets `useBuiltIns: "entry"` with
corejs 3.48. The replacement is a **polyfill-strategy change with
browser-support implications**, not a version bump — which browsers get which
polyfills is a product decision.

Reverted; build, tests, lint and artifacts all confirmed back to baseline. Filed
as #1903 with the diagnosis and a suggested order of work.

## Not applied: the submodule rows

`libraries/lib_cwmscripture` and `plugins/content/scripturelinks` are
**submodules pinned at release tags** (v1.1.18, v1.2.10). Their entries in the
report are their *own* dev dependencies, not Proclaim's.

Each is three commits behind its main — all dev-tooling chores from today, no
shipped code. Moving the pointers would take Proclaim off released versions of
both for no runtime benefit. Those update when the repositories cut releases.

Refs #1874