### PR TITLE
chore: sync the managed .gitignore block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ build.properties
 /build/dist/
 /media/js/
 /media/css/
+/media/joomla.asset.json
 # === cwm-build-tools: end extension paths ===
 
 # Claude Code personal/local settings (not shared)


### PR DESCRIPTION
`cwm-sync-configs --check` reported this: the managed block was missing
`/media/joomla.asset.json`.

```
Managed config is out of date (1):
  - .gitignore
```

It belongs there. The file is **generated** — `cwm-build.config.json` copies it
from `build/media_source/joomla.asset.json` into `media/` during the build, and
lists it under `gitignore.outputPaths`, which is what drives the block. It is
untracked and 28KB on disk, so it has been turning up as an untracked file ever
since the build started producing it.

One line:

```diff
+/media/joomla.asset.json
```

Found by the new `--check` flag rather than by anyone noticing — which is the
point of that flag. A managed block that falls behind is invisible until someone
happens to run a sync.

## Not included

`docker-compose.databases.yml`, which `cwm-sync-configs` also offers. Taking up
an opt-in template is a choice for this repository, not something to fold into a
drift fix.