### PR TITLE
chore(deps): bump cwm/build-tools to ^1.31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.29",
+    "cwm/build-tools": "^1.31",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec60bef7e149ccafbbf7407943788870",
+    "content-hash": "f76f742c33c4c2d7938f7189881c712b",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.29.1",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "14f68480c5b98eec5c663735b8ece33b805d4be9"
+                "reference": "f9921bb1a2249524020d044f2a97a211cf273390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/14f68480c5b98eec5c663735b8ece33b805d4be9",
-                "reference": "14f68480c5b98eec5c663735b8ece33b805d4be9",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f9921bb1a2249524020d044f2a97a211cf273390",
+                "reference": "f9921bb1a2249524020d044f2a97a211cf273390",
                 "shasum": ""
             },
             "require": {
@@ -665,10 +665,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.29.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.31.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-19T13:25:44+00:00"
+            "time": "2026-08-19T14:13:35+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Catches up with two releases cut while wiring schema replay through the family.

**Nothing here needs either of them.** 1.30.0 added `run-schema-replay` to the reusable `joomla-package-ci.yml`, which this project does not use — its CI is hand-written and calls `composer schema-replay` directly. 1.31.0 added the same input to the *library* workflow, for lib_cwmscripture. The bump is so the constraint reflects what is actually installed, not because a fix is being picked up.

`composer sync-configs` alongside; nothing was out of date.

## Verified, not assumed

A toolchain bump can move the very thing it is supposed to check, so the replay was re-run on 1.31.0:

```
baseline 10.0.0-20220921, 36 of 37 migrations to replay
✓ 282 statements applied, 3 CAN FAIL tolerated
```

Identical to 1.29.1.

Suite green: **2562 tests, 8049 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
