### PR TITLE
fix(backup): leave the shared scripture stack out of backup and restore

### DIFF
--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -77,7 +77,7 @@ class CwmbackupController extends BaseController
         // Initialize an empty file
         file_put_contents($tmpPath, '');
 
-        $tables     = CwmdbHelper::getObjects();
+        $tables     = CwmdbHelper::getOwnObjects();
         $tableNames = array_column($tables, 'name');
 
         // Add virtual "tables" for component config, scheduled tasks, and
@@ -522,16 +522,25 @@ class CwmbackupController extends BaseController
 
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        // For the first batch, drop existing tables (preserving downloaded Bible verse data)
+        // For the first batch, drop Proclaim's own tables.
+        //
+        // ⚠️ This used to carry `$preserve = ['#__bsms_bible_verses']`, meaning
+        // to keep downloaded bible data across a restore. It could not work.
+        // The export wrote a `DROP TABLE IF EXISTS` for every table it dumped,
+        // including that one, so skipping the drop here only deferred it by a
+        // few statements — the backup's own SQL dropped and recreated the table
+        // from the snapshot. The intent was right and the mechanism was not
+        // (#1867).
+        //
+        // getOwnObjects() excludes the whole shared scripture stack, which is
+        // the library's to manage (#1675 settled the same question for
+        // uninstall). Nothing here drops them, and Cwmrestore rejects any
+        // statement that targets them, so an older backup still carrying those
+        // tables cannot reach them either.
         if ($batch === 0) {
-            $preserve = ['#__bsms_bible_verses'];
-            $objects  = CwmdbHelper::getObjects();
+            $objects = CwmdbHelper::getOwnObjects();
 
             foreach ($objects as $object) {
-                if (\in_array($object['name'], $preserve, true)) {
-                    continue;
-                }
-
                 $dropper = 'DROP TABLE IF EXISTS ' . $db->quoteName($object['name']);
                 $db->setQuery($dropper);
                 $db->execute();

--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -529,12 +529,11 @@ class CwmbackupController extends BaseController
         // The export wrote a `DROP TABLE IF EXISTS` for every table it dumped,
         // including that one, so skipping the drop here only deferred it by a
         // few statements — the backup's own SQL dropped and recreated the table
-        // from the snapshot. The intent was right and the mechanism was not
-        // (#1867).
+        // from the snapshot. The intent was right and the mechanism was not.
         //
         // getOwnObjects() excludes the whole shared scripture stack, which is
-        // the library's to manage (#1675 settled the same question for
-        // uninstall). Nothing here drops them, and Cwmrestore rejects any
+        // the library's to manage -- as it already is on uninstall. Nothing
+        // here drops them, and Cwmrestore rejects any
         // statement that targets them, so an older backup still carrying those
         // tables cannot reach them either.
         if ($batch === 0) {

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -291,6 +291,62 @@ class CwmdbHelper
     }
 
     /**
+     * The scripture stack: tables that carry the `bsms_` prefix but belong to
+     * lib_cwmscripture, not to Proclaim.
+     *
+     * They are shared. Any consumer of the library -- Proclaim, CWMLivingWord,
+     * a third party -- reads and writes them, and the library alone decides
+     * when they are created or dropped. #1675 settled the same ownership
+     * question for uninstall: Proclaim leaves the stack alone.
+     *
+     * `#__bsms_scripture_consumers` is the sharpest case. It is derived state
+     * describing which extensions are installed on *this* site right now, and
+     * every uninstall guard consults it before dropping anything. A copy of it
+     * taken at another moment is not a backup, it is a wrong answer waiting to
+     * be believed.
+     *
+     * @return  string[]  Table names with the `#__` prefix.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function getScriptureTables(): array
+    {
+        return [
+            '#__bsms_bible_translations',
+            '#__bsms_bible_verses',
+            '#__bsms_scripture_cache',
+            '#__bsms_scripture_consumers',
+        ];
+    }
+
+    /**
+     * getObjects() minus the shared scripture stack.
+     *
+     * What Proclaim may back up, restore and drop as its own. getObjects() is
+     * prefix-driven, so it cannot tell the difference by itself: all four
+     * scripture tables are named `bsms_*` despite belonging to the library.
+     *
+     * Kept separate from getObjects() rather than filtered at source. The
+     * migration and upgrade helpers also call getObjects(), and narrowing what
+     * they see is a different decision from narrowing what a backup carries.
+     *
+     * @return  array<int, array{name: string}>
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function getOwnObjects(): array
+    {
+        $shared = self::getScriptureTables();
+
+        return array_values(
+            array_filter(
+                self::getObjects(),
+                static fn (array $object): bool => !\in_array($object['name'], $shared, true)
+            )
+        );
+    }
+
+    /**
      * Get Objects for tables
      *
      * @return array

--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -296,8 +296,8 @@ class CwmdbHelper
      *
      * They are shared. Any consumer of the library -- Proclaim, CWMLivingWord,
      * a third party -- reads and writes them, and the library alone decides
-     * when they are created or dropped. #1675 settled the same ownership
-     * question for uninstall: Proclaim leaves the stack alone.
+     * when they are created or dropped. The same ownership question was
+     * settled for uninstall: Proclaim leaves the stack alone there too.
      *
      * `#__bsms_scripture_consumers` is the sharpest case. It is derived state
      * describing which extensions are installed on *this* site right now, and

--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -56,7 +56,8 @@ class Cwmbackup
 
     /**
      * Cached list of this component's own table names (with `#__` prefix), as
-     * returned by CwmdbHelper::getObjects(). Populated on first use.
+     * returned by CwmdbHelper::getOwnObjects() -- Proclaim's own tables, which
+     * excludes the shared scripture stack. Populated on first use.
      *
      * @var string[]|null
      *
@@ -84,7 +85,9 @@ class Cwmbackup
     private static function isKnownProclaimTable(string $table): bool
     {
         if (self::$knownTables === null) {
-            self::$knownTables = array_column(CwmdbHelper::getObjects(), 'name');
+            // getOwnObjects(), not getObjects(): the shared scripture stack is
+            // the library's, so it is neither exported nor restored here (#1867).
+            self::$knownTables = array_column(CwmdbHelper::getOwnObjects(), 'name');
         }
 
         if (\in_array($table, self::$knownTables, true)) {
@@ -509,7 +512,7 @@ class Cwmbackup
     public function exportdb(int $run): bool
     {
         $this->saveAsName = self::generateBackupFilename();
-        $objects          = CwmdbHelper::getObjects();
+        $objects          = CwmdbHelper::getOwnObjects();
         $config           = Factory::getApplication()->getConfig();
         $path             = $config->get('tmp_path') . '/' . $this->saveAsName;
 

--- a/admin/src/Lib/Cwmbackup.php
+++ b/admin/src/Lib/Cwmbackup.php
@@ -86,7 +86,7 @@ class Cwmbackup
     {
         if (self::$knownTables === null) {
             // getOwnObjects(), not getObjects(): the shared scripture stack is
-            // the library's, so it is neither exported nor restored here (#1867).
+            // the library's, so it is neither exported nor restored here.
             self::$knownTables = array_column(CwmdbHelper::getOwnObjects(), 'name');
         }
 

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -89,7 +89,10 @@ class Cwmrestore
         }
 
         if (self::$bsmsTables === null) {
-            self::$bsmsTables = array_column(CwmdbHelper::getObjects(), 'name');
+            // getOwnObjects(): a statement targeting the shared scripture stack is
+            // rejected, which also protects against restoring a backup taken
+            // before this change that still carries those tables (#1867).
+            self::$bsmsTables = array_column(CwmdbHelper::getOwnObjects(), 'name');
         }
 
         if (\in_array($matches['table'], self::$bsmsTables, true) || \in_array($matches['table'], self::ALLOWED_RESTORE_TABLES, true)) {
@@ -845,7 +848,10 @@ class Cwmrestore
     public static function correctAutoIncrements(): int
     {
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
-        $tables  = CwmdbHelper::getObjects();
+        // Own tables only: the restore no longer writes the shared scripture
+        // stack, so correcting its AUTO_INCREMENT would be this component
+        // reaching into the library's tables for no reason (#1867).
+        $tables  = CwmdbHelper::getOwnObjects();
         $prefix  = $db->getPrefix();
         $fixed   = 0;
 
@@ -969,7 +975,9 @@ class Cwmrestore
         }
 
         // Check Proclaim tables count
-        $proclaimTables = CwmdbHelper::getObjects();
+        // Count what a restore actually covers, not every bsms_ table in the
+        // schema -- the shared scripture stack is not part of the round trip.
+        $proclaimTables = CwmdbHelper::getOwnObjects();
 
         return [
             'config' => $configSize > 10, // Params should be substantial JSON

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -91,7 +91,7 @@ class Cwmrestore
         if (self::$bsmsTables === null) {
             // getOwnObjects(): a statement targeting the shared scripture stack is
             // rejected, which also protects against restoring a backup taken
-            // before this change that still carries those tables (#1867).
+            // before this change that still carries those tables.
             self::$bsmsTables = array_column(CwmdbHelper::getOwnObjects(), 'name');
         }
 
@@ -850,7 +850,7 @@ class Cwmrestore
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         // Own tables only: the restore no longer writes the shared scripture
         // stack, so correcting its AUTO_INCREMENT would be this component
-        // reaching into the library's tables for no reason (#1867).
+        // reaching into the library's tables for no reason.
         $tables  = CwmdbHelper::getOwnObjects();
         $prefix  = $db->getPrefix();
         $fixed   = 0;

--- a/tests/unit/Admin/ScriptureStackOwnershipTest.php
+++ b/tests/unit/Admin/ScriptureStackOwnershipTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Backup and restore must leave the shared scripture stack alone (#1867).
+ *
+ * The four scripture tables carry the `bsms_` prefix but belong to
+ * lib_cwmscripture. `CwmdbHelper::getObjects()` is prefix-driven and cannot
+ * tell the difference, so the backup swept them in: the export wrote them, and
+ * the restore dropped and replaced them from the snapshot.
+ *
+ * `#__bsms_scripture_consumers` is the one that bites. It is derived state
+ * describing what is installed on this site *now*, and every uninstall guard
+ * consults it before dropping anything. Restoring an older copy makes the
+ * guards under-report, and the next uninstall takes the downloaded bibles with
+ * it.
+ *
+ * ⚠️ These are source-inspection tests, following the pattern already used in
+ * CwmrestoreTest: the real paths need a live database, and the property worth
+ * pinning is *which list each site consults*, which is checkable without one.
+ * The rule is one line and easy to undo by reflex -- someone "tidying" a call
+ * back to getObjects() reintroduces the whole defect silently.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ScriptureStackOwnershipTest extends ProclaimTestCase
+{
+    /**
+     * Every table the library owns, and nothing else.
+     */
+    public function testTheScriptureStackIsTheFourSharedTables(): void
+    {
+        $this->assertSame(
+            [
+                '#__bsms_bible_translations',
+                '#__bsms_bible_verses',
+                '#__bsms_scripture_cache',
+                '#__bsms_scripture_consumers',
+            ],
+            CwmdbHelper::getScriptureTables(),
+            'The stack is what lib_cwmscripture creates. Adding a table there without '
+            . 'adding it here puts it back in the backup.'
+        );
+    }
+
+    /**
+     * The registry specifically, because it is the dangerous one.
+     */
+    public function testTheConsumerRegistryIsTreatedAsShared(): void
+    {
+        $this->assertContains(
+            '#__bsms_scripture_consumers',
+            CwmdbHelper::getScriptureTables(),
+            'Restoring a stale registry makes every uninstall guard under-report, '
+            . 'which is how downloaded translations get dropped.'
+        );
+    }
+
+    /**
+     * getOwnObjects() must actually subtract, not just forward.
+     */
+    public function testOwnObjectsIsDefinedAsGetObjectsMinusTheStack(): void
+    {
+        $body = self::methodBody(CwmdbHelper::class, 'getOwnObjects');
+
+        $this->assertMatchesRegularExpression('/getScriptureTables\(\)/', $body);
+        $this->assertMatchesRegularExpression('/array_filter/', $body);
+        $this->assertMatchesRegularExpression('/self::getObjects\(\)/', $body);
+    }
+
+    /**
+     * The export gate. Rejecting a table here keeps it out of the dump
+     * entirely -- no DROP, no CREATE, no rows.
+     */
+    public function testTheExportAllowListExcludesTheStack(): void
+    {
+        $body = self::methodBody(
+            \CWM\Component\Proclaim\Administrator\Lib\Cwmbackup::class,
+            'isKnownProclaimTable'
+        );
+
+        $this->assertMatchesRegularExpression('/getOwnObjects\(\)/', $body);
+        $this->assertDoesNotMatchRegularExpression(
+            '/CwmdbHelper::getObjects\(\)/',
+            $body,
+            'getObjects() here puts the shared tables back into every backup.'
+        );
+    }
+
+    /**
+     * The restore gate. This is what protects against a backup taken *before*
+     * this change, which still carries those tables.
+     */
+    public function testTheRestoreAllowListExcludesTheStack(): void
+    {
+        $body = self::methodBody(
+            \CWM\Component\Proclaim\Administrator\Lib\Cwmrestore::class,
+            'isSafeRestoreStatement'
+        );
+
+        $this->assertMatchesRegularExpression('/getOwnObjects\(\)/', $body);
+        $this->assertDoesNotMatchRegularExpression(
+            '/CwmdbHelper::getObjects\(\)/',
+            $body,
+            'An older backup still contains the shared tables. Without this, restoring '
+            . 'one reaches them even though the export no longer writes them.'
+        );
+    }
+
+    /**
+     * The drop loop, and the dead guard it used to carry.
+     */
+    public function testTheRestoreDropLoopNeitherTouchesTheStackNorKeepsTheDeadPreserveList(): void
+    {
+        $source = (string) file_get_contents(
+            __DIR__ . '/../../../admin/src/Controller/CwmbackupController.php'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/\$objects\s*=\s*CwmdbHelper::getOwnObjects\(\)/',
+            $source,
+            'The batch-0 drop loop must not enumerate the shared tables.'
+        );
+
+        // ⚠️ The old `$preserve = ['#__bsms_bible_verses']` never worked: the
+        // export wrote a DROP for that table too, so the backup's own SQL
+        // dropped it moments later. Keeping it would suggest a protection that
+        // is not there.
+        // Anchored to the start of a line so the comment above the loop -- which
+        // quotes the old `$preserve = [...]` to explain why it went -- is not
+        // read as the code itself. An unanchored pattern matched that prose and
+        // failed, which is the same trap cwm-lint-comments exists for.
+        $this->assertDoesNotMatchRegularExpression(
+            '/^\s*\$preserve\s*=\s*\[/m',
+            $source,
+            'The preserve list was ineffective and is replaced by excluding the stack.'
+        );
+    }
+
+    private static function methodBody(string $class, string $method): string
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice(
+                $lines,
+                $reflection->getStartLine() - 1,
+                $reflection->getEndLine() - $reflection->getStartLine() + 1
+            )
+        );
+    }
+}


### PR DESCRIPTION
**Option A** on #1867: the scripture stack is not Proclaim's data.

The four scripture tables belong to `lib_cwmscripture`. Proclaim's backup
treated them as its own because `CwmdbHelper::getObjects()` is prefix-driven and
they are all named `bsms_*`.

The restore dropped and replaced them from the snapshot. That is worst for
`#__bsms_scripture_consumers` — derived state describing what is installed on
this site **now**. Every uninstall guard consults it before dropping anything,
so restoring an older copy makes the guards under-report, and the next uninstall
takes the downloaded translations with it.

## The protection that was already there did not work

```php
// For the first batch, drop existing tables (preserving downloaded Bible verse data)
$preserve = ['#__bsms_bible_verses'];
```

The export wrote a `DROP TABLE IF EXISTS` for **every** table it dumped, that
one included. Skipping the pre-emptive drop deferred it by a few statements —
the backup's own SQL then dropped and recreated the table from the snapshot. The
intent was right and the mechanism was not.

## What changed

`CwmdbHelper::getScriptureTables()` names the stack; `getOwnObjects()` returns
`getObjects()` minus it. Four sites consult it:

| site | effect |
|---|---|
| `Cwmbackup::isKnownProclaimTable` | export gate — excluded tables get no DDL and no rows |
| `Cwmrestore::isSafeRestoreStatement` | restore gate — **also protects against restoring an older backup** that still carries them |
| `CwmbackupController` batch-0 loop | no longer drops them; the dead `$preserve` goes too |
| `correctAutoIncrements` + post-restore count | describe what a restore actually covers |

That second row matters: existing backups in the wild still contain those
tables, and the restore gate is what stops them reaching the live stack.

**`getObjects()` itself is unchanged.** The migration and upgrade helpers also
call it, and narrowing what *they* see is a different decision from narrowing
what a backup carries.

Consistent with #1675, which settled the same ownership question for uninstall.

## Tests

Six, source-inspecting each call site the way `CwmrestoreTest` already does —
the real paths need a live database, and the property worth holding is *which
list each site consults*. That is also the thing most likely to be undone by
reflex: a call "tidied" back to `getObjects()` reintroduces the whole defect
silently.

All four mutations checked — reverting any single call site fails, as does
dropping a table from the stack list.

⚠️ One test was wrong first: it searched for `$preserve = [` unanchored and
matched the comment that quotes the old code to explain why it went. Anchored to
the start of a line — the same prose-matching trap `cwm-lint-comments` exists
for.

Full suite: 2558 tests, 8038 assertions. `php-cs-fixer` clean.

Closes #1867