### PR TITLE
chore(deps): bump cwm/build-tools to ^1.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.27",
+    "cwm/build-tools": "^1.28",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12af432603700a0a6a35570713cd8248",
+    "content-hash": "0b9e366487d31c6fb4ef51aeda4cce7d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.27.1",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "3e0c0d3e77fc95955816ff8498ce69133dde4bb4"
+                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/3e0c0d3e77fc95955816ff8498ce69133dde4bb4",
-                "reference": "3e0c0d3e77fc95955816ff8498ce69133dde4bb4",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/289b22ac9e0c563458c2d76a1e7240c866f7ef80",
+                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80",
                 "shasum": ""
             },
             "require": {
@@ -664,10 +664,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.27.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.28.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T18:26:38+00:00"
+            "time": "2026-08-18T21:22:29+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Two additions, both opt-in — nothing here changes until they are called.

| | |
|---|---|
| `cwm-sync-configs --check` | previews managed-config drift and **exits 1**, for CI |
| `--help` on every command | the last eight now answer it too |

⚠️ **Before wiring `--check` into this repository's CI:** it reports drift
today, and clearing that changes committed files. Worth doing as a deliberate
step rather than as a side effect of enabling the check.

## Verified after the bump

All **29** `cwm-*` commands print help and leave the working tree untouched.

That sweep is what dirtied four working trees during the 1.27 bump — running
`--help` across every binary made `cwm-sync-configs` perform a full sync,
rewriting `.gitignore`, `build.dist.properties`, `.editorconfig` and
`phpunit.xml`. Fixed in v1.27.1, and confirmed here against the published
release rather than assumed.