### PR TITLE
refactor: ask information_schema for existence, not a LIKE pattern

### DIFF
--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -291,6 +291,80 @@ class CwmdbHelper
     }
 
     /**
+     * Whether a table exists in this site's database.
+     *
+     * ⚠️ Not `SHOW TABLES LIKE`. In a LIKE pattern `_` matches any single
+     * character, and every Joomla prefix ends in one -- so
+     * `SHOW TABLES LIKE 'jos_bsms_admin'` also matches a table literally named
+     * `josXbsmsYadmin`. The query reads as an equality test and is not one.
+     *
+     * A collision needs a table of identical length differing only at the
+     * underscore positions, which is why nothing has gone wrong in practice:
+     * measured across a real 104-table schema, zero pairs collide. It is still
+     * the wrong question to ask, and asking the right one costs nothing.
+     *
+     * information_schema keeps the property the old query was chosen for --
+     * it does not enumerate every table the way getTableList() does.
+     *
+     * @param   string  $table  Table name, with either the `#__` placeholder or
+     *                          the real prefix.
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function tableExists(string $table): bool
+    {
+        $db   = Factory::getContainer()->get(DatabaseInterface::class);
+        $real = str_replace('#__', $db->getPrefix(), $table);
+
+        $query = $db->createQuery()
+            ->select('COUNT(*)')
+            ->from($db->quoteName('information_schema.TABLES'))
+            ->where($db->quoteName('TABLE_SCHEMA') . ' = DATABASE()')
+            ->where($db->quoteName('TABLE_NAME') . ' = :name')
+            ->bind(':name', $real);
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult() > 0;
+    }
+
+    /**
+     * Whether a column exists on a table.
+     *
+     * The same wildcard problem as {@see tableExists()}: `SHOW COLUMNS FROM x
+     * LIKE 'teacher_id'` also matches a column named `teacherXid`, because `_`
+     * is a single-character wildcard. Less likely to collide than a table name
+     * carrying a prefix underscore, and the same wrong question.
+     *
+     * @param   string  $table   Table name, `#__` placeholder or real prefix.
+     * @param   string  $column  Column name, matched exactly.
+     *
+     * @return  bool
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function columnExists(string $table, string $column): bool
+    {
+        $db   = Factory::getContainer()->get(DatabaseInterface::class);
+        $real = str_replace('#__', $db->getPrefix(), $table);
+
+        $query = $db->createQuery()
+            ->select('COUNT(*)')
+            ->from($db->quoteName('information_schema.COLUMNS'))
+            ->where($db->quoteName('TABLE_SCHEMA') . ' = DATABASE()')
+            ->where($db->quoteName('TABLE_NAME') . ' = :table')
+            ->where($db->quoteName('COLUMN_NAME') . ' = :column')
+            ->bind(':table', $real)
+            ->bind(':column', $column);
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult() > 0;
+    }
+
+    /**
      * The scripture stack: tables that carry the `bsms_` prefix but belong to
      * lib_cwmscripture, not to Proclaim.
      *
@@ -398,13 +472,10 @@ class CwmdbHelper
     public static function getInstallState(): bool
     {
         if (!\is_bool(self::$install_state)) {
-            $db = Factory::getContainer()->get(DatabaseInterface::class);
-
-            // Check if JBSM can be found from the database
-            $table = $db->getPrefix() . 'bsms_admin';
-            $db->setQuery("SHOW TABLES LIKE {$db->quote($table)}");
-
-            if ($db->loadResult() !== $table) {
+            // Comparing the returned name (rather than testing truthiness)
+            // made this immune to the LIKE wildcard by accident. tableExists()
+            // makes that deliberate, and says so.
+            if (!self::tableExists('#__bsms_admin')) {
                 self::$install_state = true;
             }
         }

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -364,11 +364,7 @@ class CwmmigrationHelper
         if ($dupCount > 0) {
             // ⚠️ Only while the column exists. It is retired, and this runs from
             // data fixes on databases either side of that.
-            $db->setQuery(
-                'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote('teacher_id')
-            );
-
-            if ($db->loadRow() !== null) {
+            if (CwmdbHelper::columnExists('#__bsms_studies', 'teacher_id')) {
                 $db->setQuery(
                     'UPDATE ' . $db->quoteName('#__bsms_studies') . ' s '
                     . 'INNER JOIN ' . $db->quoteName('#__bsms_teachers_merge') . ' m ON s.'
@@ -518,11 +514,7 @@ class CwmmigrationHelper
         }
 
         // Nothing to migrate once the column is gone.
-        $db->setQuery(
-            'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote('teacher_id')
-        );
-
-        if ($db->loadRow() === null) {
+        if (!CwmdbHelper::columnExists('#__bsms_studies', 'teacher_id')) {
             return 0;
         }
 
@@ -1520,11 +1512,7 @@ class CwmmigrationHelper
     {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        $db->setQuery(
-            'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote('teacher_id')
-        );
-
-        if ($db->loadRow() === null) {
+        if (!CwmdbHelper::columnExists('#__bsms_studies', 'teacher_id')) {
             return 0;
         }
 

--- a/admin/src/Helper/CwmupgradeHelper.php
+++ b/admin/src/Helper/CwmupgradeHelper.php
@@ -114,9 +114,10 @@ class CwmupgradeHelper
     }
 
     /**
-     * Check whether a specific table exists using SHOW TABLES LIKE.
+     * Check whether a specific table exists.
      *
-     * Much cheaper than getTableList() which loads ALL table names.
+     * Still much cheaper than getTableList(), which loads ALL table names --
+     * CwmdbHelper::tableExists() asks information_schema for the one name.
      *
      * @param   object  $db         Database driver instance.
      * @param   string  $tableName  Full table name (with prefix).
@@ -128,9 +129,7 @@ class CwmupgradeHelper
     private static function tableExists(object $db, string $tableName): bool
     {
         try {
-            $db->setQuery('SHOW TABLES LIKE ' . $db->quote($tableName));
-
-            return $db->loadResult() !== null;
+            return CwmdbHelper::tableExists($tableName);
         } catch (\Exception $e) {
             return false;
         }

--- a/admin/src/Lib/Cwmrestore.php
+++ b/admin/src/Lib/Cwmrestore.php
@@ -860,11 +860,13 @@ class Cwmrestore
             $realName     = str_replace('#__', $prefix, $abstractName);
 
             try {
-                // Check whether the table has an `id` column
-                $db->setQuery('SHOW COLUMNS FROM ' . $db->quoteName($abstractName) . ' LIKE ' . $db->quote('id'));
-                $column = $db->loadObject();
-
-                if (!$column) {
+                // Check whether the table has an `id` column.
+                //
+                // 'id' carries no underscore, so this one was never exposed to
+                // the LIKE wildcard the way a prefixed table name is. Converted
+                // anyway: leaving the last example of the pattern in the tree is
+                // how it gets copied into somewhere that does have one.
+                if (!CwmdbHelper::columnExists($abstractName, 'id')) {
                     continue;
                 }
 

--- a/admin/src/Lib/CwmscriptureMigration.php
+++ b/admin/src/Lib/CwmscriptureMigration.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Proclaim\Administrator\Lib;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Library\Scripture\Helper\ScriptureHelper as CwmscriptureHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
@@ -272,11 +273,7 @@ class CwmscriptureMigration
      */
     private static function columnExists(DatabaseInterface $db, string $column): bool
     {
-        $db->setQuery(
-            'SHOW COLUMNS FROM ' . $db->quoteName('#__bsms_studies') . ' LIKE ' . $db->quote($column)
-        );
-
-        return $db->loadRow() !== null;
+        return CwmdbHelper::columnExists('#__bsms_studies', $column);
     }
 
     /**

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -1240,11 +1240,9 @@ class CwminstallModel extends ListModel
     public function uninstall(): bool
     {
         // Check if CWM can be found in the database
-        $table = $this->getDatabase()->getPrefix() . 'bsms_admin';
-        $this->getDatabase()->setQuery("SHOW TABLES LIKE {$this->getDatabase()->quote($table)}");
         $drop_result = '';
 
-        if ($this->getDatabase()->loadResult()) {
+        if (CwmdbHelper::tableExists('#__bsms_admin')) {
             $query = $this->getDatabase()->createQuery();
             $query->select('*')
                 ->from($this->getDatabase()->quoteName('#__bsms_admin'))

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -10,6 +10,7 @@
  * @link           https://www.christianwebministries.org
  * */
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmguidedtourHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
@@ -1623,10 +1624,7 @@ class com_proclaimInstallerScript extends InstallerScript
     {
         try {
             // Check if the admin table exists
-            $table = $this->dbo->getPrefix() . 'bsms_admin';
-            $this->dbo->setQuery("SHOW TABLES LIKE " . $this->dbo->quote($table));
-
-            if (!$this->dbo->loadResult()) {
+            if (!CwmdbHelper::tableExists('#__bsms_admin')) {
                 return;
             }
 
@@ -2997,9 +2995,8 @@ class com_proclaimInstallerScript extends InstallerScript
 
             foreach ($tables as $name) {
                 $full = $prefix . $name;
-                $db->setQuery('SHOW TABLES LIKE ' . $db->quote($full));
 
-                if (!$db->loadResult()) {
+                if (!CwmdbHelper::tableExists($full)) {
                     continue;
                 }
 

--- a/tests/unit/Admin/Helper/TableExistenceTest.php
+++ b/tests/unit/Admin/Helper/TableExistenceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ * */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+
+/**
+ * Existence checks must ask an equality question, not a LIKE one.
+ *
+ * `SHOW TABLES LIKE 'jos_bsms_admin'` reads as an equality test and is not one:
+ * `_` matches any single character, so it also matches a table literally named
+ * `josXbsmsYadmin`. Every Joomla prefix ends in an underscore, so every such
+ * check carried at least one wildcard.
+ *
+ * Measured across a real 104-table schema, zero pairs collide -- so this was
+ * never firing in the field, and the fix is about asking the right question
+ * rather than repairing damage.
+ *
+ * ⚠️ Source-inspection, like CwmrestoreTest: the helpers read information_schema
+ * and the unit suite has no database. What is worth pinning without one is that
+ * the pattern is gone and does not come back by copy-paste -- there were seven
+ * instances, and each was a plausible model for the next.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TableExistenceTest extends ProclaimTestCase
+{
+    /**
+     * Directories holding code that ships to a site.
+     *
+     * build/ and tests/ are excluded deliberately: the harness has its own
+     * database access and is not what a user runs.
+     */
+    private const SHIPPED_PATHS = ['admin/src', 'site/src', 'api/src', 'plugins'];
+
+    /**
+     * @return list<string>  Absolute paths of shipped PHP files.
+     */
+    private static function shippedFiles(): array
+    {
+        $root  = \dirname(__DIR__, 4);
+        $files = [];
+
+        foreach (self::SHIPPED_PATHS as $relative) {
+            $dir = $root . '/' . $relative;
+
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+
+            foreach ($iterator as $file) {
+                $path = $file->getPathname();
+
+                // Bundled third-party code is not ours to hold to this.
+                if (str_contains($path, '/vendor/') || !str_ends_with($path, '.php')) {
+                    continue;
+                }
+
+                $files[] = $path;
+            }
+        }
+
+        // The installer scriptfile lives at the root and is very much shipped.
+        $files[] = $root . '/proclaim.script.php';
+
+        return $files;
+    }
+
+    /**
+     * Strip block and line comments, so prose explaining the old pattern is not
+     * mistaken for the pattern. The explanation of why `SHOW TABLES LIKE` is
+     * wrong necessarily contains the words.
+     */
+    private static function code(string $path): string
+    {
+        $source   = (string) file_get_contents($path);
+        $stripped = '';
+
+        foreach (token_get_all($source) as $token) {
+            if (\is_array($token) && \in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            $stripped .= \is_array($token) ? $token[1] : $token;
+        }
+
+        return $stripped;
+    }
+
+    public function testNoShippedCodeAsksForExistenceWithALikePattern(): void
+    {
+        $offenders = [];
+
+        foreach (self::shippedFiles() as $path) {
+            if (!is_file($path)) {
+                continue;
+            }
+
+            // ⚠️ Only the LIKE form. `SHOW COLUMNS FROM x WHERE Field IN (...)`
+            // is an exact match and perfectly fine -- an earlier version of this
+            // test flagged one of those and was wrong. Plain `SHOW TABLES` is
+            // included because its only uses are the wildcard form or a full
+            // enumeration, and neither is what these checks want.
+            $code = self::code($path);
+
+            if (
+                preg_match('/SHOW\s+TABLES\b/i', $code) === 1
+                || preg_match('/SHOW\s+COLUMNS\b[^;]*\bLIKE\b/is', $code) === 1
+            ) {
+                $offenders[] = str_replace(\dirname(__DIR__, 4) . '/', '', $path);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "Use CwmdbHelper::tableExists()/columnExists(). A LIKE pattern treats the\n"
+            . "prefix underscore as a wildcard, so the check can answer yes for a\n"
+            . 'different table. Offending files: ' . implode(', ', $offenders)
+        );
+    }
+
+    public function testTableExistsAsksInformationSchemaWithABoundEqualityMatch(): void
+    {
+        $body = self::methodBody('tableExists');
+
+        $this->assertMatchesRegularExpression('/information_schema\.TABLES/', $body);
+        $this->assertMatchesRegularExpression('/TABLE_NAME.{0,12}=\s*:name/s', $body, 'equality, not LIKE');
+        $this->assertMatchesRegularExpression('/->bind\(/', $body, 'the name is bound, not interpolated');
+        $this->assertDoesNotMatchRegularExpression('/LIKE/i', $body);
+    }
+
+    public function testColumnExistsBindsBothTheTableAndTheColumn(): void
+    {
+        $body = self::methodBody('columnExists');
+
+        $this->assertMatchesRegularExpression('/information_schema\.COLUMNS/', $body);
+        $this->assertMatchesRegularExpression('/->bind\(\':table\'/', $body);
+        $this->assertMatchesRegularExpression('/->bind\(\':column\'/', $body);
+        $this->assertDoesNotMatchRegularExpression('/LIKE/i', $body);
+    }
+
+    /**
+     * Both helpers accept either `#__x` or an already-prefixed name, because
+     * their callers hold one or the other.
+     */
+    public function testBothHelpersResolveThePlaceholderPrefix(): void
+    {
+        foreach (['tableExists', 'columnExists'] as $method) {
+            $this->assertMatchesRegularExpression(
+                "/str_replace\('#__'/",
+                self::methodBody($method),
+                $method . '() must accept a #__ token as well as a real name.'
+            );
+        }
+    }
+
+    private static function methodBody(string $method): string
+    {
+        $reflection = new \ReflectionMethod(CwmdbHelper::class, $method);
+        $lines      = file($reflection->getFileName());
+
+        return implode(
+            '',
+            \array_slice(
+                $lines,
+                $reflection->getStartLine() - 1,
+                $reflection->getEndLine() - $reflection->getStartLine() + 1
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #1896.

Seven existence checks used `SHOW TABLES LIKE` / `SHOW COLUMNS ... LIKE`. In a
LIKE pattern `_` matches any single character, and **every Joomla prefix ends in
one** — so each of these read as an equality test and was not one:

```
SHOW TABLES LIKE 'jos_bsms_admin'   also matches   josXbsmsYadmin
```

`CwmdbHelper::tableExists()` and `columnExists()` ask `information_schema` with
a **bound equality match**. That keeps the property the old query was chosen for
— `CwmupgradeHelper`'s own comment notes it is much cheaper than
`getTableList()`, and `information_schema` does not enumerate the schema either.

## Severity was measured, not assumed

A collision needs a table of identical length differing only at the underscore
positions. Across a real 104-table schema, **zero pairs collide**. Nothing was
firing in the field — this is asking the right question, not repairing damage,
which is why it was filed `priority: low`.

## Sites

| site | before |
|---|---|
| `CwmupgradeHelper::tableExists` | delegates to the shared helper now |
| `CwmdbHelper::getInstallState` | immune **by accident** — compared the returned name rather than truthiness. Now immune on purpose |
| `CwminstallModel::uninstall` | truthiness, then read `#__bsms_admin` |
| `proclaim.script.php` ×2 | same shape, one inside a `try` |
| `CwmmigrationHelper` ×3 | `teacher_id` column checks |
| `CwmscriptureMigration` | column check on a variable name |
| `Cwmrestore` | `'id'`, no underscore, never exposed — converted anyway |

That last one is deliberate: leaving the only remaining example of the pattern
in the tree is how it gets copied somewhere that *does* have an underscore.

## Tests

Four. One walks every shipped PHP file and fails if the pattern comes back —
the real risk, since seven instances existed and each was a plausible model for
the next. Comments are stripped before matching, because the explanation of why
LIKE is wrong necessarily contains the words.

Both mutations checked: reintroducing `SHOW TABLES LIKE` in shipped code fails
it, and swapping the helper's `=` back to `LIKE` fails it.

⚠️ **That test was too strict at first** and flagged
`plugins/content/scripturelinks/src/Extension/ScriptureLinks.php`, which uses
`SHOW COLUMNS FROM ... WHERE Field IN (...)` — an exact match with no wildcard.
My issue text claimed that file used the LIKE form. It does not, and I have
corrected that on the issue. The rule now covers `SHOW TABLES` in any form and
`SHOW COLUMNS` only with `LIKE`.

Full suite: 2562 tests, 8049 assertions. `lint:comments`, `lint:queries` and
`php-cs-fixer` clean.

Closes #1896