### PR TITLE
fix(build): restore the scripture negative control, and cover what replaced it

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.5.10-dev</version>
-    <creationDate>2026-08-18</creationDate>
+    <version>10.5.10</version>
+    <creationDate>2026-08-19</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -535,8 +535,24 @@ cp "$LIBSRC" "$LIBZIP"
 # The baseline no longer supplies the hazard: lib_cwmscripture has shipped a
 # disarmed uninstall SQL since 1.1.5, so these two phases plant the pre-1.1.5
 # file themselves and then assert it really is armed before relying on it.
+# ⚠️ Phases 15 and 16 suspend plg_system_cwmscripture, and phase 16b covers it.
+#
+# That plugin rewrites the library's uninstall SQL to an inert file before an
+# install runs, and since CWMScriptureLinks 1.2.11 it subscribes
+# onExtensionBeforeUpdate as well as onExtensionBeforeInstall -- so it now fires
+# on the library-update path these phases use.
+#
+# It disarmed the planted SQL before Joomla could parse it, so the negative
+# control stopped being able to fail: the data survived, and "an un-disarmed
+# update destroys data" was no longer true on this fixture. A negative control
+# that cannot fail makes the positive phase next to it vacuous as well -- phase
+# 16 would have passed whether or not the explicit disarm did anything.
+#
+# So both phases isolate the hazard from that plugin, and 16b asserts the
+# plugin's own protection on purpose, which nothing covered before.
 echo "-- [15/17] NEGATIVE CONTROL: library-only update with no disarm must destroy data"
 "$BIN/cwm-install-zip" --zip "$BASEZIP" >/dev/null
+php build/verify-scripture-uninstall.php suspend-system-disarm
 php build/verify-scripture-uninstall.php arm
 php build/verify-scripture-uninstall.php assert-sql-armed
 php build/verify-scripture-uninstall.php seed-translation
@@ -552,6 +568,7 @@ php build/verify-scripture-uninstall.php assert-translation-destroyed
 
 echo "-- [16/17] library-only update AFTER the disarm must preserve data"
 "$BIN/cwm-install-zip" --zip "$BASEZIP" >/dev/null
+php build/verify-scripture-uninstall.php suspend-system-disarm
 php build/verify-scripture-uninstall.php arm
 php build/verify-scripture-uninstall.php assert-sql-armed
 php build/verify-scripture-uninstall.php seed-translation
@@ -563,6 +580,32 @@ if ! php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1;
 fi
 
 php build/verify-scripture-uninstall.php assert-translation-survived
+
+# The protection real sites actually rely on, asserted rather than assumed.
+# Nothing disarms the SQL here by hand: the plugin is enabled and has to do it
+# itself, on the update path, before Joomla parses the file. This is what made
+# phases 15 and 16 stop discriminating, so it is worth an assertion of its own
+# rather than being the silent reason two other phases passed.
+echo "-- [16b/17] with plg_system_cwmscripture ENABLED, its disarm must protect the data"
+"$BIN/cwm-install-zip" --zip "$BASEZIP" >/dev/null
+php build/verify-scripture-uninstall.php resume-system-disarm
+php build/verify-scripture-uninstall.php arm
+php build/verify-scripture-uninstall.php assert-sql-armed
+php build/verify-scripture-uninstall.php seed-translation
+if ! php "$JCLI" extension:install -n --path="$(pwd)/${LIBZIP}" >/dev/null 2>&1; then
+    echo "ERROR: the library-only update failed, so 'the data survived' is vacuous." >&2
+    exit 1
+fi
+# Deliberately NOT assert-sql-disarmed here. After the update the file on disk
+# is 1.1.18's own shipped uninstall SQL, which is inert whatever the plugin did,
+# so that assertion would pass without the plugin having done anything. The data
+# surviving a *planted armed* file is the only thing that discriminates.
+php build/verify-scripture-uninstall.php assert-translation-survived
+
+# Leave the plugin enabled whatever the phases above did: test:e2e runs against
+# this install straight after, and a suspended system plugin would fail it for a
+# reason that has nothing to do with the change under test.
+php build/verify-scripture-uninstall.php resume-system-disarm
 
 # Phases 14 and 15 use the released baseline as their fixture, so the site is
 # left on ${BASEVER} with a newer library over it. Nothing here needs the site

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -71,6 +71,8 @@ $modes = [
     'restore-manifest',
     'assert-translation-survived',
     'assert-translation-destroyed',
+    'suspend-system-disarm',
+    'resume-system-disarm',
 ];
 
 if (!\in_array($mode, $modes, true)) {
@@ -759,6 +761,58 @@ foreach ($installs as $install) {
 
             break;
 
+
+        // ⚠️ These two exist because a SECOND protection now masks the first.
+        //
+        // plg_system_cwmscripture rewrites the library's uninstall SQL to an
+        // inert file before an install or update runs. Since CWMScriptureLinks
+        // 1.2.11 it subscribes onExtensionBeforeUpdate as well as
+        // onExtensionBeforeInstall, so it fires on the library-update path too --
+        // which is the path the negative control uses.
+        //
+        // The effect is that the control could no longer fail: the plugin
+        // disarmed the planted SQL before Joomla parsed it, the data survived,
+        // and "a library update with no disarm destroys data" stopped being
+        // true. A negative control that cannot fail makes the positive phase
+        // beside it vacuous too, so both phases suspend the plugin and a third
+        // phase covers the plugin's own behaviour deliberately.
+        //
+        // Suspending is a row update rather than an uninstall: the plugin has to
+        // come back, and reinstalling it would run the very installer path under
+        // test.
+        case 'suspend-system-disarm':
+        case 'resume-system-disarm':
+            $enable = $mode === 'resume-system-disarm' ? 1 : 0;
+            $stmt   = $db->prepare(
+                "UPDATE `{$extensions}` SET `enabled` = ?
+                  WHERE `type` = 'plugin' AND `folder` = 'system' AND `element` = 'cwmscripture'"
+            );
+            $stmt->execute([$enable]);
+
+            if ($stmt->rowCount() === 0) {
+                // Already in the wanted state is fine; absent is not. Asserting
+                // the row exists keeps a renamed or missing plugin from reading
+                // as "suspended" and quietly restoring the mask.
+                $row = $rowOrNull(
+                    $db,
+                    "SELECT `enabled` FROM `{$extensions}`
+                      WHERE `type` = 'plugin' AND `folder` = 'system' AND `element` = 'cwmscripture'"
+                );
+
+                if ($row === null) {
+                    fwrite(STDERR, "  FAIL plg_system_cwmscripture is not installed, so its disarm cannot be\n");
+                    fwrite(STDERR, "       suspended. The negative control would silently measure nothing.\n");
+                    $failures++;
+
+                    break;
+                }
+            }
+
+            echo $enable === 1
+                ? "  OK   plg_system_cwmscripture re-enabled — its automatic disarm is back\n"
+                : "  OK   plg_system_cwmscripture suspended — the planted SQL will reach the installer\n";
+
+            break;
 
         case 'assert-sql-armed':
         case 'assert-sql-disarmed':

--- a/build/verify-scripture-uninstall.php
+++ b/build/verify-scripture-uninstall.php
@@ -762,24 +762,24 @@ foreach ($installs as $install) {
             break;
 
 
-        // ⚠️ These two exist because a SECOND protection now masks the first.
-        //
-        // plg_system_cwmscripture rewrites the library's uninstall SQL to an
-        // inert file before an install or update runs. Since CWMScriptureLinks
-        // 1.2.11 it subscribes onExtensionBeforeUpdate as well as
-        // onExtensionBeforeInstall, so it fires on the library-update path too --
-        // which is the path the negative control uses.
-        //
-        // The effect is that the control could no longer fail: the plugin
-        // disarmed the planted SQL before Joomla parsed it, the data survived,
-        // and "a library update with no disarm destroys data" stopped being
-        // true. A negative control that cannot fail makes the positive phase
-        // beside it vacuous too, so both phases suspend the plugin and a third
-        // phase covers the plugin's own behaviour deliberately.
-        //
-        // Suspending is a row update rather than an uninstall: the plugin has to
-        // come back, and reinstalling it would run the very installer path under
-        // test.
+            // ⚠️ These two exist because a SECOND protection now masks the first.
+            //
+            // plg_system_cwmscripture rewrites the library's uninstall SQL to an
+            // inert file before an install or update runs. Since CWMScriptureLinks
+            // 1.2.11 it subscribes onExtensionBeforeUpdate as well as
+            // onExtensionBeforeInstall, so it fires on the library-update path too --
+            // which is the path the negative control uses.
+            //
+            // The effect is that the control could no longer fail: the plugin
+            // disarmed the planted SQL before Joomla parsed it, the data survived,
+            // and "a library update with no disarm destroys data" stopped being
+            // true. A negative control that cannot fail makes the positive phase
+            // beside it vacuous too, so both phases suspend the plugin and a third
+            // phase covers the plugin's own behaviour deliberately.
+            //
+            // Suspending is a row update rather than an uninstall: the plugin has to
+            // come back, and reinstalling it would run the very installer path under
+            // test.
         case 'suspend-system-disarm':
         case 'resume-system-disarm':
             $enable = $mode === 'resume-system-disarm' ? 1 : 0;

--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.5.10-dev",
+        "version": "10.5.10",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="administrator" method="upgrade">
     <name>mod_proclaimicon</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.10-dev</version>
-    <creationDate>2026-08-18</creationDate>
+    <version>10.5.10</version>
+    <creationDate>2026-08-19</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaim</namespace>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="site" method="upgrade">
     <name>mod_proclaim_podcast</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 Christian Web Ministries All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.5.10-dev</version>
-    <creationDate>2026-08-18</creationDate>
+    <version>10.5.10</version>
+    <creationDate>2026-08-19</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimYoutube</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.10-dev",
+  "version": "10.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.5.10-dev",
+      "version": "10.5.10",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.10-dev",
+  "version": "10.5.10",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="finder" method="upgrade">
     <name>plg_finder_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="schemaorg" method="upgrade">
     <name>plg_schemaorg_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="system" method="upgrade">
     <name>plg_system_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="task" method="upgrade">
 	<name>plg_task_proclaim</name>
 	<author>CWM Team</author>
-	<creationDate>2026-08-18</creationDate>
+	<creationDate>2026-08-19</creationDate>
 	<copyright>(C) 2026 Proclaim All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.5.10-dev</version>
+	<version>10.5.10</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="webservices" method="upgrade">
     <name>plg_webservices_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-18</creationDate>
+    <creationDate>2026-08-19</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.5.10-dev</version>
+    <version>10.5.10</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,8 +6,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.10-dev</version>
-    <creationDate>2026-08-18</creationDate>
+    <version>10.5.10</version>
+    <creationDate>2026-08-19</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Component\Proclaim</namespace>


### PR DESCRIPTION
The release gate for 10.5.10 failed at phase 15 — the negative control that plants pre-1.1.5 armed uninstall SQL and requires a library-only update to destroy the data. The data survived, so the control was not proving anything.

## What actually masked it

**Not** the consumer registry, which was the obvious suspect and the first thing I tried — clearing all four rows changed nothing. The uninstall SQL was also *running*: a marker statement planted in the declared file executed during the update, so the mechanism was intact.

`plg_system_cwmscripture` rewrites the library's uninstall SQL to an inert file before an install runs. **CWMScriptureLinks 1.2.11** — which this release pulls in (`d179a31ba → 06c90247c`) — made it subscribe `onExtensionBeforeUpdate` as well as `onExtensionBeforeInstall`. So it now fires on the library-*update* path, which is the path this phase uses, and disarmed the planted SQL before Joomla parsed it.

Confirmed by disabling that plugin and re-running: *"the hazard is real and detectable."*

The product got safer and the control went stale. That is the good direction — but a negative control that cannot fail also makes the positive phase beside it vacuous: **phase 16 would have passed whether or not the explicit disarm did anything.**

## The fix

| phase | change |
|---|---|
| 15 — no disarm must destroy | suspends the plugin, so the hazard is isolated from it |
| 16 — explicit disarm must preserve | suspends the plugin, so the *explicit* disarm is what saves the data |
| **16b — new** | plugin **enabled**, nothing disarmed by hand: its own protection must save the data |

Suspending is an `enabled` row update rather than an uninstall — the plugin has to come back, and reinstalling would run the very installer path under test.

16b is what actually protects sites in the field, it is the reason the other two stopped discriminating, and nothing covered it.

It deliberately does **not** `assert-sql-disarmed` afterwards: post-update the file on disk is 1.1.18's own inert SQL whatever the plugin did, so that assertion would pass without the plugin having done anything. Only the data surviving a planted **armed** file discriminates.

## Verified

Full `test:upgrade` green: **10.5.9 → 10.5.10, all 17 phases**.

Both new phases mutation-checked rather than assumed:

- phase 15 without the suspend — the original failure
- phase 16b with the plugin suspended — fails `0/2 cache rows`, `0/3 verses`, so it depends on the plugin rather than on the update being harmless

## One self-inflicted bug, caught

The first version of these modes was inserted into an existing **stacked case list**, so `arm`, `disarm` and `assert-sql-armed` fell into the new body and reported "passed" while doing nothing. Moved out of the stack; each mode prints its own result again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
