### PR TITLE
chore(deps): bump cwm/build-tools to ^1.29

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.28",
+    "cwm/build-tools": "^1.29",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b9e366487d31c6fb4ef51aeda4cce7d",
+    "content-hash": "ec60bef7e149ccafbbf7407943788870",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80"
+                "reference": "3b99210586ca0e8b68c87ded8028f61fbe824292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/289b22ac9e0c563458c2d76a1e7240c866f7ef80",
-                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/3b99210586ca0e8b68c87ded8028f61fbe824292",
+                "reference": "3b99210586ca0e8b68c87ded8028f61fbe824292",
                 "shasum": ""
             },
             "require": {
@@ -599,7 +599,8 @@
                 "bin/cwm-lint-comments",
                 "bin/cwm-lint-workflows",
                 "bin/cwm-reset-testsite",
-                "bin/cwm-verify-update-stream"
+                "bin/cwm-verify-update-stream",
+                "bin/cwm-schema-replay"
             ],
             "type": "library",
             "autoload": {
@@ -664,10 +665,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.28.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.29.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T21:22:29+00:00"
+            "time": "2026-08-19T12:54:25+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",

--- a/docker-compose.databases.yml
+++ b/docker-compose.databases.yml
@@ -1,0 +1,70 @@
+# Disposable MySQL and MariaDB for extension development.
+#
+# Databases only. Apache and PHP stay wherever you already have them (MAMP,
+# Herd, Valet, a system install) — this exists so schema work has a database
+# that is *known empty*, not to move your web stack.
+#
+# Why empty matters: a leftover table from the previous attempt turns a real
+# failure into a pass. That is the same defect this toolchain keeps finding
+# elsewhere — a check that reports success while testing something other than
+# what it claims.
+#
+#   docker compose -f docker-compose.databases.yml up -d       # start
+#   docker compose -f docker-compose.databases.yml down -v     # stop and wipe
+#
+# ⚠️ The reset is `down -v`, not `down`. Both images declare a VOLUME for their
+# data directory, so a plain `down` leaves an anonymous volume behind and the
+# next `up` inherits it — a leftover table from the previous attempt, which is
+# the exact failure this file exists to prevent.
+#
+# A tmpfs data directory would make that impossible, and was the first thing
+# tried here. It does not work: MySQL 8 defaults `innodb_flush_method` to
+# `O_DIRECT`, which tmpfs does not support, so the server fails to start.
+# Checked against MySQL 8.0.44 rather than assumed. `down -v` is the reset.
+#
+# Do not point anything you care about at these.
+#
+# Ports are deliberately not 3306: a developer's existing local MySQL keeps
+# running. Set them in .env if these clash.
+#
+#   CWM_MYSQL_PORT=3307   CWM_MARIADB_PORT=3308
+#
+# Point the test suite at one with:
+#
+#   CWM_TEST_MYSQL_DSN='mysql:host=127.0.0.1;port=3307;dbname=cwm_test' \
+#     CWM_TEST_MYSQL_USER=root CWM_TEST_MYSQL_PASSWORD=root composer test
+#
+# MariaDB is here because it is a real second engine our users run, not for
+# completeness. PostgreSQL is deliberately absent — this toolchain declares
+# MySQL/MariaDB only, and shipping a container for an engine we do not support
+# would imply otherwise.
+
+services:
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cwm_test
+    ports:
+      - "${CWM_MYSQL_PORT:-3307}:3306"
+    healthcheck:
+      # Same probe this project's CI uses for the same image.
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: cwm_test
+    ports:
+      - "${CWM_MARIADB_PORT:-3308}:3306"
+    healthcheck:
+      # MariaDB ships its own probe; mysqladmin ping reports healthy before
+      # InnoDB has finished coming up.
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
Picks up **v1.29.0**, which adds `cwm-schema-replay` — a command that *executes* an extension's migration files against a scratch schema, rather than checking their effects on a site that never ran them.

**That gap is this repo's.** A fresh install applies `install.sql` and Joomla stamps `#__schemas` at the newest version without running a single update file — so `test-install.sh`, `verify-migrations.php` and `verify-schema-check.php` all pass while the **37 files in `admin/sql/updates/mysql` have never been executed** by anything but a user's upgrade.

`^1.28` does not resolve 1.29, so the constraint bump is what makes it available at all.

**Not adopted here.** Using it needs a committed baseline (Joomla core schema plus `com_proclaim`'s install SQL at 10.0.0) and a `schemaReplay` block, which is its own change. Building that baseline is already proven out — replaying all 37 migrations from a real 10.0.0 start runs 286 statements, 4 of them `/** CAN FAIL **/`.

## The vendor:check fix lands here

This is the repo the 1.28.1 fix was written for. `composer vendor:check` runs the template straight out of `libraries/vendor/cwm/build-tools`, so the update alone is enough — no sync needed for that part.

Verified after updating:

```
| (root)                         | roave/security-advisories | dev-latest | dev-latest | ✗ Update    |
| libraries/lib_cwmscripture     | cwm/build-tools           | v1.15.1    | v1.29.0    | ℹ submodule |
| libraries/lib_cwmscripture     | friendsofphp/php-cs-fixer | v3.95.18   | v3.95.19   | ℹ submodule |
| libraries/lib_cwmscripture     | phpunit/phpunit           | 11.5.56    | 12.5.33    | ℹ submodule |
| plugins/content/scripturelinks | cwm/build-tools           | v1.16.1    | v1.29.0    | ℹ submodule |
| plugins/content/scripturelinks | friendsofphp/php-cs-fixer | v3.95.18   | v3.95.19   | ℹ submodule |
| plugins/content/scripturelinks | phpunit/phpunit           | 12.5.32    | 13.3.1     | ℹ submodule |
```

The six submodule rows no longer count toward the exit code — their `composer.json` lives in another repository. The remaining exit 1 is a genuine root dependency, which is the whole point.

`composer sync-configs` ran alongside; nothing was out of date. **`docker-compose.databases.yml`** is created, not updated — a one-time seed for a known-empty MySQL/MariaDB, and directly useful here since schema replay needs exactly that.

Suite green: **2562 tests, 8049 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
