### PR TITLE
fix(schema): `from` is the highest migration shipped, not the release number

### DIFF
--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -192,7 +192,7 @@
             ]
         }
     },
-    "_schemaReplay_comment": "`root` is the extension root the manifest's relative paths resolve against, as Joomla's extension_root does \u2014 proclaim.xml sits at the repo root while the sql/ it names is under admin/, so without it every path resolves one level too high. The baseline is a SITE's schema, not this extension's install SQL alone \u2014 four migrations write to core tables no Proclaim manifest creates. Order matters: core first. Raising the supported floor means replacing com_proclaim-10.0.0.sql and moving `from` to match, not editing it.",
+    "_schemaReplay_comment": "`root` is the extension root the manifest's relative paths resolve against, as Joomla's extension_root does \u2014 proclaim.xml sits at the repo root while the sql/ it names is under admin/, so without it every path resolves one level too high. The baseline is a SITE's schema, not this extension's install SQL alone \u2014 four migrations write to core tables no Proclaim manifest creates. Order matters: core first. `from` is the highest migration file SHIPPED at that tag, not the release number: v10.0.0 contains exactly one, 10.0.0-20220921.sql, and a fresh install stamps #__schemas at whatever the highest file is without running any of them. Raising the supported floor means replacing com_proclaim-10.0.0.sql and moving `from` to the highest file that release shipped, not editing it.",
     "schemaReplay": {
         "targets": [
             {
@@ -203,7 +203,7 @@
                     "build/sql-baselines/joomla-core.sql",
                     "build/sql-baselines/com_proclaim-10.0.0.sql"
                 ],
-                "from": "10.0.0"
+                "from": "10.0.0-20220921"
             }
         ]
     },


### PR DESCRIPTION
The replay started at `10.0.0` and so ran `10.0.0-20220921.sql`, **which no site running 10.0.0 has ever run.**

A fresh install applies `install.sql` and stamps `#__schemas` at the *highest migration file present in that release*, without running any of them. `v10.0.0` ships exactly one — `10.0.0-20220921.sql` — so a 10.0.0 site sits at `10.0.0-20220921`, and the first file it can run is the next one after that.

```
files at v10.0.0:  10.0.0-20220921.sql
fresh install stamps #__schemas at:  10.0.0-20220921
```

## Why it matters even though it passed

Starting lower than the baseline actually represents replays files whose changes the baseline already contains. Here that happened to pass, so the gate was merely *stricter* than reality rather than wrong.

But a check that can fail on something no site ever does is a false alarm waiting to be argued with — and the argument would be lost, because the tool would be right and the configuration wrong.

## The numbers confirm it is the intended change

| | before | after |
|---|---|---|
| migrations | 37 of 37 | **36 of 37** |
| statements | 286 | **282** |
| CAN FAIL tolerated | 4 | **3** |

The 4 statements and 1 tolerated failure that disappeared are exactly `10.0.0-20220921.sql`'s. That is the check that this is a correction and not a coverage regression.

## How it was found

While wiring the same tool into CWMLivingWord, where the equivalent mistake did **not** pass — it failed with `Duplicate column name 'join_mode'`, because that repository's `install.sql` already contains what the skipped migrations add. Proclaim's history is incremental enough that the same error was silent.

Verified against a checkout of tracked files only, not the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
